### PR TITLE
Bugfix for leaking BroadcastReceiver

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/phonegap/SmartSyncPlugin.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/phonegap/SmartSyncPlugin.java
@@ -49,6 +49,7 @@ import com.salesforce.androidsdk.smartsync.manager.SyncManager;
  * PhoneGap plugin for smart sync.
  */
 public class SmartSyncPlugin extends ForcePlugin {
+
 	// Keys in json from/to javascript
 	static final String TARGET = "target";
 	static final String SOUP_NAME = "soupName";
@@ -58,7 +59,9 @@ public class SmartSyncPlugin extends ForcePlugin {
 	// Event
 	private static final String SYNC_EVENT_TYPE = "sync";
 	private static final String DETAIL = "detail";
-	
+
+	private BroadcastReceiver syncReceiver;
+
 	// Receiver
 	class SyncReceiver extends BroadcastReceiver {
 
@@ -98,7 +101,13 @@ public class SmartSyncPlugin extends ForcePlugin {
 	@Override
 	public void initialize(CordovaInterface cordova, CordovaWebView webView) {
 		super.initialize(cordova, webView);
-		cordova.getActivity().registerReceiver(new SyncReceiver(cordova.getActivity()), new IntentFilter(SyncManager.SYNC_INTENT_ACTION));
+		syncReceiver = new SyncReceiver(cordova.getActivity());
+		cordova.getActivity().registerReceiver(syncReceiver, new IntentFilter(SyncManager.SYNC_INTENT_ACTION));
+	}
+
+	@Override
+	public void onDestroy() {
+		cordova.getActivity().unregisterReceiver(syncReceiver);
 	}
 
     @Override


### PR DESCRIPTION
Came across this while running `SimpleSync`:

```
E/ActivityThread( 4490): Activity com.salesforce.androidsdk.ui.sfhybrid.SalesforceDroidGapActivity has leaked IntentReceiver com.salesforce.androidsdk.smartsync.phonegap.SmartSyncPlugin$SyncReceiver@b1759d18 that was originally registered here. Are you missing a call to unregisterReceiver()?
E/ActivityThread( 4490): android.app.IntentReceiverLeaked: Activity com.salesforce.androidsdk.ui.sfhybrid.SalesforceDroidGapActivity has leaked IntentReceiver com.salesforce.androidsdk.smartsync.phonegap.SmartSyncPlugin$SyncReceiver@b1759d18 that was originally registered here. Are you missing a call to unregisterReceiver()?
E/ActivityThread( 4490):    at android.app.LoadedApk$ReceiverDispatcher.<init>(LoadedApk.java:805)
E/ActivityThread( 4490):    at android.app.LoadedApk.getReceiverDispatcher(LoadedApk.java:606)
E/ActivityThread( 4490):    at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1430)
E/ActivityThread( 4490):    at android.app.ContextImpl.registerReceiver(ContextImpl.java:1410)
E/ActivityThread( 4490):    at android.app.ContextImpl.registerReceiver(ContextImpl.java:1404)
E/ActivityThread( 4490):    at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:467)
E/ActivityThread( 4490):    at com.salesforce.androidsdk.smartsync.phonegap.SmartSyncPlugin.initialize(SmartSyncPlugin.java:101)
E/ActivityThread( 4490):    at org.apache.cordova.PluginEntry.createPlugin(PluginEntry.java:96)
E/ActivityThread( 4490):    at org.apache.cordova.PluginManager.getPlugin(PluginManager.java:281)
E/ActivityThread( 4490):    at org.apache.cordova.PluginManager.execHelper(PluginManager.java:232)
E/ActivityThread( 4490):    at org.apache.cordova.PluginManager.exec(PluginManager.java:227)
E/ActivityThread( 4490):    at org.apache.cordova.ExposedJsApi.exec(ExposedJsApi.java:53)
E/ActivityThread( 4490):    at com.android.org.chromium.base.SystemMessageHandler.nativeDoRunLoopOnce(Native Method)
E/ActivityThread( 4490):    at com.android.org.chromium.base.SystemMessageHandler.handleMessage(SystemMessageHandler.java:27)
E/ActivityThread( 4490):    at android.os.Handler.dispatchMessage(Handler.java:102)
E/ActivityThread( 4490):    at android.os.Looper.loop(Looper.java:136)
E/ActivityThread( 4490):    at android.os.HandlerThread.run(HandlerThread.java:61)
D/AndroidRuntime( 4670): 
D/AndroidRuntime( 4670): >>>>>> AndroidRuntime START com.android.internal.os.RuntimeInit <<<<<<
```
