### PR TITLE
RestResponses can now be consumed as InputStreams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ android:
 env:
    global:
       # install timeout in minutes
-      - ADB_INSTALL_TIMEOUT=8
+      - ADB_INSTALL_TIMEOUT=12
 
 # Create and start the emulator
 before_script:
-   - echo no | android create avd --force -n test -t android-21  --abi armeabi-v7a -c 128M
+   - echo no | android create avd --force -n test -t android-23  --abi armeabi-v7a -c 128M
    - emulator -avd test -no-skin -no-audio -no-window &
    - android-wait-for-emulator
    - adb shell input keyevent 82

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ android:
 env:
    global:
       # install timeout in minutes
-      - ADB_INSTALL_TIMEOUT=12
+      - ADB_INSTALL_TIMEOUT=8
 
 # Create and start the emulator
 before_script:
-   - echo no | android create avd --force -n test -t android-23  --abi armeabi-v7a -c 128M
+   - echo no | android create avd --force -n test -t android-21  --abi armeabi-v7a -c 128M
    - emulator -avd test -no-skin -no-audio -no-window &
    - android-wait-for-emulator
    - adb shell input keyevent 82

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ android:
    components:
       - build-tools-23.0.1
       - android-23
+      - extra-google-m2repository
+      - extra-android-m2repository
+      
 env:
    global:
       # install timeout in minutes

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'android-library'
 
 dependencies {
   compile project(':libs:SmartSync')
+  compile 'com.android.support:appcompat-v7:23.0.1'
   compile 'com.facebook.react:react-native:0.12.+'
 }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
@@ -213,7 +213,9 @@ public class HttpAccess extends BroadcastReceiver {
         httpConn.setDoOutput(true);
         httpConn.setDoInput(true);
         httpConn.setUseCaches(false);
-        long contentLength = requestEntity.getContentLength();
+
+        final long contentLength = requestEntity == null ? 0 : requestEntity.getContentLength();
+
         if (contentLength >= 0) {
 
             // Let the connection know the size of the data being sent so that it can chunk it appropriately.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
@@ -236,9 +236,8 @@ public class RestResponse {
 	 * {@link #asJSONObject()} will throw exceptions.
 	 * </p>
 	 *
-	 * @return an {@link InputStream} from the response content or {@code null} if the content
-	 *         has already been consumed
-	 * @throws IOException if the response context could not be read
+	 * @return an {@link InputStream} from the response content
+	 * @throws IOException if the stream could not be created or has already been consumed
 	 */
 	public InputStream asInputStream() throws IOException {
 		try {
@@ -246,8 +245,7 @@ public class RestResponse {
 			responseAsBytes = new byte[0];
 			return response.getEntity().getContent();
 		} catch (IllegalStateException e) {
-			Log.e("RestResponse: asInputStream()", "Content has already been consumed", e);
-			return null;
+			throw new IOException("Content has been consumed");
 		}
 	}
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -585,7 +585,7 @@ public class RestClientTest extends InstrumentationTestCase {
         final RestResponse response = getStreamTestResponse();
 
         try {
-            InputStream in = response.asInputStream()
+            InputStream in = response.asInputStream();
             inputStreamToString(in);
         } catch (IOException e) {
             fail("The InputStream should be readable and an IOException should not have been thrown");
@@ -605,16 +605,17 @@ public class RestClientTest extends InstrumentationTestCase {
         final RestResponse response = getStreamTestResponse();
 
         try {
-            InputStream in = response.asInputStream();
+            final InputStream in = response.asInputStream();
             inputStreamToString(in);
         } catch (IOException e) {
             fail("The InputStream should be readable and an IOException should not have been thrown");
         }
 
-        try (InputStream in = response.asInputStream()) {
-            assertNull("The InputStream should be null when trying to read it a second time", in);
+        try {
+            response.asInputStream();
+            fail("An IOException should have been thrown while trying to read the InputStream a second time");
         } catch (IOException e) {
-            fail("An IOException should not have been thrown");
+            // Expected
         } finally {
             response.consumeQuietly();
         }
@@ -650,7 +651,7 @@ public class RestClientTest extends InstrumentationTestCase {
                     } catch (JSONException e) {
                         // Expected
                     }
-                }catch (IOException e) {
+                } catch (IOException e) {
                     fail("IOException not expected");
                 }
             }
@@ -679,10 +680,10 @@ public class RestClientTest extends InstrumentationTestCase {
         response.asBytes();
 
         try {
-            final InputStream in = response.asInputStream();
-            assertNull("The InputStream should be null when trying to read it after calling an accessor method", in);
+            response.asInputStream();
+            fail("The InputStream should not be readable after an accessor method is called");
         } catch (IOException e) {
-            fail("An IOException should not have been thrown");
+            // Expected
         } finally {
             response.consumeQuietly();
         }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -564,7 +564,8 @@ public class RestClientTest extends InstrumentationTestCase {
     public void testResponseStreamIsReadable() throws Exception {
         final RestResponse response = getStreamTestResponse();
 
-        try (InputStream in = response.asInputStream()) {
+        try {
+            InputStream in = response.asInputStream();
             assertStreamTestResponseStreamIsValid(in);
         } catch (IOException e) {
             fail("The InputStream should be readable and an IOException should not have been thrown");
@@ -583,7 +584,8 @@ public class RestClientTest extends InstrumentationTestCase {
     public void testResponseStreamConsumedByReadingStream() throws Exception {
         final RestResponse response = getStreamTestResponse();
 
-        try (InputStream in = response.asInputStream()) {
+        try {
+            InputStream in = response.asInputStream()
             inputStreamToString(in);
         } catch (IOException e) {
             fail("The InputStream should be readable and an IOException should not have been thrown");
@@ -602,7 +604,8 @@ public class RestClientTest extends InstrumentationTestCase {
     public void testResponseStreamCannotBeReadTwice() throws Exception {
         final RestResponse response = getStreamTestResponse();
 
-        try (InputStream in = response.asInputStream()) {
+        try {
+            InputStream in = response.asInputStream();
             inputStreamToString(in);
         } catch (IOException e) {
             fail("The InputStream should be readable and an IOException should not have been thrown");
@@ -653,7 +656,8 @@ public class RestClientTest extends InstrumentationTestCase {
             }
         };
 
-        try (InputStream in = response.asInputStream()) {
+        try {
+            response.asInputStream();
             testAccessorsNotAccessible.run();
         } catch (IOException e) {
             fail("The InputStream should be readable and an IOException should not have been thrown");
@@ -674,7 +678,8 @@ public class RestClientTest extends InstrumentationTestCase {
         final RestResponse response = getStreamTestResponse();
         response.asBytes();
 
-        try (InputStream in = response.asInputStream()) {
+        try {
+            final InputStream in = response.asInputStream();
             assertNull("The InputStream should be null when trying to read it after calling an accessor method", in);
         } catch (IOException e) {
             fail("An IOException should not have been thrown");


### PR DESCRIPTION
I've added the asInputStream() method to RestResponse. In order to keep backwards-compatibility, the `consume()` method should be called in a `finally` block after reading the stream. I've also added `consumeQuietly()` as the IOException in `consume()` will never be thrown with the stream method. 

Here's a Java 6 example:
```java
try {
    final InputStream in = restResponse.asInputStream();
    // Read the stream (or don't)
} finally {
    restResponse.consumeQuietly();
}
```

and a Java 7 example:

```java
try (final InputStream in = restResponse.asInputStream()) {
    // Read the stream (or don't)
} finally {
    restResponse.consumeQuietly();
}
```

The existing RestResponse methods favor returning null instead of exceptions, so `asInputStream()` will return null if the content has already been streamed once. I can turn this into an IOException if it makes more sense. I think it's more intuitive:

```java
try (final InputStream in = restResponse.asInputStream()) {
    // No need to null-check "in"
} catch (IOException e) {
    // The stream couldn't be read for some reason
} finally {
    restResponse.consumeQuietly();
}
```