### PR TITLE
Fix for NPE

### DIFF
--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceDroidGapActivity.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceDroidGapActivity.java
@@ -308,14 +308,14 @@ public class SalesforceDroidGapActivity extends DroidGap {
                             setSidCookies();
                             loadVFPingPage();
                             if (callbackContext != null) {
-                                callbackContext.success(getJSONCredentials());	
+                                callbackContext.success(getJSONCredentials());
                             }
                         }
 
                         @Override
                         public void onError(Exception exception) {
                         	if (callbackContext != null) {
-                            	callbackContext.error(exception.getMessage());	
+                            	callbackContext.error(exception.getMessage());
                         	}
                         }
                     });


### PR DESCRIPTION
`callbackContext` can be null (we supply a null activity while logging in).
