### PR TITLE
Fix for JSONException at SmartSyncManager:isNewerThanServer

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
@@ -439,11 +439,11 @@ public class SyncManager {
         boolean locallyUpdated = record.getBoolean(LOCALLY_UPDATED);
 
         Action action = null;
-        if (record.getBoolean(LOCALLY_DELETED))
+        if (locallyDeleted)
             action = Action.delete;
-        else if (record.getBoolean(LOCALLY_CREATED))
+        else if (locallyCreated)
             action = Action.create;
-        else if (record.getBoolean(LOCALLY_UPDATED))
+        else if (locallyUpdated)
             action = Action.update;
 
         if (action == null) {

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
@@ -144,18 +144,22 @@ public class SyncUpTarget extends SyncTarget {
      * @param objectType
      * @param objectId
      * @return
-     * @throws JSONException
-     * @throws IOException
      */
-    public String fetchLastModifiedDate(SyncManager syncManager, String objectType, String objectId) throws JSONException, IOException {
-        final String query = SOQLBuilder.getInstanceWithFields(getModificationDateFieldName())
-                .from(objectType)
-                .where(getIdFieldName() + " = '" + objectId + "'")
-                .build();
+    public String fetchLastModifiedDate(SyncManager syncManager, String objectType, String objectId) {
+        try {
+            final String query = SOQLBuilder.getInstanceWithFields(getModificationDateFieldName())
+                    .from(objectType)
+                    .where(getIdFieldName() + " = '" + objectId + "'")
+                    .build();
 
-        RestResponse lastModResponse = syncManager.sendSyncWithSmartSyncUserAgent(RestRequest.getRequestForQuery(syncManager.apiVersion, query));
-        JSONArray records = lastModResponse.asJSONObject().optJSONArray(Constants.RECORDS);
-        return records != null && records.length() > 0 ? records.optJSONObject(0).optString(getModificationDateFieldName()) : null;
+            RestResponse lastModResponse = syncManager.sendSyncWithSmartSyncUserAgent(RestRequest.getRequestForQuery(syncManager.apiVersion, query));
+            JSONArray records = lastModResponse.asJSONObject().optJSONArray(Constants.RECORDS);
+            return records != null && records.length() > 0 ? records.optJSONObject(0).optString(getModificationDateFieldName()) : null;
+        }
+        catch (Exception e) {
+            // Caller expects null to be returned if the last modified date could not be fetched
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
- we shouldn't go to the server for locally created records
- but if the app code unchecks the locally_created flag (e.g. after doing an local update or delete), the smart sync code should not fail the sync up
- added tests