### PR TITLE
fix fail to submit passcode test issue

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
@@ -205,12 +205,11 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
         // Processing the editor action only on key up to avoid sending events like pass code manager unlock twice.
         if (event != null && event.getAction() == KeyEvent.ACTION_UP) {
             String pc = entry.getText().toString();
-            if (pc.length() > 0 && pc.length() < getMinPasscodeLength()) {
+            if (pc.length() >= 0 && pc.length() < getMinPasscodeLength()) {
                 error.setText(getMinLengthInstructions(getMinPasscodeLength()));
                 return false;
             }
             return pc.length() > 0 ? onSubmit(pc) : false;
-
         } else {
             return true;
         }

--- a/native/test/TemplateAppTest/src/com/salesforce/samples/templateapp/PasscodeActivityTest.java
+++ b/native/test/TemplateAppTest/src/com/salesforce/samples/templateapp/PasscodeActivityTest.java
@@ -143,6 +143,14 @@ public class PasscodeActivityTest extends
 		passcodeActivity = getActivity();
 		assertEquals("Activity expected in create mode", PasscodeMode.Create, passcodeActivity.getMode());
 
+		// Entering nothing and submitting -> expect passcode too short error
+		setText(com.salesforce.androidsdk.R.id.sf__passcode_text, "");
+		doEditorAction(com.salesforce.androidsdk.R.id.sf__passcode_text, EditorInfo.IME_ACTION_GO);
+		assertTrue("Application should still be locked", passcodeManager.isLocked());
+		assertEquals("Activity expected in create mode still", PasscodeMode.Create, passcodeActivity.getMode());
+		assertEquals("Error expected", "The passcode must be at least 4 characters long",
+				((TextView) passcodeActivity.findViewById(com.salesforce.androidsdk.R.id.sf__passcode_error)).getText());
+
 		// Entering in 123 and submitting -> expect passcode too short error
 		setText(com.salesforce.androidsdk.R.id.sf__passcode_text, "123");
 		doEditorAction(com.salesforce.androidsdk.R.id.sf__passcode_text, EditorInfo.IME_ACTION_GO);

--- a/native/test/TemplateAppTest/src/com/salesforce/samples/templateapp/PasscodeActivityTest.java
+++ b/native/test/TemplateAppTest/src/com/salesforce/samples/templateapp/PasscodeActivityTest.java
@@ -30,6 +30,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.test.ActivityInstrumentationTestCase2;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
@@ -434,6 +435,9 @@ public class PasscodeActivityTest extends
                     v.onEditorAction(actionCode);
                 }
             });
+            waitSome();
+            this.sendKeys(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER);
+            this.sendKeys(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER);
         } catch (Throwable t) {
             fail("Failed do editor action " + actionCode);
         }


### PR DESCRIPTION
Since IME_ACTION_GO action does not trigger a key DOWN and UP key event, so we need to trigger those specific key events by test.