### PR TITLE
Corrected jniLibs.srcDir for bug #1017

### DIFF
--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -20,7 +20,7 @@ android {
       renderscript.srcDirs = ['src']
       res.srcDirs = ['res']
       assets.srcDirs = ['assets']
-      jniLibs.srcDir '../../external/sqlcipher/libs'
+      jniLibs.srcDir 'libs'
     }
     androidTest.setRoot('../test/SmartStoreTest')
     androidTest {


### PR DESCRIPTION
Corrected jniLibs.srcDir for the SmartStore/build.gradle.

See #1017 for details on reproducing bug (and testing fix)