### PR TITLE
Custom PasscodeActivity should not be tied to the lifecycle of PasscodeManager

### DIFF
--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -63,6 +63,7 @@ import com.salesforce.androidsdk.security.Encryptor;
 import com.salesforce.androidsdk.security.PRNGFixes;
 import com.salesforce.androidsdk.security.PasscodeManager;
 import com.salesforce.androidsdk.ui.LoginActivity;
+import com.salesforce.androidsdk.ui.PasscodeActivity;
 import com.salesforce.androidsdk.ui.SalesforceR;
 import com.salesforce.androidsdk.ui.sfhybrid.SalesforceDroidGapActivity;
 import com.salesforce.androidsdk.util.EventsObservable;
@@ -105,6 +106,7 @@ public class SalesforceSDKManager implements AccountRemoved {
     protected LoginOptions loginOptions;
     protected Class<? extends Activity> mainActivityClass;
     protected Class<? extends Activity> loginActivityClass = LoginActivity.class;
+    protected Class<? extends PasscodeActivity> passcodeActivityClass = PasscodeActivity.class;
     protected AccountWatcher accWatcher;
     private String encryptionKey;
     private SalesforceR salesforceR = new SalesforceR();
@@ -350,8 +352,29 @@ public class SalesforceSDKManager implements AccountRemoved {
      * @param mainActivity Activity that should be launched after the login flow.
      * @param loginActivity Login activity.
 	 */
-    public static void initNative(Context context, KeyInterface keyImpl, Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
+    public static void initNative(Context context, KeyInterface keyImpl,
+    		Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
     	SalesforceSDKManager.init(context, keyImpl, mainActivity, loginActivity);
+    }
+
+    /**
+     * Sets a custom sub-class of PasscodeActivity to be used.
+     *
+     * @param activity Sub-class of PasscodeActivity.
+     */
+    public void setPasscodeActivity(Class<? extends PasscodeActivity> activity) {
+    	if (activity != null) {
+    		passcodeActivityClass = activity;
+    	}
+    }
+
+    /**
+     * Returns the custom sub-class of PasscodeActivity being used.
+     *
+     * @return Sub-class of PasscodeActivity.
+     */
+    public Class<? extends PasscodeActivity> getPasscodeActivity() {
+    	return passcodeActivityClass;
     }
 
     /**

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
@@ -36,7 +36,6 @@ import android.util.Log;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.app.UUIDManager;
-import com.salesforce.androidsdk.ui.PasscodeActivity;
 import com.salesforce.androidsdk.util.EventsObservable;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
 
@@ -92,7 +91,6 @@ public class PasscodeManager  {
     private int timeoutMs;
     private int minPasscodeLength;
     private LockChecker lockChecker;
-    private Class<? extends PasscodeActivity> passcodeActivity;
 
     /**
      * Parameterized constructor.
@@ -117,7 +115,6 @@ public class PasscodeManager  {
         // Locked at app startup if you're authenticated.
         this.locked = true;
         lockChecker = new LockChecker();
-        passcodeActivity = PasscodeActivity.class;
     }
 
     /**
@@ -379,22 +376,11 @@ public class PasscodeManager  {
         return timeoutMs > 0 && now() >= (lastActivity + timeoutMs);
     }
 
-    /**
-     * Sets a custom sub-class of PasscodeActivity to be used.
-     *
-     * @param activity Sub-class of PasscodeActivity.
-     */
-    public void setPasscodeActivity(Class<? extends PasscodeActivity> activity) {
-    	if (activity != null) {
-    		passcodeActivity = activity;
-    	}
-    }
-
     public void showLockActivity(Context ctx) {
         if (ctx == null) {
         	return;
         }
-        Intent i = new Intent(ctx, passcodeActivity);
+        Intent i = new Intent(ctx, SalesforceSDKManager.getInstance().getPasscodeActivity());
         i.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
         i.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);


### PR DESCRIPTION
There are places and situations where we tear down PasscodeManager and reset it, such as logout or clean up, for instance. In the previous implementation, we would lose the custom PasscodeActivity, unless the app sets it again, which is hard for the app to do, since it doesn't know when the SDK tears down PasscodeManager. This patch ensures that the custom PasscodeActivity is always used, as long as setPasscodeActivity() is called right after the init() call.
