### PR TITLE
Fixing build breakage of ForcePluginsTest on Eclipse and making API levels consistent

### DIFF
--- a/hybrid/SampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/SampleApps/AccountEditor/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.smartstore.app.HybridAppWithSmartStore"

--- a/hybrid/SampleApps/AccountEditor/build.gradle
+++ b/hybrid/SampleApps/AccountEditor/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/SampleApps/AccountEditor/project.properties
+++ b/hybrid/SampleApps/AccountEditor/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SmartStore
 manifestmerger.enabled=true

--- a/hybrid/SampleApps/ContactExplorer/AndroidManifest.xml
+++ b/hybrid/SampleApps/ContactExplorer/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.app.HybridApp"

--- a/hybrid/SampleApps/ContactExplorer/build.gradle
+++ b/hybrid/SampleApps/ContactExplorer/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/SampleApps/ContactExplorer/project.properties
+++ b/hybrid/SampleApps/ContactExplorer/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SalesforceSDK
 manifestmerger.enabled=true

--- a/hybrid/SampleApps/HybridFileExplorer/AndroidManifest.xml
+++ b/hybrid/SampleApps/HybridFileExplorer/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.smartstore.app.HybridAppWithSmartStore"

--- a/hybrid/SampleApps/HybridFileExplorer/build.gradle
+++ b/hybrid/SampleApps/HybridFileExplorer/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/SampleApps/HybridFileExplorer/project.properties
+++ b/hybrid/SampleApps/HybridFileExplorer/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SmartStore
 manifestmerger.enabled=true

--- a/hybrid/SampleApps/SimpleSync/AndroidManifest.xml
+++ b/hybrid/SampleApps/SimpleSync/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.smartsync.app.HybridAppWithSmartSync"

--- a/hybrid/SampleApps/SimpleSync/build.gradle
+++ b/hybrid/SampleApps/SimpleSync/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/SampleApps/SimpleSync/project.properties
+++ b/hybrid/SampleApps/SimpleSync/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SmartSync
 manifestmerger.enabled=true

--- a/hybrid/SampleApps/SmartStoreExplorer/AndroidManifest.xml
+++ b/hybrid/SampleApps/SmartStoreExplorer/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.smartstore.app.HybridAppWithSmartStore"

--- a/hybrid/SampleApps/SmartStoreExplorer/build.gradle
+++ b/hybrid/SampleApps/SmartStoreExplorer/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/SampleApps/SmartStoreExplorer/project.properties
+++ b/hybrid/SampleApps/SmartStoreExplorer/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SmartStore
 manifestmerger.enabled=true

--- a/hybrid/SampleApps/UserList/AndroidManifest.xml
+++ b/hybrid/SampleApps/UserList/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.app.HybridApp"

--- a/hybrid/SampleApps/UserList/build.gradle
+++ b/hybrid/SampleApps/UserList/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/SampleApps/UserList/project.properties
+++ b/hybrid/SampleApps/UserList/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SalesforceSDK
 manifestmerger.enabled=true

--- a/hybrid/SampleApps/VFConnector/AndroidManifest.xml
+++ b/hybrid/SampleApps/VFConnector/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.app.HybridApp"

--- a/hybrid/SampleApps/VFConnector/build.gradle
+++ b/hybrid/SampleApps/VFConnector/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/SampleApps/VFConnector/project.properties
+++ b/hybrid/SampleApps/VFConnector/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SalesforceSDK
 manifestmerger.enabled=true

--- a/hybrid/test/ForcePluginsTest/AndroidManifest.xml
+++ b/hybrid/test/ForcePluginsTest/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:anyDensity="true" />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.ForcePluginsTestApp"

--- a/hybrid/test/ForcePluginsTest/build.gradle
+++ b/hybrid/test/ForcePluginsTest/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/hybrid/test/ForcePluginsTest/project.properties
+++ b/hybrid/test/ForcePluginsTest/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SmartSync
 manifestmerger.enabled=true

--- a/libs/SmartStore/AndroidManifest.xml
+++ b/libs/SmartStore/AndroidManifest.xml
@@ -6,7 +6,7 @@
 	android:versionName="3.1.0.unstable">
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
 	<application>
 

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -7,8 +7,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
     main {

--- a/libs/SmartStore/project.properties
+++ b/libs/SmartStore/project.properties
@@ -8,7 +8,7 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library=true
 android.library.reference.1=../SalesforceSDK
 manifestmerger.enabled=true

--- a/libs/SmartSync/AndroidManifest.xml
+++ b/libs/SmartSync/AndroidManifest.xml
@@ -6,7 +6,7 @@
     android:versionName="3.1.0.unstable">
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application />
 </manifest>

--- a/libs/SmartSync/build.gradle
+++ b/libs/SmartSync/build.gradle
@@ -6,8 +6,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
     main {

--- a/libs/SmartSync/project.properties
+++ b/libs/SmartSync/project.properties
@@ -11,7 +11,7 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-19
+target=android-21
 android.library=true
 manifestmerger.enabled=true
 android.library.reference.1=../SmartStore

--- a/libs/test/SalesforceSDKTest/AndroidManifest.xml
+++ b/libs/test/SalesforceSDKTest/AndroidManifest.xml
@@ -26,5 +26,5 @@
     />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 </manifest>

--- a/libs/test/SmartStoreTest/AndroidManifest.xml
+++ b/libs/test/SmartStoreTest/AndroidManifest.xml
@@ -26,5 +26,5 @@
     />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 </manifest>

--- a/libs/test/SmartStoreTest/project.properties
+++ b/libs/test/SmartStoreTest/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../SmartStore
 manifestmerger.enabled=true

--- a/libs/test/SmartSyncTest/AndroidManifest.xml
+++ b/libs/test/SmartSyncTest/AndroidManifest.xml
@@ -28,5 +28,5 @@
     />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 </manifest>

--- a/libs/test/SmartSyncTest/project.properties
+++ b/libs/test/SmartSyncTest/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../SmartSync
 manifestmerger.enabled=true

--- a/native/SampleApps/FileExplorer/AndroidManifest.xml
+++ b/native/SampleApps/FileExplorer/AndroidManifest.xml
@@ -23,7 +23,7 @@
 	</application>
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <!--
         GCM permission to ensure that only this application can

--- a/native/SampleApps/FileExplorer/build.gradle
+++ b/native/SampleApps/FileExplorer/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/native/SampleApps/FileExplorer/project.properties
+++ b/native/SampleApps/FileExplorer/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SalesforceSDK
 manifestmerger.enabled=true

--- a/native/SampleApps/NativeSqlAggregator/AndroidManifest.xml
+++ b/native/SampleApps/NativeSqlAggregator/AndroidManifest.xml
@@ -33,7 +33,7 @@
 	</application>
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <!--
         GCM permission to ensure that only this application can

--- a/native/SampleApps/NativeSqlAggregator/build.gradle
+++ b/native/SampleApps/NativeSqlAggregator/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/native/SampleApps/NativeSqlAggregator/project.properties
+++ b/native/SampleApps/NativeSqlAggregator/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SmartStore
 manifestmerger.enabled=true

--- a/native/SampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/SampleApps/RestExplorer/AndroidManifest.xml
@@ -23,7 +23,7 @@
 	</application>
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <!--
         GCM permission to ensure that only this application can

--- a/native/SampleApps/RestExplorer/build.gradle
+++ b/native/SampleApps/RestExplorer/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/native/SampleApps/RestExplorer/project.properties
+++ b/native/SampleApps/RestExplorer/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SalesforceSDK
 manifestmerger.enabled=true

--- a/native/SampleApps/SmartSyncExplorer/AndroidManifest.xml
+++ b/native/SampleApps/SmartSyncExplorer/AndroidManifest.xml
@@ -31,7 +31,7 @@
     </application>
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <!--
         GCM permission to ensure that only this application can

--- a/native/SampleApps/SmartSyncExplorer/build.gradle
+++ b/native/SampleApps/SmartSyncExplorer/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/native/SampleApps/SmartSyncExplorer/project.properties
+++ b/native/SampleApps/SmartSyncExplorer/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../../libs/SmartSync
 manifestmerger.enabled=true

--- a/native/SampleApps/test/RestExplorerTest/AndroidManifest.xml
+++ b/native/SampleApps/test/RestExplorerTest/AndroidManifest.xml
@@ -14,5 +14,5 @@
     />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 </manifest>

--- a/native/SampleApps/test/RestExplorerTest/project.properties
+++ b/native/SampleApps/test/RestExplorerTest/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 tested.project.dir=../RestExplorer
 manifestmerger.enabled=true

--- a/native/TemplateApp/AndroidManifest.xml
+++ b/native/TemplateApp/AndroidManifest.xml
@@ -23,7 +23,7 @@
 	</application>
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <!--
         GCM permission to ensure that only this application can

--- a/native/TemplateApp/build.gradle
+++ b/native/TemplateApp/build.gradle
@@ -5,8 +5,8 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 19
-  buildToolsVersion "20.0.0"
+  compileSdkVersion 21
+  buildToolsVersion "21.1.1"
 
   sourceSets {
 

--- a/native/TemplateApp/project.properties
+++ b/native/TemplateApp/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../../libs/SalesforceSDK
 manifestmerger.enabled=true

--- a/native/test/TemplateAppTest/AndroidManifest.xml
+++ b/native/test/TemplateAppTest/AndroidManifest.xml
@@ -14,5 +14,5 @@
     />
 
     <uses-sdk android:minSdkVersion="17"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 </manifest>

--- a/native/test/TemplateAppTest/project.properties
+++ b/native/test/TemplateAppTest/project.properties
@@ -8,6 +8,6 @@
 # project structure.
 
 # Project target.
-target=android-19
+target=android-21
 tested.project.dir=../../TemplateApp
 manifestmerger.enabled=true

--- a/node/forcedroid.js
+++ b/node/forcedroid.js
@@ -44,7 +44,7 @@ var miscUtils = require('../external/shared/node/utils');
 
 var version = '3.1.0';
 var minimumCordovaVersion = '4.0';
-var minTargetApi = {'versionNumber': 19, 'versionName': 'KitKat'};
+var minTargetApi = {'versionNumber': 21, 'versionName': 'Lollipop'};
 var androidExePath;
 
 // Calling main

--- a/tools/sdk.sh
+++ b/tools/sdk.sh
@@ -190,24 +190,24 @@ else
         header "Building all"
         ./gradlew assembleDebug  | grep "$TEST_OUTPUT_FILTER"
     else
-        build_project_if_requested    "Cordova"                 $CORDOVA_TOP/framework                     19
+        build_project_if_requested    "Cordova"             $CORDOVA_TOP/framework                     19
         build_project_if_requested    "SalesforceSDK"       $LIBS_TOP/SalesforceSDK                    21 :libs:SalesforceSDK
-        build_project_if_requested    "SmartStore"          $LIBS_TOP/SmartStore                       19 :libs:SmartStore
-        build_project_if_requested    "SmartSync"           $LIBS_TOP/SmartSync                        19 :libs:SmartSync
-        build_project_if_requested    "TemplateApp"         $NATIVE_TOP/TemplateApp                    19 :native:TemplateApp
-        build_project_if_requested    "RestExplorer"        $NATIVE_TOP/SampleApps/RestExplorer        19 :native:SampleApps:RestExplorer 
+        build_project_if_requested    "SmartStore"          $LIBS_TOP/SmartStore                       21 :libs:SmartStore
+        build_project_if_requested    "SmartSync"           $LIBS_TOP/SmartSync                        21 :libs:SmartSync
+        build_project_if_requested    "TemplateApp"         $NATIVE_TOP/TemplateApp                    21 :native:TemplateApp
+        build_project_if_requested    "RestExplorer"        $NATIVE_TOP/SampleApps/RestExplorer        21 :native:SampleApps:RestExplorer 
         build_project_if_requested    "AppConfigurator"     $NATIVE_TOP/SampleApps/AppConfigurator     21 :native:SampleApps:AppConfigurator
         build_project_if_requested    "ConfiguredApp"       $NATIVE_TOP/SampleApps/ConfiguredApp       21 :native:SampleApps:ConfiguredApp
-        build_project_if_requested    "NativeSqlAggregator" $NATIVE_TOP/SampleApps/NativeSqlAggregator 19 :native:SampleApps:NativeSqlAggregator
-        build_project_if_requested    "SmartSyncExplorer"   $NATIVE_TOP/SampleApps/SmartSyncExplorer   19 :native:SampleApps:SmartSyncExplorer
-        build_project_if_requested    "FileExplorer"        $NATIVE_TOP/SampleApps/FileExplorer        19 :native:SampleApps:FileExplorer
-        build_project_if_requested    "AccountEditor"       $HYBRID_TOP/SampleApps/AccountEditor       19 :hybrid:SampleApps:AccountEditor
-        build_project_if_requested    "ContactExplorer"     $HYBRID_TOP/SampleApps/ContactExplorer     19 :hybrid:SampleApps:ContactExplorer
-        build_project_if_requested    "HybridFileExplorer"  $HYBRID_TOP/SampleApps/HybridFileExplorer  19 :hybrid:SampleApps:HybridFileExplorer
-        build_project_if_requested    "SimpleSync"          $HYBRID_TOP/SampleApps/SimpleSync          19 :hybrid:SampleApps:SimpleSync
-        build_project_if_requested    "UserList"            $HYBRID_TOP/SampleApps/UserList            19 :hybrid:SampleApps:UserList
-        build_project_if_requested    "SmartStoreExplorer"  $HYBRID_TOP/SampleApps/SmartStoreExplorer  19 :hybrid:SampleApps:SmartStoreExplorer
-        build_project_if_requested    "VFConnector"         $HYBRID_TOP/SampleApps/VFConnector         19 :hybrid:SampleApps:VFConnector
+        build_project_if_requested    "NativeSqlAggregator" $NATIVE_TOP/SampleApps/NativeSqlAggregator 21 :native:SampleApps:NativeSqlAggregator
+        build_project_if_requested    "SmartSyncExplorer"   $NATIVE_TOP/SampleApps/SmartSyncExplorer   21 :native:SampleApps:SmartSyncExplorer
+        build_project_if_requested    "FileExplorer"        $NATIVE_TOP/SampleApps/FileExplorer        21 :native:SampleApps:FileExplorer
+        build_project_if_requested    "AccountEditor"       $HYBRID_TOP/SampleApps/AccountEditor       21 :hybrid:SampleApps:AccountEditor
+        build_project_if_requested    "ContactExplorer"     $HYBRID_TOP/SampleApps/ContactExplorer     21 :hybrid:SampleApps:ContactExplorer
+        build_project_if_requested    "HybridFileExplorer"  $HYBRID_TOP/SampleApps/HybridFileExplorer  21 :hybrid:SampleApps:HybridFileExplorer
+        build_project_if_requested    "SimpleSync"          $HYBRID_TOP/SampleApps/SimpleSync          21 :hybrid:SampleApps:SimpleSync
+        build_project_if_requested    "UserList"            $HYBRID_TOP/SampleApps/UserList            21 :hybrid:SampleApps:UserList
+        build_project_if_requested    "SmartStoreExplorer"  $HYBRID_TOP/SampleApps/SmartStoreExplorer  21 :hybrid:SampleApps:SmartStoreExplorer
+        build_project_if_requested    "VFConnector"         $HYBRID_TOP/SampleApps/VFConnector         21 :hybrid:SampleApps:VFConnector
     fi
 
     if ( should_do "test{all}" )


### PR DESCRIPTION
Google recommends we use the latest target API to ensure usage of the latest APIs where available. In this case, we should use 21, since the lowest level library project (```SalesforceSDK```) uses 21 as the target API. This has no bearing on min API.