### PR TITLE
SyncUp can now have separate fieldlist for create and update

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/Constants.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/Constants.java
@@ -42,6 +42,7 @@ public class Constants {
 
     public static final String ID = "Id";
     public static final String NAME = "Name";
+    public static final String DESCRIPTION = "Description";
     public static final String TYPE = "Type";
     public static final String ATTRIBUTES = "attributes";
     public static final String RECENTLY_VIEWED = "RecentlyViewed";

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncOptions.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncOptions.java
@@ -43,10 +43,14 @@ public class SyncOptions {
 
     public static final String MERGEMODE = "mergeMode";
 	public static final String FIELDLIST = "fieldlist";
+	public static final String CREATE_FIELDLIST = "createFieldlist";
+	public static final String UPDATE_FIELDLIST = "updateFieldlist";
 
     private MergeMode mergeMode;
 	private List<String> fieldlist;
-	
+	private List<String> createFieldlist;
+	private List<String> updateFieldlist;
+
 	/**
 	 * Build SyncOptions from json
 	 * @param options as json
@@ -60,7 +64,10 @@ public class SyncOptions {
         String mergeModeStr = JSONObjectHelper.optString(options, MERGEMODE);
         MergeMode mergeMode = mergeModeStr == null ? null : MergeMode.valueOf(mergeModeStr);
 		List<String> fieldlist = toList(options.optJSONArray(FIELDLIST));
-		return new SyncOptions(fieldlist, mergeMode);
+		List<String> createFieldlist = toList(options.optJSONArray(CREATE_FIELDLIST));
+		List<String> updateFieldlist = toList(options.optJSONArray(UPDATE_FIELDLIST));
+
+		return new SyncOptions(fieldlist, createFieldlist, updateFieldlist, mergeMode);
 	}
 
 	/**
@@ -68,7 +75,7 @@ public class SyncOptions {
 	 * @return
 	 */
 	public static SyncOptions optionsForSyncUp(List<String> fieldlist) {
-		return new SyncOptions(fieldlist, MergeMode.OVERWRITE);
+		return new SyncOptions(fieldlist, null, null, MergeMode.OVERWRITE);
 	}
 
     /**
@@ -77,15 +84,26 @@ public class SyncOptions {
      * @return
      */
     public static SyncOptions optionsForSyncUp(List<String> fieldlist, MergeMode mergeMode) {
-        return new SyncOptions(fieldlist, mergeMode);
+        return new SyncOptions(fieldlist, null, null, mergeMode);
     }
+
+	/**
+	 * @param fieldlist
+	 * @param createFieldlist
+	 * @param updateFieldlist
+	 * @param mergeMode
+	 * @return
+	 */
+	public static SyncOptions optionsForSyncUp(List<String> fieldlist, List<String> createFieldlist, List<String> updateFieldlist, MergeMode mergeMode) {
+		return new SyncOptions(fieldlist, createFieldlist, updateFieldlist, mergeMode);
+	}
 
     /**
      * @param mergeMode
      * @return
      */
     public static SyncOptions optionsForSyncDown(MergeMode mergeMode) {
-        return new SyncOptions(null, mergeMode);
+        return new SyncOptions(null, null, null, mergeMode);
     }
 
 	/**
@@ -93,8 +111,10 @@ public class SyncOptions {
 	 * @param fieldlist
      * @param mergeMode
 	 */
-	private SyncOptions(List<String> fieldlist, MergeMode mergeMode) {
+	private SyncOptions(List<String> fieldlist, List<String> createFieldlist, List<String> updateFieldlist, MergeMode mergeMode) {
 		this.fieldlist = fieldlist;
+		this.createFieldlist = createFieldlist;
+		this.updateFieldlist = updateFieldlist;
         this.mergeMode = mergeMode;
 	}
 	
@@ -106,11 +126,21 @@ public class SyncOptions {
 		JSONObject options = new JSONObject();
         if (mergeMode != null) options.put(MERGEMODE, mergeMode.name());
 		if (fieldlist != null) options.put(FIELDLIST, new JSONArray(fieldlist));
+		if (createFieldlist != null) options.put(CREATE_FIELDLIST, new JSONArray(createFieldlist));
+		if (updateFieldlist != null) options.put(UPDATE_FIELDLIST, new JSONArray(updateFieldlist));
 		return options;
 	}
 
 	public List<String> getFieldlist() {
 		return fieldlist;
+	}
+
+	public List<String> getCreateFieldlist() {
+		return createFieldlist;
+	}
+
+	public List<String> getUpdateFieldlist() {
+		return updateFieldlist;
 	}
 
     public MergeMode getMergeMode() {

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
@@ -143,27 +143,44 @@ abstract public class ManagerTestCase extends InstrumentationTestCase {
         return new RestClient(clientInfo, authToken, httpAccess, null);
     }
 
+
     /**
      * Helper methods to create "count" of test records
      * @param count
-     * @return map of id to name for the created accounts
+     * @return map of id to name for the created records
      * @throws Exception
      */
     protected Map<String, String> createRecordsOnServer(int count, String objectType) throws Exception {
-        Map<String, String> idToValues = new HashMap<String, String>();
+        Map<String, Map <String, Object>> idToFields = createRecordsOnServerReturnFields(count, objectType);
+        Map<String, String> idToNames = new HashMap<>();
+        for (String id : idToFields.keySet()) {
+            idToNames.put(id, (String) idToFields.get(id).get(Constants.NAME));
+        }
+        return idToNames;
+    }
+
+    /**
+     * Helper methods to create "count" of test records
+     * @param count
+     * @return map of id to map of field name to field value for the created records
+     * @throws Exception
+     */
+    protected Map<String, Map<String, Object>> createRecordsOnServerReturnFields(int count, String objectType) throws Exception {
+        Map<String, Map <String, Object>> idToFields = new HashMap<>();
         for (int i = 0; i < count; i++) {
 
             // Request.
-            String fieldValue = createRecordName(objectType);
+            String name = createRecordName(objectType);
             Map<String, Object> fields = new HashMap<String, Object>();
             //add more object type if need to support to use this API
             //to create a new record on server
             switch (objectType) {
                 case Constants.ACCOUNT:
-                    fields.put(Constants.NAME, fieldValue);
+                    fields.put(Constants.NAME, name);
+                    fields.put(Constants.DESCRIPTION, "Description_" + name);
                     break;
                 case Constants.OPPORTUNITY:
-                    fields.put(Constants.NAME, fieldValue);
+                    fields.put(Constants.NAME, name);
                     fields.put("StageName", "Prospecting");
                     DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
                     fields.put("CloseDate", formatter.format(new Date()));
@@ -179,9 +196,9 @@ abstract public class ManagerTestCase extends InstrumentationTestCase {
             assertNotNull("Response should not be null", response);
             assertTrue("Response status should be success", response.isSuccess());
             String id = response.asJSONObject().getString(LID);
-            idToValues.put(id, fieldValue);
+            idToFields.put(id, fields);
         }
-        return idToValues;
+        return idToFields;
     }
 
     /**


### PR DESCRIPTION
Android equivalent of https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/1887

Added two optional members in SyncOptions: createFieldlist and updateFieldlist.
During sync up:
* created records use createFieldlist if available (and fieldlist otherwise).
* updated records use updateFieldlist if available (and fieldlist otherwise).

Code change very simple.

Tests changes
Tests used to deal with just one field (name) now they deal with multiple fields (name and description).
New tests were added for createUpdatelist and updateFieldlist:
* testSyncUpWithUpdateFieldList
* testSyncUpWithCreateFieldList
* testSyncUpWithCreateAndUpdateFieldList
