### PR TITLE
Bugfix. SmartQuery was failing if an non-string field is NULL

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -669,37 +669,41 @@ public class SmartStore  {
 		for (int i=0; i<columnCount; i++) {
 			String raw = cursor.getString(i);
 
-			// Is this column holding a serialized json object?
-			if (cursor.getColumnName(i).endsWith(SOUP_COL)) {
-				row.put(new JSONObject(raw));
-				// Note: we could end up returning a string if you aliased the column
-			}
-			else {
-				// TODO Leverage cursor.getType once our min api is 11 or above
-				// For now, we do our best to guess
-				
-				// Is it holding a integer ?
-	    		try {
-	    			Long n = Long.parseLong(raw);
-	    			row.put(n);
-	    			// Note: we could end up returning an integer for a string column if you have a string value that contains just an integer
-	    		}
-	    		// Is it holding a floating ?
-	    		catch (NumberFormatException e) {
-	    			try { 
-		    			Double d = Double.parseDouble(raw);
-		    			// No exception, let's get the value straight from the cursor
-		    			// XXX Double.parseDouble(cursor.getString(i)) is sometimes different from cursor.getDouble(i) !!!
-		    			d = cursor.getDouble(i);
-		    			row.put(d);
-		    			// Note: we could end up returning an integer for a string column if you have a string value that contains just an integer
-	    			}
-		    		// It must be holding a string then
-	    			catch (NumberFormatException ne) {
-		    			row.put(raw);
-	    			}
-	    		}
-			}
+            if (raw == null) {
+                row.put(raw);
+            } else {
+    			// Is this column holding a serialized json object?
+    			if (cursor.getColumnName(i).endsWith(SOUP_COL)) {
+    				row.put(new JSONObject(raw));
+    				// Note: we could end up returning a string if you aliased the column
+    			}
+    			else {
+    				// TODO Leverage cursor.getType once our min api is 11 or above
+    				// For now, we do our best to guess
+    				
+    				// Is it holding a integer ?
+    	    		try {
+    	    			Long n = Long.parseLong(raw);
+    	    			row.put(n);
+    	    			// Note: we could end up returning an integer for a string column if you have a string value that contains just an integer
+    	    		}
+    	    		// Is it holding a floating ?
+    	    		catch (NumberFormatException e) {
+    	    			try { 
+    		    			Double d = Double.parseDouble(raw);
+    		    			// No exception, let's get the value straight from the cursor
+    		    			// XXX Double.parseDouble(cursor.getString(i)) is sometimes different from cursor.getDouble(i) !!!
+    		    			d = cursor.getDouble(i);
+    		    			row.put(d);
+    		    			// Note: we could end up returning an integer for a string column if you have a string value that contains just an integer
+    	    			}
+    		    		// It must be holding a string then
+    	    			catch (NumberFormatException ne) {
+    		    			row.put(raw);
+    	    			}
+    	    		}
+    			}
+            }
 		}
 		return row;
 	}


### PR DESCRIPTION
If you run a "SELECT * .." smart query and the results include records with non-string fields that have NULL value then the command fails.

## Tests
```javascript
var smartstore = cordova.require("com.salesforce.plugin.smartstore");
smartstore.registerSoup('testSoup', [{path:"MyString",type:"string"},{path:"MyInt",type:"integer"}], function(res){console.log(res);}, function(err){console.error(err);});

// This works
var upsertArr = [{"MyString" : "1", "MyInt" : 1}];
smartstore.upsertSoupEntries('testSoup', upsertArr, function(res){console.log(res);}, function(err){console.error(err);});

var querySpec = smartstore.buildSmartQuerySpec("select * from {testSoup}");
smartstore.runSmartQuery(querySpec, function(cursor) { console.log(cursor);}, function(err){console.error(err);});

// This fails pre-fix (works after)
var upsertArr = [{"MyString" : "1", "MyInt" : null}];
smartstore.upsertSoupEntries('testSoup', upsertArr, function(res){console.log(res);}, function(err){console.error(err);});

var querySpec = smartstore.buildSmartQuerySpec("select * from {testSoup}");
smartstore.runSmartQuery(querySpec, function(cursor) { console.log(cursor);}, function(err){console.error(err);});
```