### PR TITLE
Updated build.gradle to specify 0.35.0 *or greater*

### DIFF
--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
   compile project(':libs:SmartSync')
   compile 'com.android.support:appcompat-v7:23.0.1'
-  compile 'com.facebook.react:react-native:0.35.0'
+  compile 'com.facebook.react:react-native:[0.35.0,)'
 }
 
 android {


### PR DESCRIPTION
Small update so that newer versions of react native can be used without having to modify build.gradle for each version.