### PR TITLE
Fix for NPE when turning off Wifi on Wifi only device.

### DIFF
--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
@@ -160,6 +160,7 @@ public class HttpAccess extends BroadcastReceiver {
         NetworkInfo mobileInfo = conMgr.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
         if (mobileInfo == null) {
         	setHasNetwork(false, "No active data connection");
+        	return;
         }
         
         // Reset network if type changed 


### PR DESCRIPTION
NetworkInfo mobileInfo = conMgr.getNetworkInfo(ConnectivityManager.TYPE_MOBILE); will return null on a wifi only device (e.g. a nexus 7), the code in the broadcast receiver barfs on this case. (see issue 80) 
