### PR TITLE
Mobile SDK 3.1.1 Patch Release

### DIFF
--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -2,8 +2,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="com.salesforce.androidsdk" 
-	android:versionCode="40"
-	android:versionName="3.1.0">
+	android:versionCode="41"
+	android:versionName="3.1.1">
 
     <uses-sdk android:minSdkVersion="17"
         android:targetSdkVersion="21" />

--- a/libs/SmartStore/AndroidManifest.xml
+++ b/libs/SmartStore/AndroidManifest.xml
@@ -2,8 +2,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="com.salesforce.androidsdk.smartstore"
-	android:versionCode="40"
-	android:versionName="3.1.0">
+	android:versionCode="41"
+	android:versionName="3.1.1">
 
     <uses-sdk android:minSdkVersion="17"
         android:targetSdkVersion="21" />

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SalesforceSDKManagerWithSmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SalesforceSDKManagerWithSmartStore.java
@@ -262,7 +262,8 @@ public class SalesforceSDKManagerWithSmartStore extends SalesforceSDKManager {
     	final String passcodeHash = getPasscodeHash();
         final String passcode = (passcodeHash == null ?
         		getEncryptionKeyForPasscode(null) : passcodeHash);
-        final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(context, account, communityId);
+        final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(context,
+        		dbNamePrefix, account, communityId);
         return new SmartStore(dbOpenHelper, passcode);
     }
 

--- a/libs/SmartSync/AndroidManifest.xml
+++ b/libs/SmartSync/AndroidManifest.xml
@@ -2,8 +2,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.salesforce.androidsdk.smartsync"
-    android:versionCode="40"
-    android:versionName="3.1.0">
+    android:versionCode="41"
+    android:versionName="3.1.1">
 
     <uses-sdk android:minSdkVersion="17"
         android:targetSdkVersion="21" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "forcedroid",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "description": "Utilities for creating mobile apps based on the Salesforce Mobile SDK for Android",
     "keywords": [ "salesforce mobile sdk", "android", "salesforce", "mobile", "sdk" ],
     "homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-Android",


### PR DESCRIPTION
The ability to name your own ```SmartStore``` had regressed. This addresses that.