### PR TITLE
Fix a build break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,7 @@ script:
    #run template app generation
    - travis_wait 30 set -o pipefail && node external/shared/node/test_force.js --os=android --test=native
 
-   - travis_wait 30 ./gradlew :libs:SalesforceSDK:connectedAndroidTest
-   - travis_wait 30 ./gradlew :libs:SmartStore:connectedAndroidTest
-   - travis_wait 30 ./gradlew :libs:SmartSync:connectedAndroidTest
+   - travis_wait 30 ./gradlew createDebugCoverageReport
    - travis_wait 30 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
    - ./gradlew :libs:SalesforceReact:assembleDebug
    - travis_wait 30 ./gradlew :native:NativeSampleApps:RestExplorer:connectedAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,7 @@ script:
    - travis_wait 30 ./gradlew :libs:SalesforceSDK:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SmartStore:connectedAndroidTest
    - travis_wait 30 ./gradlew :libs:SmartSync:connectedAndroidTest
-   # disable the unreliable test to reduce the impact for other tests, just build it
-   # will add it back once fix the test issue
-   - ./gradlew :libs:SalesforceHybrid:assembleDebug
+   - travis_wait 30 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
    - ./gradlew :libs:SalesforceReact:assembleDebug
    - travis_wait 30 ./gradlew :native:NativeSampleApps:RestExplorer:connectedAndroidTest
    - travis_wait 30 ./gradlew :native:TemplateApp:connectedAndroidTest

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -9,6 +9,12 @@ dependencies {
 android {
   compileSdkVersion 23
   buildToolsVersion '23.0.1'
+  
+  buildTypes {
+      debug {
+         testCoverageEnabled = true
+      }
+   }
 
   sourceSets {
     main {

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -9,6 +9,12 @@ dependencies {
 android {
   compileSdkVersion 23
   buildToolsVersion '23.0.1'
+  
+  buildTypes {
+      debug {
+         testCoverageEnabled = true
+      }
+  }
 
   sourceSets {
     main {

--- a/libs/SmartSync/build.gradle
+++ b/libs/SmartSync/build.gradle
@@ -8,6 +8,12 @@ dependencies {
 android {
   compileSdkVersion 23
   buildToolsVersion '23.0.1'
+  
+  buildTypes {
+      debug {
+         testCoverageEnabled = true
+      }
+  }
 
   sourceSets {
     main {

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
@@ -42,7 +42,7 @@ public class SmartStoreJSTest extends JSTestCase {
     
     @Override
     protected int getMaxRuntimeInSecondsForTest(String testName) {
-        return 10;
+        return 30;
     }
 
     @Override

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
@@ -82,13 +82,11 @@ public class SmartSyncJSTest extends JSTestCase {
                 "testSObjectFetch",
                 "testSObjectSave",
                 "testSObjectDestroy",
-                //comment out all apex rest object smartsync test for further investigation
-                //while allow to run other reliable hybrid test
-//                "testSyncApexRestObjectWithServerCreate",
-//                "testSyncApexRestObjectWithServerRead",
-//                "testSyncApexRestObjectWithServerUpdate",
-//                "testSyncApexRestObjectWithServerDelete",
-//                "testFetchApexRestObjectsFromServer",
+                "testSyncApexRestObjectWithServerCreate",
+                "testSyncApexRestObjectWithServerRead",
+                "testSyncApexRestObjectWithServerUpdate",
+                "testSyncApexRestObjectWithServerDelete",
+                "testFetchApexRestObjectsFromServer",
                 "testFetchSObjectsFromServer",
                 "testFetchSObjects",
                 "testSObjectCollectionFetch",
@@ -241,27 +239,26 @@ public class SmartSyncJSTest extends JSTestCase {
     public void testSObjectDestroy() {
         runTest("testSObjectDestroy");
     }
-    //comment out all apex rest object smartsync test for further investigation
-    //while allow to run other reliable hybrid test
-//    public void testSyncApexRestObjectWithServerCreate() {
-//        runTest("testSyncApexRestObjectWithServerCreate");
-//    }
-//
-//    public void testSyncApexRestObjectWithServerRead() {
-//        runTest("testSyncApexRestObjectWithServerRead");
-//    }
-//
-//    public void testSyncApexRestObjectWithServerUpdate() {
-//        runTest("testSyncApexRestObjectWithServerUpdate");
-//    }
-//
-//    public void testSyncApexRestObjectWithServerDelete() {
-//        runTest("testSyncApexRestObjectWithServerDelete");
-//    }
-//
-//    public void testFetchApexRestObjectsFromServer() {
-//        runTest("testFetchApexRestObjectsFromServer");
-//    }
+
+    public void testSyncApexRestObjectWithServerCreate() {
+        runTest("testSyncApexRestObjectWithServerCreate");
+    }
+
+    public void testSyncApexRestObjectWithServerRead() {
+        runTest("testSyncApexRestObjectWithServerRead");
+    }
+
+    public void testSyncApexRestObjectWithServerUpdate() {
+        runTest("testSyncApexRestObjectWithServerUpdate");
+    }
+
+    public void testSyncApexRestObjectWithServerDelete() {
+        runTest("testSyncApexRestObjectWithServerDelete");
+    }
+
+    public void testFetchApexRestObjectsFromServer() {
+        runTest("testFetchApexRestObjectsFromServer");
+    }
 
     public void testFetchSObjectsFromServer() {
         runTest("testFetchSObjectsFromServer");

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
@@ -82,11 +82,13 @@ public class SmartSyncJSTest extends JSTestCase {
                 "testSObjectFetch",
                 "testSObjectSave",
                 "testSObjectDestroy",
-                "testSyncApexRestObjectWithServerCreate",
-                "testSyncApexRestObjectWithServerRead",
-                "testSyncApexRestObjectWithServerUpdate",
-                "testSyncApexRestObjectWithServerDelete",
-                "testFetchApexRestObjectsFromServer",
+                //comment out all apex rest object smartsync test for further investigation
+                //while allow to run other reliable hybrid test
+//                "testSyncApexRestObjectWithServerCreate",
+//                "testSyncApexRestObjectWithServerRead",
+//                "testSyncApexRestObjectWithServerUpdate",
+//                "testSyncApexRestObjectWithServerDelete",
+//                "testFetchApexRestObjectsFromServer",
                 "testFetchSObjectsFromServer",
                 "testFetchSObjects",
                 "testSObjectCollectionFetch",
@@ -239,26 +241,27 @@ public class SmartSyncJSTest extends JSTestCase {
     public void testSObjectDestroy() {
         runTest("testSObjectDestroy");
     }
-
-    public void testSyncApexRestObjectWithServerCreate() {
-        runTest("testSyncApexRestObjectWithServerCreate");
-    }
-
-    public void testSyncApexRestObjectWithServerRead() {
-        runTest("testSyncApexRestObjectWithServerRead");
-    }
-
-    public void testSyncApexRestObjectWithServerUpdate() {
-        runTest("testSyncApexRestObjectWithServerUpdate");
-    }
-
-    public void testSyncApexRestObjectWithServerDelete() {
-        runTest("testSyncApexRestObjectWithServerDelete");
-    }
-
-    public void testFetchApexRestObjectsFromServer() {
-        runTest("testFetchApexRestObjectsFromServer");
-    }
+    //comment out all apex rest object smartsync test for further investigation
+    //while allow to run other reliable hybrid test
+//    public void testSyncApexRestObjectWithServerCreate() {
+//        runTest("testSyncApexRestObjectWithServerCreate");
+//    }
+//
+//    public void testSyncApexRestObjectWithServerRead() {
+//        runTest("testSyncApexRestObjectWithServerRead");
+//    }
+//
+//    public void testSyncApexRestObjectWithServerUpdate() {
+//        runTest("testSyncApexRestObjectWithServerUpdate");
+//    }
+//
+//    public void testSyncApexRestObjectWithServerDelete() {
+//        runTest("testSyncApexRestObjectWithServerDelete");
+//    }
+//
+//    public void testFetchApexRestObjectsFromServer() {
+//        runTest("testFetchApexRestObjectsFromServer");
+//    }
 
     public void testFetchSObjectsFromServer() {
         runTest("testFetchSObjectsFromServer");

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -307,7 +307,7 @@ public class SyncManagerTest extends ManagerTestCase {
      */
     public void testSyncUpWithLocallyCreatedAndDeletedRecords() throws Exception {
         // Create a few entries locally
-        String[] names = new String[] { createAccountName(), createAccountName(), createAccountName() };
+        String[] names = new String[] { createRecordName(Constants.ACCOUNT), createRecordName(Constants.ACCOUNT), createRecordName(Constants.ACCOUNT)};
         createAccountsLocally(names);
         Map<String, String> idToNamesCreated = getIdsForNames(names);
 


### PR DESCRIPTION
There is a change for create Account name, that we have a generic helper to create record name based on the passed in record type.  While the recent changes checked in not align to that change.

Also enable hybrid tests