### PR TITLE
Extend the Travis CI Wait time to make more reliable to completed the test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ before_script:
    - adb shell input keyevent 82
 #Build all projects and run the tests
 script:
-   - travis_wait 20 ./gradlew :libs:SalesforceSDK:connectedAndroidTest
-   - travis_wait 20 ./gradlew :libs:SmartStore:connectedAndroidTest
-   - travis_wait 20 ./gradlew :libs:SmartSync:connectedAndroidTest
-   - travis_wait 20 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
+   - travis_wait 30 ./gradlew :libs:SalesforceSDK:connectedAndroidTest
+   - travis_wait 30 ./gradlew :libs:SmartStore:connectedAndroidTest
+   - travis_wait 30 ./gradlew :libs:SmartSync:connectedAndroidTest
+   - travis_wait 30 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
    - ./gradlew :libs:SalesforceReact:assembleDebug
-   - travis_wait 20 ./gradlew :native:SampleApps:RestExplorer:connectedAndroidTest
-   - ./gradlew :native:TemplateApp:connectedAndroidTest
+   - travis_wait 30 ./gradlew :native:SampleApps:RestExplorer:connectedAndroidTest
+   - travis_wait 30 ./gradlew :native:TemplateApp:connectedAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ script:
    - travis_wait 30 ./gradlew :libs:SmartSync:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
    - ./gradlew :libs:SalesforceReact:assembleDebug
-   - travis_wait 30 ./gradlew :native:SampleApps:RestExplorer:connectedAndroidTest
+   - travis_wait 30 ./gradlew :native:NativeSampleApps:RestExplorer:connectedAndroidTest
    - travis_wait 30 ./gradlew :native:TemplateApp:connectedAndroidTest


### PR DESCRIPTION
It also fix the build failure that caused by the wrong name for native sample app. 