### PR TITLE
Fixing source directory for SmartStore

### DIFF
--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -20,7 +20,7 @@ android {
       renderscript.srcDirs = ['src']
       res.srcDirs = ['res']
       assets.srcDirs = ['assets']
-      jniLibs.srcDir '../../external/sqlcipher/libs'
+      jniLibs.srcDir 'libs'
     }
     androidTest.setRoot('../test/SmartStoreTest')
     androidTest {


### PR DESCRIPTION
The problem with the absolute here (```external...```) is that it doesn't exist in the ```CordovaPlugin```. When ```SmartStore``` is used in the plugin, this is broken. It should be ```libs``` - the binaries in there have symlinks to ```external...``` anyway.