### PR TITLE
Sync Manager delegates local store interactions to sync targets

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
@@ -319,7 +319,7 @@ public class SmartStorePlugin extends ForcePlugin {
 		String soupName = arg0.getString(SOUP_NAME);
         final SmartStore smartStore = getSmartStore(arg0);
 
-		// Run upsert
+		// Run hasSoup
 		boolean exists = smartStore.hasSoup(soupName);
 		PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, exists);
 		callbackContext.sendPluginResult(pluginResult);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -1084,6 +1084,7 @@ public class SmartStore  {
      * @param soupName
      * @param soupElt
      * @param soupEntryId
+	 * @param handleTx
      * @return
      * @throws JSONException
      */

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
@@ -504,7 +504,7 @@ public class SyncManager {
                         ? HttpURLConnection.HTTP_NOT_FOUND // if locally created it can't exist on the server - we don't need to actually do the deleteOnServer call
                         : target.deleteOnServer(this, objectType, objectId));
                 if (RestResponse.isSuccess(statusCode) || statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
-                    target.deleteInLocalStore(this, soupName, record);
+                    target.deleteFromLocalStore(this, soupName, record);
                 }
                 break;
             case update:

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncDownTarget.java
@@ -180,6 +180,16 @@ public abstract class SyncDownTarget extends SyncTarget {
     }
 
     /**
+     * Return ids of records that should not be written over
+     * during a sync down with merge mode leave-if-changed
+     * @return set of ids 
+     * @throws JSONException
+     */
+    public Set<String> getIdsToSkip(SyncManager syncManager, String soupName) throws JSONException {
+        return syncManager.getDirtyRecordIds(soupName, getIdFieldName());
+    }
+
+    /**
      * Enum for query type
      */
     public enum QueryType {

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncDownTarget.java
@@ -26,8 +26,11 @@
  */
 package com.salesforce.androidsdk.smartsync.util;
 
+import android.text.TextUtils;
 import android.util.Log;
 
+import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartsync.manager.SyncManager;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 
@@ -37,9 +40,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -186,7 +187,7 @@ public abstract class SyncDownTarget extends SyncTarget {
      * @throws JSONException
      */
     public Set<String> getIdsToSkip(SyncManager syncManager, String soupName) throws JSONException {
-        return syncManager.getDirtyRecordIds(soupName, getIdFieldName());
+        return getDirtyRecordIds(syncManager, soupName, getIdFieldName());
     }
 
     /**

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncTarget.java
@@ -26,13 +26,32 @@
  */
 package com.salesforce.androidsdk.smartsync.util;
 
+import android.text.TextUtils;
+
+import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import com.salesforce.androidsdk.smartstore.store.SmartStore;
+import com.salesforce.androidsdk.smartsync.manager.SyncManager;
+
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Abstract super class for SyncUpTarget and SyncDownTarget
  */
 public abstract class SyncTarget {
+
+    // Sync targets expect the following fields in locally stored records
+    public static final String LOCALLY_CREATED = "__locally_created__";
+    public static final String LOCALLY_UPDATED = "__locally_updated__";
+    public static final String LOCALLY_DELETED = "__locally_deleted__";
+    public static final String LOCAL = "__local__";
+
+    private static final int PAGE_SIZE = 2000;
 
     public static final String ANDROID_IMPL = "androidImpl";
     public static final String ID_FIELD_NAME = "idFieldName";
@@ -71,9 +90,171 @@ public abstract class SyncTarget {
     }
 
     /**
-     * @return The field name of the modification date field of the record.  Defaults to "LastModifiedDate".
+     * @return The fintield name of the modification date field of the record.  Defaults to "LastModifiedDate".
      */
     public String getModificationDateFieldName() {
         return modificationDateFieldName;
+    }
+
+
+    /**
+     * Return ids of "dirty" records (records locally created/upated or deleted)
+     * @param syncManager
+     * @param soupName
+     * @param idField
+     * @return
+     * @throws JSONException
+     */
+    public SortedSet<String> getDirtyRecordIds(SyncManager syncManager, String soupName, String idField) throws JSONException {
+        SortedSet<String> ids = new TreeSet<String>();
+        String dirtyRecordsSql = String.format("SELECT {%s:%s} FROM {%s} WHERE {%s:%s} = 'true' ORDER BY {%s:%s} ASC", soupName, idField, soupName, soupName, LOCAL, soupName, idField);
+        final QuerySpec smartQuerySpec = QuerySpec.buildSmartQuerySpec(dirtyRecordsSql, PAGE_SIZE);
+        boolean hasMore = true;
+        for (int pageIndex = 0; hasMore; pageIndex++) {
+            JSONArray results = syncManager.getSmartStore().query(smartQuerySpec, pageIndex);
+            hasMore = (results.length() == PAGE_SIZE);
+            ids.addAll(toSortedSet(results));
+        }
+        return ids;
+    }
+
+    /**
+     * Return ids of non-dirty records (records NOT locally created/updated or deleted)
+     * @param syncManager
+     * @param soupName
+     * @param idField
+     * @return
+     * @throws JSONException
+     */
+    public SortedSet<String> getNonDirtyRecordIds(SyncManager syncManager, String soupName, String idField) throws JSONException {
+        SortedSet<String> ids = new TreeSet<String>();
+        String nonDirtyRecordsSql = String.format("SELECT {%s:%s} FROM {%s} WHERE {%s:%s} = 'false' ORDER BY {%s:%s} ASC", soupName, getIdFieldName(), soupName, soupName, LOCAL, soupName, idField);
+        final QuerySpec smartQuerySpec = QuerySpec.buildSmartQuerySpec(nonDirtyRecordsSql, PAGE_SIZE);
+        boolean hasMore = true;
+        for (int pageIndex = 0; hasMore; pageIndex++) {
+            JSONArray results = syncManager.getSmartStore().query(smartQuerySpec, pageIndex);
+            hasMore = (results.length() == PAGE_SIZE);
+            ids.addAll(toSortedSet(results));
+        }
+        return ids;
+    }
+
+    /**
+     * Given a "dirty" record, return true if it was locally created
+     * @param record
+     * @return
+     * @throws JSONException
+     */
+    public boolean isLocallyCreated(JSONObject record) throws JSONException {
+        return record.getBoolean(LOCALLY_CREATED);
+    }
+
+    /**
+     * Given a "dirty" record, return true if it was locally updated
+     * @param record
+     * @return
+     * @throws JSONException
+     */
+    public boolean isLocallyUpdated(JSONObject record) throws JSONException {
+        return record.getBoolean(LOCALLY_UPDATED);
+    }
+
+    /**
+     * Given a "dirty" record, return true if it was locally deleted
+     * @param record
+     * @return
+     * @throws JSONException
+     */
+    public boolean isLocallyDeleted(JSONObject record) throws JSONException {
+        return record.getBoolean(LOCALLY_DELETED);
+    }
+
+    /**
+     * Get record from local store by storeId
+     * @param syncManager
+     * @param storeId
+     * @throws  JSONException
+     */
+    public JSONObject getFromLocalStore(SyncManager syncManager, String soupName, String storeId) throws JSONException {
+        return syncManager.getSmartStore().retrieve(soupName, Long.valueOf(storeId)).getJSONObject(0);
+    }
+
+    /**
+     * Clean (i.e. no longer flag as "dirty") and save record in local store
+     * @param syncManager
+     * @param soupName
+     * @param record
+     */
+    public void cleanAndSaveInLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
+        record.put(LOCAL, false);
+        record.put(LOCALLY_CREATED, false);
+        record.put(LOCALLY_UPDATED, false);
+        record.put(LOCALLY_DELETED, false);
+        syncManager.getSmartStore().update(soupName, record, record.getLong(SmartStore.SOUP_ENTRY_ID));
+    }
+
+    /**
+     * Delete record from local store
+     * @param syncManager
+     * @param soupName
+     * @param record
+     */
+    public void deleteInLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
+        syncManager.getSmartStore().delete(soupName, record.getLong(SmartStore.SOUP_ENTRY_ID));
+    }
+
+    /**
+     * Save records to local store
+     * @param syncManager
+     * @param soupName
+     * @param records
+     * @throws JSONException
+     */
+    public void saveRecordsToLocalStore(SyncManager syncManager, String soupName, JSONArray records) throws JSONException {
+        SmartStore smartStore = syncManager.getSmartStore();
+        synchronized(smartStore.getDatabase()) {
+            try {
+                smartStore.beginTransaction();
+                for (int i = 0; i < records.length(); i++) {
+                    JSONObject record = records.getJSONObject(i);
+
+                    // Save
+                    record.put(LOCAL, false);
+                    record.put(LOCALLY_CREATED, false);
+                    record.put(LOCALLY_UPDATED, false);
+                    record.put(LOCALLY_DELETED, false);
+
+                    smartStore.upsert(soupName, records.getJSONObject(i), getIdFieldName(), false);
+                }
+                smartStore.setTransactionSuccessful();
+            }
+            finally {
+                smartStore.endTransaction();
+            }
+        }
+    }
+
+    /**
+     * Delete the records with the given soup entry ids
+     * @param syncManager
+     * @param soupName
+     * @param ids
+     */
+    public void deleteRecordsFromLocalStore(SyncManager syncManager, String soupName, Set<String> ids) {
+        if (ids.size() > 0) {
+            String smartSql = String.format("SELECT {%s:%s} FROM {%s} WHERE {%s:%s} IN (%s)",
+                    soupName, SmartStore.SOUP_ENTRY_ID, soupName, soupName, getIdFieldName(),
+                    "'" + TextUtils.join("', '", ids) + "'");
+            QuerySpec querySpec = QuerySpec.buildSmartQuerySpec(smartSql, ids.size());
+            syncManager.getSmartStore().deleteByQuery(soupName, querySpec);
+        }
+    }
+
+    private SortedSet<String> toSortedSet(JSONArray jsonArray) throws JSONException {
+        SortedSet<String> set = new TreeSet<String>();
+        for (int i=0; i<jsonArray.length(); i++) {
+            set.add(jsonArray.getJSONArray(i).getString(0));
+        }
+        return set;
     }
 }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncTarget.java
@@ -42,6 +42,14 @@ import java.util.TreeSet;
 
 /**
  * Abstract super class for SyncUpTarget and SyncDownTarget
+ *
+ * Targets handle interactions with local store and with remote server
+ *
+ * Default target use SmartStore for local store and __local_*__ fields to flag dirty (i.e. locally created/updated/deleted) records
+ * Custom targets can use a different local store and/or different fields to flag dirty records
+ *
+ * Default target use SObject Rest API to read/write records to the server
+ * Custom targets can use different end points to read/write records to the server
  */
 public abstract class SyncTarget {
 
@@ -51,6 +59,7 @@ public abstract class SyncTarget {
     public static final String LOCALLY_DELETED = "__locally_deleted__";
     public static final String LOCAL = "__local__";
 
+    // Page size used when reading from smartstore
     private static final int PAGE_SIZE = 2000;
 
     public static final String ANDROID_IMPL = "androidImpl";
@@ -90,7 +99,7 @@ public abstract class SyncTarget {
     }
 
     /**
-     * @return The fintield name of the modification date field of the record.  Defaults to "LastModifiedDate".
+     * @return The field name of the modification date field of the record.  Defaults to "LastModifiedDate".
      */
     public String getModificationDateFieldName() {
         return modificationDateFieldName;
@@ -205,16 +214,6 @@ public abstract class SyncTarget {
     }
 
     /**
-     * Delete record from local store
-     * @param syncManager
-     * @param soupName
-     * @param record
-     */
-    public void deleteInLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
-        syncManager.getSmartStore().delete(soupName, record.getLong(SmartStore.SOUP_ENTRY_ID));
-    }
-
-    /**
      * Save records to local store
      * @param syncManager
      * @param soupName
@@ -235,6 +234,16 @@ public abstract class SyncTarget {
                 smartStore.endTransaction();
             }
         }
+    }
+
+    /**
+     * Delete record from local store
+     * @param syncManager
+     * @param soupName
+     * @param record
+     */
+    public void deleteFromLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
+        syncManager.getSmartStore().delete(soupName, record.getLong(SmartStore.SOUP_ENTRY_ID));
     }
 
     /**

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncTarget.java
@@ -43,13 +43,13 @@ import java.util.TreeSet;
 /**
  * Abstract super class for SyncUpTarget and SyncDownTarget
  *
- * Targets handle interactions with local store and with remote server
+ * Targets handle interactions with local store and with remote server.
  *
- * Default target use SmartStore for local store and __local_*__ fields to flag dirty (i.e. locally created/updated/deleted) records
- * Custom targets can use a different local store and/or different fields to flag dirty records
+ * Default targets use SmartStore for local store and __local_*__ fields to flag dirty (i.e. locally created/updated/deleted) records.
+ * Custom targets can use a different local store and/or different fields to flag dirty records.
  *
- * Default target use SObject Rest API to read/write records to the server
- * Custom targets can use different end points to read/write records to the server
+ * Default targets use SObject Rest API to read/write records to the server.
+ * Custom targets can use different end points to read/write records to the server.
  */
 public abstract class SyncTarget {
 

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
@@ -169,6 +169,6 @@ public class SyncUpTarget extends SyncTarget {
      * @return
      */
     public Set<String> getIdsOfRecordsToSyncUp(SyncManager syncManager, String soupName) throws JSONException {
-        return syncManager.getDirtyRecordIds(soupName, SmartStore.SOUP_ENTRY_ID);
+        return getDirtyRecordIds(syncManager, soupName, SmartStore.SOUP_ENTRY_ID);
     }
 }

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk.smartsync.manager;
 
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
 import com.salesforce.androidsdk.rest.RestRequest;
@@ -50,7 +49,6 @@ import com.salesforce.androidsdk.smartsync.util.SyncState.MergeMode;
 import com.salesforce.androidsdk.smartsync.util.SyncTarget;
 import com.salesforce.androidsdk.smartsync.util.SyncUpTarget;
 import com.salesforce.androidsdk.smartsync.util.SyncUpdateCallbackQueue;
-import com.salesforce.androidsdk.util.JSONObjectHelper;
 import com.salesforce.androidsdk.util.test.JSONTestHelper;
 
 import org.json.JSONArray;
@@ -1314,7 +1312,7 @@ public class SyncManagerTest extends ManagerTestCase {
                 new IndexSpec(Constants.ID, SmartStore.Type.string),
                 new IndexSpec(Constants.NAME, SmartStore.Type.string),
                 new IndexSpec(Constants.DESCRIPTION, SmartStore.Type.string),
-                new IndexSpec(SyncManager.LOCAL, SmartStore.Type.string)
+                new IndexSpec(SyncTarget.LOCAL, SmartStore.Type.string)
         };
         smartStore.registerSoup(soupName, indexSpecs);
     }
@@ -1352,10 +1350,10 @@ public class SyncManagerTest extends ManagerTestCase {
 			account.put(Constants.NAME, name);
             account.put(Constants.DESCRIPTION, "Description_" + name);
 			account.put(Constants.ATTRIBUTES, attributes);
-			account.put(SyncManager.LOCAL, true);
-			account.put(SyncManager.LOCALLY_CREATED, true);
-			account.put(SyncManager.LOCALLY_DELETED, false);
-			account.put(SyncManager.LOCALLY_UPDATED, false);
+			account.put(SyncTarget.LOCAL, true);
+			account.put(SyncTarget.LOCALLY_CREATED, true);
+			account.put(SyncTarget.LOCALLY_DELETED, false);
+			account.put(SyncTarget.LOCALLY_UPDATED, false);
 			smartStore.create(ACCOUNTS_SOUP, account);
 		}
 	}
@@ -1372,10 +1370,10 @@ public class SyncManagerTest extends ManagerTestCase {
             for (String fieldName : updatedFields.keySet()) {
                 account.put(fieldName, updatedFields.get(fieldName));
             }
-			account.put(SyncManager.LOCAL, true);
-			account.put(SyncManager.LOCALLY_CREATED, false);
-			account.put(SyncManager.LOCALLY_DELETED, false);
-			account.put(SyncManager.LOCALLY_UPDATED, true);
+			account.put(SyncTarget.LOCAL, true);
+			account.put(SyncTarget.LOCALLY_CREATED, false);
+			account.put(SyncTarget.LOCALLY_DELETED, false);
+			account.put(SyncTarget.LOCALLY_UPDATED, true);
 			smartStore.upsert(ACCOUNTS_SOUP, account);
 		}
 	}
@@ -1402,10 +1400,10 @@ public class SyncManagerTest extends ManagerTestCase {
 	private void deleteAccountsLocally(String[] idsLocallyDeleted) throws JSONException {
 		for (String id : idsLocallyDeleted) {
 			JSONObject account = smartStore.retrieve(ACCOUNTS_SOUP, smartStore.lookupSoupEntryId(ACCOUNTS_SOUP, Constants.ID, id)).getJSONObject(0);
-			account.put(SyncManager.LOCAL, true);
-			account.put(SyncManager.LOCALLY_CREATED, false);
-			account.put(SyncManager.LOCALLY_DELETED, true);
-			account.put(SyncManager.LOCALLY_UPDATED, false);
+			account.put(SyncTarget.LOCAL, true);
+			account.put(SyncTarget.LOCALLY_CREATED, false);
+			account.put(SyncTarget.LOCALLY_DELETED, true);
+			account.put(SyncTarget.LOCALLY_UPDATED, false);
 			smartStore.upsert(ACCOUNTS_SOUP, account);
 		}
 	}
@@ -1444,11 +1442,11 @@ public class SyncManagerTest extends ManagerTestCase {
             JSONArray row = accountsFromDb.getJSONArray(i);
             JSONObject soupElt = row.getJSONObject(0);
             String id = soupElt.getString(Constants.ID);
-            assertEquals("Wrong local flag", expectLocallyCreated || expectLocallyUpdated || expectLocallyDeleted, soupElt.getBoolean(SyncManager.LOCAL));
-            assertEquals("Wrong local flag", expectLocallyCreated, soupElt.getBoolean(SyncManager.LOCALLY_CREATED));
+            assertEquals("Wrong local flag", expectLocallyCreated || expectLocallyUpdated || expectLocallyDeleted, soupElt.getBoolean(SyncTarget.LOCAL));
+            assertEquals("Wrong local flag", expectLocallyCreated, soupElt.getBoolean(SyncTarget.LOCALLY_CREATED));
             assertEquals("Id was not updated", expectLocallyCreated, id.startsWith(LOCAL_ID_PREFIX));
-            assertEquals("Wrong local flag", expectLocallyUpdated, soupElt.getBoolean(SyncManager.LOCALLY_UPDATED));
-            assertEquals("Wrong local flag", expectLocallyDeleted, soupElt.getBoolean(SyncManager.LOCALLY_DELETED));
+            assertEquals("Wrong local flag", expectLocallyUpdated, soupElt.getBoolean(SyncTarget.LOCALLY_UPDATED));
+            assertEquals("Wrong local flag", expectLocallyDeleted, soupElt.getBoolean(SyncTarget.LOCALLY_DELETED));
         }
     }
 

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/loaders/ContactListLoader.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/loaders/ContactListLoader.java
@@ -50,6 +50,7 @@ import com.salesforce.androidsdk.smartsync.util.SyncOptions;
 import com.salesforce.androidsdk.smartsync.util.SyncState;
 import com.salesforce.androidsdk.smartsync.util.SyncState.MergeMode;
 import com.salesforce.androidsdk.smartsync.util.SyncState.Status;
+import com.salesforce.androidsdk.smartsync.util.SyncTarget;
 import com.salesforce.androidsdk.smartsync.util.SyncUpTarget;
 import com.salesforce.samples.smartsyncexplorer.objects.ContactObject;
 
@@ -75,10 +76,10 @@ public class ContactListLoader extends AsyncTaskLoader<List<ContactObject>> {
 		new IndexSpec("Id", Type.string),
 		new IndexSpec("FirstName", Type.string),
 		new IndexSpec("LastName", Type.string),
-		new IndexSpec(SyncManager.LOCALLY_CREATED, Type.string),
-		new IndexSpec(SyncManager.LOCALLY_UPDATED, Type.string),
-		new IndexSpec(SyncManager.LOCALLY_DELETED, Type.string),
-		new IndexSpec(SyncManager.LOCAL, Type.string)
+		new IndexSpec(SyncTarget.LOCALLY_CREATED, Type.string),
+		new IndexSpec(SyncTarget.LOCALLY_UPDATED, Type.string),
+		new IndexSpec(SyncTarget.LOCALLY_DELETED, Type.string),
+		new IndexSpec(SyncTarget.LOCAL, Type.string)
 	};
 
     private SmartStore smartStore;

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/objects/ContactObject.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/objects/ContactObject.java
@@ -30,9 +30,9 @@ import org.json.JSONObject;
 
 import android.text.TextUtils;
 
-import com.salesforce.androidsdk.smartsync.manager.SyncManager;
 import com.salesforce.androidsdk.smartsync.model.SalesforceObject;
 import com.salesforce.androidsdk.smartsync.util.Constants;
+import com.salesforce.androidsdk.smartsync.util.SyncTarget;
 
 /**
  * A simple representation of a Contact object.
@@ -80,9 +80,9 @@ public class ContactObject extends SalesforceObject {
 		objectType = Constants.CONTACT;
 		objectId = data.optString(Constants.ID);
 		name = data.optString(FIRST_NAME) + " " + data.optString(LAST_NAME);
-		isLocallyModified = data.optBoolean(SyncManager.LOCALLY_UPDATED) ||
-				data.optBoolean(SyncManager.LOCALLY_CREATED) ||
-				data.optBoolean(SyncManager.LOCALLY_DELETED);
+		isLocallyModified = data.optBoolean(SyncTarget.LOCALLY_UPDATED) ||
+				data.optBoolean(SyncTarget.LOCALLY_CREATED) ||
+				data.optBoolean(SyncTarget.LOCALLY_DELETED);
 	}
 
 	/**

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/DetailActivity.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/DetailActivity.java
@@ -46,8 +46,8 @@ import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartsync.app.SmartSyncSDKManager;
-import com.salesforce.androidsdk.smartsync.manager.SyncManager;
 import com.salesforce.androidsdk.smartsync.util.Constants;
+import com.salesforce.androidsdk.smartsync.util.SyncTarget;
 import com.salesforce.androidsdk.ui.SalesforceActivity;
 import com.salesforce.samples.smartsyncexplorer.R;
 import com.salesforce.samples.smartsyncexplorer.loaders.ContactDetailLoader;
@@ -166,8 +166,8 @@ public class DetailActivity extends SalesforceActivity implements LoaderManager.
 			contact = smartStore.retrieve(ContactListLoader.CONTACT_SOUP,
 					smartStore.lookupSoupEntryId(ContactListLoader.CONTACT_SOUP,
 					Constants.ID, objectId)).getJSONObject(0);
-			contact.put(SyncManager.LOCAL, true);
-			contact.put(SyncManager.LOCALLY_DELETED, true);
+			contact.put(SyncTarget.LOCAL, true);
+			contact.put(SyncTarget.LOCALLY_DELETED, true);
 			smartStore.upsert(ContactListLoader.CONTACT_SOUP, contact);
 			Toast.makeText(this, "Delete successful!", Toast.LENGTH_LONG).show();
 			finish();
@@ -236,10 +236,10 @@ public class DetailActivity extends SalesforceActivity implements LoaderManager.
 			contact.put(ContactObject.EMAIL, email);
 			contact.put(ContactObject.DEPARTMENT, department);
 			contact.put(ContactObject.HOME_PHONE, homePhone);
-			contact.put(SyncManager.LOCAL, true);
-			contact.put(SyncManager.LOCALLY_UPDATED, !isCreate);
-			contact.put(SyncManager.LOCALLY_CREATED, isCreate);
-			contact.put(SyncManager.LOCALLY_DELETED, false);
+			contact.put(SyncTarget.LOCAL, true);
+			contact.put(SyncTarget.LOCALLY_UPDATED, !isCreate);
+			contact.put(SyncTarget.LOCALLY_CREATED, isCreate);
+			contact.put(SyncTarget.LOCALLY_DELETED, false);
 			if (isCreate) {
 				smartStore.create(ContactListLoader.CONTACT_SOUP, contact);
 			} else {


### PR DESCRIPTION
At the beginning SyncManager dealt with local store and remote server interactions during sync up / down. Then the code was refactored to delegate the remote server interactions to the sync up / down targets (allowing custom targets to read/write from arbitrary end points).

With this PR, the local store interactions are now delegated to the sync targets.
That will allow custom targets to use a different local store and/or flag dirty records differently.
It will also allow supporting syncing sets of related records.