### PR TITLE
Added content length and chunking hints to POST connections

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
@@ -388,10 +388,10 @@ public class HttpAccess extends BroadcastReceiver {
      * @throws IOException
      */
     private HttpURLConnection createHttpUrlConnection(URI uri, String requestMethod) throws IOException {
-        HttpURLConnection httpConn = null;
-        if (uri != null) {
-            URL url = uri.toURL();
-            if (url != null) {
+    	HttpURLConnection httpConn = null;
+    	if (uri != null) {
+    		URL url = uri.toURL();
+    		if (url != null) {
 
     			/*
     			 * FIXME: PATCH has been added to the latest OkHttp library,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
@@ -47,6 +47,7 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.HttpEntityWrapper;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 
@@ -57,6 +58,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.http.AndroidHttpClient;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 
@@ -101,10 +103,8 @@ public class HttpAccess extends BroadcastReceiver {
     /**
      * Parameterized constructor.
      *
-     * @param app
-     *         Reference to the application.
-     * @param userAgent
-     *         The user agent to be used with requests.
+     * @param app Reference to the application.
+     * @param userAgent The user agent to be used with requests.
      */
     public HttpAccess(Context app, String userAgent) {
         this.userAgent = userAgent;
@@ -125,10 +125,8 @@ public class HttpAccess extends BroadcastReceiver {
     /**
      * Detects network changes and sets the network connectivity status.
      *
-     * @param context
-     *         The context of the request.
-     * @param intent
-     *         Intent.
+     * @param context The context of the request.
+     * @param intent Intent.
      */
     @Override
     public void onReceive(Context context, Intent intent) {
@@ -173,14 +171,13 @@ public class HttpAccess extends BroadcastReceiver {
      * @return User agent.
      */
     public String getUserAgent() {
-        return userAgent;
+    	return userAgent;
     }
 
     /**
      * Sets the status of network connectivity.
      *
-     * @param b
-     *         True - if network connectivity is available, False - otherwise.
+     * @param b True - if network connectivity is available, False - otherwise.
      */
     private synchronized void setHasNetwork(boolean b) {
         hasNetwork = b;
@@ -201,21 +198,16 @@ public class HttpAccess extends BroadcastReceiver {
     /**
      * Executes an HTTP POST.
      *
-     * @param headers
-     *         The headers associated with the post.
-     * @param uri
-     *         The URI to post to.
-     * @param requestEntity
-     *         The entity to post.
-     *
+     * @param headers The headers associated with the post.
+     * @param uri The URI to post to.
+     * @param requestEntity The entity to post.
      * @return The execution response.
-     *
      * @throws IOException
      */
     @TargetApi(19)
     public Execution doPost(Map<String, String> headers, URI uri, HttpEntity requestEntity) throws IOException {
-        final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpPost.METHOD_NAME);
-        addHeaders(httpConn, headers);
+    	final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpPost.METHOD_NAME);
+    	addHeaders(httpConn, headers);
 
         // Allow input and output on this connection
         httpConn.setDoOutput(true);
@@ -234,21 +226,16 @@ public class HttpAccess extends BroadcastReceiver {
             }
         }
 
-        return execute(httpConn, requestEntity);
+    	return execute(httpConn, requestEntity);
     }
 
     /**
      * Executes an HTTP PATCH.
      *
-     * @param headers
-     *         The headers associated with the post.
-     * @param uri
-     *         The URI to post to.
-     * @param requestEntity
-     *         The entity to post.
-     *
+     * @param headers The headers associated with the post.
+     * @param uri The URI to post to.
+     * @param requestEntity The entity to post.
      * @return The execution response.
-     *
      * @throws IOException
      */
     public Execution doPatch(Map<String, String> headers, URI uri, HttpEntity requestEntity) throws IOException {
@@ -260,107 +247,86 @@ public class HttpAccess extends BroadcastReceiver {
     /**
      * Executes an HTTP PUT.
      *
-     * @param headers
-     *         The headers associated with the post.
-     * @param uri
-     *         The URI to post to.
-     * @param requestEntity
-     *         The entity to post.
-     *
+     * @param headers The headers associated with the post.
+     * @param uri The URI to post to.
+     * @param requestEntity The entity to post.
      * @return The execution response.
-     *
      * @throws IOException
      */
     public Execution doPut(Map<String, String> headers, URI uri, HttpEntity requestEntity) throws IOException {
-        final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpPut.METHOD_NAME);
-        addHeaders(httpConn, headers);
-        return execute(httpConn, requestEntity);
+    	final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpPut.METHOD_NAME);
+    	addHeaders(httpConn, headers);
+    	return execute(httpConn, requestEntity);
     }
 
     /**
      * Executes an HTTP GET.
      *
-     * @param headers
-     *         The headers associated with the get.
-     * @param uri
-     *         The URI to get.
-     *
+     * @param headers The headers associated with the get.
+     * @param uri The URI to get.
      * @return The execution response.
-     *
      * @throws IOException
      */
     public Execution doGet(Map<String, String> headers, URI uri) throws IOException {
-        final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpGet.METHOD_NAME);
-        addHeaders(httpConn, headers);
-        return execute(httpConn, null);
+    	final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpGet.METHOD_NAME);
+    	addHeaders(httpConn, headers);
+    	return execute(httpConn, null);
     }
 
     /**
      * Executes an HTTP HEAD.
      *
-     * @param headers
-     *         The headers associated with the get.
-     * @param uri
-     *         The URI to get.
-     *
+     * @param headers The headers associated with the get.
+     * @param uri The URI to get.
      * @return The execution response.
-     *
      * @throws IOException
      */
     public Execution doHead(Map<String, String> headers, URI uri) throws IOException {
-        final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpHead.METHOD_NAME);
-        addHeaders(httpConn, headers);
-        return execute(httpConn, null);
+    	final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpHead.METHOD_NAME);
+    	addHeaders(httpConn, headers);
+    	return execute(httpConn, null);
     }
 
     /**
      * Executes an HTTP DELETE.
      *
-     * @param headers
-     *         The headers associated with the delete.
-     * @param uri
-     *         The URI to delete from.
-     *
+     * @param headers The headers associated with the delete.
+     * @param uri The URI to delete from.
      * @return The execution response.
-     *
      * @throws IOException
      */
     public Execution doDelete(Map<String, String> headers, URI uri) throws IOException {
-        final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpDelete.METHOD_NAME);
-        addHeaders(httpConn, headers);
-        return execute(httpConn, null);
+    	final HttpURLConnection httpConn = createHttpUrlConnection(uri, HttpDelete.METHOD_NAME);
+    	addHeaders(httpConn, headers);
+    	return execute(httpConn, null);
     }
 
     /**
      * Executes a fully formed request, and returns the results.
      *
-     * @param httpConn
-     *         HTTP connection object.
-     * @param reqEntity
-     *         Request entity.
-     *
+     * @param httpConn HTTP connection object.
+     * @param reqEntity Request entity.
      * @return The execution response.
-     *
      * @throws IOException
      */
     protected Execution execute(HttpURLConnection httpConn, HttpEntity reqEntity) throws IOException {
-        if (httpConn == null) {
-            return null;
-        }
-        Execution exec = null;
-        if (reqEntity != null) {
-            final Header contentType = reqEntity.getContentType();
-            if (contentType != null) {
-                httpConn.setRequestProperty(contentType.getName(), contentType.getValue());
-            }
-            final Header contentEncoding = reqEntity.getContentEncoding();
-            if (contentEncoding != null) {
-                httpConn.setRequestProperty(contentEncoding.getName(), contentEncoding.getValue());
-            }
-            final long contentLen = reqEntity.getContentLength();
-            if (contentLen > 0) {
-                httpConn.setRequestProperty("Content-Length", Long.toString(contentLen));
-            }
+    	if (httpConn == null) {
+    		return null;
+    	}
+    	Execution exec = null;
+    	if (reqEntity != null) {
+    		final Header contentType = reqEntity.getContentType();
+    		if (contentType != null) {
+        		httpConn.setRequestProperty(contentType.getName(), contentType.getValue());
+    		}
+    		final Header contentEncoding = reqEntity.getContentEncoding();
+    		if (contentEncoding != null) {
+        		httpConn.setRequestProperty(contentEncoding.getName(), contentEncoding.getValue());
+    		}
+    		final long contentLen = reqEntity.getContentLength();
+    		if (contentLen > 0) {
+        		httpConn.setRequestProperty("Content-Length", Long.toString(contentLen));
+    		}
             final OutputStream outputStream = httpConn.getOutputStream();
 
             if (outputStream != null) {
@@ -376,18 +342,18 @@ public class HttpAccess extends BroadcastReceiver {
         final String reasonPhrase = httpConn.getResponseMessage();
         final ProtocolVersion protocolVersion = new HttpVersion(1, 1);
         final StatusLine statusLine = new BasicStatusLine(protocolVersion,
-                                                          statusCode, reasonPhrase);
+        		statusCode, reasonPhrase);
         final HttpResponse response = new BasicHttpResponse(statusLine);
-        InputStream responseInputStream = null;
+    	InputStream responseInputStream = null;
 
     	/*
-         * Tries to read the response stream here. If it fails with a
+    	 * Tries to read the response stream here. If it fails with a
     	 * FileNotFoundException, tries to read the error stream instead.
     	 */
         try {
-            responseInputStream = httpConn.getInputStream();
+        	responseInputStream = httpConn.getInputStream();
         } catch (FileNotFoundException e) {
-            responseInputStream = httpConn.getErrorStream();
+        	responseInputStream = httpConn.getErrorStream();
         }
         if (responseInputStream != null) {
             final BasicHttpEntity entity = new BasicHttpEntity();
@@ -395,36 +361,30 @@ public class HttpAccess extends BroadcastReceiver {
             response.setEntity(entity);
         }
         exec = new Execution(response);
-        return exec;
+    	return exec;
     }
 
     /**
      * Adds headers to the HTTP request.
      *
-     * @param httpConn
-     *         HTTP connection object.
-     * @param headers
-     *         Headers.
+     * @param httpConn HTTP connection object.
+     * @param headers Headers.
      */
     private void addHeaders(HttpURLConnection httpConn, Map<String, String> headers) {
         if (headers == null || httpConn == null) {
-            return;
+        	return;
         }
         for (final Map.Entry<String, String> h : headers.entrySet()) {
-            httpConn.setRequestProperty(h.getKey(), h.getValue());
+        	httpConn.setRequestProperty(h.getKey(), h.getValue());
         }
     }
 
     /**
      * Creates a HTTP connection to the URI specified.
      *
-     * @param uri
-     *         URI.
-     * @param requestMethod
-     *         HTTP method.
-     *
+     * @param uri URI.
+     * @param requestMethod HTTP method.
      * @return HttpUrlConnection instance.
-     *
      * @throws IOException
      */
     private HttpURLConnection createHttpUrlConnection(URI uri, String requestMethod) throws IOException {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
@@ -68,14 +68,14 @@ import android.os.Build.VERSION_CODES;
  */
 public class HttpAccess extends BroadcastReceiver {
 
-    public static final String USER_AGENT = "User-Agent";
+	public static final String USER_AGENT = "User-Agent";
 
-    /*
-     * FIXME: Remove this when PATCH is available out of the box.
-     *
-     * https://code.google.com/p/android/issues/detail?id=76611
-     */
-    private static final String PATCH = "PATCH";
+	/*
+	 * FIXME: Remove this when PATCH is available out of the box.
+	 *
+	 * https://code.google.com/p/android/issues/detail?id=76611
+	 */
+	private static final String PATCH = "PATCH";
 
     // Fields to keep track of network.
     private boolean hasNetwork = true;
@@ -164,7 +164,7 @@ public class HttpAccess extends BroadcastReceiver {
     public synchronized boolean hasNetwork() {
         return hasNetwork;
     }
-
+    
     /**
      * Returns the current user agent.
      *
@@ -239,9 +239,9 @@ public class HttpAccess extends BroadcastReceiver {
      * @throws IOException
      */
     public Execution doPatch(Map<String, String> headers, URI uri, HttpEntity requestEntity) throws IOException {
-        final HttpURLConnection httpConn = createHttpUrlConnection(uri, PATCH);
-        addHeaders(httpConn, headers);
-        return execute(httpConn, requestEntity);
+    	final HttpURLConnection httpConn = createHttpUrlConnection(uri, PATCH);
+    	addHeaders(httpConn, headers);
+    	return execute(httpConn, requestEntity);
     }
 
     /**
@@ -401,17 +401,17 @@ public class HttpAccess extends BroadcastReceiver {
     			 *
     			 * https://code.google.com/p/android/issues/detail?id=76611
     			 */
-                if (PATCH.equals(requestMethod)) {
-                    final String urlString = url.toString() + "?_HttpMethod=PATCH";
-                    url = new URL(urlString);
-                    requestMethod = HttpPost.METHOD_NAME;
-                }
-                httpConn = (HttpURLConnection) url.openConnection();
-                httpConn.setRequestMethod(requestMethod);
-                httpConn.setRequestProperty(USER_AGENT, userAgent);
-            }
-        }
-        return httpConn;
+    			if (PATCH.equals(requestMethod)) {
+    				final String urlString = url.toString() + "?_HttpMethod=PATCH";
+    				url = new URL(urlString);
+    				requestMethod = HttpPost.METHOD_NAME;
+    			}
+    			httpConn = (HttpURLConnection) url.openConnection();
+    			httpConn.setRequestMethod(requestMethod);
+    			httpConn.setRequestProperty(USER_AGENT, userAgent);
+    		}
+    	}
+    	return httpConn;
     }
 
     /**


### PR DESCRIPTION
Large POST requests (i.e. file uploads) load all entity content into memory. Android now uses okhttp internally and this is default behaviour. This is a problem if more data is being sent over the network than can fit into an application's heap.

okhttp expects that multipart form uploads give the connection a hint on content length or if content is streaming, set a chunk size. Setting either of these should prevent OOM errors from occurring. This
fix isn't available for SDK users on API levels < 19