### PR TITLE
Looking at issues with building the package from CI

### DIFF
--- a/build_npm.xml
+++ b/build_npm.xml
@@ -1,12 +1,24 @@
 <project name="SalesforceMobileSDK-Android-Package" basedir="." default="makeNpm">
-    
     <target name="makeNpm">
+        
+        <!-- Create the temporary working folder. -->
+        <tempfile property="packageTempDir" destdir="/tmp" prefix="sdkNpmBuild" />
+        <mkdir dir="${packageTempDir}" />
+        
         <!-- Make the npm package -->
         <echo>--- Creating the npm package ---</echo>
-        <exec executable="npm" failonerror="true" logError="true">
+        <exec executable="npm" dir="${packageTempDir}" failonerror="true" logError="true">
             <arg value="pack" />
-            <arg file="." />
+            <arg file="${basedir}" />
         </exec>
+        
+        <!-- Move the package to the root folder. -->
+        <move todir="${basedir}" overwrite="true">
+            <fileset dir="${packageTempDir}">
+                <include name="forcedroid*" />
+            </fileset>
+        </move>
+        <delete dir="${packageTempDir}" />
         
         <!-- Reset the repo (post-publish) -->
         <echo>--- Reverting the symbolic links ---</echo>

--- a/node/postpublish.js
+++ b/node/postpublish.js
@@ -37,7 +37,7 @@ var readmeBackupPath = readmePath + '.orig';
 console.log('Moving original repo README file back into place.');
 exec('mv "' + readmeBackupPath + '" "' + readmePath + '"', function (error, stdout, stderr) {
 	if (error) {
-		console.log('WARNING: Could not move ' + read + ' to ' + readmePath + '.');
+		console.log('WARNING: Could not move ' + readmeBackupPath + ' to ' + readmePath + ': ' + error);
 	}
 
 	// Revert symlinks from the root of the git repo.


### PR DESCRIPTION
- Building the npm package from outside of its root directory seems to fix some things (though not others).
- There was an error in the postpublish error handling, which was masking other errors along the way.
