### PR TITLE
Fix for timing issues with cert based auth

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -107,10 +107,9 @@ public class LoginActivity extends AccountAuthenticatorActivity
 		if (shouldUseCertBasedAuth()) {
 			final String alias = RuntimeConfig.getRuntimeConfig(this).getString(ConfigKey.ManagedAppCertAlias);
 			KeyChain.choosePrivateKeyAlias(this, webviewHelper, null, null, null, 0, alias);
+		} else {
+			webviewHelper.loadLoginPage();
 		}
-
-		// Load login page
-		webviewHelper.loadLoginPage();
 	}
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -655,6 +655,13 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 		try {
 			certChain = KeyChain.getCertificateChain(activity, alias);
 			key = KeyChain.getPrivateKey(activity, alias);
+			activity.runOnUiThread(new Runnable() {
+
+                @Override
+                public void run() {
+                	loadLoginPage();
+                }
+            });
 		} catch (KeyChainException e) {
 			e.printStackTrace();
 		} catch (InterruptedException e) {


### PR DESCRIPTION
Certificate loading from ```KeyChain``` can not be done from the UI thread. However, the ```WebView``` continues to load the login page in the background, and issues a certificate authentication request callback. But by then, we may not have the alias yet, if the user hasn't made his/her selection yet. This leads to timing issues and failures occasionally. This ensures that the login page is loaded only after the certificate selection has been made, to ensure that we always have the certificate authentication callback covered.