### PR TITLE
Update SoqlSyncDownTarget.java

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SoqlSyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SoqlSyncDownTarget.java
@@ -104,6 +104,10 @@ public class SoqlSyncDownTarget extends SyncDownTarget {
         RestResponse response = syncManager.sendSyncWithSmartSyncUserAgent(request);
         JSONObject responseJson = response.asJSONObject();
         JSONArray records = responseJson.getJSONArray(Constants.RECORDS);
+        
+         // Capture next records url
+        nextRecordsUrl = JSONObjectHelper.optString(responseJson, Constants.NEXT_RECORDS_URL);
+        
         return records;
     }
 


### PR DESCRIPTION
When quering more than 2000 records, the continueFetch method keeps extracting the same url this cause an infinite loop