### PR TITLE
Full-text indexes now using FTS5

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
@@ -495,9 +495,9 @@ public class AlterSoupLongOperation extends LongOperation {
 			List<String> oldColumnsFts = new ArrayList<String>();
 			List<String> newColumnsFts = new ArrayList<String>();
 
-			// Adding docid column
+			// Adding rowid column
 			oldColumnsFts.add(SmartStore.ID_COL);
-			newColumnsFts.add(SmartStore.DOCID_COL);
+			newColumnsFts.add(SmartStore.ROWID_COL);
 
 			// Adding indexed path columns that we are keeping
 			for (String keptPath : keptPaths) {

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/QuerySpec.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/QuerySpec.java
@@ -381,7 +381,7 @@ public class QuerySpec {
                 }
             case match:
                 pred = computeFieldReference(SmartStore.SOUP_ENTRY_ID) + " IN ("
-                        + SELECT + SmartStore.DOCID_COL + " " + FROM + computeSoupFtsReference() + " " + WHERE
+                        + SELECT + SmartStore.ROWID_COL + " " + FROM + computeSoupFtsReference() + " " + WHERE
                         + field + " MATCH '" + matchKey + "'" // statement arg binding doesn't seem to work so inlining matchKey
                         + ") ";
                 break;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
@@ -54,7 +54,7 @@ public class SmartSqlHelper  {
 	 */
 	public static synchronized SmartSqlHelper getInstance(SQLiteDatabase db) {
 		if (INSTANCES == null) {
-			INSTANCES = new HashMap<SQLiteDatabase, SmartSqlHelper>();
+			INSTANCES = new HashMap<>();
 		}
 		SmartSqlHelper instance = INSTANCES.get(db);
 		if (instance == null) {

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -106,7 +106,10 @@ public class SmartStore  {
 	protected SQLiteOpenHelper dbOpenHelper;
 	private String passcode;
 
-    /**
+	// FTS extension to use
+	protected FtsExtension ftsExtension = FtsExtension.fts5;
+
+	/**
      * Changes the encryption key on the smartstore.
      *
      * @param db Database object.
@@ -357,7 +360,7 @@ public class SmartStore  {
 
 		// fts
 		if (columnsForFts.size() > 0) {
-			createFtsStmt.append(String.format("CREATE VIRTUAL TABLE %s%s USING fts4(%s)", soupTableName, FTS_SUFFIX, TextUtils.join(",", columnsForFts)));
+			createFtsStmt.append(String.format("CREATE VIRTUAL TABLE %s%s USING %s(%s)", soupTableName, FTS_SUFFIX, ftsExtension, TextUtils.join(",", columnsForFts)));
 		}
 
         // Run SQL for creating soup table and its indices
@@ -1212,6 +1215,22 @@ public class SmartStore  {
         return String.format("%s IN (%s)", col, inPredicate);
     }
 
+	/**
+	 * @return ftsX to be used when creating the virtual table to support full_text queries
+     */
+	public FtsExtension getFtsExtension() {
+		return ftsExtension;
+	}
+
+	/**
+	 * Sets the ftsX to be used when creating the virtual table to support full_text queries
+	 * NB: only used in tests
+	 * @param ftsExtension
+     */
+	public void setFtsExtension(FtsExtension ftsExtension) {
+		this.ftsExtension = ftsExtension;
+	}
+
     /**
      * @param soupId
      * @return
@@ -1334,6 +1353,14 @@ public class SmartStore  {
 
         public abstract boolean isMember(Type type);
     }
+
+	/**
+	 * Enum for fts extensions
+	 */
+	public enum FtsExtension {
+		fts4,
+		fts5
+	}
 
     /**
      * Exception thrown by smart store

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -84,7 +84,7 @@ public class SmartStore  {
     protected static final String SOUP_COL = "soup";
 
 	// Column of a fts soup table
-	protected static final String DOCID_COL = "docid";
+	protected static final String ROWID_COL = "rowid";
 
     // Columns of long operations status table
 	protected static final String TYPE_COL = "type";
@@ -99,7 +99,7 @@ public class SmartStore  {
     // Predicates
     protected static final String SOUP_NAME_PREDICATE = SOUP_NAME_COL + " = ?";
 	protected static final String ID_PREDICATE = ID_COL + " = ?";
-	protected static final String DOCID_PREDICATE = DOCID_COL + " =?";
+	protected static final String ROWID_PREDICATE = ROWID_COL + " =?";
 
 	// Backing database
 	protected SQLiteDatabase dbLocal;
@@ -512,7 +512,7 @@ public class SmartStore  {
 								String soupTableNameFts = soupTableName + FTS_SUFFIX;
 								ContentValues contentValuesFts = new ContentValues();
 								projectIndexedPaths(soupElt, contentValuesFts, indexSpecs, TypeGroup.value_extracted_to_fts_column);
-								DBHelper.getInstance(db).update(db, soupTableNameFts, contentValuesFts, DOCID_PREDICATE, soupEntryId + "");
+								DBHelper.getInstance(db).update(db, soupTableNameFts, contentValuesFts, ROWID_PREDICATE, soupEntryId + "");
 							}
 			        	}
 			        	catch (JSONException e) {
@@ -805,7 +805,7 @@ public class SmartStore  {
 				if (success && hasFTS(soupName)) {
 					String soupTableNameFts = soupTableName + FTS_SUFFIX;
 					ContentValues contentValuesFts = new ContentValues();
-					contentValuesFts.put(DOCID_COL, soupEntryId);
+					contentValuesFts.put(ROWID_COL, soupEntryId);
 					projectIndexedPaths(soupElt, contentValuesFts, indexSpecs, TypeGroup.value_extracted_to_fts_column);
 					// InsertHelper not working against virtual fts table
 					db.insert(soupTableNameFts, null, contentValuesFts);
@@ -982,7 +982,7 @@ public class SmartStore  {
 					String soupTableNameFts = soupTableName + FTS_SUFFIX;
 					ContentValues contentValuesFts = new ContentValues();
 					projectIndexedPaths(soupElt, contentValuesFts, indexSpecs, TypeGroup.value_extracted_to_fts_column);
-					success = DBHelper.getInstance(db).update(db, soupTableNameFts, contentValuesFts, DOCID_PREDICATE, soupEntryId + "") == 1;
+					success = DBHelper.getInstance(db).update(db, soupTableNameFts, contentValuesFts, ROWID_PREDICATE, soupEntryId + "") == 1;
 				}
 
 				if (success) {
@@ -1128,7 +1128,7 @@ public class SmartStore  {
 	            db.delete(soupTableName, getSoupEntryIdsPredicate(soupEntryIds), (String []) null);
 
 				if (hasFTS(soupName)) {
-					db.delete(soupTableName + FTS_SUFFIX, getDocidsPredicate(soupEntryIds), (String[]) null);
+					db.delete(soupTableName + FTS_SUFFIX, getRowIdsPredicate(soupEntryIds), (String[]) null);
 				}
 
 	            if (handleTx) {
@@ -1174,7 +1174,7 @@ public class SmartStore  {
                 db.delete(soupTableName, buildInStatement(ID_COL, subQuerySql), args);
 
 				if (hasFTS(soupName)) {
-                    db.delete(soupTableName + FTS_SUFFIX, buildInStatement(DOCID_COL, subQuerySql), args);
+                    db.delete(soupTableName + FTS_SUFFIX, buildInStatement(ROWID_COL, subQuerySql), args);
 				}
 
 				if (handleTx) {
@@ -1197,10 +1197,10 @@ public class SmartStore  {
 
 
 	/**
-	 * @return predicate to match entries by docid
+	 * @return predicate to match entries by rowid
 	 */
-	private String getDocidsPredicate(Long[] docids) {
-        return buildInStatement(DOCID_COL, TextUtils.join(",", docids));
+	private String getRowIdsPredicate(Long[] rowids) {
+        return buildInStatement(ROWID_COL, TextUtils.join(",", rowids));
 	}
 
     /**

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
@@ -98,22 +98,22 @@ public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testMatchQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees}_fts MATCH '{employees:lastName}:Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
     }
 
     public void testMatchQuerySmartSqlWithSelectPaths() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", new String[]{"firstName", "lastName", "title"}, "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees}_fts MATCH '{employees:lastName}:Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
     }
 
     public void testMatchQueryCountSmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong count smart sql for match query spec", "SELECT count(*) FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ", querySpec.countSmartSql);
+        assertEquals("Wrong count smart sql for match query spec", "SELECT count(*) FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees}_fts MATCH '{employees:lastName}:Bond') ", querySpec.countSmartSql);
     }
 
     public void testMatchQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong ids smart sql for match query spec", "SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.idsSmartSql);
+        assertEquals("Wrong ids smart sql for match query spec", "SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees}_fts MATCH '{employees:lastName}:Bond') ORDER BY {employees:firstName} ASC ", querySpec.idsSmartSql);
     }
 
     public void testLikeQuerySmartSql() {
@@ -139,5 +139,21 @@ public class QuerySpecTest extends InstrumentationTestCase {
     public void testSmartQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildSmartQuerySpec("select {employees:salary} from {employees} where {employees:lastName} = 'Haas'", 1);
         assertEquals("Wrong ids smart sql", "SELECT id FROM (select {employees:salary} from {employees} where {employees:lastName} = 'Haas')", querySpec.idsSmartSql);
+    }
+
+    public void testQualifyMatchKey() {
+        assertEquals("Wrong qualified match query", "abc", QuerySpec.qualifyMatchKey(null, "abc"));
+        assertEquals("Wrong qualified match query", "{soup:path}:abc", QuerySpec.qualifyMatchKey("{soup:path}", "abc"));
+        assertEquals("Wrong qualified match query", "{soup:path2}:abc", QuerySpec.qualifyMatchKey("{soup:path1}", "{soup:path2}:abc"));
+
+
+        // FIXME - following are not working yet
+        assertEquals("Wrong qualified match query", "{soup:path}:abc AND {soup:path}:def", QuerySpec.qualifyMatchKey("{soup:path}", "abc AND def"));
+        assertEquals("Wrong qualified match query", "{soup:path}:abc OR {soup:path}:def", QuerySpec.qualifyMatchKey("{soup:path}", "abc OR def"));
+        assertEquals("Wrong qualified match query", "{soup:path1}:abc OR {soup:path2}:def", QuerySpec.qualifyMatchKey("{soup:path1}", "abc OR {soup:path2}.def"));
+        assertEquals("Wrong qualified match query", "({soup:path}:abc AND {soup:path}:def) OR {soup:path}:ghi", QuerySpec.qualifyMatchKey("{soup:path}", "(abc AND def) OR ghi"));
+
+        // TODO - add more
+
     }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
@@ -145,15 +145,10 @@ public class QuerySpecTest extends InstrumentationTestCase {
         assertEquals("Wrong qualified match query", "abc", QuerySpec.qualifyMatchKey(null, "abc"));
         assertEquals("Wrong qualified match query", "{soup:path}:abc", QuerySpec.qualifyMatchKey("{soup:path}", "abc"));
         assertEquals("Wrong qualified match query", "{soup:path2}:abc", QuerySpec.qualifyMatchKey("{soup:path1}", "{soup:path2}:abc"));
-
-
-        // FIXME - following are not working yet
         assertEquals("Wrong qualified match query", "{soup:path}:abc AND {soup:path}:def", QuerySpec.qualifyMatchKey("{soup:path}", "abc AND def"));
         assertEquals("Wrong qualified match query", "{soup:path}:abc OR {soup:path}:def", QuerySpec.qualifyMatchKey("{soup:path}", "abc OR def"));
-        assertEquals("Wrong qualified match query", "{soup:path1}:abc OR {soup:path2}:def", QuerySpec.qualifyMatchKey("{soup:path1}", "abc OR {soup:path2}.def"));
+        assertEquals("Wrong qualified match query", "{soup:path1}:abc OR {soup:path2}:def", QuerySpec.qualifyMatchKey("{soup:path1}", "abc OR {soup:path2}:def"));
         assertEquals("Wrong qualified match query", "({soup:path}:abc AND {soup:path}:def) OR {soup:path}:ghi", QuerySpec.qualifyMatchKey("{soup:path}", "(abc AND def) OR ghi"));
-
-        // TODO - add more
-
+        assertEquals("Wrong qualified match query", "({soup:path1}:abc AND {soup:path2}:def) OR {soup:path1}:ghi", QuerySpec.qualifyMatchKey("{soup:path1}", "(abc AND {soup:path2}:def) OR ghi"));
     }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
@@ -98,22 +98,22 @@ public class QuerySpecTest extends InstrumentationTestCase {
 
     public void testMatchQuerySmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
     }
 
     public void testMatchQuerySmartSqlWithSelectPaths() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", new String[]{"firstName", "lastName", "title"}, "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
+        assertEquals("Wrong smart sql for match query spec", "SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql);
     }
 
     public void testMatchQueryCountSmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong count smart sql for match query spec", "SELECT count(*) FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ", querySpec.countSmartSql);
+        assertEquals("Wrong count smart sql for match query spec", "SELECT count(*) FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ", querySpec.countSmartSql);
     }
 
     public void testMatchQueryIdsSmartSql() {
         QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "Bond", "firstName", QuerySpec.Order.ascending, 1);
-        assertEquals("Wrong ids smart sql for match query spec", "SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.idsSmartSql);
+        assertEquals("Wrong ids smart sql for match query spec", "SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.idsSmartSql);
     }
 
     public void testLikeQuerySmartSql() {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
@@ -362,7 +362,7 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         }
 
         // Check columns of fts table
-        List<String> expectedFtsColumnNames = new ArrayList<>(); // NB: docid not returned by pragma table_info for fts virtual table
+        List<String> expectedFtsColumnNames = new ArrayList<>(); // NB: rowid not returned by pragma table_info for fts virtual table
         if (cityColType == SmartStore.Type.full_text) expectedFtsColumnNames.add(CITY_COL);
         if (countryColType == SmartStore.Type.full_text) expectedFtsColumnNames.add(COUNTRY_COL);
         checkColumns(TEST_SOUP_TABLE_NAME + SmartStore.FTS_SUFFIX, expectedFtsColumnNames);
@@ -370,13 +370,13 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         // Check rows of fts table
         try {
             final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
-            expectedFtsColumnNames.add(0, "docid");
-            c = DBHelper.getInstance(db).query(db, TEST_SOUP_TABLE_NAME + SmartStore.FTS_SUFFIX, expectedFtsColumnNames.toArray(new String[0]), "docid ASC", null, null);
+            expectedFtsColumnNames.add(0, "rowid");
+            c = DBHelper.getInstance(db).query(db, TEST_SOUP_TABLE_NAME + SmartStore.FTS_SUFFIX, expectedFtsColumnNames.toArray(new String[0]), "rowid ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertEquals("Wrong number of rows", expectedIds.length, c.getCount());
 
             for (int i = 0; i < expectedIds.length; i++) {
-                assertEquals("Wrong docid", expectedIds[i], c.getLong(c.getColumnIndex("docid")));
+                assertEquals("Wrong rowid", expectedIds[i], c.getLong(c.getColumnIndex("rowid")));
                 if (cityColType == SmartStore.Type.full_text)
                     assertEquals("Wrong value in index column", cities[i], c.getString(c.getColumnIndex(CITY_COL)));
                 if (countryColType == SmartStore.Type.full_text)

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
@@ -148,28 +148,28 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             safeClose(c);
 
             // Check fts table columns
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "rowid ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertTrue("Wrong columns", Arrays.deepEquals(new String[]{FIRST_NAME_COL, LAST_NAME_COL}, c.getColumnNames()));
 
             safeClose(c);
 
             // Check fts table data
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, new String[] {"docid", FIRST_NAME_COL, LAST_NAME_COL}, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, new String[] {"rowid", FIRST_NAME_COL, LAST_NAME_COL}, "rowid ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertEquals("Expected two rows", 3, c.getCount());
 
-            assertEquals("Wrong id", firstEmployeeId, c.getLong(c.getColumnIndex("docid")));
+            assertEquals("Wrong id", firstEmployeeId, c.getLong(c.getColumnIndex("rowid")));
             assertEquals("Wrong value in index column", "Christine", c.getString(c.getColumnIndex(FIRST_NAME_COL)));
             assertEquals("Wrong value in index column", "Haas", c.getString(c.getColumnIndex(LAST_NAME_COL)));
 
             c.moveToNext();
-            assertEquals("Wrong id", secondEmployeeId, c.getLong(c.getColumnIndex("docid")));
+            assertEquals("Wrong id", secondEmployeeId, c.getLong(c.getColumnIndex("rowid")));
             assertEquals("Wrong value in index column", "Michael", c.getString(c.getColumnIndex(FIRST_NAME_COL)));
             assertEquals("Wrong value in index column", "Thompson", c.getString(c.getColumnIndex(LAST_NAME_COL)));
 
             c.moveToNext();
-            assertEquals("Wrong id", thirdEmployeeId, c.getLong(c.getColumnIndex("docid")));
+            assertEquals("Wrong id", thirdEmployeeId, c.getLong(c.getColumnIndex("rowid")));
             assertEquals("Wrong value in index column", null, c.getString(c.getColumnIndex(FIRST_NAME_COL)));
             assertEquals("Wrong value in index column", null, c.getString(c.getColumnIndex(LAST_NAME_COL)));
         }
@@ -200,7 +200,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             safeClose(c);
 
             // Check fts table data
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "rowid ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertEquals("Expected two rows", 2, c.getCount());
         }
@@ -225,10 +225,10 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             safeClose(c);
 
             // Check fts table data
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, new String[] {"docid", FIRST_NAME_COL, LAST_NAME_COL}, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, new String[] {"rowid", FIRST_NAME_COL, LAST_NAME_COL}, "rowid ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertEquals("Expected one row", 1, c.getCount());
-            assertEquals("Wrong id", firstEmployeeId, c.getLong(c.getColumnIndex("docid")));
+            assertEquals("Wrong id", firstEmployeeId, c.getLong(c.getColumnIndex("rowid")));
         }
         finally {
             safeClose(c);
@@ -249,7 +249,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             safeClose(c);
 
             // Check fts table data
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "rowid ASC", null, null);
             assertFalse("Expected no rows", c.moveToFirst());
         }
         finally {
@@ -279,7 +279,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             safeClose(c);
 
             // Check fts table data
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "rowid ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertEquals("Expected two rows", 2, c.getCount());
         }
@@ -302,7 +302,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             safeClose(c);
 
             // Check fts table data
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, null, "rowid ASC", null, null);
             assertFalse("Expected no rows", c.moveToFirst());
         }
         finally {
@@ -354,16 +354,16 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             safeClose(c);
 
             // Check fts table data
-            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, new String[] {"docid", FIRST_NAME_COL, LAST_NAME_COL}, "docid ASC", null, null);
+            c = DBHelper.getInstance(db).query(db, soupTableName + SmartStore.FTS_SUFFIX, new String[] {"rowid", FIRST_NAME_COL, LAST_NAME_COL}, "rowid ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertEquals("Expected two rows", 2, c.getCount());
 
-            assertEquals("Wrong id", firstEmployeeId, c.getLong(c.getColumnIndex("docid")));
+            assertEquals("Wrong id", firstEmployeeId, c.getLong(c.getColumnIndex("rowid")));
             assertEquals("Wrong value in index column", "Christine", c.getString(c.getColumnIndex(FIRST_NAME_COL)));
             assertEquals("Wrong value in index column", "Haas", c.getString(c.getColumnIndex(LAST_NAME_COL)));
 
             c.moveToNext();
-            assertEquals("Wrong id", secondEmployeeId, c.getLong(c.getColumnIndex("docid")));
+            assertEquals("Wrong id", secondEmployeeId, c.getLong(c.getColumnIndex("rowid")));
             assertEquals("Wrong value in index column", "Michael-updated", c.getString(c.getColumnIndex(FIRST_NAME_COL)));
             assertEquals("Wrong value in index column", "Thompson", c.getString(c.getColumnIndex(LAST_NAME_COL)));
         }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
@@ -31,7 +31,6 @@ import android.database.Cursor;
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
-import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 
@@ -73,10 +72,8 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         return "";
     }
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-
+    private void setupSoup(SmartStore.FtsExtension ftsExtension) {
+        store.setFtsExtension(ftsExtension);
         store.registerSoup(EMPLOYEES_SOUP, new IndexSpec[]{   // should be TABLE_1
                 new IndexSpec(FIRST_NAME, Type.full_text),    // should be TABLE_1_0
                 new IndexSpec(LAST_NAME, Type.full_text),     // should be TABLE_1_1
@@ -85,14 +82,35 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test register/drop soup that uses full-text search indices
+     * Test that fts5 is used by default
      */
-    public void testRegisterDropSoup() {
+    public void testFtsExtension() {
+        assertEquals("Expected fts5", store.getFtsExtension(), SmartStore.FtsExtension.fts5);
+    }
+
+    /**
+     * Test register/drop soup that uses full-text search indices with fts4
+     */
+    public void testRegisterDropSoupFts4() {
+        tryRegisterDropSoup(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test register/drop soup that uses full-text search indices with fts5
+     */
+    public void testRegisterDropSoupFts5() {
+        tryRegisterDropSoup(SmartStore.FtsExtension.fts5);
+    }
+
+    private void tryRegisterDropSoup(SmartStore.FtsExtension ftsExtension) {
+        setupSoup(ftsExtension);
+
         String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
         assertEquals("getSoupTableName should have returned TABLE_1", TABLE_NAME, soupTableName);
         assertTrue("Table for soup employees does exist", hasTable(soupTableName));
         assertTrue("FTS table for soup employees does exist", hasTable(soupTableName + SmartStore.FTS_SUFFIX));
         assertTrue("Register soup call failed", store.hasSoup(EMPLOYEES_SOUP));
+        checkCreateTableStatement(soupTableName + SmartStore.FTS_SUFFIX, "CREATE VIRTUAL TABLE " + soupTableName + SmartStore.FTS_SUFFIX + " USING " + ftsExtension);
 
         // Drop
         store.dropSoup(EMPLOYEES_SOUP);
@@ -105,9 +123,22 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test inserting rows
+     * Test inserting rows with fts4
      */
-    public void testInsert() throws JSONException {
+    public void testInsertWithFts4() throws JSONException {
+        tryInsert(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test inserting rows with fts5
+     */
+    public void testInsertWithFts5() throws JSONException {
+        tryInsert(SmartStore.FtsExtension.fts5);
+    }
+
+    private void tryInsert(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        setupSoup(ftsExtension);
+
         // Insert a couple of rows
         long firstEmployeeId = createEmployee("Christine", "Haas", "00010");
         long secondEmployeeId = createEmployee("Michael", "Thompson", "00020");
@@ -179,9 +210,22 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test deleting rows
+     * Test deleting rows with fts4
      */
-    public void testDelete() throws JSONException {
+    public void testDeleteWithFts4() throws JSONException {
+        tryDelete(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test deleting rows with fts5
+     */
+    public void testDeleteWithFts5() throws JSONException {
+        tryDelete(SmartStore.FtsExtension.fts5);
+    }
+
+    private void tryDelete(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        setupSoup(ftsExtension);
+
         // Insert a couple of rows
         long firstEmployeeId = createEmployee("Christine", "Haas", "00010");
         long secondEmployeeId = createEmployee("Michael", "Thompson", "00020");
@@ -258,9 +302,22 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test clearing soup
+     * Test clearing soup with fts4
      */
-    public void testClear() throws JSONException {
+    public void testClearWithFts4() throws JSONException {
+        tryClear(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test clearing soup with fts5
+     */
+    public void testClearWithFts5() throws JSONException {
+        tryClear(SmartStore.FtsExtension.fts5);
+    }
+
+    private void tryClear(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        setupSoup(ftsExtension);
+
         // Insert a couple of rows
         long firstEmployeeId = createEmployee("Christine", "Haas", "00010");
         long secondEmployeeId = createEmployee("Michael", "Thompson", "00020");
@@ -311,9 +368,22 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test updating rows
+     * Test updating rows with fts4
      */
-    public void testUpdate() throws JSONException {
+    public void testUpdateWithFts4() throws JSONException {
+        setupSoup(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test updating rows with fts5
+     */
+    public void testUpdateWithFts5() throws JSONException {
+        setupSoup(SmartStore.FtsExtension.fts5);
+    }
+
+    private void tryUpdate(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        setupSoup(ftsExtension);
+
         // Insert a couple of rows
         long firstEmployeeId = createEmployee("Christine", "Haas", "00010");
         long secondEmployeeId = createEmployee("Michael", "Thompson", "00020");
@@ -374,10 +444,21 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
 
 
     /**
-     * Test search on single field returning no results
+     * Test search on single field returning no results with fts4 table
      */
-    public void testSearchSingleFielNoResults() throws JSONException {
-        loadData();
+    public void testSearchSingleFiedlNoResultsWithFts4() throws JSONException {
+        trySearchSingleFieldNoResults(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test search on single field returning no results with fts5 table
+     */
+    public void testSearchSingleFieldNoResultsWithFts5() throws JSONException {
+        trySearchSingleFieldNoResults(SmartStore.FtsExtension.fts5);
+    }
+
+    private void trySearchSingleFieldNoResults(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        loadData(ftsExtension);
 
         // One field - full word - no results
         trySearch(new long[]{}, FIRST_NAME, "Christina", null);
@@ -392,10 +473,21 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test search on single field returning a single result
+     * Test search on single field returning a single result with fts4
      */
-    public void testSearchSingleFieldSingleResult() throws JSONException {
-        loadData();
+    public void testSearchSingleFieldSingleResultWithFts4() throws JSONException {
+        trySearchSingleFieldSingleResult(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test search on single field returning a single result with fts5
+     */
+    public void testSearchSingleFieldSingleResultWithFts5() throws JSONException {
+        trySearchSingleFieldSingleResult(SmartStore.FtsExtension.fts5);
+    }
+
+    private void trySearchSingleFieldSingleResult(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        loadData(ftsExtension);
         
         // One field - full word - one result
         trySearch(new long[]{christineHaasId}, FIRST_NAME, "Christine", null);
@@ -410,10 +502,24 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
+     * Test search on single field returning multiple results - testing ordering - with fts4
+     */
+    public void testSearchSingleFieldMultipleResultsWithFts4() throws JSONException {
+        trySearchSingleFieldMultipleResults(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test search on single field returning multiple results - testing ordering - with fts5
+     */
+    public void testSearchSingleFieldMultipleResultsWithFts5() throws JSONException {
+        trySearchSingleFieldMultipleResults(SmartStore.FtsExtension.fts5);
+    }
+
+    /**
      * Test search on single field returning multiple results - testing ordering
      */
-    public void testSearchSingleFieldMultipleResults() throws JSONException {
-        loadData();
+    private void trySearchSingleFieldMultipleResults(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        loadData(ftsExtension);
         
         // One field - full word - more than one results
         trySearch(new long[]{christineHaasId, aliHaasId}, LAST_NAME, "Haas", EMPLOYEE_ID);
@@ -430,10 +536,24 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
+     * Test search on all fields returning no results with fts4
+     */
+    public void testSearchAllFieldsNoResultsWithFts4() throws JSONException {
+        trySearchAllFieldsNoResults(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test search on all fields returning no results with fts5
+     */
+    public void testSearchAllFieldsNoResultsWithFts5() throws JSONException {
+        trySearchAllFieldsNoResults(SmartStore.FtsExtension.fts5);
+    }
+
+    /**
      * Test search on all fields returning no results
      */
-    public void testSearchAllFieldsNoResults() throws JSONException {
-        loadData();
+    private void trySearchAllFieldsNoResults(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        loadData(ftsExtension);
 
         // All fields - full word - no results
         trySearch(new long[]{}, null, "Sternn", null);
@@ -449,10 +569,21 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test search on all fields returning a single result
+     * Test search on all fields returning a single result with fts4
      */
-    public void testSearchAllFieldsSingleResult() throws JSONException {
-        loadData();
+    public void testSearchAllFieldsSingleResultWithFts4() throws JSONException {
+        trySearchAllFieldsSingleResult(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test search on all fields returning a single result with fts5
+     */
+    public void testSearchAllFieldsSingleResultWithFts5() throws JSONException {
+        trySearchAllFieldsSingleResult(SmartStore.FtsExtension.fts5);
+    }
+
+    private void trySearchAllFieldsSingleResult(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        loadData(ftsExtension);
 
         // All fields - full word - one result
         trySearch(new long[]{irvingSternId}, null, "Stern", null);
@@ -470,8 +601,19 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     /**
      * Test search on all fields returning multiple results - testing ordering
      */
-    public void testSearchAllFieldMultipleResults() throws JSONException {
-        loadData();
+    public void testSearchAllFieldMultipleResultsWithFts4() throws JSONException {
+        trySearchAllFieldMultipleResults(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test search on all fields returning multiple results - testing ordering
+     */
+    public void testSearchAllFieldMultipleResultsWithFts5() throws JSONException {
+        trySearchAllFieldMultipleResults(SmartStore.FtsExtension.fts5);
+    }
+
+    private void trySearchAllFieldMultipleResults(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        loadData(ftsExtension);
 
         // All fields - full word - more than one results
         trySearch(new long[]{evaPulaskiId, eileenEvaId}, null, "Eva", EMPLOYEE_ID);
@@ -489,10 +631,21 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     }
 
     /**
-     * Test search with queries that have field:value predicates
+     * Test search with queries that have field:value predicates with fts4
      */
-    public void testSearchWithFieldColonQueries() throws JSONException {
-        loadData();
+    public void testSearchWithFieldColonQueriesWithFts4() throws JSONException {
+        trySearchWithFieldColonQueries(SmartStore.FtsExtension.fts4);
+    }
+
+    /**
+     * Test search with queries that have field:value predicates with fts5
+     */
+    public void testSearchWithFieldColonQueriesWithFts5() throws JSONException {
+        trySearchWithFieldColonQueries(SmartStore.FtsExtension.fts5);
+    }
+
+    private void trySearchWithFieldColonQueries(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        loadData(ftsExtension);
 
         // All fields - full word - no results
         trySearch(new long[]{}, null, "{employees:firstName}:Haas", null);
@@ -530,7 +683,9 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         }
     }
 
-    private void loadData() throws JSONException {
+    private void loadData(SmartStore.FtsExtension ftsExtension) throws JSONException {
+        setupSoup(ftsExtension);
+
         christineHaasId = createEmployee("Christine", "Haas", "00010");
         michaelThompsonId = createEmployee("Michael", "Thompson", "00020");
         aliHaasId = createEmployee("Ali", "Haas", "00030");

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
@@ -127,6 +127,30 @@ public abstract class SmartStoreTestCase extends InstrumentationTestCase {
         JSONTestHelper.assertSameJSONArray("Wrong index specs", IndexSpec.toJSON(expectedIndexSpecs), IndexSpec.toJSON(actualIndexSpecs));
     }
 
+	/**
+	 * Helper method to check create table statement that was used to create a table
+	 * @param tableName
+	 * @param subStringExpected that created the indexes
+	 */
+	protected void checkCreateTableStatement(String tableName, String subStringExpected) {
+		Cursor c = null;
+		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getPasscode());
+		try {
+			List<String> actualSqlStatements = new ArrayList<>();
+			c = db.rawQuery(String.format("SELECT sql FROM sqlite_master WHERE type='table' AND tbl_name='%s' ORDER BY name", tableName), null);
+			assertEquals("Expected one statement", 1, c.getCount());
+			c.moveToFirst();
+			String actualStatement = c.getString(0);
+			assertTrue("Wrong statement: " + actualStatement, actualStatement.contains(subStringExpected));
+		}
+		catch (Exception e) {
+			fail("Failed with error:" + e.getMessage());
+		}
+		finally {
+			safeClose(c);
+		}
+	}
+
     /**
      * Helper method to check db indexes on a table
      * @param tableName


### PR DESCRIPTION


NB: In the future we should provide a way for developers to use advanced FTS features like selecting the tokenizer (https://www.sqlite.org/fts5.html#section_4_3) or sorting using bm25 (https://www.sqlite.org/fts5.html#section_5_1_1).

Added a way to select FTS4 or FTS5 -- not meant for app but used by tests to make sure no behavior changed.

For a soup created before 4.2, one simply needs to do an alterSoup passing in the original index specs, and the FTS virtual table will be recreated using FTS5 (there is a test for that).
