### PR TITLE
Adding missing architecture for SQLCipher

### DIFF
--- a/libs/SmartStore/libs/armeabi-v7a
+++ b/libs/SmartStore/libs/armeabi-v7a
@@ -1,0 +1,1 @@
+../../../external/sqlcipher/libs/armeabi-v7a


### PR DESCRIPTION
We had forgotten to link up ```armeabi-v7a``` (causes issues on ```Samsung Galaxy S6```).