### PR TITLE
Add test_force.js to travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ licenses:
     - android-sdk-license-5be876d5
 
 before_install:
-    - nvm install node 0.12.0  
+    - nvm install 0.12.0
+    - nvm use 0.12.0
     - npm install shelljs@0.7.0
 
 # Create and start the emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,6 @@ before_script:
 script:
    #run template app generation
    - set -o pipefail && node external/shared/node/test_force.js --os=android --test=native
-   - set -o pipefail && node external/shared/node/test_force.js --os=android --test=hybrid_local
-   - set -o pipefail && node external/shared/node/test_force.js --os=android --test=hybrid_remote
 
    - travis_wait 30 ./gradlew :libs:SalesforceSDK:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SmartStore:connectedAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,11 @@ before_script:
 
 #Build all projects and run the tests
 script:
+   #run template app generation
+   - set -o pipefail && node external/shared/node/test_force.js --os=android --test=native
+   - set -o pipefail && node external/shared/node/test_force.js --os=android --test=hybrid_local
+   - set -o pipefail && node external/shared/node/test_force.js --os=android --test=hybrid_remote
+
    - travis_wait 30 ./gradlew :libs:SalesforceSDK:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SmartStore:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SmartSync:connectedAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ licenses:
     - android-sdk-license-5be876d5
 
 before_install:
- - npm install -g shelljs@0.7.0
+ - nvm install node
+ - npm install shelljs@0.7.0
 
 # Create and start the emulator
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ licenses:
     - android-sdk-license-5be876d5
 
 before_install:
- - nvm install node
  - npm install shelljs@0.7.0
 
 # Create and start the emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ licenses:
     - android-sdk-license-5be876d5
 
 before_install:
- - npm install shelljs@0.7.0
+ - npm install -g shelljs@0.7.0
 
 # Create and start the emulator
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ licenses:
     - android-sdk-license-5be876d5
 
 before_install:
- - npm install shelljs@0.7.0
+    - nvm install node 0.12.0  
+    - npm install shelljs@0.7.0
 
 # Create and start the emulator
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ env:
 licenses:
     - android-sdk-license-5be876d5
 
+install: ant deps 
+
 # Create and start the emulator
 before_script:
    - echo no | android create avd --force -n test -t $ANDROID_TARGET  --abi armeabi-v7a -c 128M

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ licenses:
 
 before_install:
  - npm install shelljs@0.7.0
- - brew update
- - brew install ant
 
 # Create and start the emulator
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,10 @@ env:
 licenses:
     - android-sdk-license-5be876d5
 
-install: ant deps 
+before_install:
+ - npm install shelljs@0.7.0
+ - brew update
+ - brew install ant
 
 # Create and start the emulator
 before_script:


### PR DESCRIPTION
I will add hybrid apps later. Right now when the test script creates a hybrid app, it fails on ./install.sh as its trying to do a xcdoebuild. Will have to see how we can build only the android sources and skip the iOS ones.