### PR TITLE
fix for null "integer" and "floating" SmartStore indexes crash

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -764,11 +764,11 @@ public class SmartStore  {
         Object value = project(soupElt, indexSpec.path);
         switch (indexSpec.type) {
         case integer:
-            contentValues.put(indexSpec.columnName, ((Number) value).longValue()); break;
+            contentValues.put(indexSpec.columnName, value != null ? ((Number) value).longValue() : null); break;
         case string:
             contentValues.put(indexSpec.columnName, value != null ? value.toString() : null); break;
         case floating:
-        	contentValues.put(indexSpec.columnName, ((Number) value).doubleValue()); break;
+            contentValues.put(indexSpec.columnName, value != null ? ((Number) value).doubleValue() : null); break;
         }
     }
 


### PR DESCRIPTION
SmartStore was crashing if values for integer/floating indexes were null