### PR TITLE
Fix for logout not working in one.app

### DIFF
--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/sfhybrid/SalesforceGapViewClient.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/ui/sfhybrid/SalesforceGapViewClient.java
@@ -102,15 +102,17 @@ public class SalesforceGapViewClient extends CordovaWebViewClient {
     	final String ec = params.get("ec");
     	int ecInt = (ec != null ? Integer.parseInt(ec) : -1);
         final String startURL = params.get("startURL");
-        if (commStartUrl != null && startURL != null) {
-    		return commStartUrl;
-    	}
-    	if (uri != null && uri.getPath() != null && uri.getPath().equals("/")
+        if (startURL != null) {
+        	if (commStartUrl != null) {
+        		return commStartUrl;
+        	} else if (uri != null && uri.getPath() != null && uri.getPath().equals("/")
     			&& (ecInt == HttpStatus.SC_MOVED_PERMANENTLY
-    			|| ecInt == HttpStatus.SC_MOVED_TEMPORARILY)
-    			&& startURL != null) {
-    		return startURL;
-    	} else {
+    			|| ecInt == HttpStatus.SC_MOVED_TEMPORARILY)) {
+        		return startURL;
+        	} else {
+        		return null;
+        	}
+        } else {
     		return null;
     	}
     }


### PR DESCRIPTION
The `Logout` button on stage left redirects to `logout.jsp` as well. Basically, we need to ensure that the redirect is to `logout.jsp` AND a `startURL` is supplied, to clearly identify a login redirect in the community context. Not ideal - but it is what it is :-(
