### PR TITLE
Disallowing removal of accounts from the Settings app

### DIFF
--- a/native/SalesforceSDK/AndroidManifest.xml
+++ b/native/SalesforceSDK/AndroidManifest.xml
@@ -76,5 +76,6 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.GET_TASKS" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 </manifest>


### PR DESCRIPTION
Removal of accounts from the Settings app is currently kinda broken with multiple accounts, since we don't know which account is being yanked out from under us. Hence, we can't clean up the correct DBs, shared prefs, and switch to another user if necessary. Also, since the app is backgrounded at this point, the flow becomes even more complicated. The simplest solution is to disallow removal of accounts from the Settings app, forcing the user to log out through the app.
