### PR TITLE
Switched logging to INFO for connected Android test tasks

### DIFF
--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -39,3 +39,9 @@ android {
     exclude 'META-INF/NOTICE'
   }
 }
+
+afterEvaluate {
+  // Find all connected Android tests and ensure they log all passed tests. This keeps the Travis
+  // from timing out since executing tests are printed to the console.
+  tasks.matching { it.name ==~ /^connected.*AndroidTest$/ }*.logging*.setLevel(LogLevel.INFO)
+}

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -30,3 +30,9 @@ android {
     exclude 'META-INF/NOTICE'
   }
 }
+
+afterEvaluate {
+  // Find all connected Android tests and ensure they log all passed tests. This keeps the Travis
+  // from timing out since executing tests are printed to the console.
+  tasks.matching { it.name ==~ /^connected.*AndroidTest$/ }*.logging*.setLevel(LogLevel.INFO)
+}

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -43,3 +43,9 @@ android {
     exclude 'META-INF/NOTICE'
   }
 }
+
+afterEvaluate {
+  // Find all connected Android tests and ensure they log all passed tests. This keeps the Travis
+  // from timing out since executing tests are printed to the console.
+  tasks.matching { it.name ==~ /^connected.*AndroidTest$/ }*.logging*.setLevel(LogLevel.INFO)
+}

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -40,3 +40,9 @@ android {
     exclude 'META-INF/NOTICE'
   }
 }
+
+afterEvaluate {
+  // Find all connected Android tests and ensure they log all passed tests. This keeps the Travis
+  // from timing out since executing tests are printed to the console.
+  tasks.matching { it.name ==~ /^connected.*AndroidTest$/ }*.logging*.setLevel(LogLevel.DEBUG)
+}

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -39,3 +39,9 @@ android {
     exclude 'META-INF/NOTICE'
   }
 }
+
+afterEvaluate {
+  // Find all connected Android tests and ensure they log all passed tests. This keeps the Travis
+  // from timing out since executing tests are printed to the console.
+  tasks.matching { it.name ==~ /^connected.*AndroidTest$/ }*.logging*.setLevel(LogLevel.DEBUG)
+}

--- a/native/NativeSampleApps/SmartSyncExplorer/build.gradle
+++ b/native/NativeSampleApps/SmartSyncExplorer/build.gradle
@@ -28,3 +28,9 @@ android {
     exclude 'META-INF/NOTICE'
   }
 }
+
+afterEvaluate {
+  // Find all connected Android tests and ensure they log all passed tests. This keeps the Travis
+  // from timing out since executing tests are printed to the console.
+  tasks.matching { it.name ==~ /^connected.*AndroidTest$/ }*.logging*.setLevel(LogLevel.DEBUG)
+}

--- a/native/TemplateApp/build.gradle
+++ b/native/TemplateApp/build.gradle
@@ -39,3 +39,9 @@ android {
     exclude 'META-INF/NOTICE'
   }
 }
+
+afterEvaluate {
+  // Find all connected Android tests and ensure they log all passed tests. This keeps the Travis
+  // from timing out since executing tests are printed to the console.
+  tasks.matching { it.name ==~ /^connected.*AndroidTest$/ }*.logging*.setLevel(LogLevel.DEBUG)
+}


### PR DESCRIPTION
When the connected Android tests are running, there's no log output and Travis thinks that the build has hung after 10 minutes. This change makes the test task (and only the test task) print out both passed and failed tests. I think that having a 10 minute watchdog is a good idea and it's better to make the  test task more verbose.

Unfortunately due to the way the Android Gradle plugin works, I have to add a snippet of Groovy to each build file instead of being able to add it once in an `allprojects` block.