### PR TITLE
Populating application's dataDir in constructor of DBOpenHelper

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -123,7 +123,6 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	public static DBOpenHelper getOpenHelper(Context ctx, String dbNamePrefix,
 			UserAccount account, String communityId) {
 		final StringBuffer dbName = new StringBuffer(dbNamePrefix);
-		dataDir = ctx.getApplicationInfo().dataDir;
 
 		// If we have account information, we will use it to create a database suffix for the user.
 		if (account != null) {
@@ -146,6 +145,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		super(context, dbName, null, DB_VERSION, new DBHook());
 		this.loadLibs(context);
 		this.dbName = dbName;
+		dataDir = context.getApplicationInfo().dataDir;
 	}
 
 	 protected void loadLibs(Context context) {
@@ -460,7 +460,11 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 * @return True if directory was removed, false otherwise.
 	 */
 	public boolean removeExternalBlobsDirectory(String soupTableName) {
-		return removeAllFiles(new File(getExternalSoupBlobsPath(soupTableName)));
+		if (dataDir != null) {
+			return removeAllFiles(new File(getExternalSoupBlobsPath(soupTableName)));
+		} else {
+			return false;
+		}
 	}
 
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/DBOpenHelperTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/DBOpenHelperTest.java
@@ -378,7 +378,7 @@ public class DBOpenHelperTest extends InstrumentationTestCase {
 	}
 
 	/**
-	 * Ensures expected folder was created
+	 * Ensures external blobs directory was removed
 	 */
 	public void testRemoveExternalBlobsDirectory() {
 		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, TEST_DB, null, null);
@@ -394,6 +394,25 @@ public class DBOpenHelperTest extends InstrumentationTestCase {
 		// Test
 		assertTrue("Remove operation was not successful", result);
 		assertFalse("Folder for external blobs was not removed.", folder.exists());
+	}
+
+	/**
+	 * Ensures error is not thrown if dataDir is null
+	 */
+	public void testRemoveExternalBlobsDirectoryNullDataDir() {
+		String realDataDir = targetContext.getApplicationInfo().dataDir;
+		targetContext.getApplicationInfo().dataDir = null;
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, "test_db_null_datadir", null, null);
+
+		// Act - attempt to delete external blobs dir with null dataDir
+		boolean result = helper.removeExternalBlobsDirectory(TEST_SOUP);
+
+		// Test
+		assertFalse("Remove operation was not successful since dataDir was null", result);
+
+		// Reset dataDir back to real value (calling getOpenHelper with a new db resets the dataDir)
+		targetContext.getApplicationInfo().dataDir = realDataDir;
+		DBOpenHelper.getOpenHelper(targetContext, "some_uncached_helper", null, null);
 	}
 
 	/**


### PR DESCRIPTION
Also added a null check for removeExternalBlobsDirectory if in case it remains null