### PR TITLE
Disable the unreliable hybrid test 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,9 @@ script:
    - travis_wait 30 ./gradlew :libs:SalesforceSDK:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SmartStore:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SmartSync:connectedAndroidTest
-   - travis_wait 30 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
+   # disable the unreliable test to reduce the impact for other tests, just build it
+   # will add it back once fix the test issue
+   - ./gradlew :libs:SalesforceHybrid:assembleDebug
    - ./gradlew :libs:SalesforceReact:assembleDebug
    - travis_wait 30 ./gradlew :native:NativeSampleApps:RestExplorer:connectedAndroidTest
    - travis_wait 30 ./gradlew :native:TemplateApp:connectedAndroidTest

--- a/native/test/TemplateAppTest/src/com/salesforce/samples/templateapp/PasscodeActivityTest.java
+++ b/native/test/TemplateAppTest/src/com/salesforce/samples/templateapp/PasscodeActivityTest.java
@@ -444,8 +444,8 @@ public class PasscodeActivityTest extends
                 }
             });
             waitSome();
-            //the key down action for enter key will send ACTION_DOWN and ACTION_UP both events out
-            this.sendKeys(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER);
+            //the enter key will send ACTION_DOWN and ACTION_UP both events out
+            this.sendKeys(KeyEvent.KEYCODE_ENTER);
         } catch (Throwable t) {
             fail("Failed do editor action " + actionCode);
         }


### PR DESCRIPTION
And for the smart sync conflict issue for running test for different api versions concurrently, change the PR build on travis ci to one build concurrently for Android. Tried on my fork repo, the total build time will be around 1 and half hour for all supported versions, while the builds are green for all. 