### PR TITLE
allow login UI type to set to something other than "mobile"

### DIFF
--- a/native/SalesforceSDK/res/values/strings.xml
+++ b/native/SalesforceSDK/res/values/strings.xml
@@ -6,4 +6,7 @@
     -->
 	<string name="app_name">SalesforceSDK</string>
    	<string name="account_type">com.salesforce.androisdk</string>
+   	
+   	<!-- If you're only supporting recent versions of Android (e.g. 3.x and up), you can override this to be touch and get a better looking login UI  -->
+   	<string name="sf__oauth_display_type">mobile</string>
 </resources>

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -101,9 +101,9 @@ public class OAuth2 {
     private static final String ACTIVATED_CLIENT_CODE = "activated_client_code";
 
     // Login paths
-    private static final String OAUTH_AUTH_PATH = "/services/oauth2/authorize?display=mobile";
+    private static final String OAUTH_AUTH_PATH = "/services/oauth2/authorize?display=";
     private static final String OAUTH_TOKEN_PATH = "/services/oauth2/token";
-
+    
     /**
      * Build the URL to the authorization web page for this login server.
      * You need not provide refresh_token, as it is provided automatically.
@@ -123,13 +123,20 @@ public class OAuth2 {
      */
     public static URI getAuthorizationUrl(URI loginServer, String clientId,
             String callbackUrl, String[] scopes) {
-       return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, null);
+       return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, null, null);
     }
 
     public static URI getAuthorizationUrl(URI loginServer, String clientId,
             String callbackUrl, String[] scopes, String clientSecret) {
+    	return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, clientSecret, null);
+    }
+    
+    public static URI getAuthorizationUrl(URI loginServer, String clientId,
+            String callbackUrl, String[] scopes, String clientSecret, String displayType) {
+        if (displayType == null) displayType = "mobile";
         final StringBuilder sb = new StringBuilder(loginServer.toString());
         sb.append(OAUTH_AUTH_PATH);
+        sb.append(displayType);
         if (clientSecret != null) {
             sb.append("&").append(RESPONSE_TYPE).append("=").append(ACTIVATED_CLIENT_CODE);
         } else {

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -44,6 +44,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
 
+import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.app.ForceApp;
 import com.salesforce.androidsdk.auth.HttpAccess;
 import com.salesforce.androidsdk.auth.OAuth2;
@@ -244,9 +245,22 @@ public class OAuthWebviewHelper {
                 new URI(loginOptions.loginUrl),
                 getOAuthClientId(),
                 loginOptions.oauthCallbackUrl,
-                loginOptions.oauthScopes);
+                loginOptions.oauthScopes,
+                null,
+                getAuthorizationDisplayType());
     }
 
+   	/** 
+   	 * If you're only supporting recent versions of Android (e.g. 3.x and up), you can override this to be touch and get a better looking login UI
+   	 * You can override this by either subclass this class, or adding <string name="sf__oauth_display_type">touch</string> to your app's value
+   	 * resource so that it overrides the default value in the SDK library.
+   	 * 
+   	 * @return the OAuth login display type, e.g. mobile, touch, see the OAuth docs for the complete list of valid values.
+   	 */
+    protected String getAuthorizationDisplayType() {
+    	return this.getContext().getString(R.string.sf__oauth_display_type);
+    }
+    
     /**
      * Override this method to customize the login url.
      * @return login url

--- a/native/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/native/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -76,7 +76,10 @@ public class OAuth2Test extends InstrumentationTestCase {
 		URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID, callbackUrl,null);
 		URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL + "/services/oauth2/authorize?display=mobile&response_type=token&client_id=" + TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
 		assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        
+		
+		authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch");
+		expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL + "/services/oauth2/authorize?display=touch&response_type=token&client_id=" + TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
+		assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
 	}
 	
     /**


### PR DESCRIPTION
Currently the display type for login is hard coded to mobile. Depending on your target OS, "touch" can provide a better looking UI. This change allows an app to override (via a resource string) the display type, so that they can use touch if they so wish.
