### PR TITLE
Lint: DefaultLocale

### DIFF
--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -28,6 +28,7 @@ package com.salesforce.androidsdk.ui;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Map;
 
 import android.app.Activity;
@@ -288,7 +289,7 @@ public class OAuthWebviewHelper {
 
 		@Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
-			boolean isDone = url.replace("///", "/").toLowerCase().startsWith(loginOptions.oauthCallbackUrl.replace("///", "/").toLowerCase());
+			boolean isDone = url.replace("///", "/").toLowerCase(Locale.US).startsWith(loginOptions.oauthCallbackUrl.replace("///", "/").toLowerCase(Locale.US));
             if (isDone) {
                 Uri callbackUri = Uri.parse(url);
                 Map<String, String> params = UriFragmentParser.parse(callbackUri);

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/sfhybrid/SalesforceGapViewClient.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/sfhybrid/SalesforceGapViewClient.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.ui.sfhybrid;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.cordova.CordovaWebView;
@@ -160,7 +161,7 @@ public class SalesforceGapViewClient extends CordovaWebViewClient {
         if (url == null || url.trim().equals(""))
             return false;
         for (String reservedUrlPattern : RESERVED_URL_PATTERNS) {
-            if (url.toLowerCase().contains(reservedUrlPattern.toLowerCase()))
+            if (url.toLowerCase(Locale.US).contains(reservedUrlPattern.toLowerCase(Locale.US)))
                 return true;
         }
         return false;


### PR DESCRIPTION
Replaced calls to `String.toLowerCase()` with
`String.toLowerCase(Locale.US)`. `Locale.US` is guaranteed by Java to be
installed, and can be used to downcase URLs expressed as
Strings.
