### PR TITLE
fix the out of memory test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,5 @@ script:
    - travis_wait 30 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
    - ./gradlew :libs:SalesforceReact:assembleDebug
    - travis_wait 30 ./gradlew :native:NativeSampleApps:RestExplorer:connectedAndroidTest
-   # make sure the screen is unlocked
-   - adb shell input keyevent 82
-   - adb shell input keyevent 84
-   - adb shell input keyevent 84
-   - travis_wait 30 ./gradlew :native:TemplateApp:connectedAndroidTest
+   # disable this ui test until fix the unstable test failure 
+   - ./gradlew :native:TemplateApp:assembleDebug

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,8 @@ script:
    - travis_wait 30 ./gradlew :libs:SalesforceHybrid:connectedAndroidTest
    - ./gradlew :libs:SalesforceReact:assembleDebug
    - travis_wait 30 ./gradlew :native:NativeSampleApps:RestExplorer:connectedAndroidTest
-   # disable this ui test until fix the unstable test failure 
-   - ./gradlew :native:TemplateApp:assembleDebug
+   # make sure the screen is unlocked
+   - adb shell input keyevent 82
+   - adb shell input keyevent 84
+   - adb shell input keyevent 84
+   - travis_wait 30 ./gradlew :native:TemplateApp:connectedAndroidTest

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadExternalStorageTest.java
@@ -43,7 +43,7 @@ import android.util.Log;
  */
 public class SmartStoreLoadExternalStorageTest extends SmartStoreLoadTest {
 
-    static final int ONE_MEGABYTE = 1024 * 1024;
+    static final int LARGE_BYTES = 512 * 1024;
 
     @Override
     protected String getPasscode() {
@@ -63,7 +63,7 @@ public class SmartStoreLoadExternalStorageTest extends SmartStoreLoadTest {
 
         for (int i = 0; i < 5; i++) {
             StringBuilder sb = new StringBuilder();
-            for (int j = 0; j < ONE_MEGABYTE; j++) {
+            for (int j = 0; j < LARGE_BYTES; j++) {
                 sb.append(i);
             }
             entry.put("value_" + i, sb.toString());


### PR DESCRIPTION
reduce the tested large bytes entry to make it not exceed the maximum external storage supported on emulator 