### PR TITLE
SyncManager / sync target / sync options refactor

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncDownTarget.java
@@ -26,11 +26,8 @@
  */
 package com.salesforce.androidsdk.smartsync.util;
 
-import android.text.TextUtils;
 import android.util.Log;
 
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartsync.manager.SyncManager;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncOptions.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncOptions.java
@@ -33,7 +33,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -42,14 +41,12 @@ import java.util.List;
 public class SyncOptions {
 
     public static final String MERGEMODE = "mergeMode";
+
+	// Fieldlist really belongs in sync up/down target - keeping it here for backwards compatiblity
 	public static final String FIELDLIST = "fieldlist";
-	public static final String CREATE_FIELDLIST = "createFieldlist";
-	public static final String UPDATE_FIELDLIST = "updateFieldlist";
 
     private MergeMode mergeMode;
 	private List<String> fieldlist;
-	private List<String> createFieldlist;
-	private List<String> updateFieldlist;
 
 	/**
 	 * Build SyncOptions from json
@@ -63,11 +60,8 @@ public class SyncOptions {
 
         String mergeModeStr = JSONObjectHelper.optString(options, MERGEMODE);
         MergeMode mergeMode = mergeModeStr == null ? null : MergeMode.valueOf(mergeModeStr);
-		List<String> fieldlist = toList(options.optJSONArray(FIELDLIST));
-		List<String> createFieldlist = toList(options.optJSONArray(CREATE_FIELDLIST));
-		List<String> updateFieldlist = toList(options.optJSONArray(UPDATE_FIELDLIST));
-
-		return new SyncOptions(fieldlist, createFieldlist, updateFieldlist, mergeMode);
+		List<String> fieldlist = JSONObjectHelper.toList(options.optJSONArray(FIELDLIST));
+		return new SyncOptions(fieldlist, mergeMode);
 	}
 
 	/**
@@ -75,7 +69,7 @@ public class SyncOptions {
 	 * @return
 	 */
 	public static SyncOptions optionsForSyncUp(List<String> fieldlist) {
-		return new SyncOptions(fieldlist, null, null, MergeMode.OVERWRITE);
+		return new SyncOptions(fieldlist, MergeMode.OVERWRITE);
 	}
 
     /**
@@ -84,26 +78,15 @@ public class SyncOptions {
      * @return
      */
     public static SyncOptions optionsForSyncUp(List<String> fieldlist, MergeMode mergeMode) {
-        return new SyncOptions(fieldlist, null, null, mergeMode);
+        return new SyncOptions(fieldlist, mergeMode);
     }
-
-	/**
-	 * @param fieldlist
-	 * @param createFieldlist
-	 * @param updateFieldlist
-	 * @param mergeMode
-	 * @return
-	 */
-	public static SyncOptions optionsForSyncUp(List<String> fieldlist, List<String> createFieldlist, List<String> updateFieldlist, MergeMode mergeMode) {
-		return new SyncOptions(fieldlist, createFieldlist, updateFieldlist, mergeMode);
-	}
 
     /**
      * @param mergeMode
      * @return
      */
     public static SyncOptions optionsForSyncDown(MergeMode mergeMode) {
-        return new SyncOptions(null, null, null, mergeMode);
+        return new SyncOptions(null, mergeMode);
     }
 
 	/**
@@ -111,10 +94,8 @@ public class SyncOptions {
 	 * @param fieldlist
      * @param mergeMode
 	 */
-	private SyncOptions(List<String> fieldlist, List<String> createFieldlist, List<String> updateFieldlist, MergeMode mergeMode) {
+	private SyncOptions(List<String> fieldlist, MergeMode mergeMode) {
 		this.fieldlist = fieldlist;
-		this.createFieldlist = createFieldlist;
-		this.updateFieldlist = updateFieldlist;
         this.mergeMode = mergeMode;
 	}
 	
@@ -126,8 +107,6 @@ public class SyncOptions {
 		JSONObject options = new JSONObject();
         if (mergeMode != null) options.put(MERGEMODE, mergeMode.name());
 		if (fieldlist != null) options.put(FIELDLIST, new JSONArray(fieldlist));
-		if (createFieldlist != null) options.put(CREATE_FIELDLIST, new JSONArray(createFieldlist));
-		if (updateFieldlist != null) options.put(UPDATE_FIELDLIST, new JSONArray(updateFieldlist));
 		return options;
 	}
 
@@ -135,27 +114,8 @@ public class SyncOptions {
 		return fieldlist;
 	}
 
-	public List<String> getCreateFieldlist() {
-		return createFieldlist;
-	}
-
-	public List<String> getUpdateFieldlist() {
-		return updateFieldlist;
-	}
-
     public MergeMode getMergeMode() {
         return mergeMode;
     }
-	
-	@SuppressWarnings("unchecked")
-	private static <T> List<T> toList(JSONArray jsonArray) throws JSONException {
-		if (jsonArray == null) {
-			return null;
-		}
-		List<T> arr = new ArrayList<T>();
-		for (int i=0; i<jsonArray.length(); i++) {
-			arr.add((T) jsonArray.get(i));
-		}
-		return arr;
-	}
+
 }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncOptions.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncOptions.java
@@ -42,7 +42,7 @@ public class SyncOptions {
 
     public static final String MERGEMODE = "mergeMode";
 
-	// Fieldlist really belongs in sync up/down target - keeping it here for backwards compatiblity
+	// Fieldlist really belongs in sync up/down target - keeping it here for backwards compatibility
 	public static final String FIELDLIST = "fieldlist";
 
     private MergeMode mergeMode;

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
@@ -151,7 +151,7 @@ public class SyncUpTarget extends SyncTarget {
      * @param syncManager
      * @param objectType
      * @param fields
-     * @return
+     * @return server record id or null if creation failed
      * @throws IOException
      * @throws JSONException
      */
@@ -168,7 +168,7 @@ public class SyncUpTarget extends SyncTarget {
      * Delete locally deleted record from server
      * @param syncManager
      * @param record
-     * @return true if successful
+     * @return server response status code
      * @throws JSONException
      * @throws IOException
      */
@@ -185,7 +185,7 @@ public class SyncUpTarget extends SyncTarget {
      * @param syncManager
      * @param objectType
      * @param objectId
-     * @return
+     * @return server response status code
      * @throws IOException
      */
     public int deleteOnServer(SyncManager syncManager, String objectType, String objectId) throws IOException {
@@ -227,7 +227,7 @@ public class SyncUpTarget extends SyncTarget {
      * @param objectType
      * @param objectId
      * @param fields
-     * @return
+     * @return true if successful
      * @throws IOException
      */
     public int updateOnServer(SyncManager syncManager, String objectType, String objectId, Map<String, Object> fields) throws IOException {

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncUpTarget.java
@@ -105,8 +105,8 @@ public class SyncUpTarget extends SyncTarget {
      */
     public SyncUpTarget(JSONObject target) throws JSONException {
         super(target);
-        List<String> createFieldlist = JSONObjectHelper.toList(target.optJSONArray(CREATE_FIELDLIST));
-        List<String> updateFieldlist = JSONObjectHelper.toList(target.optJSONArray(UPDATE_FIELDLIST));
+        this.createFieldlist = JSONObjectHelper.toList(target.optJSONArray(CREATE_FIELDLIST));
+        this.updateFieldlist = JSONObjectHelper.toList(target.optJSONArray(UPDATE_FIELDLIST));
     }
 
     /**
@@ -142,6 +142,20 @@ public class SyncUpTarget extends SyncTarget {
             }
         }
 
+        return createOnServer(syncManager, objectType, fields);
+    }
+
+    /**
+     * Save locally created record back to server (original method)
+     * Called by createOnServer(SyncManager syncManager, JSONObject record, List<String> fieldlist)
+     * @param syncManager
+     * @param objectType
+     * @param fields
+     * @return
+     * @throws IOException
+     * @throws JSONException
+     */
+    public String createOnServer(SyncManager syncManager, String objectType, Map<String, Object> fields) throws IOException, JSONException {
         RestRequest request = RestRequest.getRequestForCreate(syncManager.apiVersion, objectType, fields);
         RestResponse response = syncManager.sendSyncWithSmartSyncUserAgent(request);
 
@@ -162,6 +176,19 @@ public class SyncUpTarget extends SyncTarget {
         final String objectType = (String) SmartStore.project(record, Constants.SOBJECT_TYPE);
         final String objectId = record.getString(getIdFieldName());
 
+        return deleteOnServer(syncManager, objectType, objectId);
+    }
+
+    /**
+     * Delete locally deleted record from server (original method)
+     * Called by deleteOnServer(SyncManager syncManager, JSONObject record)
+     * @param syncManager
+     * @param objectType
+     * @param objectId
+     * @return
+     * @throws IOException
+     */
+    public int deleteOnServer(SyncManager syncManager, String objectType, String objectId) throws IOException {
         RestRequest request = RestRequest.getRequestForDelete(syncManager.apiVersion, objectType, objectId);
         RestResponse response = syncManager.sendSyncWithSmartSyncUserAgent(request);
 
@@ -178,7 +205,7 @@ public class SyncUpTarget extends SyncTarget {
      * @throws IOException
      */
     public int updateOnServer(SyncManager syncManager, JSONObject record, List<String> fieldlist) throws JSONException, IOException {
-        fieldlist = this.createFieldlist != null ? this.updateFieldlist : fieldlist;
+        fieldlist = this.updateFieldlist != null ? this.updateFieldlist : fieldlist;
         final String objectType = (String) SmartStore.project(record, Constants.SOBJECT_TYPE);
         final String objectId = record.getString(getIdFieldName());
 
@@ -190,6 +217,20 @@ public class SyncUpTarget extends SyncTarget {
             }
         }
 
+        return updateOnServer(syncManager, objectType, objectId, fields);
+    }
+
+    /**
+     * Save locally updated record back to server - original signature
+     * Called by updateOnServer(SyncManager syncManager, JSONObject record, List<String> fieldlist)
+     * @param syncManager
+     * @param objectType
+     * @param objectId
+     * @param fields
+     * @return
+     * @throws IOException
+     */
+    public int updateOnServer(SyncManager syncManager, String objectType, String objectId, Map<String, Object> fields) throws IOException {
         RestRequest request = RestRequest.getRequestForUpdate(syncManager.apiVersion, objectType, objectId, fields);
         RestResponse response = syncManager.sendSyncWithSmartSyncUserAgent(request);
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -1032,9 +1032,8 @@ public class SyncManagerTest extends ManagerTestCase {
         Map<String, Map<String, Object>> idToFieldsLocallyUpdated = makeSomeLocalChanges();
 
         // Sync up with update field list including only name
-        SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[] { Constants.NAME, Constants.DESCRIPTION }),
-                null, Arrays.asList(new String[] { Constants.NAME }), MergeMode.OVERWRITE);
-        trySyncUp(idToFieldsLocallyUpdated.size(), options);
+        SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[] { Constants.NAME, Constants.DESCRIPTION }), MergeMode.OVERWRITE);
+        trySyncUp(new SyncUpTarget(null, Arrays.asList(new String[] { Constants.NAME })), idToFieldsLocallyUpdated.size(), options, false);
 
         // Check that db doesn't show entries as locally modified anymore
         Set<String> ids = idToFieldsLocallyUpdated.keySet();
@@ -1063,9 +1062,8 @@ public class SyncManagerTest extends ManagerTestCase {
         createAccountsLocally(names);
 
         // Sync up with create field list including only name
-        SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[] { Constants.NAME, Constants.DESCRIPTION }),
-                Arrays.asList(new String[] { Constants.NAME }), null,  MergeMode.OVERWRITE);
-        trySyncUp(3, options);
+        SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[] { Constants.NAME, Constants.DESCRIPTION }), MergeMode.OVERWRITE);
+        trySyncUp(new SyncUpTarget(Arrays.asList(new String[] { Constants.NAME }), null), 3, options, false);
 
         // Check that db doesn't show entries as locally created anymore and that they use sfdc id
         Map<String, Map<String, Object>> idToFieldsCreated = getIdsForNames(names);
@@ -1103,11 +1101,10 @@ public class SyncManagerTest extends ManagerTestCase {
 
         // Sync up with different create and update field lists
         SyncOptions options = SyncOptions.optionsForSyncUp(
-                Arrays.asList(new String[] { Constants.NAME, Constants.DESCRIPTION }),
-                Arrays.asList(new String[] { Constants.NAME }),
-                Arrays.asList(new String[] { Constants.DESCRIPTION }),
+                Arrays.asList(new String[]{Constants.NAME, Constants.DESCRIPTION}),
                 MergeMode.OVERWRITE);
-        trySyncUp(namesOfCreated.length + namesOfUpdated.length, options);
+        trySyncUp(new SyncUpTarget(Arrays.asList(new String[]{Constants.NAME}), Arrays.asList(new String[]{Constants.DESCRIPTION})),
+                namesOfCreated.length + namesOfUpdated.length, options, false);
 
         // Check that db doesn't show created entries as locally created anymore and that they use sfdc id
         Map<String, Map<String, Object>> idToFieldsCreated = getIdsForNames(namesOfCreated);

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/TestSyncUpTarget.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/TestSyncUpTarget.java
@@ -92,7 +92,7 @@ public class TestSyncUpTarget extends SyncUpTarget {
     }
 
     @Override
-    public int deleteOnServer(SyncManager syncManager, String objectType, String objectId) throws JSONException, IOException {
+    public int deleteOnServer(SyncManager syncManager, String objectType, String objectId) throws IOException {
         switch (syncBehavior) {
             case SOFT_FAIL_ON_SYNC:
                 return HttpURLConnection.HTTP_BAD_REQUEST;
@@ -108,7 +108,7 @@ public class TestSyncUpTarget extends SyncUpTarget {
     }
 
     @Override
-    public int updateOnServer(SyncManager syncManager, String objectType, String objectId, Map<String, Object> fields) throws JSONException, IOException {
+    public int updateOnServer(SyncManager syncManager, String objectType, String objectId, Map<String, Object> fields) throws IOException {
         switch (syncBehavior) {
             case SOFT_FAIL_ON_SYNC:
                 return HttpURLConnection.HTTP_BAD_REQUEST;


### PR DESCRIPTION
Sync targets are getting "smarter" and SyncManager / SyncOptions are getting simpler - which gives app developers more power (since sync targets can be customized by subclassing) and also will enable us to support sync up / down of related records.

New createOnServer/updateOnServer/deleteOnServer methods expecting record object instead of object type and fields : SyncManager is no longer pulling object type from record or figuring out what fields to save, sync targets handle that.
Kept old createOnServer/updateOnServer/deleteOnServer methods for backwards compatibility (but they are called from the new methods in SyncUpTarget instead of being called from SyncManager).

Moved newly introduced createFieldlist/updateFieldlist from SyncOptions to SyncUpTarget (those fields were introduced in dev for 5.1, so moving them is not breaking any apps).
Ideally fieldlist should also move, but decided to leave it in SyncOptions so as not to break existing apps.