### PR TITLE
Adding support for global SmartStore in hybrid

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/phonegap/SmartStorePlugin.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/phonegap/SmartStorePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2012, salesforce.com, inc.
+ * Copyright (c) 2011-2015, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -38,7 +38,6 @@ import org.json.JSONObject;
 import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
-import android.util.SparseArray;
 
 import com.salesforce.androidsdk.phonegap.ForcePlugin;
 import com.salesforce.androidsdk.phonegap.JavaScriptPluginVersion;
@@ -54,35 +53,34 @@ import com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity;
  * PhoneGap plugin for smart store.
  */
 public class SmartStorePlugin extends ForcePlugin {
+
 	// Keys in json from/to javascript
 	public static final String BEGIN_KEY = "beginKey";
-	static final String CURRENT_PAGE_INDEX = "currentPageIndex";
-	static final String CURRENT_PAGE_ORDERED_ENTRIES = "currentPageOrderedEntries";
-	static final String CURSOR_ID = "cursorId";
 	public static final String END_KEY = "endKey";
-	private static final String ENTRIES = "entries";
-	private static final String ENTRY_IDS = "entryIds";
-	private static final String INDEX = "index";
-	private static final String INDEXES = "indexes";
 	public static final String INDEX_PATH = "indexPath";
 	public static final String LIKE_KEY = "likeKey";
 	public static final String MATCH_KEY = "matchKey";
 	public static final String SMART_SQL = "smartSql";
-	private static final String EXTERNAL_ID_PATH = "externalIdPath";
 	public static final String ORDER = "order";
 	public static final String PAGE_SIZE = "pageSize";
+	public static final String QUERY_TYPE = "queryType";
+	static final String TOTAL_ENTRIES = "totalEntries";
+	static final String TOTAL_PAGES = "totalPages";
+	static final String RE_INDEX_DATA = "reIndexData";
+	static final String CURRENT_PAGE_INDEX = "currentPageIndex";
+	static final String CURRENT_PAGE_ORDERED_ENTRIES = "currentPageOrderedEntries";
+	static final String CURSOR_ID = "cursorId";
+	private static final String TYPE = "type";
+	private static final String SOUP_NAME = "soupName";
 	private static final String PATH = "path";
 	private static final String PATHS = "paths";
 	private static final String QUERY_SPEC = "querySpec";
-	public static final String QUERY_TYPE = "queryType";
-	private static final String SOUP_NAME = "soupName";
-	static final String TOTAL_ENTRIES = "totalEntries";
-	static final String TOTAL_PAGES = "totalPages";
-	private static final String TYPE = "type";
-	static final String RE_INDEX_DATA = "reIndexData";
-
-	// Map of cursor id to StoreCursor
-	private static SparseArray<StoreCursor> storeCursors = new SparseArray<StoreCursor>();
+	private static final String EXTERNAL_ID_PATH = "externalIdPath";
+	private static final String ENTRIES = "entries";
+	private static final String ENTRY_IDS = "entryIds";
+	private static final String INDEX = "index";
+	private static final String INDEXES = "indexes";
+	private static final String IS_GLOBAL_STORE = "isGlobalStore";
 
 	/**
 	 * Supported plugin actions that the client can take.
@@ -107,22 +105,25 @@ public class SmartStorePlugin extends ForcePlugin {
 	}
 
     @Override
-    public boolean execute(String actionStr, JavaScriptPluginVersion jsVersion, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    public boolean execute(String actionStr, JavaScriptPluginVersion jsVersion,
+    		final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     	final long start = System.currentTimeMillis();
+
     	// Figure out action
     	final Action action;
     	try {
     		action = Action.valueOf(actionStr);
-    	}
-    	catch (IllegalArgumentException e) {
+    	} catch (IllegalArgumentException e) {
     		Log.e("SmartStorePlugin.execute", "Unknown action " + actionStr);
             return false;
     	}
 
     	// Not running smartstore action on the main thread
     	cordova.getThreadPool().execute(new Runnable() {
+
 			@Override
 			public void run() {
+
 		    	// All smart store action need to be serialized
 				synchronized(SmartStorePlugin.class) {
 	        		try {
@@ -145,8 +146,7 @@ public class SmartStorePlugin extends ForcePlugin {
 		                  case pgUpsertSoupEntries:     upsertSoupEntries(args, callbackContext); break;
 		                  default: throw new SmartStoreException("No handler for action " + action);
 		    	    	}
-	        		}
-	            	catch (Exception e) {
+	        		} catch (Exception e) {
 	            		Log.w("SmartStorePlugin.execute", e.getMessage(), e);
 	            		callbackContext.error(e.getMessage());
 	            	}	        		
@@ -165,18 +165,20 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void removeFromSoup(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 		JSONArray jsonSoupEntryIds = arg0.getJSONArray(ENTRY_IDS);
 		Long[] soupEntryIds = new Long[jsonSoupEntryIds.length()];
-		for (int i=0; i<jsonSoupEntryIds.length(); i++)
-			soupEntryIds[i] = jsonSoupEntryIds.getLong(i); 
+		for (int i = 0; i < jsonSoupEntryIds.length(); i++) {
+			soupEntryIds[i] = jsonSoupEntryIds.getLong(i);
+		}
 		
 		// Run remove
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		smartStore.delete(soupName, soupEntryIds);
-		
 		callbackContext.success();
 	}
 
@@ -188,18 +190,20 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void retrieveSoupEntries(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 		JSONArray jsonSoupEntryIds = arg0.getJSONArray(ENTRY_IDS);
 		Long[] soupEntryIds = new Long[jsonSoupEntryIds.length()];
-		for (int i=0; i<jsonSoupEntryIds.length(); i++)
-			soupEntryIds[i] = jsonSoupEntryIds.getLong(i); 
+		for (int i = 0; i < jsonSoupEntryIds.length(); i++) {
+			soupEntryIds[i] = jsonSoupEntryIds.getLong(i);
+		}
 		
 		// Run retrieve
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		JSONArray result = smartStore.retrieve(soupName, soupEntryIds);
-
 		PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, result);
 		callbackContext.sendPluginResult(pluginResult);
 	}
@@ -212,16 +216,18 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void closeCursor(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		Integer cursorId = arg0.getInt(CURSOR_ID);
-		
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
+
 		// Drop cursor from storeCursors map
-		storeCursors.remove(cursorId);
-		
+		smartStore.STORE_CURSORS.remove(cursorId);
 		callbackContext.success();		
-	}	
-	
+	}
+
 	/**
 	 * Native implementation of pgMoveCursorToPageIndex
 	 * @param args
@@ -230,24 +236,26 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void moveCursorToPageIndex(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		Integer cursorId = arg0.getInt(CURSOR_ID);
 		Integer index = arg0.getInt(INDEX);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 
 		// Get cursor
-		StoreCursor storeCursor = storeCursors.get(cursorId);
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
+		final StoreCursor storeCursor = smartStore.STORE_CURSORS.get(cursorId);
 		if (storeCursor == null) {
 			callbackContext.error("Invalid cursor id");
 		}
-		
+
 		// Change page
 		storeCursor.moveToPageIndex(index);
-		
+
 		// Build json result
-		SmartStore smartStore = getSmartStore();
 		JSONObject result = storeCursor.getData(smartStore);
-		
+
 		// Done
 		callbackContext.success(result);
 	}
@@ -263,9 +271,8 @@ public class SmartStorePlugin extends ForcePlugin {
 		Activity activity = cordova.getActivity();
 		final Intent i = new Intent(activity, SmartStoreInspectorActivity.class);
 		activity.startActivity(i);
-	}	
-	
-	
+	}
+
 	/**
 	 * Native implementation of pgSoupExists
 	 * @param args
@@ -274,18 +281,19 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void soupExists(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 
 		// Run upsert
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		boolean exists = smartStore.hasSoup(soupName);
-		
 		PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, exists);
 		callbackContext.sendPluginResult(pluginResult);
-	}	
-	
+	}
+
 	/**
 	 * Native implementation of pgUpsertSoupEntries
 	 * @param args
@@ -294,18 +302,20 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void upsertSoupEntries(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 		JSONArray entriesJson = arg0.getJSONArray(ENTRIES);
 		String externalIdPath = arg0.getString(EXTERNAL_ID_PATH);
 		List<JSONObject> entries = new ArrayList<JSONObject>();
-		for (int i=0; i<entriesJson.length(); i++) {
+		for (int i = 0; i < entriesJson.length(); i++) {
 			entries.add(entriesJson.getJSONObject(i));
 		}
-		
+
 		// Run upsert
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		smartStore.beginTransaction();
 		try {
 			JSONArray results = new JSONArray();			
@@ -315,8 +325,7 @@ public class SmartStorePlugin extends ForcePlugin {
 			smartStore.setTransactionSuccessful();
 			PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, results);
 			callbackContext.sendPluginResult(pluginResult);
-	    }
-		finally {
+	    } finally {
 			smartStore.endTransaction();
 		}
 		
@@ -330,18 +339,20 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void registerSoup(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.isNull(SOUP_NAME) ? null : arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 		List<IndexSpec> indexSpecs = new ArrayList<IndexSpec>();
 		JSONArray indexesJson = arg0.getJSONArray(INDEXES);
-		for (int i=0; i<indexesJson.length(); i++) {
+		for (int i = 0; i < indexesJson.length(); i++) {
 			JSONObject indexJson = indexesJson.getJSONObject(i);
 			indexSpecs.add(new IndexSpec(indexJson.getString(PATH), SmartStore.Type.valueOf(indexJson.getString(TYPE))));
 		}
 
 		// Run register
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		smartStore.registerSoup(soupName, indexSpecs.toArray(new IndexSpec[0]));
 		callbackContext.success(soupName);
 	}
@@ -354,18 +365,20 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void querySoup(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 		JSONObject querySpecJson = arg0.getJSONObject(QUERY_SPEC);
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		QuerySpec querySpec = QuerySpec.fromJSON(soupName, querySpecJson);
-		
 		if (querySpec.queryType == QueryType.smart) {
 			throw new RuntimeException("Smart queries can only be run through runSmartQuery");
 		}
-		
+
 		// Run query
-		runQuery(querySpec, callbackContext);
+		runQuery(smartStore, querySpec, callbackContext);
 	}
 
 	/**
@@ -374,17 +387,19 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @param callbackContext
 	 */
 	private void runSmartQuery(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		JSONObject querySpecJson = arg0.getJSONObject(QUERY_SPEC);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		QuerySpec querySpec = QuerySpec.fromJSON(null, querySpecJson);
-		
 		if (querySpec.queryType != QueryType.smart) {
 			throw new RuntimeException("runSmartQuery can only run smart queries");
 		}
-		
+
 		// Run query
-		runQuery(querySpec, callbackContext);
+		runQuery(smartStore, querySpec, callbackContext);
 	}
 
 	/**
@@ -393,19 +408,20 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @param callbackContext
 	 * @throws JSONException
 	 */
-	private void runQuery(QuerySpec querySpec, CallbackContext callbackContext) throws JSONException {
+	private void runQuery(SmartStore smartStore, QuerySpec querySpec,
+			CallbackContext callbackContext) throws JSONException {
+
 		// Build store cursor
-		SmartStore smartStore = getSmartStore();
-		StoreCursor storeCursor = new StoreCursor(smartStore, querySpec);
-		storeCursors.put(storeCursor.cursorId, storeCursor);
-		
+		final StoreCursor storeCursor = new StoreCursor(smartStore, querySpec);
+		smartStore.STORE_CURSORS.put(storeCursor.cursorId, storeCursor);
+
 		// Build json result
 		JSONObject result = storeCursor.getData(smartStore);
-		
+
 		// Done
 		callbackContext.success(result);
 	}
-	
+
 	/**
 	 * Native implementation of pgRemoveSoup
 	 * @param args
@@ -414,12 +430,14 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void removeSoup(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
-		
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
+
 		// Run remove
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		smartStore.dropSoup(soupName);
 		callbackContext.success();
 	}
@@ -432,16 +450,18 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void clearSoup(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
-		
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
+
 		// Run clear
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		smartStore.clearSoup(soupName);
 		callbackContext.success();
 	}
-	
+
 	/**
 	 * Native implementation of pgGetDatabaseSize
 	 * @param args
@@ -450,7 +470,15 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void getDatabaseSize(JSONArray args, CallbackContext callbackContext) throws JSONException {
-		int databaseSize = getSmartStore().getDatabaseSize();
+
+		// Parse args
+		final JSONObject arg0 = args.optJSONObject(0);
+		boolean isGlobal = false;
+		if (arg0 != null) {
+			isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
+		}
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
+		int databaseSize = smartStore.getDatabaseSize();
 		callbackContext.success(databaseSize);
 	}	
 
@@ -462,19 +490,21 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void alterSoup(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 		List<IndexSpec> indexSpecs = new ArrayList<IndexSpec>();
 		JSONArray indexesJson = arg0.getJSONArray(INDEXES);
-		for (int i=0; i<indexesJson.length(); i++) {
+		for (int i = 0; i < indexesJson.length(); i++) {
 			JSONObject indexJson = indexesJson.getJSONObject(i);
 			indexSpecs.add(new IndexSpec(indexJson.getString(PATH), SmartStore.Type.valueOf(indexJson.getString(TYPE))));
 		}
 		boolean reIndexData = arg0.getBoolean(RE_INDEX_DATA);
 
 		// Run register
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		smartStore.alterSoup(soupName, indexSpecs.toArray(new IndexSpec[0]), reIndexData);
 		callbackContext.success(soupName);
 	}	
@@ -487,22 +517,23 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void reIndexSoup(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
 		List<String> indexPaths = new ArrayList<String>();
 		JSONArray indexPathsJson = arg0.getJSONArray(PATHS);
-		for (int i=0; i<indexPathsJson.length(); i++) {
+		for (int i = 0; i < indexPathsJson.length(); i++) {
 			indexPaths.add(indexPathsJson.getString(i));
 		}
 
 		// Run register
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		smartStore.reIndexSoup(soupName, indexPaths.toArray(new String[0]), true);
 		callbackContext.success(soupName);
-	}	
-	
-	
+	}
+
 	/**
 	 * Native implementation of pgGetSoupIndexSpecs
 	 * @param args
@@ -511,15 +542,17 @@ public class SmartStorePlugin extends ForcePlugin {
 	 * @throws JSONException 
 	 */
 	private void getSoupIndexSpecs(JSONArray args, CallbackContext callbackContext) throws JSONException {
+
 		// Parse args
 		JSONObject arg0 = args.getJSONObject(0);
 		String soupName = arg0.getString(SOUP_NAME);
-		
+		boolean isGlobal = arg0.optBoolean(IS_GLOBAL_STORE, false);
+
 		// Get soup index specs
-		SmartStore smartStore = getSmartStore();
+		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 		IndexSpec[] indexSpecs = smartStore.getSoupIndexSpecs(soupName);
 		JSONArray indexSpecsJson = new JSONArray();
-		for (int i=0; i<indexSpecs.length; i++) {
+		for (int i = 0; i < indexSpecs.length; i++) {
 			JSONObject indexSpecJson = new JSONObject();
 			IndexSpec indexSpec = indexSpecs[i];
 			indexSpecJson.put(PATH, indexSpec.path);
@@ -529,8 +562,11 @@ public class SmartStorePlugin extends ForcePlugin {
 		callbackContext.success(indexSpecsJson);
 	}	
 
-	
-	private SmartStore getSmartStore() {
+	private SmartStore getUserSmartStore() {
 		return SalesforceSDKManagerWithSmartStore.getInstance().getSmartStore();
+	}
+
+	private SmartStore getGlobalSmartStore() {
+		return SalesforceSDKManagerWithSmartStore.getInstance().getGlobalSmartStore(null);
 	}
 }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/phonegap/SmartStorePlugin.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/phonegap/SmartStorePlugin.java
@@ -90,7 +90,7 @@ public class SmartStorePlugin extends ForcePlugin {
 	// Map of cursor id to StoreCursor, per database.
 	private static Map<SQLiteDatabase, SparseArray<StoreCursor>> STORE_CURSORS = new HashMap<SQLiteDatabase, SparseArray<StoreCursor>>();
 
-	private static SparseArray<StoreCursor> getStoreCursor(SmartStore store) {
+	private synchronized static SparseArray<StoreCursor> getSmartStoreCursors(SmartStore store) {
 		final SQLiteDatabase db = store.getDatabase();
 		if (!STORE_CURSORS.containsKey(db)) {
 			STORE_CURSORS.put(db, new SparseArray<StoreCursor>());
@@ -240,7 +240,7 @@ public class SmartStorePlugin extends ForcePlugin {
 		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
 
 		// Drop cursor from storeCursors map
-		getStoreCursor(smartStore).remove(cursorId);
+		getSmartStoreCursors(smartStore).remove(cursorId);
 		callbackContext.success();		
 	}
 
@@ -261,7 +261,7 @@ public class SmartStorePlugin extends ForcePlugin {
 
 		// Get cursor
 		final SmartStore smartStore = (isGlobal ? getGlobalSmartStore() : getUserSmartStore());
-		final StoreCursor storeCursor = getStoreCursor(smartStore).get(cursorId);
+		final StoreCursor storeCursor = getSmartStoreCursors(smartStore).get(cursorId);
 		if (storeCursor == null) {
 			callbackContext.error("Invalid cursor id");
 		}
@@ -429,7 +429,7 @@ public class SmartStorePlugin extends ForcePlugin {
 
 		// Build store cursor
 		final StoreCursor storeCursor = new StoreCursor(smartStore, querySpec);
-		getStoreCursor(smartStore).put(storeCursor.cursorId, storeCursor);
+		getSmartStoreCursors(smartStore).put(storeCursor.cursorId, storeCursor);
 
 		// Build json result
 		JSONObject result = storeCursor.getData(smartStore);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -42,7 +42,9 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.text.TextUtils;
 import android.util.Log;
+import android.util.SparseArray;
 
+import com.salesforce.androidsdk.smartstore.phonegap.StoreCursor;
 import com.salesforce.androidsdk.smartstore.store.LongOperation.LongOperationType;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec.QueryType;
 
@@ -55,6 +57,7 @@ import com.salesforce.androidsdk.smartstore.store.QuerySpec.QueryType;
  * The main challenge here is how to effectively store documents with dynamic fields, and still allow indexing and searching.
  */
 public class SmartStore  {
+
     // Default
     public static final int DEFAULT_PAGE_SIZE = 10;
 
@@ -92,6 +95,9 @@ public class SmartStore  {
     protected static final String SOUP_NAME_PREDICATE = SOUP_NAME_COL + " = ?";
     protected static final String PATH_PREDICATE = PATH_COL + " = ?";
 	protected static final String ID_PREDICATE = ID_COL + " = ?";
+
+	// Map of cursor id to StoreCursor (used only by hybrid).
+	public SparseArray<StoreCursor> STORE_CURSORS = new SparseArray<StoreCursor>();
 
     // Backing database
 	protected SQLiteDatabase dbLocal;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -42,9 +42,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.text.TextUtils;
 import android.util.Log;
-import android.util.SparseArray;
 
-import com.salesforce.androidsdk.smartstore.phonegap.StoreCursor;
 import com.salesforce.androidsdk.smartstore.store.LongOperation.LongOperationType;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec.QueryType;
 
@@ -95,9 +93,6 @@ public class SmartStore  {
     protected static final String SOUP_NAME_PREDICATE = SOUP_NAME_COL + " = ?";
     protected static final String PATH_PREDICATE = PATH_COL + " = ?";
 	protected static final String ID_PREDICATE = ID_COL + " = ?";
-
-	// Map of cursor id to StoreCursor (used only by hybrid).
-	public SparseArray<StoreCursor> STORE_CURSORS = new SparseArray<StoreCursor>();
 
     // Backing database
 	protected SQLiteDatabase dbLocal;
@@ -196,7 +191,7 @@ public class SmartStore  {
     /**
      * Return db
      */
-    protected SQLiteDatabase getDatabase() {
+    public SQLiteDatabase getDatabase() {
     	if (dbLocal != null) {
             return dbLocal;
         } else {


### PR DESCRIPTION
* Moved ```STORE_CURSORS``` to the ```SmartStore``` class, so that it is per ```SmartStore``` instance.
* Added a ```boolean``` argument that can be passed in for a global database. The default is still the user's database.