### PR TITLE
DDL operations are transactional for SQLite

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -276,19 +276,21 @@ public class SmartStore  {
 	            db.beginTransaction();
 	            long soupId = DBHelper.getInstance(db).insert(db, SOUP_NAMES_TABLE, soupMapValues);
 	            soupTableName = getSoupTableName(soupId);
+
+				// Do the rest - create table / indexes
+				registerSoupUsingTableName(soupName, indexSpecs, soupTableName);
+
 	            db.setTransactionSuccessful();
 	        } finally {
 	            db.endTransaction();
 	        }
-	        
-	        // Do the rest - create table / indexes
-	        registerSoupUsingTableName(soupName, indexSpecs, soupTableName);
     	}
     }
         
     
     /**
      * Helper method for registerSoup
+	 * NB: caller is expected to wrap call in a transaction
      * 
 	 * @param soupName
 	 * @param indexSpecs


### PR DESCRIPTION
Using transactions where we were not (register table, alter soup)