### PR TITLE
Changes to support 64 bits devices with react native

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 cdvCompileSdkVersion=android-23
 cdvMinSdkVersion=19
 cdvBuildToolsVersion=23.0.1
+android.useDeprecatedNdk=true

--- a/reactnative/ReactNativeTemplateApp/build.gradle
+++ b/reactnative/ReactNativeTemplateApp/build.gradle
@@ -28,11 +28,19 @@ android {
         }
     }
 
-  packagingOptions {
-    exclude 'META-INF/LICENSE'
-    exclude 'META-INF/LICENSE.txt'
-    exclude 'META-INF/DEPENDENCIES'
-    exclude 'META-INF/NOTICE'
-  }
+    // To avoid could find DSO to load: libreactnativejni.so
+    // See https://corbt.com/posts/2015/09/18/mixing-32-and-64bit-dependencies-in-android.html
+    defaultConfig {
+        ndk {
+            abiFilters "armeabi-v7a", "x86"
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'META-INF/NOTICE'
+    }
 
 }


### PR DESCRIPTION
Based on workaround offered here: https://corbt.com/posts/2015/09/18/mixing-32-and-64bit-dependencies-in-android.html