### PR TITLE
Bugfix around consume()

### DIFF
--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -612,7 +612,7 @@ public class SalesforceSDKManager {
     /**
      * Starts account switcher activity if an account has been removed.
      */
-    protected void startSwitcherActivityIfRequired() {
+    public void startSwitcherActivityIfRequired() {
 
         // Clears cookies.
         CookieSyncManager.createInstance(context);

--- a/native/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
+++ b/native/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
@@ -128,7 +128,8 @@ public class RestResponse {
 	 */
 	public void consume() throws IOException {
 		if (responseAsBytes != null) {
-			// already consumed
+
+			// Already consumed.
 			return;			
 		}
 		HttpEntity entity = null;
@@ -136,8 +137,15 @@ public class RestResponse {
 			entity = response.getEntity();
 		}
 		if (entity != null) {
-			responseCharSet = EntityUtils.getContentCharSet(entity);		
-			responseAsBytes = EntityUtils.toByteArray(entity);
+			try {
+				responseCharSet = EntityUtils.getContentCharSet(entity);		
+				responseAsBytes = EntityUtils.toByteArray(entity);
+			} catch (IllegalStateException ex) {
+
+				// Content has already been consumed, but 'responseAsBytes' is probably not set yet.
+				Log.e("RestResponse: consume()", "Content has already been consumed", ex);
+				responseAsBytes = new byte[0];
+			}
 		} else {
 			responseAsBytes = new byte[0];
 		}


### PR DESCRIPTION
Looks like calling `consume()` a second time can still cause some problems even if `responseAsBytes` is set. We simply catch the exception to avoid the crash at this time. There's nothing else to do with the response at this point anyway.
