### PR TITLE
Adding true support for multi user scenarios in the managers and making it more robust

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -56,12 +56,12 @@ public class UserAccount {
 	public static final String CLIENT_ID = "clientId";
 	public static final String COMMUNITY_ID = "communityId";
 	public static final String COMMUNITY_URL = "communityUrl";
+	public static final String INTERNAL_COMMUNITY_ID = "000000000000000000";
 
 	private static final String TAG = "UserAccount";
 	private static final String INTERNAL_COMMUNITY_PATH = "internal";
 	private static final String FORWARD_SLASH = "/";
 	private static final String UNDERSCORE = "_";
-	private static final String INTERNAL_COMMUNITY_ID = "000000000000000000";
 
 	private String authToken;
 	private String refreshToken;

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/SmartSyncUserAccountManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/SmartSyncUserAccountManager.java
@@ -58,16 +58,17 @@ public class SmartSyncUserAccountManager extends UserAccountManagerWithSmartStor
 	@Override
 	public void switchToUser(UserAccount user) {
 		super.switchToUser(user);
-		CacheManager.softReset();
-		MetadataManager.reset();
-		NetworkManager.reset();
+		CacheManager.softReset(user);
+		MetadataManager.reset(user);
+		NetworkManager.reset(user);
 	}
 
 	@Override
 	public void switchToNewUser() {
 		super.switchToNewUser();
-		CacheManager.softReset();
-		MetadataManager.reset();
-		NetworkManager.reset();
+    	final UserAccount userAccount = SmartSyncUserAccountManager.getInstance().getCurrentUser();
+		CacheManager.softReset(userAccount);
+		MetadataManager.reset(userAccount);
+		NetworkManager.reset(userAccount);
 	}
 }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
@@ -30,6 +30,7 @@ import android.accounts.Account;
 import android.app.Activity;
 import android.content.Context;
 
+import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.smartstore.app.SalesforceSDKManagerWithSmartStore;
 import com.salesforce.androidsdk.smartsync.SmartSyncUserAccountManager;
@@ -170,14 +171,15 @@ public class SmartSyncSDKManager extends SalesforceSDKManagerWithSmartStore {
 
     @Override
     protected void cleanUp(Activity frontActivity, Account account) {
-    	MetadataManager.reset();
+    	final UserAccount userAccount = SmartSyncUserAccountManager.getInstance().buildUserAccount(account);
+    	MetadataManager.reset(userAccount);
 
     	/*
     	 * We don't have to do a hard reset on the cache manager here, since
     	 * the underlying database will be wiped in the super class.
     	 */
-    	CacheManager.softReset();
-    	NetworkManager.reset();
+    	CacheManager.softReset(userAccount);
+    	NetworkManager.reset(userAccount);
         super.cleanUp(frontActivity, account);
     }
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/MetadataManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/MetadataManagerTest.java
@@ -41,7 +41,9 @@ import android.test.InstrumentationTestCase;
 import com.salesforce.androidsdk.auth.HttpAccess;
 import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse;
+import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.RestClient;
+import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo;
 import com.salesforce.androidsdk.smartsync.TestCredentials;
 import com.salesforce.androidsdk.smartsync.TestForceApp;
@@ -78,6 +80,9 @@ public class MetadataManagerTest extends InstrumentationTestCase {
 	private static final String ALL_OBJECTS_FILE = "all_objects.json";
 	private static final String ACCOUNT_METADATA_FILE = "account_metadata.json";
 	private static final String CASE_METADATA_FILE = "case_metadata.json";
+	private static final String[] TEST_SCOPES = new String[] {"web"};
+	private static final String TEST_CALLBACK_URL = "test://callback";
+	private static final String TEST_AUTH_TOKEN = "test_auth_token";
 
     private Context targetContext;
     private EventsListenerQueue eq;
@@ -96,9 +101,22 @@ public class MetadataManagerTest extends InstrumentationTestCase {
         if (SmartSyncSDKManager.getInstance() == null) {
             eq.waitForEvent(EventType.AppCreateComplete, 5000);
         }
-    	MetadataManager.reset();
-    	CacheManager.hardReset();
-        metadataManager = MetadataManager.getInstance(initRestClient());
+        final LoginOptions loginOptions = new LoginOptions(TestCredentials.LOGIN_URL,
+        		null, TEST_CALLBACK_URL, TestCredentials.CLIENT_ID, TEST_SCOPES);
+        final ClientManager clientManager = new ClientManager(targetContext,
+        		TestCredentials.ACCOUNT_TYPE, loginOptions, true);
+        clientManager.createNewAccount(TestCredentials.ACCOUNT_NAME,
+        		TestCredentials.USERNAME, TestCredentials.REFRESH_TOKEN,
+        		TEST_AUTH_TOKEN, TestCredentials.INSTANCE_URL,
+        		TestCredentials.LOGIN_URL, TestCredentials.IDENTITY_URL,
+        		TestCredentials.CLIENT_ID, TestCredentials.ORG_ID,
+        		TestCredentials.USER_ID, null);
+    	MetadataManager.reset(null);
+    	CacheManager.hardReset(null);
+        metadataManager = MetadataManager.getInstance(null);
+        final NetworkManager networkManager = NetworkManager.getInstance(null);
+        networkManager.setRestClient(null, initRestClient());
+        metadataManager.setNetworkManager(networkManager);
     }
 
     @Override
@@ -108,8 +126,8 @@ public class MetadataManagerTest extends InstrumentationTestCase {
             eq = null;
         }
     	httpAccess.resetNetwork();
-    	MetadataManager.reset();
-    	CacheManager.hardReset();
+    	MetadataManager.reset(null);
+    	CacheManager.hardReset(null);
         super.tearDown();
     }
 


### PR DESCRIPTION
I'm following the same pattern as I was using in `DBOpenHelper`. Otherwise, we were running into problems with DB swaps in `CacheManager` when an account switch occurs, etc.
