### PR TITLE
A couple of tests were broken when getAuthorizationUrl was refactored

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -26,22 +26,11 @@
  */
 package com.salesforce.androidsdk.auth;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import android.net.Uri;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.salesforce.androidsdk.auth.HttpAccess.Execution;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -53,11 +42,17 @@ import org.apache.http.util.EntityUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.net.Uri;
-import android.text.TextUtils;
-import android.util.Log;
-
-import com.salesforce.androidsdk.auth.HttpAccess.Execution;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Helper methods for common OAuth2 requests.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -32,11 +32,16 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -150,14 +155,14 @@ public class OAuth2 {
         sb.append(OAUTH_AUTH_PATH).append(displayType == null ? TOUCH : displayType);
         sb.append(AND).append(RESPONSE_TYPE).append(EQUAL).append(clientSecret == null ? TOKEN : ACTIVATED_CLIENT_CODE);
         sb.append(AND).append(CLIENT_ID).append(EQUAL).append(Uri.encode(clientId));
-        sb.append(AND).append(SCOPE).append(EQUAL).append(Uri.encode(computeScopeParameter(scopes)));
+        if (scopes != null && scopes.length > 0) sb.append(AND).append(SCOPE).append(EQUAL).append(Uri.encode(computeScopeParameter(scopes)));
         sb.append(AND).append(REDIRECT_URI).append(EQUAL).append(callbackUrl);
         return URI.create(sb.toString());
     }
 
     private static String computeScopeParameter(String[] scopes) {
         final List<String> scopesList = Arrays.asList(scopes == null ? new String[]{} : scopes);
-        Set<String> scopesSet = new HashSet<String>(scopesList);
+        Set<String> scopesSet = new TreeSet<String>(scopesList); // sorted set to make tests easier
         scopesSet.add(REFRESH_TOKEN);
         return TextUtils.join(" ", scopesSet.toArray(new String[]{}));
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -101,7 +101,7 @@ public class OAuth2Test extends InstrumentationTestCase {
         	param = listor.next();
             if (param.getName().equalsIgnoreCase("scope")) {
                 scopesFound = true;
-                assertEquals("Wrong scopes included", "refresh_token foo bar", param.getValue());
+                assertEquals("Wrong scopes included", "bar foo refresh_token", param.getValue());
                 break;
             }
         }
@@ -118,7 +118,7 @@ public class OAuth2Test extends InstrumentationTestCase {
         	param = listor.next();
             if (param.getName().equalsIgnoreCase("scope")) {
                 scopesFound = true;
-                assertEquals("Wrong scopes included on redundant", "refresh_token foo bar", param.getValue());
+                assertEquals("Wrong scopes included on redundant", "bar foo refresh_token", param.getValue());
                 break;
             }
         }


### PR DESCRIPTION
As of 3.0, no scope parameter was put in (even for refresh token) if the scopes array passed in was null or empty
Going back to 3.0 behavior