### PR TITLE
Support for changing storage type for alterSoup

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
@@ -27,6 +27,7 @@
 package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.ContentValues;
+import android.database.Cursor;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -55,6 +56,8 @@ public class AlterSoupLongOperation extends LongOperation {
 	// Fields of details for alter soup long operation row in long_operations_status table
 	private static final String SOUP_NAME = "soupName";
 	private static final String SOUP_TABLE_NAME = "soupTableName";
+	private static final String OLD_SOUP_SPEC = "oldSoupFeatures";
+	private static final String NEW_SOUP_SPEC = "newSoupFeatures";
 	private static final String OLD_INDEX_SPECS = "oldIndexSpecs";
 	private static final String NEW_INDEX_SPECS = "newIndexSpecs";
 	private static final String RE_INDEX_DATA = "reIndexData";
@@ -83,7 +86,13 @@ public class AlterSoupLongOperation extends LongOperation {
 	
 	// Last step completed
 	private AlterSoupStep afterStep;
-	
+
+	// New soup spec
+	private SoupSpec newSoupSpec;
+
+	// Old soup spec
+	private SoupSpec oldSoupSpec;
+
 	// New index specs
 	private IndexSpec[] newIndexSpecs;
 	
@@ -114,12 +123,12 @@ public class AlterSoupLongOperation extends LongOperation {
 	 * Constructor
 	 * 
 	 * @param store
-	 * @param soupName
+	 * @param newSoupSpec
 	 * @param newIndexSpecs
 	 * @param reIndexData
 	 * @throws JSONException 
 	 */
-	public AlterSoupLongOperation(SmartStore store, String soupName, IndexSpec[] newIndexSpecs,
+	public AlterSoupLongOperation(SmartStore store, SoupSpec newSoupSpec, IndexSpec[] newIndexSpecs,
 			boolean reIndexData) throws JSONException {
 		
     	synchronized(SmartStore.class) {
@@ -130,8 +139,15 @@ public class AlterSoupLongOperation extends LongOperation {
     		this.db = store.getDatabase();
     		
     		// Setting soupName field
-    		this.soupName = soupName;
-    		
+    		this.soupName = newSoupSpec.getSoupName();
+
+			// Setting new soup spec
+			this.newSoupSpec = newSoupSpec;
+
+			// Get old soup spec
+			List<String> features = DBHelper.getInstance(db).getFeatures(db, soupName);
+			this.oldSoupSpec = new SoupSpec(soupName, features.size() == 0 ? null : features.toArray(new String[features.size()]));
+
 			// Get backing table for soup
 	        this.soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
@@ -186,6 +202,8 @@ public class AlterSoupLongOperation extends LongOperation {
 		this.rowId = rowId;
 		this.afterStep = AlterSoupStep.valueOf(statusStr);
 		this.soupName = details.getString(SOUP_NAME);
+		this.newSoupSpec = SoupSpec.fromJSON(details.optJSONObject(NEW_SOUP_SPEC));
+		this.oldSoupSpec = SoupSpec.fromJSON(details.optJSONObject(OLD_SOUP_SPEC));
 		this.newIndexSpecs = IndexSpec.fromJSON(details.getJSONArray(NEW_INDEX_SPECS));
 		this.oldIndexSpecs = IndexSpec.fromJSON(details.getJSONArray(OLD_INDEX_SPECS));
 		this.reIndexData = details.getBoolean(RE_INDEX_DATA);
@@ -292,8 +310,15 @@ public class AlterSoupLongOperation extends LongOperation {
 		try {
 			db.beginTransaction();
 
+			// Update soup_attrs table for soup
+			ContentValues soupMapValues = new ContentValues();
+			for (String feature : SoupSpec.ALL_FEATURES) {
+				soupMapValues.put(feature, newSoupSpec.getFeatures().contains(feature) ? 1 : 0);
+			}
+			DBHelper.getInstance(db).update(db, SmartStore.SOUP_ATTRS_TABLE, soupMapValues, SmartStore.SOUP_NAME_PREDICATE, soupName);
+
 			// Create new table for soup
-			store.registerSoupUsingTableName(new SoupSpec(soupName, store.usesExternalStorage(soupName) ? SoupSpec.FEATURE_EXTERNAL_STORAGE : null), newIndexSpecs, soupTableName);
+			store.registerSoupUsingTableName(newSoupSpec, newIndexSpecs, soupTableName);
 
 			// Update row in alter status table
 			updateLongOperationDbRow(AlterSoupStep.REGISTER_SOUP_USING_TABLE_NAME);
@@ -316,7 +341,7 @@ public class AlterSoupLongOperation extends LongOperation {
 			this.newIndexSpecs = store.getSoupIndexSpecs(soupName);
 		
 			// Move data (core columns + indexed paths that we are still indexing)
-			copyOldData(store.usesExternalStorage(soupName));
+			copyOldData();
 
 			// Update row in alter status table 
 			updateLongOperationDbRow(AlterSoupStep.COPY_TABLE);
@@ -414,6 +439,8 @@ public class AlterSoupLongOperation extends LongOperation {
 		JSONObject details = new JSONObject();
     	details.put(SOUP_NAME, soupName);
     	details.put(SOUP_TABLE_NAME, soupTableName);
+		details.put(OLD_SOUP_SPEC, oldSoupSpec.toJSON());
+		details.put(NEW_SOUP_SPEC, newSoupSpec.toJSON());
     	details.put(OLD_INDEX_SPECS, IndexSpec.toJSON(oldIndexSpecs));
     	details.put(NEW_INDEX_SPECS, IndexSpec.toJSON(newIndexSpecs));
     	details.put(RE_INDEX_DATA, reIndexData);
@@ -444,11 +471,9 @@ public class AlterSoupLongOperation extends LongOperation {
 	/**
 	 * Helper method
 	 *
-	 * @param usesExternalStorage True if the soup uses external storage, false otherwise.
-	 *
 	 * @return insert statement to copy data from soup old backing table to soup new backing table
 	 */
-	private void copyOldData(boolean usesExternalStorage) {
+	private void copyOldData() {
 		Map<String, IndexSpec> mapOldSpecs = IndexSpec.mapForIndexSpecs(oldIndexSpecs);
 		Map<String, IndexSpec> mapNewSpecs = IndexSpec.mapForIndexSpecs(newIndexSpecs);
 
@@ -463,7 +488,8 @@ public class AlterSoupLongOperation extends LongOperation {
 
 		// Adding core columns
 		String[] columns;
-		if (usesExternalStorage) {
+		if (newSoupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE) || oldSoupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE)) {
+			// either the new or old soup spec contains external storage, so do not add soup column to directly copy
 			columns = new String[] {SmartStore.ID_COL, SmartStore.CREATED_COL, SmartStore.LAST_MODIFIED_COL};
 		} else {
 			columns = new String[] {SmartStore.ID_COL, SmartStore.SOUP_COL, SmartStore.CREATED_COL, SmartStore.LAST_MODIFIED_COL};
@@ -527,6 +553,51 @@ public class AlterSoupLongOperation extends LongOperation {
 
 			// Execute copy
 			db.execSQL(copyToFtsTable);
+		}
+
+		if (oldSoupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE) && !newSoupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE)) {
+			// External to internal storage
+			Cursor c = null;
+			try {
+				c = db.query(getOldSoupTableName(), new String[] { SmartStore.ID_COL }, null, null, null, null, null);
+				if (c.moveToFirst()) {
+					Long[] ids = new Long[c.getCount()];
+					int counter = 0;
+					do {
+						ids[counter++] = c.getLong(0);
+					} while (c.moveToNext());
+
+					for (long id : ids) {
+						store.upsert(soupName, ((DBOpenHelper) store.dbOpenHelper).loadSoupBlob(soupTableName, id, store.passcode));
+						((DBOpenHelper) store.dbOpenHelper).removeSoupBlob(soupTableName, new Long[] {id});
+					}
+				}
+			} catch (JSONException ex) {
+				throw new SmartStoreException("Error inserting external soup entry into new soup.");
+			} finally {
+				if (c != null) {
+					c.close();
+				}
+			}
+		} else if (!oldSoupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE) && newSoupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE)) {
+			// Internal to external storage
+			Cursor c = null;
+			try {
+				c = db.query(getOldSoupTableName(), new String[] { SmartStore.ID_COL, SmartStore.SOUP_COL }, null, null, null, null, null);
+				if (c.moveToFirst()) {
+					do {
+						long id = c.getLong(0);
+						JSONObject entry = new JSONObject(c.getString(1));
+						store.update(soupName, entry, id);
+					} while (c.moveToNext());
+				}
+			} catch (JSONException ex) {
+				throw new SmartStoreException("Error creating external soup entry from old soup entry.");
+			} finally {
+				if (c != null) {
+					c.close();
+				}
+			}
 		}
 	}
 	

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
@@ -141,12 +141,12 @@ public class AlterSoupLongOperation extends LongOperation {
     		// Setting soupName field
     		this.soupName = newSoupSpec.getSoupName();
 
-			// Setting new soup spec
-			this.newSoupSpec = newSoupSpec;
+    		// Setting new soup spec
+    		this.newSoupSpec = newSoupSpec;
 
-			// Get old soup spec
-			List<String> features = DBHelper.getInstance(db).getFeatures(db, soupName);
-			this.oldSoupSpec = new SoupSpec(soupName, features.size() == 0 ? null : features.toArray(new String[features.size()]));
+    		// Get old soup spec
+    		List<String> features = DBHelper.getInstance(db).getFeatures(db, soupName);
+    		this.oldSoupSpec = new SoupSpec(soupName, features.size() == 0 ? null : features.toArray(new String[features.size()]));
 
 			// Get backing table for soup
 	        this.soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
@@ -439,8 +439,8 @@ public class AlterSoupLongOperation extends LongOperation {
 		JSONObject details = new JSONObject();
     	details.put(SOUP_NAME, soupName);
     	details.put(SOUP_TABLE_NAME, soupTableName);
-		details.put(OLD_SOUP_SPEC, oldSoupSpec.toJSON());
-		details.put(NEW_SOUP_SPEC, newSoupSpec.toJSON());
+    	details.put(OLD_SOUP_SPEC, oldSoupSpec.toJSON());
+    	details.put(NEW_SOUP_SPEC, newSoupSpec.toJSON());
     	details.put(OLD_INDEX_SPECS, IndexSpec.toJSON(oldIndexSpecs));
     	details.put(NEW_INDEX_SPECS, IndexSpec.toJSON(newIndexSpecs));
     	details.put(RE_INDEX_DATA, reIndexData);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -111,7 +111,7 @@ public class SmartStore  {
 	// Backing database
 	protected SQLiteDatabase dbLocal;
 	protected SQLiteOpenHelper dbOpenHelper;
-	private String passcode;
+	protected String passcode;
 
 	// FTS extension to use
 	protected FtsExtension ftsExtension = FtsExtension.fts5;
@@ -508,7 +508,7 @@ public class SmartStore  {
 	}
     
 	/**
-	 * Alter soup
+	 * Alter soup using only soup name without extra soup features.
 	 * 
 	 * @param soupName
 	 * @param indexSpecs array of index specs
@@ -517,7 +517,20 @@ public class SmartStore  {
 	 */
 	public void alterSoup(String soupName, IndexSpec[] indexSpecs,
 			boolean reIndexData) throws JSONException {
-		AlterSoupLongOperation operation = new AlterSoupLongOperation(this, soupName, indexSpecs, reIndexData);
+		alterSoup(new SoupSpec(soupName), indexSpecs, reIndexData);
+	}
+
+	/**
+	 * Alter soup with new soup spec.
+	 *
+	 * @param soupSpec
+	 * @param indexSpecs array of index specs
+	 * @param reIndexData
+	 * @throws JSONException
+	 */
+	public void alterSoup(SoupSpec soupSpec, IndexSpec[] indexSpecs,
+			boolean reIndexData) throws JSONException {
+		AlterSoupLongOperation operation = new AlterSoupLongOperation(this, soupSpec, indexSpecs, reIndexData);
 		operation.run();
 	}
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SoupSpec.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SoupSpec.java
@@ -47,6 +47,9 @@ public class SoupSpec {
     private String soupName;
     private List<String> features;
 
+    private static final String NAME = "name";
+    private static final String FEATURES = "features";
+
     /**
      * Creates a soup spec without any features.
      *
@@ -96,8 +99,29 @@ public class SoupSpec {
      */
     public JSONObject toJSON() throws JSONException {
         JSONObject result = new JSONObject();
-        result.put("name", soupName);
-        result.put("features", new JSONArray(features));
+        result.put(NAME, soupName);
+        result.put(FEATURES, new JSONArray(features));
         return result;
+    }
+
+    /**
+     * Constructs a soup spec from JSON
+     *
+     * @param json JSON with which to construct soup spec
+     * @return Soup Spec from given JSON
+     * @throws JSONException
+     */
+    public static SoupSpec fromJSON(JSONObject json) throws JSONException {
+        JSONArray jsonArray = json.optJSONArray(FEATURES);
+        if (jsonArray != null) {
+            String[] featureArray = new String[jsonArray.length()];
+            for (int i = 0; i < jsonArray.length(); i++) {
+                featureArray[i] = (String) jsonArray.get(i);
+            }
+
+            return new SoupSpec(json.getString(NAME), featureArray);
+        } else {
+            return new SoupSpec(json.getString(NAME));
+        }
     }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
@@ -425,8 +425,8 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
 
         // Alter soup - country now full_text
         IndexSpec[] indexSpecsNew = new IndexSpec[] {new IndexSpec(CITY, fromType), new IndexSpec(COUNTRY, toType)};
-        store.alterSoup(TEST_SOUP, indexSpecsNew, true);
-        // TODO alterSoup to use storage according to toStorageInternal
+        SoupSpec toSoupSpec = toStorageInternal ? new SoupSpec(TEST_SOUP) : new SoupSpec(TEST_SOUP, SoupSpec.FEATURE_EXTERNAL_STORAGE);
+        store.alterSoup(toSoupSpec, indexSpecsNew, true);
 
         // Checking db
         checkDb(new long[]{elt1Id, elt2Id}, indexSpecsNew[0].type, indexSpecsNew[1].type, toStorageInternal);
@@ -436,8 +436,8 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
 
         // Alter soup - city now full_text
         indexSpecsNew = new IndexSpec[] {new IndexSpec(CITY, toType), new IndexSpec(COUNTRY, toType)};
-        store.alterSoup(TEST_SOUP, indexSpecsNew, true);
-        // TODO alterSoup to use storage according to toStorageInternal2
+        SoupSpec toSoupSpec2 = toStorageInternal2 ? new SoupSpec(TEST_SOUP) : new SoupSpec(TEST_SOUP, SoupSpec.FEATURE_EXTERNAL_STORAGE);
+        store.alterSoup(toSoupSpec2, indexSpecsNew, true);
 
         // Checking db
         checkDb(new long[]{elt1Id, elt2Id}, indexSpecsNew[0].type, indexSpecsNew[1].type, toStorageInternal2);
@@ -738,7 +738,7 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
 
         // Partial alter - up to toStep included
         IndexSpec[] indexSpecsNew = new IndexSpec[] {new IndexSpec("lastName", SmartStore.Type.string), new IndexSpec("address.city", SmartStore.Type.string), new IndexSpec("address.street", SmartStore.Type.string)};
-        AlterSoupLongOperation operation = new AlterSoupLongOperation(store, TEST_SOUP, indexSpecsNew, true);
+        AlterSoupLongOperation operation = new AlterSoupLongOperation(store, new SoupSpec(TEST_SOUP), indexSpecsNew, true);
         operation.run(toStep);
 
         // Validate long_operations_status table

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
@@ -172,7 +172,7 @@ public class SmartStoreExternalStorageTest extends SmartStoreTest {
 	protected void tryAllQueryOnChangedSoupWithUpdate(String soupName, JSONObject deletedEntry, String orderPath,
 			IndexSpec[] newIndexSpecs, JSONObject... expectedResults) throws JSONException {
 		//alert the soup
-		store.alterSoup(soupName, newIndexSpecs, true);
+		store.alterSoup(new SoupSpec(soupName, SoupSpec.FEATURE_EXTERNAL_STORAGE), newIndexSpecs, true);
 
 		//delete an entry
 		store.delete(soupName, idOf(deletedEntry));
@@ -204,7 +204,7 @@ public class SmartStoreExternalStorageTest extends SmartStoreTest {
 	protected void tryExactQueryOnChangedSoup(String soupName, String orderPath, String value,
 			IndexSpec[] newIndexSpecs, JSONObject expectedResult) throws JSONException {
 		//alert the soup
-		store.alterSoup(soupName, newIndexSpecs, true);
+		store.alterSoup(new SoupSpec(soupName, SoupSpec.FEATURE_EXTERNAL_STORAGE), newIndexSpecs, true);
 
 		// Exact Query
 		runQueryCheckResultsAndExplainPlan(soupName,
@@ -228,7 +228,7 @@ public class SmartStoreExternalStorageTest extends SmartStoreTest {
 		JSONObject soupElt3ForUpsert = new JSONObject("{'key':'ka3u', 'value':'va3u'}");
 
 		//CASE 1: index spec from key to value
-		store.alterSoup(TEST_SOUP, new IndexSpec[]{new IndexSpec("value", Type.string)}, true);
+		store.alterSoup(new SoupSpec(TEST_SOUP, SoupSpec.FEATURE_EXTERNAL_STORAGE), new IndexSpec[]{new IndexSpec("value", Type.string)}, true);
 		//upsert an entry
 		JSONObject soupElt1Upserted = store.upsert(TEST_SOUP, soupElt1ForUpsert);
 		// Query all - small page


### PR DESCRIPTION
Allowed AlterSoupLongOperation to support changing soup spec. This enables a store to be
converted from internal storage to external and vice versa. Storing the new/old soup specs
in the long operations table allows resuming of this kind of operation. If these entries are not found
in the db (in the case of client upgrade), they will be assumed to be internal (see SoupSpec.fromJSON)