### PR TITLE
Making SmartStore's backing DB access more stable

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SalesforceSDKManagerWithSmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SalesforceSDKManagerWithSmartStore.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.smartstore.app;
 import java.util.List;
 
 import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteOpenHelper;
 import android.accounts.Account;
 import android.app.Activity;
 import android.content.Context;
@@ -257,10 +258,10 @@ public class SalesforceSDKManagerWithSmartStore extends SalesforceSDKManager {
      */
     public SmartStore getSmartStore(String dbNamePrefix, UserAccount account, String communityId) {
     	final String passcodeHash = getPasscodeHash();
-        final SQLiteDatabase db = DBOpenHelper.getOpenHelper(context, dbNamePrefix,
-        		account, communityId).getWritableDatabase(passcodeHash == null ?
+        final String passcode = (passcodeHash == null ?
         		getEncryptionKeyForPasscode(null) : passcodeHash);
-        return new SmartStore(db);
+        final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(context, account, communityId);
+        return new SmartStore(dbOpenHelper, passcode);
     }
 
     /**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -155,6 +155,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	}
 	
 	@Override
+	@SuppressWarnings("deprecation")
 	public void onOpen(SQLiteDatabase db) {
 		(new SmartStore(db)).resumeLongOperations();
 	}

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteOpenHelper;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -93,7 +94,9 @@ public class SmartStore  {
 	protected static final String ID_PREDICATE = ID_COL + " = ?";
 
     // Backing database
-    protected SQLiteDatabase db;
+	protected SQLiteDatabase dbLocal;
+	protected SQLiteOpenHelper dbOpenHelper;
+	private String passcode;
 
     /**
      * Changes the encryption key on the smartstore.
@@ -168,43 +171,59 @@ public class SmartStore  {
     /**
      * @param db
      */
+    @Deprecated
     public SmartStore(SQLiteDatabase db) {
-        this.db = db;
+        this.dbLocal = db;
     }
-    
+
+    /**
+     * Relies on SQLiteOpenHelper for database handling.
+     *
+     * @param dbOpenHelper DB open helper.
+     * @param passcode Passcode.
+     */
+    public SmartStore(SQLiteOpenHelper dbOpenHelper, String passcode) {
+    	this.dbOpenHelper = dbOpenHelper;
+        this.passcode = passcode;
+    }
+
     /**
      * Return db
      */
     protected SQLiteDatabase getDatabase() {
-    	return db;
+    	if (dbLocal != null) {
+            return dbLocal;
+        } else {
+            return this.dbOpenHelper.getWritableDatabase(passcode);
+        }
     }
 
     /**
      * Get database size
      */
     public int getDatabaseSize() {
-    	return (int) (new File(db.getPath()).length()); // XXX That cast will be trouble if the file is more than 2GB 
+    	return (int) (new File(getDatabase().getPath()).length()); // XXX That cast will be trouble if the file is more than 2GB 
     }
     
     /**
      * Start transaction
      */
     public void beginTransaction() {
-        db.beginTransaction();
+    	getDatabase().beginTransaction();
     }
 
     /**
      * End transaction (commit or rollback)
      */
     public void endTransaction() {
-        db.endTransaction();
+    	getDatabase().endTransaction();
     }
 
     /**
      * Mark transaction as successful (next call to endTransaction will be a commit)
      */
     public void setTransactionSuccessful() {
-        db.setTransactionSuccessful();
+    	getDatabase().setTransactionSuccessful();
     }
 
     /**
@@ -217,6 +236,7 @@ public class SmartStore  {
      * @param indexSpecs
      */
     public void registerSoup(String soupName, IndexSpec[] indexSpecs) {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        if (soupName == null) throw new SmartStoreException("Bogus soup name:" + soupName);
 	        if (indexSpecs.length == 0) throw new SmartStoreException("No indexSpecs specified for soup: " + soupName);
@@ -287,6 +307,7 @@ public class SmartStore  {
             i++;
         }
         createTableStmt.append(")");
+        final SQLiteDatabase db = getDatabase();
 
         // Run SQL for creating soup table and its indices
         db.execSQL(createTableStmt.toString());
@@ -332,9 +353,11 @@ public class SmartStore  {
 		List<LongOperation> longOperations = new ArrayList<LongOperation>();
 		synchronized(SmartStore.class) {
 			Cursor cursor = null;
+			final SQLiteDatabase db = getDatabase();
 			try {
-				cursor = DBHelper.getInstance(db).query(db, LONG_OPERATIONS_STATUS_TABLE, new String[] {ID_COL, TYPE_COL, DETAILS_COL, STATUS_COL}, null, null, null);
-	
+				cursor = DBHelper.getInstance(db).query(db,
+						LONG_OPERATIONS_STATUS_TABLE, new String[] {ID_COL, TYPE_COL, DETAILS_COL, STATUS_COL},
+						null, null, null);
 			    if (cursor.moveToFirst()) {
 			        do {
 			        	try {
@@ -351,8 +374,7 @@ public class SmartStore  {
 			        }
 			        while (cursor.moveToNext());
 			    }
-			}
-			finally {
+			} finally {
 			    safeClose(cursor);
 			}
 		}
@@ -383,6 +405,7 @@ public class SmartStore  {
 	 */
 	public void reIndexSoup(String soupName, String[] indexPaths, boolean handleTx) {
 		synchronized(SmartStore.class) {
+			final SQLiteDatabase db = getDatabase();
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
 
@@ -448,6 +471,7 @@ public class SmartStore  {
 	 */
 	public IndexSpec[] getSoupIndexSpecs(String soupName) {
     	synchronized(SmartStore.class) {
+    		final SQLiteDatabase db = getDatabase();
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
 	        return DBHelper.getInstance(db).getIndexSpecs(db, soupName);
@@ -460,13 +484,13 @@ public class SmartStore  {
 	 */
 	public void clearSoup(String soupName) {
     	synchronized(SmartStore.class) {
+    		final SQLiteDatabase db = getDatabase();
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
 			db.beginTransaction();
 			try {
 				DBHelper.getInstance(db).delete(db, soupTableName, null);
-			}
-			finally {
+			} finally {
 				db.setTransactionSuccessful();
 				db.endTransaction();
 			}
@@ -480,6 +504,7 @@ public class SmartStore  {
      * @return true if soup exists, false otherwise
      */
     public boolean hasSoup(String soupName) {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
     		return DBHelper.getInstance(db).getSoupTableName(db, soupName) != null;
     	}
@@ -493,6 +518,7 @@ public class SmartStore  {
      * @param soupName
      */
     public void dropSoup(String soupName) {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName != null) {
@@ -505,8 +531,7 @@ public class SmartStore  {
 	
 	                // Remove from cache
 	                DBHelper.getInstance(db).removeFromCache(soupName);
-	            }
-	            finally {
+	            } finally {
 	                db.endTransaction();
 	            }
 	        }
@@ -517,6 +542,7 @@ public class SmartStore  {
      * Destroy all the soups in the smartstore
      */
     public void dropAllSoups() {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	    	List<String> soupNames = getAllSoupNames();
 	        for(String soupName : soupNames) {
@@ -529,6 +555,7 @@ public class SmartStore  {
      * @return all soup names in the smartstore
      */
     public List<String> getAllSoupNames() {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	    	List<String> soupNames = new ArrayList<String>();
 	        Cursor cursor = null;
@@ -555,6 +582,7 @@ public class SmartStore  {
      * @throws JSONException 
 	 */
 	public JSONArray query(QuerySpec querySpec, int pageIndex) throws JSONException {
+		final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 			QueryType qt = querySpec.queryType;
 	    	String sql = convertSmartSql(querySpec.smartSql);
@@ -563,8 +591,6 @@ public class SmartStore  {
 	        int offsetRows = querySpec.pageSize * pageIndex;
 	        int numberRows = querySpec.pageSize;
 	        String limit = offsetRows + "," + numberRows;
-	    	
-	    	
 	    	Cursor cursor = null;
 	    	try {
 	    		cursor = DBHelper.getInstance(db).limitRawQuery(db, sql, limit, querySpec.getArgs());
@@ -640,6 +666,7 @@ public class SmartStore  {
 	 * @return count of results for a "smart" query
 	 */
 	public int countQuery(QuerySpec querySpec) {
+		final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 			String countSql = convertSmartSql(querySpec.countSmartSql);
 			return DBHelper.getInstance(db).countRawCountQuery(db, countSql, querySpec.getArgs());
@@ -651,6 +678,7 @@ public class SmartStore  {
 	 * @return
 	 */
 	public String convertSmartSql(String smartSql) {
+		final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
     		return SmartSqlHelper.getInstance(db).convertSmartSql(db, smartSql);
     	}
@@ -666,6 +694,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONObject create(String soupName, JSONObject soupElt) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
     		return create(soupName, soupElt, true);
     	}
@@ -680,6 +709,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONObject create(String soupName, JSONObject soupElt, boolean handleTx) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
@@ -689,7 +719,6 @@ public class SmartStore  {
 	            if (handleTx) {
 	                db.beginTransaction();
 	            }
-	
 	            long now = System.currentTimeMillis();
 	            long soupEntryId = DBHelper.getInstance(db).getNextId(db, soupTableName);
 	
@@ -751,6 +780,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONArray retrieve(String soupName, Long... soupEntryIds) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
@@ -786,6 +816,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONObject update(String soupName, JSONObject soupElt, long soupEntryId) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
     		return update(soupName, soupElt, soupEntryId, true);
     	}
@@ -801,6 +832,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONObject update(String soupName, JSONObject soupElt, long soupEntryId, boolean handleTx) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
@@ -820,7 +852,6 @@ public class SmartStore  {
 	        for (IndexSpec indexSpec : indexSpecs) {
 	            projectIndexedPaths(soupElt, contentValues, indexSpec);
 	        }
-	
 	        try {
 	            if (handleTx) {
 	                db.beginTransaction();
@@ -851,6 +882,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONObject upsert(String soupName, JSONObject soupElt, String externalIdPath) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
     		return upsert(soupName, soupElt, externalIdPath, true);
     	}
@@ -864,6 +896,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONObject upsert(String soupName, JSONObject soupElt) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
     		return upsert(soupName, soupElt, SOUP_ENTRY_ID);
     	}
@@ -879,6 +912,7 @@ public class SmartStore  {
      * @throws JSONException
      */
     public JSONObject upsert(String soupName, JSONObject soupElt, String externalIdPath, boolean handleTx) throws JSONException {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        long entryId = -1;
 	        if (externalIdPath.equals(SOUP_ENTRY_ID)) {
@@ -913,6 +947,7 @@ public class SmartStore  {
      * @param fieldValue
      */
     public long lookupSoupEntryId(String soupName, String fieldPath, String fieldValue) {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
@@ -941,6 +976,7 @@ public class SmartStore  {
      * @param soupEntryIds
      */
     public void delete(String soupName, Long... soupEntryIds) {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
     		delete(soupName, soupEntryIds, true);
     	}
@@ -953,6 +989,7 @@ public class SmartStore  {
      * @param handleTx
      */
     public void delete(String soupName, Long[] soupEntryIds, boolean handleTx) {
+    	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/AbstractSmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/AbstractSmartStoreTest.java
@@ -68,8 +68,6 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		assertTrue("Table for test_soup should now exist", hasTable("TABLE_1"));
 		assertTrue("Soup test_soup should now exist", store.hasSoup(TEST_SOUP));
 	}
-	
-	protected abstract SQLiteDatabase getWritableDatabase();
 
 	/**
 	 * Testing method with paths to top level string/integer/array/map as well as edge cases (null object/null or empty path)
@@ -186,6 +184,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, null, null, null);
 			assertTrue("Expected a soup element", c.moveToFirst());
@@ -224,7 +223,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 			String soupTableName = getSoupTableName(OTHER_TEST_SOUP);
 			assertEquals("Table for other_test_soup was expected to be called TABLE_2", "TABLE_2", soupTableName);
 			assertTrue("Table for other_test_soup should now exist", hasTable("TABLE_2"));
-			
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			assertTrue("Expected a soup element", c.moveToFirst());
 			assertEquals("Expected three soup elements", 3, c.getCount());
@@ -283,7 +282,8 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			String soupTableName = getSoupTableName(TEST_SOUP);			
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
+			String soupTableName = getSoupTableName(TEST_SOUP);		
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			assertTrue("Expected a soup element", c.moveToFirst());
 			assertEquals("Expected three soup elements", 3, c.getCount());
@@ -335,6 +335,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			String soupTableName = getSoupTableName(TEST_SOUP);			
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			assertTrue("Expected a soup element", c.moveToFirst());
@@ -387,6 +388,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			String soupTableName = getSoupTableName(TEST_SOUP);			
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			assertTrue("Expected a soup element", c.moveToFirst());
@@ -418,12 +420,10 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 	 */
 	public void testUpsertWithNonIndexedExternalId() throws JSONException {
 		JSONObject soupElt = new JSONObject("{'key':'ka1', 'value':'va1'}");
-		
 		try {
 			store.upsert(TEST_SOUP, soupElt, "value");
 			fail("Exception was expected: value is not an indexed field");
-		}
-		catch (RuntimeException e) {
+		} catch (RuntimeException e) {
 			assertTrue("Wrong exception", e.getMessage().contains("does not have an index"));
 		}
 	}
@@ -449,8 +449,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		try {
 			store.upsert(TEST_SOUP, soupElt3, "key");
 			fail("Exception was expected: key is not unique in the soup");
-		}
-		catch (RuntimeException e) {
+		} catch (RuntimeException e) {
 			assertTrue("Wrong exception", e.getMessage().contains("are more than one soup elements"));
 		}
 	}
@@ -503,6 +502,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			assertTrue("Expected a soup element", c.moveToFirst());
@@ -512,8 +512,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 			
 			c.moveToNext();
 			assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
-		}
-		finally {
+		} finally {
 			safeClose(c);
 		}
 	}
@@ -544,11 +543,11 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			assertFalse("Expected no soup element", c.moveToFirst());
-		}
-		finally {
+		} finally {
 			safeClose(c);
 		}
 	}
@@ -812,6 +811,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		
 		Cursor c = null;
 		try {
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			String soupTableName = getSoupTableName(FOURTH_TEST_SOUP);
 			String amountColumnName = store.getSoupIndexSpecs(FOURTH_TEST_SOUP)[0].columnName;
 			c = DBHelper.getInstance(db).query(db, soupTableName, new String[] { amountColumnName }, null, null, "id = " + id);
@@ -821,8 +821,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 				assertEquals("Not the value expected", valueOut.longValue(), c.getLong(0));
 			else if (fieldType == Type.floating)
 				assertEquals("Not the value expected", valueOut.doubleValue(), c.getDouble(0)); 
-		}
-		finally {
+		} finally {
 			safeClose(c);
 		}
 	}
@@ -982,6 +981,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 			String soupTableName = getSoupTableName(OTHER_TEST_SOUP);
 			assertEquals("Table for other_test_soup was expected to be called TABLE_2", "TABLE_2", soupTableName);
 			assertTrue("Table for other_test_soup should now exist", hasTable("TABLE_2"));
@@ -1158,6 +1158,7 @@ public abstract class AbstractSmartStoreTest extends SmartStoreTestCase {
 	 * @throws JSONException
 	 */
 	private void tryAlterSoupInterruptResume(AlterSoupStep toStep) throws JSONException {
+		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
 		assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
 		IndexSpec[] indexSpecs = new IndexSpec[] {new IndexSpec("lastName", Type.string)};
 		store.registerSoup(OTHER_TEST_SOUP, indexSpecs);

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/EncryptedSmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/EncryptedSmartStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, salesforce.com, inc.
+ * Copyright (c) 2011-2014, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -26,18 +26,14 @@
  */
 package com.salesforce.androidsdk.store;
 
-import net.sqlcipher.database.SQLiteDatabase;
-
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 
 /**
  * Tests for encrypted smart store
- *
  */
 public class EncryptedSmartStoreTest extends AbstractSmartStoreTest {
 
 	@Override
-	protected SQLiteDatabase getWritableDatabase() {
-		return DBOpenHelper.getOpenHelper(targetContext, null).getWritableDatabase("test123");
+	protected String getPasscode() {
+		return "test123";
 	}
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/PlainSmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/PlainSmartStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, salesforce.com, inc.
+ * Copyright (c) 2011-2014, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -26,18 +26,14 @@
  */
 package com.salesforce.androidsdk.store;
 
-import net.sqlcipher.database.SQLiteDatabase;
-
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 
 /**
  * Tests for plain smart store
- *
  */
 public class PlainSmartStoreTest extends AbstractSmartStoreTest {
 
 	@Override
-	protected SQLiteDatabase getWritableDatabase() {
-		return DBOpenHelper.getOpenHelper(targetContext, null).getWritableDatabase("");
+	protected String getPasscode() {
+		return "";
 	}
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlTest.java
@@ -26,13 +26,10 @@
  */
 package com.salesforce.androidsdk.store;
 
-import net.sqlcipher.database.SQLiteDatabase;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper.SmartSqlException;
@@ -58,8 +55,8 @@ public class SmartSqlTest extends SmartStoreTestCase {
 	private static final String DEPARTMENTS_SOUP = "departments";
 
 	@Override
-	protected SQLiteDatabase getWritableDatabase() {
-		return DBOpenHelper.getOpenHelper(targetContext, null).getWritableDatabase("");
+	protected String getPasscode() {
+		return "";
 	}
 
 	@Override

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreInspectorActivityTest.java
@@ -29,7 +29,7 @@ package com.salesforce.androidsdk.store;
 import java.util.HashSet;
 import java.util.Set;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteOpenHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -211,10 +211,10 @@ public class SmartStoreInspectorActivityTest extends
 	}
 
 	private void createStore() {
-		DBOpenHelper.deleteDatabase(targetContext, null);
-		SQLiteDatabase db = DBOpenHelper.getOpenHelper(targetContext, null).getWritableDatabase("");
-		DBHelper.getInstance(db).clearMemoryCache();
-		store = new SmartStore(db);
+		final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(targetContext, null);
+		DBHelper.getInstance(dbOpenHelper.getWritableDatabase("")).clearMemoryCache();
+		store = new SmartStore(dbOpenHelper, "");
+		store.dropAllSoups();
 	}
 
 	private void createSoups() {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sqlcipher.database.SQLiteDatabase;
+import net.sqlcipher.database.SQLiteOpenHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -64,30 +65,29 @@ public class SmartStoreLoadTest extends InstrumentationTestCase {
 	private static final String TEST_SOUP = "test_soup";
 	
 	protected Context targetContext;
-	private SQLiteDatabase db;
 	private SmartStore store;
-	
+
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
 		targetContext = getInstrumentation().getTargetContext();
-		DBHelper.getInstance(db).clearMemoryCache();
-		DBHelper.getInstance(db).reset(targetContext, null);
-		db = getWritableDatabase();
-		store = new SmartStore(db);
+		final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(targetContext, null);
+		DBHelper.getInstance(dbOpenHelper.getWritableDatabase(getPasscode())).reset(targetContext, null);
+		store = new SmartStore(dbOpenHelper, getPasscode());
+		store.dropAllSoups();
 		assertFalse("Soup test_soup should not exist", store.hasSoup(TEST_SOUP));
 		store.registerSoup(TEST_SOUP, new IndexSpec[] {new IndexSpec("key", Type.string)});
 		assertTrue("Soup test_soup should now exist", store.hasSoup(TEST_SOUP));
 	}
-	
-	protected SQLiteDatabase getWritableDatabase() {
-		return DBOpenHelper.getOpenHelper(targetContext, null).getWritableDatabase("");
+
+	protected String getPasscode() {
+		return "";
 	}
 
 	@Override
 	protected void tearDown() throws Exception {
+		final SQLiteDatabase db = DBOpenHelper.getOpenHelper(targetContext, null).getWritableDatabase(getPasscode());
 		db.close();
-		// Not cleaning up after the test to make diagnosing issues easier
 		super.tearDown();
 	}
 


### PR DESCRIPTION
This ensures every access to the DB goes through ```DBOpenHelper```, which ensures we always access a DB instance that hasn't been closed.