### PR TITLE
Lint fix: NewApi

### DIFF
--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
@@ -40,6 +40,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import android.annotation.TargetApi;
 import android.app.Service;
 import android.app.admin.DevicePolicyManager;
 import android.content.Context;
@@ -64,6 +65,7 @@ public class Encryptor {
      * @return true if the cryptographic module was successfully initialized
      * @throws GeneralSecurityException
      */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static boolean init(Context ctx) {
         // Check if file system encryption is available and active
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -36,6 +36,7 @@ import android.net.Uri;
 import android.net.http.SslError;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.CookieManager;
 import android.webkit.SslErrorHandler;
@@ -375,7 +376,7 @@ public class OAuthWebviewHelper {
             	// Register for push notifications, if push notification client ID is present.
             	final Context appContext = SalesforceSDKManager.getInstance().getAppContext();
             	final String pushNotificationId = BootConfig.getBootConfig(appContext).getPushNotificationClientId();
-            	if (pushNotificationId != null && !pushNotificationId.trim().isEmpty()) {
+            	if (!TextUtils.isEmpty(pushNotificationId)) {
                 	PushMessaging.register(appContext);
             	}
 


### PR DESCRIPTION
`Encryptor#init` already has a version check, so we can safely wrap the
whole method as `@TargetApi(HONEYCOMB)`

`OAuthWebviewHelper.BaseRinishAuthFlowTask#onPostExecute` was using
`String.isEmpty()`, which was added in API 9, but the library project is
currently set to build with API 8. This was replaced with a call to
`TextUtils.isEmpty(CharSequence)`
