### PR TITLE
Adding support for 'communityId' and 'communityUrl' at token endpoint

### DIFF
--- a/hybrid/test/ForcePluginsTest/src/com/salesforce/androidsdk/ui/sfhybrid/ForcePluginsTestActivity.java
+++ b/hybrid/test/ForcePluginsTest/src/com/salesforce/androidsdk/ui/sfhybrid/ForcePluginsTestActivity.java
@@ -72,6 +72,8 @@ public class ForcePluginsTestActivity extends SalesforceDroidGapActivity {
 			String loginUrl = "https://test.salesforce.com";
 			String orgId = "00DS0000000HDptMAG";
 			String userId = "005S0000003yO7jIAE";
+			String communityId = null;
+			String communityUrl = null;
 			LoginOptions loginOptions = SalesforceSDKManager.getInstance().getLoginOptions();
 			
 			try {
@@ -80,7 +82,7 @@ public class ForcePluginsTestActivity extends SalesforceDroidGapActivity {
 				ClientInfo clientInfo = new ClientInfo(
 						loginOptions.oauthClientId, new URI(instanceUrl),
 						new URI(loginUrl), new URI(identityUrl),
-						accountName, username, userId, orgId);
+						accountName, username, userId, orgId, communityId, communityUrl);
 				return new RestClient(clientInfo, authToken,
 						HttpAccess.DEFAULT, authTokenProvider);
 			} catch (URISyntaxException e) {

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -356,11 +356,24 @@ public class UserAccountManager {
 		final String username = SalesforceSDKManager.decryptWithPasscode(accountManager.getUserData(account, AuthenticatorService.KEY_USERNAME), SalesforceSDKManager.getInstance().getPasscodeHash());
 		final String accountName = accountManager.getUserData(account, AccountManager.KEY_ACCOUNT_NAME);
 		final String clientId = SalesforceSDKManager.decryptWithPasscode(accountManager.getUserData(account, AuthenticatorService.KEY_CLIENT_ID), SalesforceSDKManager.getInstance().getPasscodeHash());
+		final String encCommunityId = accountManager.getUserData(account, AuthenticatorService.KEY_COMMUNITY_ID);
+        String communityId = null;
+        if (encCommunityId != null) {
+        	communityId = SalesforceSDKManager.decryptWithPasscode(encCommunityId,
+        			SalesforceSDKManager.getInstance().getPasscodeHash());
+        }
+        final String encCommunityUrl = accountManager.getUserData(account, AuthenticatorService.KEY_COMMUNITY_URL);
+        String communityUrl = null;
+        if (encCommunityUrl != null) {
+        	communityUrl = SalesforceSDKManager.decryptWithPasscode(encCommunityUrl,
+        			SalesforceSDKManager.getInstance().getPasscodeHash());
+        }
 		if (authToken == null || instanceServer == null || userId == null || orgId == null) {
 			return null;
 		}
 		return new UserAccount(authToken, refreshToken, loginServer, idUrl,
-				instanceServer, orgId, userId, username, accountName, clientId);
+				instanceServer, orgId, userId, username, accountName, clientId,
+				communityId, communityUrl);
 	}
 
 	/**

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -65,6 +65,8 @@ public class AuthenticatorService extends Service {
     public static final String KEY_USERNAME = "username";
     public static final String KEY_ID_URL = "id";
     public static final String KEY_CLIENT_SECRET = "clientSecret";
+    public static final String KEY_COMMUNITY_ID = "communityId";
+    public static final String KEY_COMMUNITY_URL = "communityUrl";
 
     private Authenticator getAuthenticator() {
         if (authenticator == null)
@@ -138,6 +140,18 @@ public class AuthenticatorService extends Service {
             if (encClientSecret != null) {
                 clientSecret = SalesforceSDKManager.decryptWithPasscode(encClientSecret, passcodeHash);
             }
+            final String encCommunityId = mgr.getUserData(account, AuthenticatorService.KEY_COMMUNITY_ID);
+            String communityId = null;
+            if (encCommunityId != null) {
+            	communityId = SalesforceSDKManager.decryptWithPasscode(encCommunityId,
+            			SalesforceSDKManager.getInstance().getPasscodeHash());
+            }
+            final String encCommunityUrl = mgr.getUserData(account, AuthenticatorService.KEY_COMMUNITY_URL);
+            String communityUrl = null;
+            if (encCommunityUrl != null) {
+            	communityUrl = SalesforceSDKManager.decryptWithPasscode(encCommunityUrl,
+            			SalesforceSDKManager.getInstance().getPasscodeHash());
+            }
             final Bundle resBundle = new Bundle();
             try {
                 final TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT, new URI(loginServer), clientId, refreshToken, clientSecret);
@@ -163,6 +177,16 @@ public class AuthenticatorService extends Service {
                     encrClientSecret = SalesforceSDKManager.encryptWithPasscode(clientSecret, passcodeHash);
                 }
                 resBundle.putString(AuthenticatorService.KEY_CLIENT_SECRET, encrClientSecret);
+                String encrCommunityId = null;
+                if (communityId != null) {
+                	encrCommunityId = SalesforceSDKManager.encryptWithPasscode(communityId, passcodeHash);
+                }
+                resBundle.putString(AuthenticatorService.KEY_COMMUNITY_ID, encrCommunityId);
+                String encrCommunityUrl = null;
+                if (communityUrl != null) {
+                	encrCommunityUrl = SalesforceSDKManager.encryptWithPasscode(communityUrl, passcodeHash);
+                }
+                resBundle.putString(AuthenticatorService.KEY_COMMUNITY_URL, encrCommunityUrl);
                 // Log.i("Authenticator:getAuthToken", "Returning auth bundle for " + account.name);
             } catch (ClientProtocolException e) {
                 Log.w("Authenticator:getAuthToken", "", e);

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, salesforce.com, inc.
+ * Copyright (c) 2014, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -100,6 +100,8 @@ public class OAuth2 {
     private static final String CODE = "code";
     private static final String ACTIVATED_CLIENT_CODE = "activated_client_code";
     private static final String CUSTOM_ATTRIBUTES = "custom_attributes";
+    private static final String SFDC_COMMUNITY_ID = "sfdc_community_id";
+    private static final String SFDC_COMMUNITY_URL = "sfdc_community_url";
 
     // Login paths
     private static final String OAUTH_AUTH_PATH = "/services/oauth2/authorize?display=";
@@ -372,7 +374,7 @@ public class OAuth2 {
                     screenLockTimeout = parsedResponse.getJSONObject(MOBILE_POLICY).getInt(SCREEN_LOCK);
                 }
             } catch (Exception e) {
-                Log.w("IdServiceResponse:contructor", "", e);
+                Log.w("IdServiceResponse:constructor", "", e);
             }
         }
     }
@@ -391,7 +393,7 @@ public class OAuth2 {
                 errorDescription = parsedResponse
                         .getString(ERROR_DESCRIPTION);
             } catch (Exception e) {
-                Log.w("TokenErrorResponse:contructor", "", e);
+                Log.w("TokenErrorResponse:constructor", "", e);
             }
         }
 
@@ -405,6 +407,7 @@ public class OAuth2 {
      * Helper class to parse a token refresh response.
      */
     public static class TokenEndpointResponse extends AbstractResponse {
+
         public String authToken;
         public String refreshToken;
         public String instanceUrl;
@@ -413,6 +416,8 @@ public class OAuth2 {
         public String orgId;
         public String userId;
         public String code;
+        public String communityId;
+        public String communityUrl;
 
         /**
          * Constructor used during login flow
@@ -426,8 +431,10 @@ public class OAuth2 {
                 idUrl = callbackUrlParams.get(ID);
                 code = callbackUrlParams.get(CODE);
                 computeOtherFields();
+                communityId = callbackUrlParams.get(SFDC_COMMUNITY_ID);
+                communityUrl = callbackUrlParams.get(SFDC_COMMUNITY_URL);
             } catch (Exception e) {
-                Log.w("TokenEndpointResponse:contructor", "", e);
+                Log.w("TokenEndpointResponse:constructor", "", e);
             }
         }
 
@@ -445,8 +452,14 @@ public class OAuth2 {
                 if (parsedResponse.has(REFRESH_TOKEN)) {
                     refreshToken = parsedResponse.getString(REFRESH_TOKEN);
                 }
+                if (parsedResponse.has(SFDC_COMMUNITY_ID)) {
+                	communityId = parsedResponse.getString(SFDC_COMMUNITY_ID);
+                }
+                if (parsedResponse.has(SFDC_COMMUNITY_URL)) {
+                	communityUrl = parsedResponse.getString(SFDC_COMMUNITY_URL);
+                }
             } catch (Exception e) {
-                Log.w("TokenEndpointResponse:contructor", "", e);
+                Log.w("TokenEndpointResponse:constructor", "", e);
             }
         }
 

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -157,7 +157,16 @@ public class ClientManager {
         String username = SalesforceSDKManager.decryptWithPasscode(accountManager.getUserData(acc, AuthenticatorService.KEY_USERNAME), passcodeHash);
         String accountName = accountManager.getUserData(acc, AccountManager.KEY_ACCOUNT_NAME);
         String clientId = SalesforceSDKManager.decryptWithPasscode(accountManager.getUserData(acc, AuthenticatorService.KEY_CLIENT_ID), passcodeHash);
-
+        final String encCommunityId = accountManager.getUserData(acc, AuthenticatorService.KEY_COMMUNITY_ID);
+        String communityId = null;
+        if (encCommunityId != null) {
+        	communityId = SalesforceSDKManager.decryptWithPasscode(encCommunityId, passcodeHash);
+        }
+        final String encCommunityUrl = accountManager.getUserData(acc, AuthenticatorService.KEY_COMMUNITY_URL);
+        String communityUrl = null;
+        if (encCommunityUrl != null) {
+        	communityUrl = SalesforceSDKManager.decryptWithPasscode(encCommunityUrl, passcodeHash);
+        }
         if (authToken == null)
             throw new AccountInfoNotFoundException(AccountManager.KEY_AUTHTOKEN);
         if (instanceServer == null)
@@ -169,7 +178,9 @@ public class ClientManager {
 
         try {
             AccMgrAuthTokenProvider authTokenProvider = new AccMgrAuthTokenProvider(this, authToken, refreshToken);
-            ClientInfo clientInfo = new ClientInfo(clientId, new URI(instanceServer), new URI(loginServer), new URI(idUrl), accountName, username, userId, orgId);
+            ClientInfo clientInfo = new ClientInfo(clientId, new URI(instanceServer),
+            		new URI(loginServer), new URI(idUrl), accountName, username,
+            		userId, orgId, communityId, communityUrl);
             return new RestClient(clientInfo, authToken, HttpAccess.DEFAULT, authTokenProvider);
         } catch (URISyntaxException e) {
             Log.w("ClientManager:peekRestClient", "Invalid server URL", e);
@@ -250,15 +261,27 @@ public class ClientManager {
      * @param passcodeHash
      * @return
      */
-    public Bundle createNewAccount(String accountName, String username, String refreshToken, String authToken,
-                                   String instanceUrl, String loginUrl, String idUrl, String clientId, String orgId, String userId, String passcodeHash) {
+    public Bundle createNewAccount(String accountName, String username, String refreshToken,
+    		String authToken, String instanceUrl, String loginUrl, String idUrl,
+    		String clientId, String orgId, String userId, String passcodeHash) {
         return createNewAccount(accountName, username, refreshToken, authToken,
-                                instanceUrl, loginUrl, idUrl, clientId, orgId, userId, passcodeHash, null);
+                                instanceUrl, loginUrl, idUrl, clientId, orgId,
+                                userId, passcodeHash, null);
     }
 
-    public Bundle createNewAccount(String accountName, String username, String refreshToken, String authToken,
-                                   String instanceUrl, String loginUrl, String idUrl, String clientId, String orgId, String userId, String passcodeHash,
+    public Bundle createNewAccount(String accountName, String username, String refreshToken,
+    		String authToken, String instanceUrl, String loginUrl, String idUrl,
+    		String clientId, String orgId, String userId, String passcodeHash,
             String clientSecret) {
+        return createNewAccount(accountName, username, refreshToken, authToken,
+                instanceUrl, loginUrl, idUrl, clientId, orgId,
+                userId, passcodeHash, clientSecret, null, null);
+    }
+
+    public Bundle createNewAccount(String accountName, String username, String refreshToken,
+    		String authToken, String instanceUrl, String loginUrl, String idUrl,
+    		String clientId, String orgId, String userId, String passcodeHash,
+            String clientSecret, String communityId, String communityUrl) {
         Bundle extras = new Bundle();
         extras.putString(AccountManager.KEY_ACCOUNT_NAME, accountName);
         extras.putString(AccountManager.KEY_ACCOUNT_TYPE, getAccountType());
@@ -271,6 +294,12 @@ public class ClientManager {
         extras.putString(AuthenticatorService.KEY_USER_ID, SalesforceSDKManager.encryptWithPasscode(userId, passcodeHash));
         if (clientSecret != null) {
             extras.putString(AuthenticatorService.KEY_CLIENT_SECRET, SalesforceSDKManager.encryptWithPasscode(clientSecret, passcodeHash));
+        }
+        if (communityId != null) {
+            extras.putString(AuthenticatorService.KEY_COMMUNITY_ID, SalesforceSDKManager.encryptWithPasscode(communityId, passcodeHash));
+        }
+        if (communityUrl != null) {
+            extras.putString(AuthenticatorService.KEY_COMMUNITY_URL, SalesforceSDKManager.encryptWithPasscode(communityUrl, passcodeHash));
         }
         extras.putString(AccountManager.KEY_AUTHTOKEN, SalesforceSDKManager.encryptWithPasscode(authToken, passcodeHash));
         Account acc = new Account(accountName, getAccountType());
@@ -313,6 +342,21 @@ public class ClientManager {
                     final String userId = SalesforceSDKManager.decryptWithPasscode(acctManager.getUserData(account, AuthenticatorService.KEY_USER_ID), oldPass);
                     final String username = SalesforceSDKManager.decryptWithPasscode(acctManager.getUserData(account, AuthenticatorService.KEY_USERNAME), oldPass);
                     final String clientId = SalesforceSDKManager.decryptWithPasscode(acctManager.getUserData(account, AuthenticatorService.KEY_CLIENT_ID), oldPass);
+                    final String encClientSecret = acctManager.getUserData(account, AuthenticatorService.KEY_CLIENT_SECRET);
+                    String clientSecret = null;
+                    if (encClientSecret != null) {
+                    	clientSecret = SalesforceSDKManager.decryptWithPasscode(encClientSecret, oldPass);
+                    }
+                    final String encCommunityId = acctManager.getUserData(account, AuthenticatorService.KEY_COMMUNITY_ID);
+                    String communityId = null;
+                    if (encCommunityId != null) {
+                    	communityId = SalesforceSDKManager.decryptWithPasscode(encCommunityId, oldPass);
+                    }
+                    final String encCommunityUrl = acctManager.getUserData(account, AuthenticatorService.KEY_COMMUNITY_URL);
+                    String communityUrl = null;
+                    if (encCommunityUrl != null) {
+                    	communityUrl = SalesforceSDKManager.decryptWithPasscode(encCommunityUrl, oldPass);
+                    }
 
                     // Encrypt data with new hash and put it back in AccountManager.
                     acctManager.setUserData(account, AccountManager.KEY_AUTHTOKEN, SalesforceSDKManager.encryptWithPasscode(authToken, newPass));
@@ -324,6 +368,15 @@ public class ClientManager {
                     acctManager.setUserData(account, AuthenticatorService.KEY_USER_ID, SalesforceSDKManager.encryptWithPasscode(userId, newPass));
                     acctManager.setUserData(account, AuthenticatorService.KEY_USERNAME, SalesforceSDKManager.encryptWithPasscode(username, newPass));
                     acctManager.setUserData(account, AuthenticatorService.KEY_CLIENT_ID, SalesforceSDKManager.encryptWithPasscode(clientId, newPass));
+                    if (clientSecret != null) {
+                        acctManager.setUserData(account, AuthenticatorService.KEY_CLIENT_SECRET, SalesforceSDKManager.encryptWithPasscode(clientSecret, newPass));
+                    }
+                    if (communityId != null) {
+                        acctManager.setUserData(account, AuthenticatorService.KEY_COMMUNITY_ID, SalesforceSDKManager.encryptWithPasscode(communityId, newPass));
+                    }
+                    if (communityUrl != null) {
+                        acctManager.setUserData(account, AuthenticatorService.KEY_COMMUNITY_URL, SalesforceSDKManager.encryptWithPasscode(communityUrl, newPass));
+                    }
                     acctManager.setAuthToken(account, AccountManager.KEY_AUTHTOKEN, authToken);
                 }
             }

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -215,6 +215,7 @@ public class RestClient {
 	 * All immutable information for an authenticated client (e.g. username, org ID, etc.).
 	 */
 	public static class ClientInfo {
+
 		public final String clientId;
 		public final URI instanceUrl;
 		public final URI loginUrl;
@@ -223,8 +224,12 @@ public class RestClient {
 		public final String username;
 		public final String userId;
 		public final String orgId;
+		public final String communityId;
+		public final String communityUrl;
 		
-		public ClientInfo(String clientId, URI instanceUrl, URI loginUrl, URI identityUrl, String accountName, String username, String userId, String orgId) {
+		public ClientInfo(String clientId, URI instanceUrl, URI loginUrl,
+				URI identityUrl, String accountName, String username,
+				String userId, String orgId, String communityId, String communityUrl) {
 			this.clientId = clientId;
 			this.instanceUrl = instanceUrl;
 			this.loginUrl = loginUrl;
@@ -233,6 +238,8 @@ public class RestClient {
 			this.username = username;	
 			this.userId = userId;
 			this.orgId = orgId;
+			this.communityId = communityId;
+			this.communityUrl = communityUrl;
 		}
 		
 		public String toString() {
@@ -245,6 +252,8 @@ public class RestClient {
 			  .append("     username: ").append(username).append("\n")
 			  .append("     userId: ").append(userId).append("\n")
 			  .append("     orgId: ").append(orgId).append("\n")
+			  .append("     communityId: ").append(communityId).append("\n")
+			  .append("     communityUrl: ").append(communityUrl).append("\n")
 			  .append("  }\n");
 			return sb.toString();
 		}

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -382,7 +382,8 @@ public class OAuthWebviewHelper {
 
                 // Putting together all the information needed to create the new account.
                 accountOptions = new AccountOptions(id.username, tr.refreshToken,
-                		tr.authToken, tr.idUrl, tr.instanceUrl, tr.orgId, tr.userId);
+                		tr.authToken, tr.idUrl, tr.instanceUrl, tr.orgId, tr.userId,
+                		tr.communityId, tr.communityUrl);
 
                 // Sets additional admin prefs, if they exist.
                 final UserAccount account = new UserAccount(accountOptions.authToken,
@@ -390,7 +391,8 @@ public class OAuthWebviewHelper {
                 		accountOptions.identityUrl, accountOptions.instanceUrl,
                 		accountOptions.orgId, accountOptions.userId,
                 		accountOptions.username, buildAccountName(accountOptions.username),
-                		loginOptions.clientSecret);
+                		loginOptions.clientSecret, accountOptions.communityId,
+                		accountOptions.communityUrl);
                 if (id.adminPrefs != null) {
                     final AdminPrefsManager prefManager = SalesforceSDKManager.getInstance().getAdminPrefsManager();
                     prefManager.setPrefs(id.adminPrefs, account);
@@ -485,7 +487,9 @@ public class OAuthWebviewHelper {
                 accountOptions.orgId,
                 accountOptions.userId,
                 loginOptions.passcodeHash,
-                loginOptions.clientSecret);
+                loginOptions.clientSecret,
+                accountOptions.communityId,
+                accountOptions.communityUrl);
 
     	/*
     	 * Registers for push notifications, if push notification client ID is present.
@@ -500,7 +504,8 @@ public class OAuthWebviewHelper {
             		accountOptions.identityUrl, accountOptions.instanceUrl,
             		accountOptions.orgId, accountOptions.userId,
             		accountOptions.username, accountName,
-            		loginOptions.clientSecret);
+            		loginOptions.clientSecret, accountOptions.communityId,
+            		accountOptions.communityUrl);
         	PushMessaging.register(appContext, account);
     	}
         callback.onAccountAuthenticatorResult(extras);
@@ -536,6 +541,8 @@ public class OAuthWebviewHelper {
         private static final String AUTH_TOKEN = "authToken";
         private static final String REFRESH_TOKEN = "refreshToken";
         private static final String USERNAME = "username";
+        private static final String COMMUNITY_ID = "communityId";
+        private static final String COMMUNITY_URL = "communityUrl";
 
         public final String username;
         public final String refreshToken;
@@ -544,12 +551,14 @@ public class OAuthWebviewHelper {
         public final String instanceUrl;
         public final String orgId;
         public final String userId;
+        public final String communityId;
+        public final String communityUrl;
 
         private final Bundle bundle;
 
         public AccountOptions(String username, String refreshToken,
                 String authToken, String identityUrl, String instanceUrl,
-                String orgId, String userId) {
+                String orgId, String userId, String communityId, String communityUrl) {
             super();
             this.username = username;
             this.refreshToken = refreshToken;
@@ -558,6 +567,8 @@ public class OAuthWebviewHelper {
             this.instanceUrl = instanceUrl;
             this.orgId = orgId;
             this.userId = userId;
+            this.communityId = communityId;
+            this.communityUrl = communityUrl;
 
             bundle = new Bundle();
             bundle.putString(USERNAME, username);
@@ -566,6 +577,8 @@ public class OAuthWebviewHelper {
             bundle.putString(INSTANCE_URL, instanceUrl);
             bundle.putString(ORG_ID, orgId);
             bundle.putString(USER_ID, userId);
+            bundle.putString(COMMUNITY_ID, communityId);
+            bundle.putString(COMMUNITY_URL, communityUrl);
         }
 
         public Bundle asBundle() {
@@ -581,7 +594,9 @@ public class OAuthWebviewHelper {
                     options.getString(IDENTITY_URL),
                     options.getString(INSTANCE_URL),
                     options.getString(ORG_ID),
-                    options.getString(USER_ID)
+                    options.getString(USER_ID),
+                    options.getString(COMMUNITY_ID),
+                    options.getString(COMMUNITY_URL)
                     );
         }
 

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/sfhybrid/SalesforceDroidGapActivity.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/sfhybrid/SalesforceDroidGapActivity.java
@@ -87,6 +87,8 @@ public class SalesforceDroidGapActivity extends DroidGap {
     private static final String USER_ID = "userId";
     private static final String REFRESH_TOKEN = "refreshToken";
     private static final String ACCESS_TOKEN = "accessToken";
+    private static final String COMMUNITY_ID = "communityId";
+    private static final String COMMUNITY_URL = "communityUrl";
 	
     // Used in refresh REST call
     private static final String API_VERSION = ApiVersionStrings.VERSION_NUMBER;
@@ -545,6 +547,8 @@ public class SalesforceDroidGapActivity extends DroidGap {
 	       data.put(IDENTITY_URL, clientInfo.identityUrl.toString());
 	       data.put(INSTANCE_URL, clientInfo.instanceUrl.toString());
 	       data.put(USER_AGENT, SalesforceSDKManager.getInstance().getUserAgent());
+	       data.put(COMMUNITY_ID, clientInfo.communityId);
+	       data.put(COMMUNITY_URL, clientInfo.communityUrl);
 	       return new JSONObject(data);
 	   } else {
 		   return null;

--- a/native/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
+++ b/native/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
@@ -165,14 +165,14 @@ public class UserAccountManagerTest extends InstrumentationTestCase {
         		ClientManagerTest.TEST_IDENTITY_URL, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_ORG_ID, ClientManagerTest.TEST_USER_ID,
         		ClientManagerTest.TEST_USERNAME, ClientManagerTest.TEST_ACCOUNT_NAME,
-        		ClientManagerTest.TEST_CLIENT_ID);
+        		ClientManagerTest.TEST_CLIENT_ID, null, null);
     	assertTrue("User account should exist", userAccMgr.doesUserAccountExist(userAcc));
     	userAcc = new UserAccount(ClientManagerTest.TEST_AUTH_TOKEN,
         		ClientManagerTest.TEST_REFRESH_TOKEN, ClientManagerTest.TEST_LOGIN_URL,
         		ClientManagerTest.TEST_IDENTITY_URL, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_ORG_ID_2, ClientManagerTest.TEST_USER_ID_2,
         		ClientManagerTest.TEST_OTHER_USERNAME, ClientManagerTest.TEST_OTHER_ACCOUNT_NAME,
-        		ClientManagerTest.TEST_CLIENT_ID);
+        		ClientManagerTest.TEST_CLIENT_ID, null, null);
     	assertFalse("User account should not exist", userAccMgr.doesUserAccountExist(userAcc));
     }
 
@@ -209,8 +209,8 @@ public class UserAccountManagerTest extends InstrumentationTestCase {
         		ClientManagerTest.TEST_IDENTITY_URL, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_ORG_ID, ClientManagerTest.TEST_USER_ID,
         		ClientManagerTest.TEST_USERNAME, ClientManagerTest.TEST_ACCOUNT_NAME,
-        		ClientManagerTest.TEST_CLIENT_ID);
-    	userAccMgr.signoutUser(userAcc, null);
+        		ClientManagerTest.TEST_CLIENT_ID, null, null);
+    	userAccMgr.signoutUser(userAcc, null, false);
     	eq.waitForEvent(EventType.LogoutComplete, 30000);
     	users = userAccMgr.getAuthenticatedUsers();
     	assertEquals("There should be 1 authenticated user", 1, users.size());

--- a/native/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/native/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -74,7 +74,12 @@ public class RestClientTest extends InstrumentationTestCase {
         httpAccess = new HttpAccess(null, null);
         TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN);
         authToken = refreshResponse.authToken;
-        clientInfo = new ClientInfo(TestCredentials.CLIENT_ID, new URI(TestCredentials.INSTANCE_URL), new URI(TestCredentials.LOGIN_URL), new URI(TestCredentials.IDENTITY_URL), TestCredentials.ACCOUNT_NAME, TestCredentials.USERNAME, TestCredentials.USER_ID, TestCredentials.ORG_ID);
+        clientInfo = new ClientInfo(TestCredentials.CLIENT_ID,
+        		new URI(TestCredentials.INSTANCE_URL),
+        		new URI(TestCredentials.LOGIN_URL),
+        		new URI(TestCredentials.IDENTITY_URL),
+        		TestCredentials.ACCOUNT_NAME, TestCredentials.USERNAME,
+        		TestCredentials.USER_ID, TestCredentials.ORG_ID, null, null);
         restClient = new RestClient(clientInfo, authToken, httpAccess, null);
     }
 


### PR DESCRIPTION
This pull request reads the `communityId` and `communityUrl` from the token endpoint, if available, and persists it. The code changes are really just permeating these two params through the codebase. I ran all tests, and verified that they're passing. Also verified that this works with a community login and a regular org login.
