### PR TITLE
ForcePluginsTest were not running at all after recent merge from unstabl...

### DIFF
--- a/hybrid/test/ForcePluginsTest/res/xml/config.xml
+++ b/hybrid/test/ForcePluginsTest/res/xml/config.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugins>
+    <access origin="http://127.0.0.1*"/> <!-- allow local pages -->
+    <access origin="https://force.com" subdomains="true" />
+    <access origin="https://salesforce.com" subdomains="true" />
+    <log level="DEBUG"/>
+    <preference name="classicRender" value="true" />
+
     <plugin name="App" value="org.apache.cordova.App"/>
     <plugin name="Geolocation" value="org.apache.cordova.GeoBroker"/>
     <plugin name="Device" value="org.apache.cordova.Device"/>


### PR DESCRIPTION
...e (because we now only define the TestRunnerPlugin in the test project) and unstable is still using plugins.xml while unstable20 uses config.xml
