### PR TITLE
sendAsync returns a OkHttp Call object instead of a Request object.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -269,24 +269,24 @@ public class RestClient {
 	 * Note: Intended to be used by code on the UI thread.
 	 * @param restRequest
 	 * @param callback
-	 * @return okHttp Request object
-	 */
-	public Request sendAsync(final RestRequest restRequest, final AsyncRequestCallback callback) {
-        Request request = buildRequest(restRequest);
-        okHttpClient.newCall(request)
-                .enqueue(new Callback() {
-                             @Override
-                             public void onFailure(Call call, IOException e) {
-                                 callback.onError(e);
-                             }
+	 * @return okHttp Call object (through which you can cancel the request or get the request back)
+		 */
+		public Call sendAsync(final RestRequest restRequest, final AsyncRequestCallback callback) {
+			Request request = buildRequest(restRequest);
+			Call call = okHttpClient.newCall(request);
+			call.enqueue(new Callback() {
+								 @Override
+								 public void onFailure(Call call, IOException e) {
+									 callback.onError(e);
+								 }
 
-                             @Override
-                             public void onResponse(Call call, Response response) throws IOException {
-                                 callback.onSuccess(restRequest, new RestResponse(response));
-                             }
-                         }
-                );
-        return request;
+								 @Override
+								 public void onResponse(Call call, Response response) throws IOException {
+									 callback.onSuccess(restRequest, new RestResponse(response));
+								 }
+							 }
+					);
+			return call;
 	}
 
 	/**


### PR DESCRIPTION
Before 4.2, when we were using Volley, we used to return the Volley Request object which has a method for cancellation.

With OkHttp, cancellation is done through the Call object instead. So it makes sense to return that object instead. Also from the Call object you can get a reference to the Request.

That way, developers don't need to go to the okHttpClient's dispatcher and loop through queuedCalls or runningCalls if they keep a reference to the Call object returned when invoking sendAsync.
However to cancel all requests, it's probably still easier to call cancelAll on the okHttpClient's dispatcher.
@rwhitley 