### PR TITLE
External storage post merge work (incomplete)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
@@ -120,7 +120,7 @@ public class Encryptor {
      * @return decrypted data
      */
     public static String decrypt(String data, String key) {
-        if (key == null || data == null) {
+        if (key == null || key.isEmpty() || data == null) {
             return data;
         }
         try {
@@ -145,7 +145,7 @@ public class Encryptor {
      * @return base64, aes256 encrypted data
      */
     public static String encrypt(String data, String key) {
-        if (key == null || data == null) {
+        if (key == null || key.isEmpty() || data == null) {
             return data;
         }
         try {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/Encryptor.java
@@ -43,6 +43,7 @@ import javax.crypto.spec.SecretKeySpec;
 import android.app.Service;
 import android.app.admin.DevicePolicyManager;
 import android.content.Context;
+import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 
@@ -116,11 +117,11 @@ public class Encryptor {
     /**
      * Decrypt data with key using aes256
      * @param data
-     * @param key base64 encoded 256 bits key or null to leave data unchanged
+     * @param key base64 encoded 256 bits key or null/"" to leave data unchanged
      * @return decrypted data
      */
     public static String decrypt(String data, String key) {
-        if (key == null || key.isEmpty() || data == null) {
+        if (TextUtils.isEmpty(key) || data == null) {
             return data;
         }
         try {
@@ -141,11 +142,11 @@ public class Encryptor {
     /**
      * Encrypt data with key using aes256
      * @param data
-     * @param key base64 encoded 256 bits key or null to leave data unchanged
+     * @param key base64 encoded 256 bits key or null/"" to leave data unchanged
      * @return base64, aes256 encrypted data
      */
     public static String encrypt(String data, String key) {
-        if (key == null || key.isEmpty() || data == null) {
+        if (TextUtils.isEmpty(key) || data == null) {
             return data;
         }
         try {

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/IndexSpec.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/IndexSpec.java
@@ -168,5 +168,18 @@ public class IndexSpec {
 		}
 		return false;
 	}
-	
+
+	/**
+	 * @param indexSpecs
+	 * @return true if at least one of the indexSpec is of type json1
+	 */
+	public static boolean hasJSON1(IndexSpec[] indexSpecs) {
+		for (IndexSpec indexSpec : indexSpecs) {
+			if (indexSpec.type == Type.json1) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -302,6 +302,7 @@ public class SmartStore  {
 			String soupName = soupSpec.getSoupName();
 			if (soupName == null) throw new SmartStoreException("Bogus soup name:" + soupName);
 			if (indexSpecs.length == 0) throw new SmartStoreException("No indexSpecs specified for soup: " + soupName);
+			if (IndexSpec.hasJSON1(indexSpecs) && soupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE))  throw new SmartStoreException("Can't have JSON1 index specs in externally stored soup:" + soupName);
 			if (hasSoup(soupName)) return; // soup already exist - do nothing
 
 			// First get a table name

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
@@ -32,11 +32,13 @@ import android.util.Log;
 
 import com.salesforce.androidsdk.smartstore.store.AlterSoupLongOperation;
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
+import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.LongOperation;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
+import com.salesforce.androidsdk.smartstore.store.SoupSpec;
 import com.salesforce.androidsdk.util.test.JSONTestHelper;
 
 import net.sqlcipher.database.SQLiteDatabase;
@@ -45,6 +47,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -203,6 +206,55 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         tryAlterSoupTypeChange(SmartStore.Type.json1, SmartStore.Type.full_text);
     }
 
+
+    /**
+     * Test for alterSoup with column type change from string to json1
+     * and storage goes from external to internal
+     */
+    public void testAlterSoupTypeChangeStringToJSON1ExternalToInternal() throws JSONException {
+        tryAlterSoupTypeChange(SmartStore.Type.string, SmartStore.Type.json1, false, true, true);
+    }
+
+    /**
+     * Test for alterSoup with column type change from json1 to string
+     * and storage change from internal to external
+     */
+    public void testAlterSoupTypeChangeJSON1ToStringInternalToExternal() throws JSONException {
+        tryAlterSoupTypeChange(SmartStore.Type.json1, SmartStore.Type.string, true, true, false);
+    }
+
+    /**
+     * Test for alterSoup with column type change from string to full_text
+     * and storage change from external to internal
+     */
+    public void testAlterSoupTypeChangeStringToFullTextExternalToInternal() throws JSONException {
+        tryAlterSoupTypeChange(SmartStore.Type.string, SmartStore.Type.full_text, false, true, true);
+    }
+        
+    /**
+     * Test for alterSoup with column type change from full_text to string
+     * and storage change from internal to external
+     */
+    public void testAlterSoupTypeChangeFullTextToStringInternalToExternal() throws JSONException {
+        tryAlterSoupTypeChange(SmartStore.Type.full_text, SmartStore.Type.string, true, true, false);
+    }
+
+    /**
+     * Test for alterSoup with string column
+     * and storage change from internal to external to internal
+     */
+    public void testAlterSoupStringInternalToExternalToInternal() throws JSONException {
+        tryAlterSoupTypeChange(SmartStore.Type.string, SmartStore.Type.string, true, false, true);
+    }
+
+    /**
+     * Test for alterSoup with full_text column
+     * and storage change from internal to external to internal
+     */
+    public void testAlterSoupFullTextInternalToExternalToInternal() throws JSONException {
+        tryAlterSoupTypeChange(SmartStore.Type.full_text, SmartStore.Type.string, true, false, true);
+    }
+
     /**
      * Test for alterSoup passing in same index specs (string)
      * Make sure db table / indexes are recreated
@@ -319,11 +371,40 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         checkDb(new long[]{elt1Id, elt2Id}, indexSpecs[0].type, indexSpecs[1].type);
     }
 
+    /**
+     * Start with country and city as fromType
+     * Alter soup to have country as toType
+     * Alter soup a second time to have city as toType
+     *
+     * Only use internal storage
+     *
+     * @param fromType
+     * @param toType
+     * @throws JSONException
+     */
     public void tryAlterSoupTypeChange(SmartStore.Type fromType, SmartStore.Type toType) throws JSONException {
+        tryAlterSoupTypeChange(fromType, toType, true, true, true);
+    }
+
+    /**
+     * Start with soup with country and city as fromType and storage based on fromStorageInternal
+     * Alter soup to have country as toType and storage based on toStorageInternal
+     * Alter soup a second time to have city as toType and storage based on toStorageInternal2
+     *
+     * @param fromType
+     * @param toType
+     * @param fromStorageInternal
+     * @param toStorageInternal
+     * @param toStorageInternal2
+     * @throws JSONException
+     */
+    public void tryAlterSoupTypeChange(SmartStore.Type fromType, SmartStore.Type toType, boolean fromStorageInternal,
+                                       boolean toStorageInternal, boolean toStorageInternal2) throws JSONException {
         IndexSpec[] indexSpecs = new IndexSpec[] {new IndexSpec(CITY, fromType), new IndexSpec(COUNTRY, fromType)};
 
         assertFalse("Soup test_soup should not exist", store.hasSoup(TEST_SOUP));
-        store.registerSoup(TEST_SOUP, indexSpecs);
+        SoupSpec soupSpec = fromStorageInternal ? new SoupSpec(TEST_SOUP) : new SoupSpec(TEST_SOUP, SoupSpec.FEATURE_EXTERNAL_STORAGE);
+        store.registerSoupWithSpec(soupSpec, indexSpecs);
         assertTrue("Register soup call failed", store.hasSoup(TEST_SOUP));
 
         JSONObject soupElt1 = new JSONObject();
@@ -337,30 +418,47 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         long elt2Id = idOf(store.create(TEST_SOUP, soupElt2));
 
         // Checking db
-        checkDb(new long[]{elt1Id, elt2Id}, indexSpecs[0].type, indexSpecs[1].type);
+        checkDb(new long[]{elt1Id, elt2Id}, indexSpecs[0].type, indexSpecs[1].type, fromStorageInternal);
+
+        // Checking filesystem if applicable
+        checkFileSystem(TEST_SOUP, new long[]{elt1Id, elt2Id}, !fromStorageInternal);
 
         // Alter soup - country now full_text
         IndexSpec[] indexSpecsNew = new IndexSpec[] {new IndexSpec(CITY, fromType), new IndexSpec(COUNTRY, toType)};
         store.alterSoup(TEST_SOUP, indexSpecsNew, true);
+        // TODO alterSoup to use storage according to toStorageInternal
 
         // Checking db
-        checkDb(new long[]{elt1Id, elt2Id}, indexSpecsNew[0].type, indexSpecsNew[1].type);
+        checkDb(new long[]{elt1Id, elt2Id}, indexSpecsNew[0].type, indexSpecsNew[1].type, toStorageInternal);
+
+        // Checking filesystem if applicable
+        checkFileSystem(TEST_SOUP,new long[]{elt1Id, elt2Id}, !toStorageInternal);
 
         // Alter soup - city now full_text
         indexSpecsNew = new IndexSpec[] {new IndexSpec(CITY, toType), new IndexSpec(COUNTRY, toType)};
         store.alterSoup(TEST_SOUP, indexSpecsNew, true);
+        // TODO alterSoup to use storage according to toStorageInternal2
 
         // Checking db
-        checkDb(new long[]{elt1Id, elt2Id}, indexSpecsNew[0].type, indexSpecsNew[1].type);
+        checkDb(new long[]{elt1Id, elt2Id}, indexSpecsNew[0].type, indexSpecsNew[1].type, toStorageInternal2);
+
+        // Checking filesystem if applicable
+        checkFileSystem(TEST_SOUP, new long[]{elt1Id, elt2Id}, !toStorageInternal2);
     }
 
-
     private void checkDb(long[] expectedIds, SmartStore.Type cityColType, SmartStore.Type countryColType) throws JSONException {
+        checkDb(expectedIds, cityColType, countryColType, true);
+    }
+
+    private void checkDb(long[] expectedIds, SmartStore.Type cityColType, SmartStore.Type countryColType, boolean useInternalStorage) throws JSONException {
         String[] cities = new String[] {SAN_FRANCISCO, PARIS};
         String[] countries = new String[] {USA, FRANCE};
 
         // Check columns of soup table
-        List<String> expectedColumnNames = new ArrayList<>(Arrays.asList("id", "soup", "created", "lastModified"));
+        List<String> expectedColumnNames = useInternalStorage
+                ? new ArrayList<>(Arrays.asList("id", "soup", "created", "lastModified"))
+                : new ArrayList<>(Arrays.asList("id", "created", "lastModified"));
+
         if (cityColType != SmartStore.Type.json1) expectedColumnNames.add(CITY_COL);
         if (countryColType != SmartStore.Type.json1) expectedColumnNames.add(COUNTRY_COL);
         checkColumns(TEST_SOUP_TABLE_NAME, expectedColumnNames);

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
@@ -68,6 +68,21 @@ public class SmartStoreExternalStorageTest extends SmartStoreTest {
 	}
 
 	/**
+	 * Ensure that a soup cannot be using external storage and JSON1
+	 */
+	public void testRegisterSoupWithExternalStorageAndJSON1() {
+		assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
+		try {
+			registerSoup(store, OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("lastName", Type.json1), new IndexSpec("address.city", Type.string)});
+			fail("Registering soup with external storage and json1 should have thrown an exception");
+		}
+		catch (SmartStore.SmartStoreException e) {
+			assertEquals("Wrong exception", "Can't have JSON1 index specs in externally stored soup:" + OTHER_TEST_SOUP, e.getMessage());
+		}
+		assertFalse("Register soup call should have failed", store.hasSoup(OTHER_TEST_SOUP));
+	}
+
+	/**
 	 * Ensure data is still accessible after changing key
 	 */
 	public void testChangeKey() throws JSONException {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-present, salesforce.com, inc.
+ * Copyright (c) 2016-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
@@ -27,12 +27,9 @@
 package com.salesforce.androidsdk.store;
 
 
-import java.io.File;
+import android.database.Cursor;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
+import com.google.common.primitives.Longs;
 import com.salesforce.androidsdk.security.Encryptor;
 import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
@@ -45,7 +42,13 @@ import com.salesforce.androidsdk.util.test.JSONTestHelper;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
-import android.database.Cursor;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests for encrypted smart store with external storage
@@ -233,4 +236,16 @@ public class SmartStoreExternalStorageTest extends SmartStoreTest {
 										   QuerySpec.buildAllQuerySpec(TEST_SOUP, "value", Order.ascending, 10),
 										   0, true, "SCAN", soupElt1Created, soupElt1Upserted, soupElt2Created, soupElt3Created);
 	}
+
+    @Override
+    public void testDeleteByQuery() throws JSONException {
+        List<Long> idsDeleted = new ArrayList<>();
+        List<Long> idsNotDeleted = new ArrayList<>();
+
+        tryDeleteByQuery(idsDeleted, idsNotDeleted);
+
+        // Check file system
+        checkFileSystem(TEST_SOUP, Longs.toArray(idsDeleted), false);
+        checkFileSystem(TEST_SOUP, Longs.toArray(idsNotDeleted), true);
+    }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFTSExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFTSExternalStorageTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.store;
+
+
+import com.salesforce.androidsdk.smartstore.store.IndexSpec;
+import com.salesforce.androidsdk.smartstore.store.SmartStore;
+import com.salesforce.androidsdk.smartstore.store.SoupSpec;
+
+/**
+ * Tests for full-text search in smartstore soups using external storage
+ */
+public class SmartStoreFTSExternalStorageTest extends SmartStoreFullTextSearchTest {
+
+    @Override
+    protected void registerSoup(SmartStore store, String soupName, IndexSpec[] indexSpecs) {
+        store.registerSoupWithSpec(new SoupSpec(soupName, SoupSpec.FEATURE_EXTERNAL_STORAGE), indexSpecs);
+    }
+
+    @Override
+    protected String[] getExpectedColumns() {
+        return new String[]{"id", "created", "lastModified", FIRST_NAME_COL, LAST_NAME_COL, EMPLOYEE_ID_COL};
+    }
+
+}

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
@@ -33,6 +33,7 @@ import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
+import com.salesforce.androidsdk.smartstore.store.SoupSpec;
 
 import net.sqlcipher.database.SQLiteDatabase;
 
@@ -54,9 +55,9 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
     private static final String EMPLOYEES_SOUP = "employees";
 
     private static final String TABLE_NAME = "TABLE_1";
-    private static final String FIRST_NAME_COL = TABLE_NAME + "_0";
-    private static final String LAST_NAME_COL = TABLE_NAME + "_1";
-    private static final String EMPLOYEE_ID_COL = TABLE_NAME + "_2";
+    protected static final String FIRST_NAME_COL = TABLE_NAME + "_0";
+    protected static final String LAST_NAME_COL = TABLE_NAME + "_1";
+    protected static final String EMPLOYEE_ID_COL = TABLE_NAME + "_2";
     
     // Populated by loadData()
     private long christineHaasId;
@@ -74,7 +75,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
 
     private void setupSoup(SmartStore.FtsExtension ftsExtension) {
         store.setFtsExtension(ftsExtension);
-        store.registerSoup(EMPLOYEES_SOUP, new IndexSpec[]{   // should be TABLE_1
+        registerSoup(store, EMPLOYEES_SOUP, new IndexSpec[]{   // should be TABLE_1
                 new IndexSpec(FIRST_NAME, Type.full_text),    // should be TABLE_1_0
                 new IndexSpec(LAST_NAME, Type.full_text),     // should be TABLE_1_1
                 new IndexSpec(EMPLOYEE_ID, Type.string),      // should be TABLE_1_2
@@ -157,7 +158,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
             assertTrue("Expected a row", c.moveToFirst());
             assertEquals("Expected two rows", 3, c.getCount());
-            assertTrue("Wrong columns", Arrays.deepEquals(new String[]{"id", "soup", "created", "lastModified", FIRST_NAME_COL, LAST_NAME_COL, EMPLOYEE_ID_COL}, c.getColumnNames()));
+            assertTrue("Wrong columns", Arrays.deepEquals(getExpectedColumns(), c.getColumnNames()));
 
             assertEquals("Wrong id", firstEmployeeId, c.getLong(c.getColumnIndex("id")));
             assertEquals("Wrong value in index column", "Christine", c.getString(c.getColumnIndex(FIRST_NAME_COL)));
@@ -706,5 +707,19 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         if (employeeId != null) employee.put(EMPLOYEE_ID, employeeId);
         JSONObject employeeSaved = store.create(EMPLOYEES_SOUP, employee);
         return idOf(employeeSaved);
+    }
+
+    /**
+     * Registers a soup with the given name and index specs. Can be overridden if extra features are desired.
+     */
+    protected void registerSoup(SmartStore store, String soupName, IndexSpec[] indexSpecs) {
+        store.registerSoup(soupName, indexSpecs);
+    }
+
+    /**
+     * @return expected columns in soup table
+     */
+    protected String[] getExpectedColumns() {
+        return new String[]{"id", "soup", "created", "lastModified", FIRST_NAME_COL, LAST_NAME_COL, EMPLOYEE_ID_COL};
     }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
@@ -54,7 +54,7 @@ import android.os.SystemClock;
 public class SmartStoreTest extends SmartStoreTestCase {
 
 	protected static final String TEST_SOUP = "test_soup";
-	private static final String OTHER_TEST_SOUP = "other_test_soup";
+	protected static final String OTHER_TEST_SOUP = "other_test_soup";
 	private static final String THIRD_TEST_SOUP = "third_test_soup";
 	private static final String FOURTH_TEST_SOUP = "fourth_test_soup";
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
@@ -26,6 +26,7 @@
  */
 package com.salesforce.androidsdk.store;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -190,6 +191,18 @@ public abstract class SmartStoreTestCase extends InstrumentationTestCase {
         assertTrue("Wrong query plan:" + detail, detail.startsWith(expectedDetailPrefix));
     }
 
+	public void checkFileSystem(String soupName, long[] expectedIds, boolean shouldExist) {
+		String soupTableName = getSoupTableName(soupName);
+		for (long expectedId : expectedIds) {
+			File file = ((DBOpenHelper) dbOpenHelper).getSoupBlobFile(soupTableName, expectedId);
+			if (shouldExist) {
+				assertTrue("External file for " + expectedId + " should exist", file.exists());
+			}
+			else {
+				assertFalse("External file for " + expectedId + " should not exist", file.exists());
+			}
+		}
+	}
 
 	/**
 	 * Close cursor if not null


### PR DESCRIPTION
Code to prevent soup from having json1 index and external storage (and new test for it)
1) New tests for externally stored soup with full text
2) New test for delete by query against externally stored soup
3) New tests for alter soup with storage change and column type changes
NB: There doesn't seem to be an API to alter soup with soup spec on Android - so the tests are incomplete (have TODOs) and fail