### PR TITLE
Adds pass-through constructors so Hybrid apps can implement their own WebView and WebViewClient subclasses

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewEngine.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewEngine.java
@@ -35,6 +35,7 @@ import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CordovaWebViewEngine;
 import org.apache.cordova.NativeToJsMessageQueue;
 import org.apache.cordova.PluginManager;
+import org.apache.cordova.engine.SystemWebView;
 import org.apache.cordova.engine.SystemWebViewEngine;
 
 /**
@@ -52,6 +53,14 @@ public class SalesforceWebViewEngine extends SystemWebViewEngine {
      */
     public SalesforceWebViewEngine(Context context, CordovaPreferences preferences) {
         super(new SalesforceWebView(context));
+    }
+
+    public SalesforceWebViewEngine(SystemWebView webView) {
+        super(webView, null);
+    }
+
+    public SalesforceWebViewEngine(SystemWebView webView, CordovaPreferences preferences) {
+        super(webView, preferences);
     }
 
     @Override


### PR DESCRIPTION
The upgrade to MobileSDK 4 has made it impossible to implement `WebView` and `WebViewClient` subclasses for Hybrid apps

I can override `makeWebViewEngine` in my `Activity` ... and implement my own `WebViewEngine` subclass which derives from `SalesforceWebViewEngine`

However, inside my subclass, I'm unable to call the `SystemWebViewEngine` constructors to properly set the appView 

These pass-through constructors are necessary so I can call `super(webView,preferences)` in my subclass the same way `SalesforceWebViewEngine` does