### PR TITLE
Padding not needed

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
@@ -252,20 +252,6 @@ public class Encryptor {
     private static byte[] encrypt(byte[] data, byte[] key) throws GeneralSecurityException,
             InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
 
-        // must be a multiple of a block length (16 bytes)
-        int length = data == null ? 0 : data.length;
-        int len = (length + 15) & ~15;
-
-        //pad with the number of pad bytes
-        byte paddingValue = (byte) (len - length);
-        byte[] padded = new byte[len];
-        System.arraycopy(data, 0, padded, 0, length);
-        for (int i = length; i < len; i++)
-            padded[i] = paddingValue;
-
-        // update length to be what we will actually send
-        length = len;
-
         // encrypt
         Cipher cipher = getBestCipher();
         SecretKeySpec skeySpec = new SecretKeySpec(key, cipher.getAlgorithm());
@@ -274,7 +260,7 @@ public class Encryptor {
         byte[] initVector = generateInitVector();
         IvParameterSpec ivSpec = new IvParameterSpec(initVector);
         cipher.init(Cipher.ENCRYPT_MODE, skeySpec, ivSpec);
-        byte[] meat = cipher.doFinal(padded);
+        byte[] meat = cipher.doFinal(data);
 
         //prepend the IV to the encoded data (first 16 bytes / 128 bits )
         byte[] result = new byte[initVector.length + meat.length];


### PR DESCRIPTION
"Manually" tested with https://github.com/wmathurin/SalesforceMobileSDK-Android/commit/ff007d56d1b29d8fbc9995a766b8c25c9ad17fe9

Addressing bug: "MobileSDK Android: unnecessary padding in crypto method"
