### PR TITLE
Making constructor protected, so application can override DBOpenHelper. ...

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -127,7 +127,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		return helper;
 	}
 
-	private DBOpenHelper(Context context, String dbName) {
+	protected DBOpenHelper(Context context, String dbName) {
 		super(context, dbName, null, DB_VERSION, new DBHook());
 		SQLiteDatabase.loadLibs(context);
 	}


### PR DESCRIPTION
...This is useful if the application is packing databases with the apk