### PR TITLE
Moving the Notification out of initInternal 

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -333,6 +333,7 @@ public class SalesforceSDKManager {
     		INSTANCE = new SalesforceSDKManager(context, keyImpl, mainActivity, loginActivity);
     	}
     	initInternal(context);
+        EventsObservable.get().notifyEvent(EventType.AppCreateComplete);
     }
 
 	/**
@@ -351,7 +352,6 @@ public class SalesforceSDKManager {
 
         // Upgrades to the latest version.
         SalesforceSDKUpgradeManager.getInstance().upgrade();
-        EventsObservable.get().notifyEvent(EventType.AppCreateComplete);
     }
 
     /**


### PR DESCRIPTION
This allows SDK Managers to notify when they are ready.
Also to avoid duplicate notifications.