### PR TITLE
New optional parameter (selectPaths) for query specs

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/JSONObjectHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/JSONObjectHelper.java
@@ -26,6 +26,7 @@
  */
 package com.salesforce.androidsdk.util;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -34,6 +35,36 @@ import org.json.JSONObject;
  */
 public class JSONObjectHelper {
 
+	/**
+	 * Return the null if obj doesn't have key or if obj has null for key - and return value as a  String[] otherwise
+	 * JSONObject.optString(key, fallback) returns the string "null" if object has null for key and null is object doesn't have key
+	 *
+	 * @param obj
+	 * @param key
+	 * @return
+	 * @throws JSONException
+	 */ 
+	public static String[] optStringArray(JSONObject obj, String key) throws JSONException {
+        String[] result = null;
+		JSONArray jsonArray = obj.isNull(key) ? null : obj.getJSONArray(key);
+		if (jsonArray != null) {
+            result = new String[jsonArray.length()];
+            for (int i=0; i<result.length; i++) {
+                result[i] = jsonArray.getString(i);
+            }
+        }
+        return result;
+	}
+
+	/**
+	 * Return null if obj doesn't have key or if obj has null for key
+	 * JSONObject.optString(key, fallback) returns the string "null" if object has null for key and null is object doesn't have key
+	 *
+	 * @param obj
+	 * @param key
+	 * @return
+	 * @throws JSONException
+	 */
 	public static String optString(JSONObject obj, String key) throws JSONException {
 		return optString(obj, key, null);
 	}

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/QuerySpec.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/QuerySpec.java
@@ -26,11 +26,16 @@
  */
 package com.salesforce.androidsdk.smartstore.store;
 
+import android.text.TextUtils;
+
 import com.salesforce.androidsdk.smartstore.store.SmartStore.SmartStoreException;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Simple class to represent a query spec
@@ -58,6 +63,7 @@ public class QuerySpec {
     public static final String ORDER = "order";
     public static final String PAGE_SIZE = "pageSize";
     public static final String QUERY_TYPE = "queryType";
+    public static final String SELECT_PATHS = "selectPaths";
 
     // Key members
 	public final QueryType queryType;
@@ -68,6 +74,7 @@ public class QuerySpec {
 
     // Exact/Range/Like/Match
 	public final String soupName;
+    public final String[] selectPaths;
     public final String path;
     public final String orderPath;
     public final Order order;
@@ -81,8 +88,9 @@ public class QuerySpec {
     public final String likeKey;
 
     // Private constructor for soup query spec
-    private QuerySpec(String soupName, String path, QueryType queryType, String matchKey, String beginKey, String endKey, String likeKey, String orderPath, Order order, int pageSize) {
+    private QuerySpec(String soupName, String[] selectPaths, QueryType queryType, String matchKey, String beginKey, String endKey, String likeKey, String orderPath, Order order, int pageSize, String path) {
     	this.soupName = soupName;
+        this.selectPaths = selectPaths;
         this.path = path;
         this.queryType = queryType;
         this.matchKey = matchKey;
@@ -107,6 +115,7 @@ public class QuerySpec {
     	
     	// Not applicable
         this.soupName = null;
+        this.selectPaths = null;
         this.path = null;
         this.matchKey = null;
         this.beginKey = null;
@@ -117,7 +126,7 @@ public class QuerySpec {
     }
 
     /**
-     * Return q auery spec for an all query
+     * Return query spec for an all query
      * @param soupName
      * @param orderPath
      * @param order
@@ -125,9 +134,22 @@ public class QuerySpec {
      * @return
      */
     public static QuerySpec buildAllQuerySpec(String soupName, String orderPath, Order order, int pageSize) {
-        return new QuerySpec(soupName, null, QueryType.range, null, null, null, null, orderPath, order, pageSize);
+        return buildAllQuerySpec(soupName, null, orderPath, order, pageSize);
     }
-    
+
+    /**
+     * Return query spec for an all query
+     * @param soupName
+     * @param selectPaths
+     * @param orderPath
+     * @param order
+     * @param pageSize
+     * @return
+     */
+    public static QuerySpec buildAllQuerySpec(String soupName, String[] selectPaths, String orderPath, Order order, int pageSize) {
+        return new QuerySpec(soupName, selectPaths, QueryType.range, null, null, null, null, orderPath, order, pageSize, null);
+    }
+
     /**
      * Return a query spec for an exact match query
      * @param soupName
@@ -139,7 +161,22 @@ public class QuerySpec {
      * @return
      */
     public static QuerySpec buildExactQuerySpec(String soupName, String path, String exactMatchKey, String orderPath, Order order, int pageSize) {
-        return new QuerySpec(soupName, path, QueryType.exact, exactMatchKey, null, null, null, orderPath, order, pageSize);
+        return buildExactQuerySpec(soupName, null, path, exactMatchKey, orderPath, order, pageSize);
+    }
+
+    /**
+     * Return a query spec for an exact match query
+     * @param soupName
+     * @param selectPaths
+     * @param path
+     * @param exactMatchKey
+     * @param orderPath
+     * @param order
+     * @param pageSize
+     * @return
+     */
+    public static QuerySpec buildExactQuerySpec(String soupName, String[] selectPaths, String path, String exactMatchKey, String orderPath, Order order, int pageSize) {
+        return new QuerySpec(soupName, selectPaths, QueryType.exact, exactMatchKey, null, null, null, orderPath, order, pageSize, path);
     }
 
     /**
@@ -154,7 +191,23 @@ public class QuerySpec {
      * @return
      */
     public static QuerySpec buildRangeQuerySpec(String soupName, String path, String beginKey, String endKey, String orderPath, Order order, int pageSize) {
-        return new QuerySpec(soupName, path, QueryType.range, null, beginKey, endKey, null, orderPath, order, pageSize);
+        return buildRangeQuerySpec(soupName, null, path, beginKey, endKey, orderPath, order, pageSize);
+    }
+
+    /**
+     * Return a query spec for a range query
+     * @param soupName
+     * @param selectPaths
+     * @param path
+     * @param beginKey
+     * @param endKey
+     * @param orderPath
+     * @param order
+     * @param pageSize
+     * @return
+     */
+    public static QuerySpec buildRangeQuerySpec(String soupName, String[] selectPaths, String path, String beginKey, String endKey, String orderPath, Order order, int pageSize) {
+        return new QuerySpec(soupName, selectPaths, QueryType.range, null, beginKey, endKey, null, orderPath, order, pageSize, path);
     }
 
     /**
@@ -168,7 +221,22 @@ public class QuerySpec {
      * @return
      * */
     public static QuerySpec buildLikeQuerySpec(String soupName, String path, String likeKey, String orderPath, Order order, int pageSize) {
-        return new QuerySpec(soupName, path, QueryType.like, null, null, null, likeKey, orderPath, order, pageSize);
+        return buildLikeQuerySpec(soupName, null, path, likeKey, orderPath, order, pageSize);
+    }
+
+    /**
+     * Return a query spec for a like query
+     * @param soupName
+     * @param selectPaths
+     * @param path
+     * @param likeKey
+     * @param orderPath
+     * @param order
+     * @param pageSize
+     * @return
+     * */
+    public static QuerySpec buildLikeQuerySpec(String soupName, String[] selectPaths, String path, String likeKey, String orderPath, Order order, int pageSize) {
+        return new QuerySpec(soupName, selectPaths, QueryType.like, null, null, null, likeKey, orderPath, order, pageSize, path);
     }
 
     /**
@@ -182,7 +250,22 @@ public class QuerySpec {
      * @return
      */
     public static QuerySpec buildMatchQuerySpec(String soupName, String path, String matchKey, String orderPath, Order order, int pageSize) {
-        return new QuerySpec(soupName, path, QueryType.match, matchKey, null, null, null, orderPath, order, pageSize);
+        return buildMatchQuerySpec(soupName, null, path, matchKey, orderPath, order, pageSize);
+    }
+
+    /**
+     * Return a query spec for a match query (full-text search)
+     * @param soupName
+     * @param selectPaths
+     * @param path
+     * @param matchKey
+     * @param orderPath
+     * @param order
+     * @param pageSize
+     * @return
+     */
+    public static QuerySpec buildMatchQuerySpec(String soupName, String[] selectPaths, String path, String matchKey, String orderPath, Order order, int pageSize) {
+        return new QuerySpec(soupName, selectPaths, QueryType.match, matchKey, null, null, null, orderPath, order, pageSize, path);
     }
 
     /**
@@ -243,7 +326,11 @@ public class QuerySpec {
      * @return select clause for exact/like/range/match queries
      */
     private String computeSelectClause() {
-        return SELECT + computeFieldReference(SmartSqlHelper.SOUP) + " ";
+        List<String> fieldReferences = new ArrayList<>();
+        for (String selectPath : (selectPaths != null ? selectPaths : new String[] {SmartSqlHelper.SOUP})) {
+            fieldReferences.add(computeFieldReference(selectPath));
+        }
+        return SELECT + TextUtils.join(", ", fieldReferences) + " ";
     }
 
     /**
@@ -376,6 +463,7 @@ public class QuerySpec {
 	public static QuerySpec fromJSON(String soupName, JSONObject querySpecJson)
 			throws JSONException {
 		QueryType queryType = QueryType.valueOf(querySpecJson.getString(QUERY_TYPE));
+        String[] selectPaths = JSONObjectHelper.optStringArray(querySpecJson, SELECT_PATHS);
 		String path = JSONObjectHelper.optString(querySpecJson, INDEX_PATH);
 		String matchKey = JSONObjectHelper.optString(querySpecJson, MATCH_KEY);
 		String beginKey = JSONObjectHelper.optString(querySpecJson, BEGIN_KEY);
@@ -389,10 +477,10 @@ public class QuerySpec {
 		// Building query spec
 		QuerySpec querySpec = null;
 		switch (queryType) {
-	    case exact:   querySpec = buildExactQuerySpec(soupName, path, matchKey, orderPath, order, pageSize); break;
-	    case range:   querySpec = buildRangeQuerySpec(soupName, path, beginKey, endKey, orderPath, order, pageSize); break;
-	    case like:    querySpec = buildLikeQuerySpec(soupName, path, likeKey, orderPath, order, pageSize); break;
-        case match:   querySpec = buildMatchQuerySpec(soupName, path, matchKey, orderPath, order, pageSize); break;
+	    case exact:   querySpec = buildExactQuerySpec(soupName, selectPaths, path, matchKey, orderPath, order, pageSize); break;
+	    case range:   querySpec = buildRangeQuerySpec(soupName, selectPaths, path, beginKey, endKey, orderPath, order, pageSize); break;
+	    case like:    querySpec = buildLikeQuerySpec(soupName, selectPaths, path, likeKey, orderPath, order, pageSize); break;
+        case match:   querySpec = buildMatchQuerySpec(soupName, selectPaths, path, matchKey, orderPath, order, pageSize); break;
 	    case smart:   querySpec = buildSmartQuerySpec(smartSql, pageSize); break;
 	    default: throw new RuntimeException("Fell through switch: " + queryType);
 		}

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -673,7 +673,7 @@ public class SmartStore  {
 	            if (cursor.moveToFirst()) {
 	                do {
 	                	// Smart queries
-	                	if (qt == QueryType.smart) {
+	                	if (qt == QueryType.smart || querySpec.selectPaths != null) {
 	                		results.put(getDataFromRow(cursor));	
 	                	}
 	            		// Exact/like/range queries

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
@@ -37,8 +37,13 @@ import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testAllQuerySmartSql() {
-    QuerySpec querySpec = QuerySpec.buildAllQuerySpec("employees", "lastName", QuerySpec.Order.descending, 1);
-    assertEquals("Wrong smart sql for all query spec", "SELECT {employees:_soup} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql);
+        QuerySpec querySpec = QuerySpec.buildAllQuerySpec("employees", "lastName", QuerySpec.Order.descending, 1);
+        assertEquals("Wrong smart sql for all query spec", "SELECT {employees:_soup} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql);
+    }
+
+    public void testAllQuerySmartSqlWithSelectPaths() {
+        QuerySpec querySpec = QuerySpec.buildAllQuerySpec("employees", new String[] {"firstName", "lastName"}, "lastName", QuerySpec.Order.descending, 1);
+        assertEquals("Wrong smart sql for all query spec", "SELECT {employees:firstName}, {employees:lastName} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql);
     }
 
     public void testAllQueryCountSmartSql() {
@@ -56,6 +61,11 @@ public class QuerySpecTest extends InstrumentationTestCase {
         assertEquals("Wrong smart sql for range query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
     }
 
+    public void testRangeQuerySmartSqlWithSelectPaths() {
+        QuerySpec querySpec = QuerySpec.buildRangeQuerySpec("employees", new String[] {"firstName"}, "lastName", "Bond", "Smith", "lastName", QuerySpec.Order.ascending, 1);
+        assertEquals("Wrong smart sql for range query spec", "SELECT {employees:firstName} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
+    }
+
     public void testRangeQueryCountSmartSql() {
         QuerySpec querySpec = QuerySpec.buildRangeQuerySpec("employees", "lastName", "Bond", "Smith", "lastName", QuerySpec.Order.ascending, 1);
         assertEquals("Wrong count smart sql for range query spec", "SELECT count(*) FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ", querySpec.countSmartSql);
@@ -66,10 +76,14 @@ public class QuerySpecTest extends InstrumentationTestCase {
         assertEquals("Wrong ids smart sql for range query spec", "SELECT id FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql);
     }
 
-    public void testExactQuerySmartSql()
-    {
+    public void testExactQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildExactQuerySpec("employees", "lastName", "Bond", "lastName", QuerySpec.Order.ascending, 1);
         assertEquals("Wrong smart sql for exact query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
+    }
+
+    public void testExactQuerySmartSqlWithSelectPaths() {
+        QuerySpec querySpec = QuerySpec.buildExactQuerySpec("employees", new String[]{"firstName", "lastName"}, "lastName", "Bond", "lastName", QuerySpec.Order.ascending, 1);
+        assertEquals("Wrong smart sql for exact query spec", "SELECT {employees:firstName}, {employees:lastName} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
     }
 
     public void testExactQueryCountSmartSql() {
@@ -85,6 +99,11 @@ public class QuerySpecTest extends InstrumentationTestCase {
     public void testMatchQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
         assertEquals("Wrong smart sql for match query spec", "SELECT {employees:_soup} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql);
+    }
+
+    public void testMatchQuerySmartSqlWithSelectPaths() {
+        QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", new String[]{"firstName", "lastName", "title"}, "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
+        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql);
     }
 
     public void testMatchQueryCountSmartSql() {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
@@ -38,12 +38,12 @@ public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testAllQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildAllQuerySpec("employees", "lastName", QuerySpec.Order.descending, 1);
-        assertEquals("Wrong smart sql for all query spec", "SELECT {employees:_soup} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for all query spec", "SELECT {employees:_soup} FROM {employees} ORDER BY {employees:lastName} DESC ", querySpec.smartSql);
     }
 
     public void testAllQuerySmartSqlWithSelectPaths() {
         QuerySpec querySpec = QuerySpec.buildAllQuerySpec("employees", new String[] {"firstName", "lastName"}, "lastName", QuerySpec.Order.descending, 1);
-        assertEquals("Wrong smart sql for all query spec", "SELECT {employees:firstName}, {employees:lastName} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for all query spec", "SELECT {employees:firstName}, {employees:lastName} FROM {employees} ORDER BY {employees:lastName} DESC ", querySpec.smartSql);
     }
 
     public void testAllQueryCountSmartSql() {
@@ -53,17 +53,17 @@ public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testAllQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildAllQuerySpec("employees", "lastName", QuerySpec.Order.descending, 1);
-        assertEquals("Wrong ids smart sql for all query spec", "SELECT id FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.idsSmartSql);
+        assertEquals("Wrong ids smart sql for all query spec", "SELECT id FROM {employees} ORDER BY {employees:lastName} DESC ", querySpec.idsSmartSql);
     }
 
     public void testRangeQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildRangeQuerySpec("employees", "lastName", "Bond", "Smith", "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for range query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for range query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql);
     }
 
     public void testRangeQuerySmartSqlWithSelectPaths() {
         QuerySpec querySpec = QuerySpec.buildRangeQuerySpec("employees", new String[] {"firstName"}, "lastName", "Bond", "Smith", "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for range query spec", "SELECT {employees:firstName} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for range query spec", "SELECT {employees:firstName} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql);
     }
 
     public void testRangeQueryCountSmartSql() {
@@ -73,17 +73,17 @@ public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testRangeQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildRangeQuerySpec("employees", "lastName", "Bond", "Smith", "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong ids smart sql for range query spec", "SELECT id FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql);
+        assertEquals("Wrong ids smart sql for range query spec", "SELECT id FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees:lastName} ASC ", querySpec.idsSmartSql);
     }
 
     public void testExactQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildExactQuerySpec("employees", "lastName", "Bond", "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for exact query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for exact query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql);
     }
 
     public void testExactQuerySmartSqlWithSelectPaths() {
         QuerySpec querySpec = QuerySpec.buildExactQuerySpec("employees", new String[]{"firstName", "lastName"}, "lastName", "Bond", "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for exact query spec", "SELECT {employees:firstName}, {employees:lastName} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for exact query spec", "SELECT {employees:firstName}, {employees:lastName} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql);
     }
 
     public void testExactQueryCountSmartSql() {
@@ -93,32 +93,32 @@ public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testExactQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildExactQuerySpec("employees", "lastName", "Bond", "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong ids smart sql for exact query spec", "SELECT id FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql);
+        assertEquals("Wrong ids smart sql for exact query spec", "SELECT id FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees:lastName} ASC ", querySpec.idsSmartSql);
     }
 
     public void testMatchQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:_soup} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
     }
 
     public void testMatchQuerySmartSqlWithSelectPaths() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", new String[]{"firstName", "lastName", "title"}, "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
     }
 
     public void testMatchQueryCountSmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong count smart sql for match query spec", "SELECT count(*) FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ", querySpec.countSmartSql);
+        assertEquals("Wrong count smart sql for match query spec", "SELECT count(*) FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ", querySpec.countSmartSql);
     }
 
     public void testMatchQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong ids smart sql for match query spec", "SELECT id FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.idsSmartSql);
+        assertEquals("Wrong ids smart sql for match query spec", "SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.idsSmartSql);
     }
 
     public void testLikeQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildLikeQuerySpec("employees", "lastName", "Bon%" , "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for like query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for like query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql);
     }
 
     public void testLikeQueryCountSmartSql() {
@@ -128,7 +128,7 @@ public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testLikeQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildLikeQuerySpec("employees", "lastName", "Bon%" , "lastName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong ids smart sql for like query spec", "SELECT id FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql);
+        assertEquals("Wrong ids smart sql for like query spec", "SELECT id FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees:lastName} ASC ", querySpec.idsSmartSql);
     }
 
     public void testSmartQueryCountSmartSql() {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, salesforce.com, inc.
+ * Copyright (c) 2015-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@ import android.database.Cursor;
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 
@@ -515,10 +516,17 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     private void trySearch(long[] expectedIds, String path, String matchKey, String orderPath) throws JSONException {
+        // Returning soup elements
         JSONArray results = store.query(QuerySpec.buildMatchQuerySpec(EMPLOYEES_SOUP, path, matchKey, orderPath, QuerySpec.Order.ascending, 25), 0);
         assertEquals("Wrong number of results", expectedIds.length, results.length());
         for (int i=0; i<results.length(); i++) {
             assertEquals("Wrong result", expectedIds[i], idOf(results.getJSONObject(i)));
+        }
+        // Returning just ids
+        results = store.query(QuerySpec.buildMatchQuerySpec(EMPLOYEES_SOUP, new String[]{SmartStore.SOUP_ENTRY_ID}, path, matchKey, orderPath, QuerySpec.Order.ascending, 25), 0);
+        assertEquals("Wrong number of results", expectedIds.length, results.length());
+        for (int i=0; i<results.length(); i++) {
+            assertEquals("Wrong result", expectedIds[i], results.getJSONArray(i).getLong(0));
         }
     }
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
@@ -153,15 +153,16 @@ public abstract class SmartStoreTestCase extends InstrumentationTestCase {
 
     /**
      * Get explain query plan of last query run and make sure the given index was used
-     * @param soupName
+	 * @param soupName
      * @param index the index of the index spec in the array of index specs passed to register soup
-     * @param dbOperation e.g. SCAN or SEARCH
-     */
-    public void checkExplainQueryPlan(String soupName, int index, String dbOperation) throws JSONException {
+	 * @param covering
+	 * @param dbOperation e.g. SCAN or SEARCH
+	 */
+    public void checkExplainQueryPlan(String soupName, int index, boolean covering, String dbOperation) throws JSONException {
         JSONObject explainQueryPlan = store.getLastExplainQueryPlan();
         String soupTableName = getSoupTableName(soupName);
         String indexName = soupTableName + "_" + index + "_idx";
-        String expectedDetailPrefix = String.format("%s TABLE %s USING INDEX %s", dbOperation, soupTableName, indexName);
+        String expectedDetailPrefix = String.format("%s TABLE %s USING %sINDEX %s", dbOperation, soupTableName, covering ? "COVERING " : "", indexName);
         String detail = explainQueryPlan.getJSONArray(DBHelper.EXPLAIN_ROWS).getJSONObject(0).getString("detail");
 
         assertTrue("Wrong query plan:" + detail, detail.startsWith(expectedDetailPrefix));


### PR DESCRIPTION
If you specify [path1, path2] you get back [soupElt[path1], soupElt[path2]] for each matching row instead of the soupElt's.

