### PR TITLE
Added the ability to merge manifest files from library project

### DIFF
--- a/hybrid/SampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/SampleApps/AccountEditor/AndroidManifest.xml
@@ -4,7 +4,7 @@
     package="com.salesforce.samples.accounteditor"
     android:versionCode="1"
     android:versionName="1.0"
-	android:installLocation="internalOnly">
+    android:installLocation="internalOnly">
 
     <supports-screens android:largeScreens="true"
         android:normalScreens="true"
@@ -12,29 +12,11 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-
     <uses-sdk android:minSdkVersion="8" />
 
     <application android:label="@string/app_name"
         android:name=".AccountEditorApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
-
-		<!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
 
         <!--  Main activity -->
         <activity android:label="@string/app_name"
@@ -45,23 +27,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-        <!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
     </application>
 </manifest>

--- a/hybrid/SampleApps/AccountEditor/project.properties
+++ b/hybrid/SampleApps/AccountEditor/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../../hybrid/SmartStore
+manifestmerger.enabled=true

--- a/hybrid/SampleApps/ContactExplorer/AndroidManifest.xml
+++ b/hybrid/SampleApps/ContactExplorer/AndroidManifest.xml
@@ -12,13 +12,7 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
 
     <uses-sdk android:minSdkVersion="8" />
@@ -26,21 +20,9 @@
     <application android:label="@string/app_name" 
         android:name=".ContactExplorerApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
-
-		<!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
         
         <!--  Main activity -->
-        <activity
-            android:label="@string/app_name"
+        <activity android:label="@string/app_name"
             android:name="com.salesforce.androidsdk.ui.sfhybrid.SalesforceDroidGapActivity"
             android:configChanges="orientation|keyboardHidden" >
             <intent-filter >
@@ -48,23 +30,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-		<!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
     </application>
 </manifest>

--- a/hybrid/SampleApps/ContactExplorer/project.properties
+++ b/hybrid/SampleApps/ContactExplorer/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../../native/SalesforceSDK
+manifestmerger.enabled=true

--- a/hybrid/SampleApps/HybridFileExplorer/AndroidManifest.xml
+++ b/hybrid/SampleApps/HybridFileExplorer/AndroidManifest.xml
@@ -12,29 +12,11 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-
     <uses-sdk android:minSdkVersion="8" />
 
     <application android:label="@string/app_name"
         android:name=".HybridFileExplorerApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
-
-		<!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
 
         <!--  Main activity -->
         <activity android:label="@string/app_name"
@@ -45,23 +27,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-        <!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
     </application>
 </manifest>

--- a/hybrid/SampleApps/HybridFileExplorer/project.properties
+++ b/hybrid/SampleApps/HybridFileExplorer/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../../hybrid/SmartStore
+manifestmerger.enabled=true

--- a/hybrid/SampleApps/SmartStoreExplorer/AndroidManifest.xml
+++ b/hybrid/SampleApps/SmartStoreExplorer/AndroidManifest.xml
@@ -12,28 +12,11 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <uses-sdk android:minSdkVersion="8" />
 
     <application android:label="@string/app_name"
         android:name=".SmartStoreExplorerApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
-
-        <!-- Service required for authentication -->
-        <service android:exported="true" android:process=":auth"
-            android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-            <intent-filter>
-                <action android:name="android.accounts.AccountAuthenticator" />
-            </intent-filter>
-            <meta-data android:name="android.accounts.AccountAuthenticator"
-                android:resource="@xml/authenticator" />
-        </service>
 
         <!--  Main activity -->
         <activity android:label="@string/app_name"
@@ -44,23 +27,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <!-- Login activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity" 
-            android:theme="@android:style/Theme.NoTitleBar"/>
-
-        <!-- Passcode activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-        <!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-        <!-- Choose server activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-            android:excludeFromRecents="true" 
-            android:theme="@android:style/Theme.NoTitleBar"/>
     </application>
 </manifest>

--- a/hybrid/SampleApps/SmartStoreExplorer/project.properties
+++ b/hybrid/SampleApps/SmartStoreExplorer/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../SmartStore
+manifestmerger.enabled=true

--- a/hybrid/SampleApps/VFConnector/AndroidManifest.xml
+++ b/hybrid/SampleApps/VFConnector/AndroidManifest.xml
@@ -12,28 +12,11 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <uses-sdk android:minSdkVersion="8" />
 
     <application android:label="@string/app_name"
         android:name=".VFConnectorApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
-
-		<!-- Service required for authentication -->
-		<service android:exported="true" android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
 
         <!--  Main activity -->
         <activity android:label="@string/app_name"
@@ -44,23 +27,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-		<!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
     </application>
 </manifest>

--- a/hybrid/SampleApps/VFConnector/project.properties
+++ b/hybrid/SampleApps/VFConnector/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../../native/SalesforceSDK
+manifestmerger.enabled=true

--- a/hybrid/SampleApps/test/ContactExplorerTest/project.properties
+++ b/hybrid/SampleApps/test/ContactExplorerTest/project.properties
@@ -12,3 +12,4 @@
 
 # Project target.
 target=android-8
+manifestmerger.enabled=true

--- a/hybrid/SampleApps/test/SmartStoreExplorerTest/project.properties
+++ b/hybrid/SampleApps/test/SmartStoreExplorerTest/project.properties
@@ -12,3 +12,4 @@
 
 # Project target.
 target=android-8
+manifestmerger.enabled=true

--- a/hybrid/SampleApps/test/VFConnectorTest/project.properties
+++ b/hybrid/SampleApps/test/VFConnectorTest/project.properties
@@ -12,4 +12,4 @@
 
 # Project target.
 target=android-8
-
+manifestmerger.enabled=true

--- a/hybrid/SmartStore/AndroidManifest.xml
+++ b/hybrid/SmartStore/AndroidManifest.xml
@@ -5,5 +5,6 @@
 	android:versionCode="31"
 	android:versionName="2.1.0.unstable">
     <application />
+
     <uses-sdk android:minSdkVersion="8" />
 </manifest>

--- a/hybrid/SmartStore/project.properties
+++ b/hybrid/SmartStore/project.properties
@@ -11,3 +11,4 @@
 target=android-8
 android.library=true
 android.library.reference.1=../../native/SalesforceSDK
+manifestmerger.enabled=true

--- a/hybrid/test/ForcePluginsTest/AndroidManifest.xml
+++ b/hybrid/test/ForcePluginsTest/AndroidManifest.xml
@@ -3,20 +3,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="com.salesforce.androidsdk.tests" 
     android:versionCode="1"
-    android:versionName="1.0" >
+    android:versionName="1.0">
 
     <supports-screens android:largeScreens="true"
         android:normalScreens="true"
         android:smallScreens="true"
         android:resizeable="true"
         android:anyDensity="true" />
-
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
 
     <uses-sdk android:minSdkVersion="8" />
 

--- a/hybrid/test/ForcePluginsTest/project.properties
+++ b/hybrid/test/ForcePluginsTest/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../SmartStore
+manifestmerger.enabled=true

--- a/hybrid/test/SmartStoreTest/AndroidManifest.xml
+++ b/hybrid/test/SmartStoreTest/AndroidManifest.xml
@@ -10,34 +10,11 @@
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
 
         <uses-library android:name="android.test.runner" />
-
-        <!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-        <!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
 	</application>
 
     <instrumentation android:targetPackage="com.salesforce.androidsdk.smartstore.tests" 
         android:name="com.salesforce.androidsdk.util.JUnitReportTestRunner" 
         android:label="Tests for SmartStore" />
-
-    <uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
 	<uses-sdk android:minSdkVersion="8" />
 </manifest>

--- a/hybrid/test/SmartStoreTest/project.properties
+++ b/hybrid/test/SmartStoreTest/project.properties
@@ -10,4 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../SmartStore
-
+manifestmerger.enabled=true

--- a/native/SalesforceSDK/AndroidManifest.xml
+++ b/native/SalesforceSDK/AndroidManifest.xml
@@ -4,6 +4,45 @@
 	package="com.salesforce.androidsdk" 
 	android:versionCode="31"
 	android:versionName="2.1.0.unstable">
-    <application />
+
+    <application>
+
+        <!-- Service required for authentication -->
+        <service android:exported="true"
+            android:process=":auth"
+            android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
+            <intent-filter>
+                <action android:name="android.accounts.AccountAuthenticator" />
+            </intent-filter>
+            <meta-data android:name="android.accounts.AccountAuthenticator"
+                android:resource="@xml/authenticator" />
+        </service>
+
+        <!-- Login activity -->
+        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:theme="@android:style/Theme.NoTitleBar" />
+
+        <!-- Passcode activity -->
+        <activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <!-- Manage space activity -->
+        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.NoTitleBar" />
+
+        <!-- Choose server activity -->
+        <activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.NoTitleBar" />
+    </application>
+
     <uses-sdk android:minSdkVersion="8" />
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
+    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
 </manifest>

--- a/native/SampleApps/FileExplorer/AndroidManifest.xml
+++ b/native/SampleApps/FileExplorer/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.samples.fileexplorer" android:versionCode="1"
+	package="com.salesforce.samples.fileexplorer"
+	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">
 
@@ -10,52 +11,16 @@
 		android:name=".FileExplorerApp"
 		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
 
-		<!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
-
 		<!-- Launcher screen -->
-		<activity android:name=".MainActivity" android:label="@string/app_name"
+		<activity android:name=".MainActivity"
+		    android:label="@string/app_name"
 			android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
-
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity" 
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-		<!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
 	</application>
 
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-	<!-- device os versions http://developer.android.com/guide/publishing/versioning.html -->
 	<uses-sdk android:minSdkVersion="12" />
 </manifest>

--- a/native/SampleApps/FileExplorer/project.properties
+++ b/native/SampleApps/FileExplorer/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-12
 android.library.reference.1=../../SalesforceSDK
+manifestmerger.enabled=true

--- a/native/SampleApps/NativeSqlAggregator/AndroidManifest.xml
+++ b/native/SampleApps/NativeSqlAggregator/AndroidManifest.xml
@@ -11,17 +11,6 @@
 		android:name=".NativeSqlAggregatorApp"
 		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
 
-		<!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
-
 		<!-- Launcher screen -->
 		<activity android:name=".MainActivity"
 		    android:label="@string/app_name"
@@ -41,32 +30,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
-
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
 	</application>
-
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
 	<uses-sdk android:minSdkVersion="8" />
 </manifest>

--- a/native/SampleApps/NativeSqlAggregator/project.properties
+++ b/native/SampleApps/NativeSqlAggregator/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../../hybrid/SmartStore
+manifestmerger.enabled=true

--- a/native/SampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/SampleApps/RestExplorer/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.samples.restexplorer" android:versionCode="1"
+	package="com.salesforce.samples.restexplorer"
+	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">
 
@@ -9,17 +10,6 @@
 	    android:label="@string/app_name"
 		android:name=".RestExplorerApp"
 		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
-
-		<!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
 
 		<!-- Launcher screen -->
 		<activity android:name=".ExplorerActivity" android:label="@string/app_name"
@@ -29,33 +19,7 @@
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
-
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity" 
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-		<!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
 	</application>
 
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-	<!-- device os versions http://developer.android.com/guide/publishing/versioning.html -->
 	<uses-sdk android:minSdkVersion="8" />
 </manifest>

--- a/native/SampleApps/RestExplorer/project.properties
+++ b/native/SampleApps/RestExplorer/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../SalesforceSDK
+manifestmerger.enabled=true

--- a/native/SampleApps/test/RestExplorerTest/project.properties
+++ b/native/SampleApps/test/RestExplorerTest/project.properties
@@ -11,3 +11,4 @@
 target=android-8
 
 tested.project.dir=../RestExplorer
+manifestmerger.enabled=true

--- a/native/TemplateApp/AndroidManifest.xml
+++ b/native/TemplateApp/AndroidManifest.xml
@@ -11,17 +11,6 @@
 		android:name=".TemplateApp"
 		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
 
-		<!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
-
 		<!-- Launcher screen -->
 		<activity android:name=".MainActivity"
 		    android:label="@string/app_name"
@@ -31,33 +20,7 @@
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
-
-		<!-- Login activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
-		    android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-		<!-- Passcode activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"
-		    android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-
-		<!-- Choose server activity -->
-		<activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
-		    android:excludeFromRecents="true"
-		    android:theme="@android:style/Theme.NoTitleBar" />
 	</application>
 
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-	<!-- device os versions http://developer.android.com/guide/publishing/versioning.html -->
 	<uses-sdk android:minSdkVersion="8" />
 </manifest>

--- a/native/TemplateApp/project.properties
+++ b/native/TemplateApp/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../SalesforceSDK
+manifestmerger.enabled=true

--- a/native/test/SalesforceSDKTest/AndroidManifest.xml
+++ b/native/test/SalesforceSDKTest/AndroidManifest.xml
@@ -10,34 +10,11 @@
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
 
         <uses-library android:name="android.test.runner" />
-
-        <!-- Manage space activity -->
-        <activity android:name="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-            android:excludeFromRecents="true"
-            android:theme="@android:style/Theme.NoTitleBar" />
-
-        <!-- Service required for authentication -->
-		<service android:exported="true"
-		    android:process=":auth"
-			android:name="com.salesforce.androidsdk.auth.AuthenticatorService">
-			<intent-filter>
-				<action android:name="android.accounts.AccountAuthenticator" />
-			</intent-filter>
-			<meta-data android:name="android.accounts.AccountAuthenticator"
-				android:resource="@xml/authenticator" />
-		</service>
 	</application>
 
     <instrumentation android:targetPackage="com.salesforce.androidsdk.tests"
         android:name="com.salesforce.androidsdk.util.JUnitReportTestRunner"
         android:label="Tests for SalesforceSDK" />
-
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
-	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
-	<uses-permission android:name="android.permission.USE_CREDENTIALS" />
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
 	<uses-sdk android:minSdkVersion="8" />
 </manifest>

--- a/native/test/SalesforceSDKTest/project.properties
+++ b/native/test/SalesforceSDKTest/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 android.library.reference.1=../../SalesforceSDK
+manifestmerger.enabled=true

--- a/native/test/TemplateAppTest/project.properties
+++ b/native/test/TemplateAppTest/project.properties
@@ -10,3 +10,4 @@
 # Project target.
 target=android-8
 tested.project.dir=../../TemplateApp
+manifestmerger.enabled=true


### PR DESCRIPTION
Finally, the new ADT tools allow us to merge `AndroidManifest.xml` from library projects.

Summary of changes:
- Pulled out all the SDK activities and services from the app manifest files to the SDK's manifest file.
- Modified `project.properties` to allow merging of manifest files.

This helps us going forward, as we add more activities and services (new service for push coming up).
