### PR TITLE
Added timeout to fix the following situation (related to issue #1026)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
@@ -413,6 +413,8 @@ public class HttpAccess extends BroadcastReceiver {
     			httpConn = (HttpsURLConnection) url.openConnection();
     			httpConn.setRequestMethod(requestMethod);
     			httpConn.setRequestProperty(USER_AGENT, userAgent);
+    			httpConn.setConnectTimeout(60000);
+    			httpConn.setReadTimeout(20000);
 
                 /*
                  * FIXME: Remove this piece of code once minApi >= Lollipop.


### PR DESCRIPTION
1- Open an Salesforce application (SmartSync explorer example for instance)
2- Let it finish loading and sync down data
3- Turn Airplane mode on
4- Edit a record and click save
5- Turn Airplane mode off
6- Synchronize up records

Result: Synchronization takes a very long time (>20min) or hangs indefinitely 
Expected: Synchronization should happen quickly

PS: Values could be configurable in XML file