### PR TITLE
Adding more error checking to install.vbs

### DIFF
--- a/install.vbs
+++ b/install.vbs
@@ -1,5 +1,5 @@
 Option Explicit
-On Error GoTo 0
+On Error Resume Next
 
 ' ***                                                                      ***
 ' *                                                                          *
@@ -12,7 +12,8 @@ On Error GoTo 0
 ' *    From the command line: cscript install.vbs                            *
 ' ***                                                                      ***
 
-Dim strWorkingDirectory, strSymlinkFilesListPath, objShell, intReturnVal
+Dim strWorkingDirectory, strSymlinkFilesListPath, objShell, intReturnVal, _
+    strErrorDescription, objFso
 
 ' Set the working folder to the script location (i.e. the repo root)
 strWorkingDirectory = GetDirectoryName(WScript.ScriptFullName)
@@ -20,12 +21,33 @@ Set objShell = WScript.CreateObject("WScript.Shell")
 objShell.CurrentDirectory = strWorkingDirectory
 strSymlinkFilesListPath = strWorkingDirectory & "tools\symlink_files.txt"
 
+' If the symlink files list does not exist, we can't continue.
+Set objFso = WScript.CreateObject("Scripting.FileSystemObject")
+If Not objFso.FileExists(strSymlinkFilesListPath) Then
+    WScript.Echo "The file '" & strSymlinkFilesListPath & "' does not exist.  Cannot continue."
+    Set objFso = Nothing
+    WScript.Quit 9
+End If
+Set objFso = Nothing
+
 ' If git is not in the path, this script cannot run.
 Set objShell = WScript.CreateObject("WScript.Shell")
 intReturnVal = objShell.Run("git status", 1, True)
-If intReturnVal <> 0 Then
-    WScript.Echo "Git not found!  The 'git' command must be part of your PATH."
+If Err.number <> 0 Then
+    strErrorDescription = Err.Description
+    Err.Clear
+    WScript.Echo "There was an error getting the status of the git repository: '" & strErrorDescription & "' Make sure the 'git' executable is on your PATH variable."
     WScript.Quit 1
+End If
+
+If intReturnVal <> 0 Then
+    If intReturnVal = 128 Then
+        WScript.Echo "Git repository not initialized!  You must clone this repository via the 'git clone' command to run this script."
+        WScript.Quit 7
+    Else
+        WScript.Echo "Unknown error getting the git repository status (" & intReturnVal & ").  Make sure git is installed and part of your PATH, and that you've cloned the git repository using the 'git clone' command."
+        WScript.Quit 8
+    End If
 End If
 
 ' Initialze and update the submodules.
@@ -33,6 +55,11 @@ intReturnVal = objShell.Run("git submodule init", 1, True)
 If intReturnVal <> 0 Then
     WScript.Echo "Error initializing the submodules!"
     WScript.Quit 2
+End If
+intReturnVal = objShell.Run("git submodule sync", 1, True)
+If intReturnVal <> 0 Then
+    WScript.Echo "Error syncing the submodules!"
+    WScript.Quit 6
 End If
 intReturnVal = objShell.Run("git submodule update", 1, True)
 If intReturnVal <> 0 Then
@@ -63,7 +90,9 @@ Sub CopySymlinkFiles
     WScript.Echo
     objAdoStream.LoadFromFile strSymlinkFilesListPath
     If Err.number <> 0 Then
-        WScript.Echo "Error opening '" & strSymlinkFilesListPath & "' for reading: " & Err.Description
+        strErrorDescription = Err.Description
+        Err.Clear
+        WScript.Echo "Error opening '" & strSymlinkFilesListPath & "' for reading: " & strErrorDescription
         Set objAdoStream = Nothing
         WScript.Quit 4
     End If
@@ -81,6 +110,16 @@ Sub CopySymlinkFiles
 	    Set objMatch = objMatches.Item(0)
 	    strSrcFile = objMatch.SubMatches.Item(0)
 	    strDestFile = objMatch.SubMatches.Item(1)
+
+            ' Make sure source file exists.
+            If Not objFso.FileExists(strSrcFile) And Not objFso.FolderExists(strSrcFile) Then
+                WScript.Echo "Source file '" & strSrcFile & "' does not exist!  Cannot continue."
+                Set objFso = Nothing
+                objAdoStream.Close
+                Set objAdoStream = Nothing
+                WScript.Quit 10
+            End If
+
 	    WScript.Echo "Copying '" & strSrcFile & "' to '" & strDestFile & "'"
 	    If objFso.FileExists(strDestFile) Then
 	        objFso.DeleteFile strDestFile, True
@@ -93,12 +132,14 @@ Sub CopySymlinkFiles
 	        objFso.CopyFolder strSrcFile, strDestFile, True  ' Overwrite
 	    End If
 	    If Err.number <> 0 Then
-	        WScript.Echo "Error copying '" & strSrcFile & "' to '" & strDestFile & "': " & Err.Description
+                strErrorDescription = Err.Description
+                Err.Clear
+	        WScript.Echo "Error copying '" & strSrcFile & "' to '" & strDestFile & "': " & strErrorDescription
 	        Set objFso = Nothing
 	        objAdoStream.Close
 	        Set objAdoStream = Nothing
 	        WScript.Quit 5
-	    End If
+            End If
         End If
     Wend
     


### PR DESCRIPTION
Making some error granularity adjustments, based on some feedback from the forums.  Among other things, these updates should now inform you that you have to run 'git clone' to work with the repository, if you happened to copy it down directly from github.
