### PR TITLE
Fixing 404 happening in tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "external/cordova"]
 	path = external/cordova
 	url = https://github.com/apache/cordova-android.git
+[submodule "external/cordova-plugin-whitelist"]
+	path = external/cordova-plugin-whitelist
+	url = https://github.com/apache/cordova-plugin-whitelist

--- a/hybrid/HybridSampleApps/AccountEditor/src/org/apache/cordova/whitelist/WhitelistPlugin.java
+++ b/hybrid/HybridSampleApps/AccountEditor/src/org/apache/cordova/whitelist/WhitelistPlugin.java
@@ -1,0 +1,1 @@
+../../../../../../../../external/cordova-plugin-whitelist/src/android/WhitelistPlugin.java

--- a/hybrid/HybridSampleApps/NoteSync/src/org/apache/cordova/whitelist/WhitelistPlugin.java
+++ b/hybrid/HybridSampleApps/NoteSync/src/org/apache/cordova/whitelist/WhitelistPlugin.java
@@ -1,0 +1,1 @@
+../../../../../../../../external/cordova-plugin-whitelist/src/android/WhitelistPlugin.java

--- a/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/src/WhitelistPlugin.java
+++ b/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/src/WhitelistPlugin.java
@@ -1,0 +1,1 @@
+../../../../external/cordova-plugin-whitelist/src/android/WhitelistPlugin.java

--- a/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/src/WhitelistPlugin.java
+++ b/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/src/WhitelistPlugin.java
@@ -1,1 +1,0 @@
-../../../../external/cordova-plugin-whitelist/src/android/WhitelistPlugin.java

--- a/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/src/org/apache/cordova/whitelist/WhitelistPlugin.java
+++ b/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/src/org/apache/cordova/whitelist/WhitelistPlugin.java
@@ -1,0 +1,1 @@
+../../../../../../../../external/cordova-plugin-whitelist/src/android/WhitelistPlugin.java

--- a/libs/SalesforceHybrid/res/xml/config.xml
+++ b/libs/SalesforceHybrid/res/xml/config.xml
@@ -3,6 +3,11 @@
     id        = "com.salesforce.androidsdk"
     version   = "4.2.0">
 
+    <feature name="Whitelist">
+        <param name="android-package" value="org.apache.cordova.whitelist.WhitelistPlugin" />
+        <param name="onload" value="true" />
+    </feature>
+
     <!-- To allow XHR requests with the new Whitelist plugin -->
     <allow-navigation href="https://localhost" />
     <allow-navigation href="https://*.force.com" />

--- a/libs/test/SalesforceHybridTest/res/xml/config.xml
+++ b/libs/test/SalesforceHybridTest/res/xml/config.xml
@@ -3,6 +3,11 @@
     id        = "com.salesforce.androidsdk"
     version   = "4.2.0">
 
+    <feature name="Whitelist">
+        <param name="android-package" value="org.apache.cordova.whitelist.WhitelistPlugin" />
+        <param name="onload" value="true" />
+    </feature>
+
     <!-- To allow XHR requests with the new Whitelist plugin -->
     <allow-navigation href="https://localhost" />
     <allow-navigation href="https://*.force.com" />

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ui/SalesforceHybridTestActivity.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ui/SalesforceHybridTestActivity.java
@@ -39,7 +39,7 @@ public class SalesforceHybridTestActivity extends SalesforceDroidGapActivity {
 
 	static String username = "sdktest@cs1.com";
 	static String accountName = username + " (SalesforceHybridTest)";
-	static String refreshToken = "5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5LuEc0OGFQRIHGNkCvWU1XiK0TI7w==";
+	static String refreshToken = "5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5JBvMTJpGUqYVUV75yA0OrsBLKqwPm83CUMok.Q";
 	static String authToken = "--will-be-set-through-refresh--";
 	static String identityUrl = "https://test.salesforce.com";
 	static String instanceUrl = "https://cs1.salesforce.com";

--- a/libs/test/SalesforceHybridTest/src/org/apache/cordova/whitelist/WhitelistPlugin.java
+++ b/libs/test/SalesforceHybridTest/src/org/apache/cordova/whitelist/WhitelistPlugin.java
@@ -1,0 +1,1 @@
+../../../../../../../../external/cordova-plugin-whitelist/src/android/WhitelistPlugin.java

--- a/libs/test/SalesforceSDKTest/res/values/bootconfig.xml
+++ b/libs/test/SalesforceSDKTest/res/values/bootconfig.xml
@@ -14,7 +14,7 @@
     <string name="community_url">https://cs1.salesforce.com/androidcomm</string>
     <string name="identity_url">https://test.salesforce.com</string>
     <string name="login_url">https://test.salesforce.com</string>
-    <string name="oauth_refresh_token">5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5JPlgkezkgDiE1o9mI4jd6mD4ZFYA==</string>
+    <string name="oauth_refresh_token">5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5JBvMTJpGUqYVUV75yA0OrsBLKqwPm83CUMok.Q</string>
     <string name="org_id">00DS0000000HDptMAG</string>
     <string name="user_id">005S0000003yaERIAY</string>
     <string name="username">sdktest@cs1.com</string>

--- a/libs/test/SmartStoreTest/res/values/bootconfig.xml
+++ b/libs/test/SmartStoreTest/res/values/bootconfig.xml
@@ -13,7 +13,7 @@
     <string name="instance_url">https://cs1.salesforce.com</string>
     <string name="identity_url">https://test.salesforce.com</string>
     <string name="login_url">https://test.salesforce.com</string>
-    <string name="oauth_refresh_token">5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5JPlgkezkgDiE1o9mI4jd6mD4ZFYA==</string>
+    <string name="oauth_refresh_token">5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5JBvMTJpGUqYVUV75yA0OrsBLKqwPm83CUMok.Q</string>
     <string name="org_id">00DS0000000HDptMAG</string>
     <string name="user_id">005S0000003yaERIAY</string>
     <string name="username">sdktest@cs1.com</string>

--- a/libs/test/SmartSyncTest/res/values/bootconfig.xml
+++ b/libs/test/SmartSyncTest/res/values/bootconfig.xml
@@ -14,7 +14,7 @@
     <string name="community_url">https://cs1.salesforce.com/androidcomm</string>
     <string name="identity_url">https://test.salesforce.com</string>
     <string name="login_url">https://test.salesforce.com</string>
-    <string name="oauth_refresh_token">5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5JPlgkezkgDiE1o9mI4jd6mD4ZFYA==</string>
+    <string name="oauth_refresh_token">5Aep861KIwKdekr90KlxVVUI47zdR6dX_VeBWZBS.SiQYYAy5JBvMTJpGUqYVUV75yA0OrsBLKqwPm83CUMok.Q</string>
     <string name="org_id">00DS0000000HDptMAG</string>
     <string name="user_id">005S0000003yaERIAY</string>
     <string name="username">sdktest@cs1.com</string>

--- a/tools/symlink_files.txt
+++ b/tools/symlink_files.txt
@@ -1,3 +1,5 @@
+"external\cordova-plugin-whitelist\src\android\WhitelistPlugin.java" "hybrid\HybridSampleApps\SmartSyncExplorerHybrid\src\WhitelistPlugin.java"
+"external\cordova-plugin-whitelist\src\android\WhitelistPlugin.java" "libs\test\SalesforceHybridTest\src\org\apache\cordova\whitelist\WhitelistPlugin.java"
 "external\cordova\bin\templates\project\assets\www\cordova.js" "hybrid\HybridSampleApps\AccountEditor\assets\www\cordova.js"
 "external\cordova\bin\templates\project\assets\www\cordova.js" "hybrid\HybridSampleApps\NoteSync\assets\www\cordova.js"
 "external\cordova\bin\templates\project\assets\www\cordova.js" "hybrid\HybridSampleApps\SmartSyncExplorerHybrid\assets\www\cordova.js"


### PR DESCRIPTION
It looks like missing the whitelist plugin and having an invalid refresh token caused the 404.
Adding the whitelist plugin, and still having an invalid refresh token gives a 401 instead.
Removing the whitelist plugin and having a valid refresh token works fine.