### PR TITLE
Soup table will now have db indexes on created and last modified

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
@@ -247,10 +247,13 @@ public class AlterSoupLongOperation extends LongOperation {
 	 * Step 2: drop old indexes / remove entries in soup_index_map / cleaanup cache
 	 */
 	protected void dropOldIndexes() {
+		String dropIndexFormat = "DROP INDEX IF EXISTS %s_%s_idx";
 		// Removing db indexes on table (otherwise registerSoup will fail to create indexes with the same name)
+		for (String col : new String[] { SmartStore.CREATED_COL, SmartStore.LAST_MODIFIED_COL}) {
+			db.execSQL(String.format(dropIndexFormat, soupTableName, col));
+		}
 		for (int i=0; i<oldIndexSpecs.length; i++) {
-		    String indexName = soupTableName + "_" + i + "_idx";
-		    db.execSQL("DROP INDEX IF EXISTS "  + indexName);
+			db.execSQL(String.format(dropIndexFormat, soupTableName, "" + i));
 		}
 
 		// Cleaning up soup index map table and cache

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
@@ -113,6 +113,10 @@ public class SmartSqlHelper  {
 				else if (path.equals(SmartStore.SOUP_ENTRY_ID)) {
 					matcher.appendReplacement(sql, tableQualifier + SmartStore.ID_COL);
 				}
+				// {soupName:_soupCreatedDate}
+				else if (path.equals(SmartStore.SOUP_CREATED_DATE)) {
+					matcher.appendReplacement(sql, tableQualifier + SmartStore.CREATED_COL);
+				}
 				// {soupName:_soupLastModifiedDate}
 				else if (path.equals(SmartStore.SOUP_LAST_MODIFIED_DATE)) {
 					matcher.appendReplacement(sql, tableQualifier + SmartStore.LAST_MODIFIED_COL);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -94,6 +94,7 @@ public class SmartStore  {
     // JSON fields added to soup element on insert/update
     public static final String SOUP_ENTRY_ID = "_soupEntryId";
     public static final String SOUP_LAST_MODIFIED_DATE = "_soupLastModifiedDate";
+	public static final String SOUP_CREATED_DATE = "_soupCreatedDate";
 
     // Predicates
     protected static final String SOUP_NAME_PREDICATE = SOUP_NAME_COL + " = ?";
@@ -309,6 +310,12 @@ public class SmartStore  {
                         .append(", ").append(CREATED_COL).append(" INTEGER")
                         .append(", ").append(LAST_MODIFIED_COL).append(" INTEGER");
 
+		final String createIndexFormat = "CREATE INDEX %s_%s_idx on %s ( %s )";
+
+		for (String col : new String[]{CREATED_COL, LAST_MODIFIED_COL}) {
+			createIndexStmts.add(String.format(createIndexFormat, soupTableName, col, soupTableName, col));
+		}
+
         int i = 0;
         for (IndexSpec indexSpec : indexSpecs) {
             // Column name or expression the db index is on
@@ -337,8 +344,7 @@ public class SmartStore  {
             soupIndexMapInserts.add(values);
 
             // for create index
-            String indexName = soupTableName + "_" + i + "_idx";
-            createIndexStmts.add(String.format("CREATE INDEX %s on %s ( %s )", indexName, soupTableName, columnName));;
+			createIndexStmts.add(String.format(createIndexFormat, soupTableName, "" + i, soupTableName, columnName));;
 
             // for the cache
             indexSpecsToCache[i] = new IndexSpec(indexSpec.path, indexSpec.type, columnName);

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlTest.java
@@ -122,8 +122,8 @@ public class SmartSqlTest extends SmartStoreTestCase {
 	 * Testing smart sql to sql conversion when path is: _soup, _soupEntryId or _soupLastModifiedDate
 	 */
 	public void testConvertSmartSqlWithSpecialColumns() {
-		assertEquals("select TABLE_1.id, TABLE_1.lastModified, TABLE_1.soup from TABLE_1", 
-				store.convertSmartSql("select {employees:_soupEntryId}, {employees:_soupLastModifiedDate}, {employees:_soup} from {employees}"));
+		assertEquals("select TABLE_1.id, TABLE_1.created, TABLE_1.lastModified, TABLE_1.soup from TABLE_1",
+				store.convertSmartSql("select {employees:_soupEntryId}, {employees:_soupCreatedDate}, {employees:_soupLastModifiedDate}, {employees:_soup} from {employees}"));
 	}
 	
 	/**

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTest.java
@@ -55,7 +55,7 @@ public class SmartStoreLoadTest extends InstrumentationTestCase {
 
     private static final String TEST_SOUP = "test_soup";
 
-    private static final int NUMBER_ENTRIES = 10000;
+    private static final int NUMBER_ENTRIES = 1000;//0;
     private static final int NUMBER_ENTRIES_PER_BATCH = 100;
     private static final int NS_IN_MS = 1000000;
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
@@ -184,7 +184,9 @@ public class SmartStoreTest extends SmartStoreTestCase {
         // Check db indexes
         checkDatabaseIndexes(soupTableName, Arrays.asList(new String[] {
                 "CREATE INDEX " + soupTableName + "_0_idx on " + soupTableName + " ( " + soupTableName + "_0 )",
-                "CREATE INDEX " + soupTableName + "_1_idx on " + soupTableName + " ( " + soupTableName + "_1 )"
+                "CREATE INDEX " + soupTableName + "_1_idx on " + soupTableName + " ( " + soupTableName + "_1 )",
+                "CREATE INDEX " + soupTableName + "_created_idx on " + soupTableName + " ( created )",
+                "CREATE INDEX " + soupTableName + "_lastModified_idx on " + soupTableName + " ( lastModified )"
         }));
 
 		// Drop
@@ -1080,7 +1082,9 @@ public class SmartStoreTest extends SmartStoreTestCase {
         checkDatabaseIndexes(soupTableName, Arrays.asList(new String[] {
             "CREATE INDEX " + soupTableName + "_0_idx on " + soupTableName + " ( json_extract(soup, '$.lastName') )",
             "CREATE INDEX " + soupTableName + "_1_idx on " + soupTableName + " ( json_extract(soup, '$.address.city') )",
-            "CREATE INDEX " + soupTableName + "_2_idx on " + soupTableName + " ( " + soupTableName + "_2 )"
+            "CREATE INDEX " + soupTableName + "_2_idx on " + soupTableName + " ( " + soupTableName + "_2 )",
+            "CREATE INDEX " + soupTableName + "_created_idx on " + soupTableName + " ( created )",
+            "CREATE INDEX " + soupTableName + "_lastModified_idx on " + soupTableName + " ( lastModified )"
         }));
     }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
@@ -44,6 +44,7 @@ import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.test.JSONTestHelper;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -117,6 +118,14 @@ public abstract class SmartStoreTestCase extends InstrumentationTestCase {
 			safeClose(c);
 		}
 	}
+
+    /**
+     * Helper method to check index specs on a soup
+     */
+    protected void checkIndexSpecs(String soupName, IndexSpec[] expectedIndexSpecs) throws JSONException {
+        final IndexSpec[] actualIndexSpecs = store.getSoupIndexSpecs(soupName);
+        JSONTestHelper.assertSameJSONArray("Wrong index specs", IndexSpec.toJSON(expectedIndexSpecs), IndexSpec.toJSON(actualIndexSpecs));
+    }
 
     /**
      * Helper method to check db indexes on a table


### PR DESCRIPTION
To get them for an existing soup, simply alter the soup passing in the original set of index specs