### PR TITLE
Shelljs update is breaking forcedroid

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ],
     "bin" : { "forcedroid" : "node/forcedroid.js" },
     "dependencies": {
-        "shelljs": ">=0.1.4"
+        "shelljs": "~0.5.3"
     },
     "scripts": {
         "prepublish": "external/shared/node/prepublish.js",


### PR DESCRIPTION
While testing with test_force.js I was very puzzled to have all android app generation fail (even though they were working last night). For a while, I thought I had lost something in my recent refactoring.

It turns out that shelljs released v0.6.0 a few hours ago and now forcedroid breaks.
This is a quick fix to make it work again - a better fix would be to revisit our use of shelljs and see how they need to be changed.

People that now install forcedroid and didn't previously have shelljs will run into the issue. So we shouldn't take too long releasing our next release.