### PR TITLE
Moving EventBuilderHelper stuff to run in the background

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
@@ -75,6 +75,10 @@ public class EventBuilderHelper {
      */
     public static void createAndStoreEvent(final String name, final UserAccount userAccount, final String className,
             final JSONObject attributes) {
+        // Do nothing if not enabled
+        if (!enabled)
+            return;
+        
         // don't run on background if this is a test run
         if (SalesforceSDKManager.getInstance().getIsTestRun()) {
             createAndStore(name, userAccount, className, attributes);
@@ -98,7 +102,6 @@ public class EventBuilderHelper {
      */
     public static void createAndStoreEventSync(String name, UserAccount userAccount, String className,
                                            JSONObject attributes) {
-
         createAndStore(name, userAccount, className, attributes);
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
@@ -37,6 +37,9 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 /**
  * A simple helper class to facilitate creation of common types of events.
  */
@@ -44,6 +47,9 @@ public class EventBuilderHelper {
 
     private static final String TAG = "EventBuilderHelper";
     private static boolean enabled = true;
+
+    // background executor
+    private static final ExecutorService threadPool = Executors.newFixedThreadPool(2);
 
     /**
      * This method allows event creation/storage to be disabled across the board.
@@ -59,6 +65,25 @@ public class EventBuilderHelper {
     }
 
     /**
+     * Creates and stores an analytics event with the supplied parameters.  By default all createAndStoreEvent's are placed
+     * into a background thread pool for posting.
+     *
+     * @param name Event name.
+     * @param userAccount User account.
+     * @param className Class name or context where the event was generated.
+     * @param attributes Addiitonal attributes.
+     */
+    public static void createAndStoreEvent(final String name, final UserAccount userAccount, final String className,
+            final JSONObject attributes) {
+        threadPool.execute(new Runnable() {
+            @Override
+            public void run() {
+                createAndStore(name, userAccount, className, attributes);
+            }
+        });
+    }
+
+    /**
      * Creates and stores an analytics event with the supplied parameters.
      *
      * @param name Event name.
@@ -66,11 +91,18 @@ public class EventBuilderHelper {
      * @param className Class name or context where the event was generated.
      * @param attributes Addiitonal attributes.
      */
-    public static void createAndStoreEvent(String name, UserAccount userAccount, String className,
+    public static void createAndStoreEventSync(String name, UserAccount userAccount, String className,
                                            JSONObject attributes) {
 
+        createAndStore(name, userAccount, className, attributes);
+    }
+
+    private static void createAndStore(String name, UserAccount userAccount, String className,
+            JSONObject attributes) {
+
         // Do nothing if not enabled
-        if (!enabled) return;
+        if (!enabled)
+            return;
 
         UserAccount account = userAccount;
         if (account == null) {
@@ -81,7 +113,7 @@ public class EventBuilderHelper {
         }
         final SalesforceAnalyticsManager manager = SalesforceAnalyticsManager.getInstance(account);
         final InstrumentationEventBuilder builder = InstrumentationEventBuilder.getInstance(manager.getAnalyticsManager(),
-                SalesforceSDKManager.getInstance().getAppContext());
+                                                                                            SalesforceSDKManager.getInstance().getAppContext());
         builder.name(name);
         builder.startTime(System.currentTimeMillis());
         final JSONObject page = new JSONObject();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
@@ -75,12 +75,17 @@ public class EventBuilderHelper {
      */
     public static void createAndStoreEvent(final String name, final UserAccount userAccount, final String className,
             final JSONObject attributes) {
-        threadPool.execute(new Runnable() {
-            @Override
-            public void run() {
-                createAndStore(name, userAccount, className, attributes);
-            }
-        });
+        // don't run on background if this is a test run
+        if (SalesforceSDKManager.getInstance().getIsTestRun()) {
+            createAndStore(name, userAccount, className, attributes);
+        } else {
+            threadPool.execute(new Runnable() {
+                @Override
+                public void run() {
+                    createAndStore(name, userAccount, className, attributes);
+                }
+            });
+        }
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -80,6 +80,8 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Helper class to manage a WebView instance that is going through the OAuth login process.
@@ -103,6 +105,8 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     public static final String RESPONSE_ERROR_DESCRIPTION_INTENT = "com.salesforce.auth.intent.RESPONSE_ERROR_DESCRIPTION";
     private static final String TAG = "OAuthWebViewHelper";
     private static final String ACCOUNT_OPTIONS = "accountOptions";
+    // background executor
+    private final ExecutorService threadPool = Executors.newFixedThreadPool(1);
 
     /**
      * the host activity/fragment should pass in an implementation of this
@@ -212,7 +216,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     protected WebViewClient makeWebViewClient() {
     	return new AuthWebViewClient();
     }
-    
+
     /** Factory method for the WebChromeClient, you can replace this with something else if you need to */
     protected WebChromeClient makeWebChromeClient() {
         return new AuthWebChromeClient();
@@ -304,7 +308,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     protected String getOAuthClientId() {
     	return loginOptions.getOauthClientId();
     }
-    
+
     protected URI getAuthorizationUrl(Boolean jwtFlow) throws URISyntaxException {
         if (jwtFlow) {
             return OAuth2.getAuthorizationUrl(
@@ -328,7 +332,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
         return getAuthorizationUrl(false);
     }
 
-   	/** 
+   	/**
    	 * Override this to replace the default login webview's display param with
    	 * your custom display param. You can override this by either subclassing this class,
    	 * or adding "<string name="sf__oauth_display_type">desiredDisplayParam</string>"
@@ -340,7 +344,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     protected String getAuthorizationDisplayType() {
     	return this.getContext().getString(R.string.oauth_display_type);
     }
-    
+
     /**
      * Override this method to customize the login url.
      * @return login url
@@ -598,12 +602,12 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
     protected void addAccount() {
         ClientManager clientManager = new ClientManager(getContext(),
-        		SalesforceSDKManager.getInstance().getAccountType(),
-        		loginOptions, SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked());
+                SalesforceSDKManager.getInstance().getAccountType(),
+                loginOptions, SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked());
 
         // Create account name (shown in Settings -> Accounts & sync)
         String accountName = buildAccountName(accountOptions.username,
-        		accountOptions.instanceUrl);
+                accountOptions.instanceUrl);
 
         // New account
         Bundle extras = clientManager.createNewAccount(accountName,
@@ -633,8 +637,8 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     	 * This step needs to happen after the account has been added by client
     	 * manager, so that the push service has all the account info it needs.
     	 */
-    	final Context appContext = SalesforceSDKManager.getInstance().getAppContext();
-    	final String pushNotificationId = BootConfig.getBootConfig(appContext).getPushNotificationClientId();
+        final Context appContext = SalesforceSDKManager.getInstance().getAppContext();
+        final String pushNotificationId = BootConfig.getBootConfig(appContext).getPushNotificationClientId();
         final UserAccount account = new UserAccount(accountOptions.authToken,
                 accountOptions.refreshToken, loginOptions.getLoginUrl(),
                 accountOptions.identityUrl, accountOptions.instanceUrl,
@@ -644,9 +648,9 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 accountOptions.communityUrl, accountOptions.firstName,
                 accountOptions.lastName, accountOptions.displayName, accountOptions.email,
                 accountOptions.photoUrl, accountOptions.thumbnailUrl, accountOptions.additionalOauthValues);
-    	if (!TextUtils.isEmpty(pushNotificationId)) {
-        	PushMessaging.register(appContext, account);
-    	}
+        if (!TextUtils.isEmpty(pushNotificationId)) {
+            PushMessaging.register(appContext, account);
+        }
 
         // Logs analytics event for new user.
         final JSONObject userAttr = new JSONObject();
@@ -656,27 +660,32 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
         } catch (JSONException e) {
             Log.e(TAG, "Exception thrown while creating JSON", e);
         }
-        EventBuilderHelper.createAndStoreEvent("addUser", account, TAG, userAttr);
 
-        // Logs analytics event for servers.
-        final JSONObject serverAttr = new JSONObject();
-        try {
-            final List<LoginServerManager.LoginServer> servers = SalesforceSDKManager.getInstance().getLoginServerManager().getLoginServers();
-            serverAttr.put("numLoginServers", (servers == null) ? 0 : servers.size());
-            if (servers != null) {
-                final JSONArray serversJson = new JSONArray();
-                for (final LoginServerManager.LoginServer server : servers) {
-                    if (server != null) {
-                        serversJson.put(server.url);
-                    }
-                }
-                serverAttr.put("loginServers", serversJson);
-            }
-        } catch (JSONException e) {
-            Log.e(TAG, "Exception thrown while creating JSON", e);
-        }
-        EventBuilderHelper.createAndStoreEvent("addUser", account, TAG, serverAttr);
         callback.onAccountAuthenticatorResult(extras);
+
+        threadPool.execute(new Runnable() {
+            @Override
+            public void run() {
+                // Logs analytics event for servers.
+                final JSONObject serverAttr = new JSONObject();
+                try {
+                    final List<LoginServerManager.LoginServer> servers = SalesforceSDKManager.getInstance().getLoginServerManager().getLoginServers();
+                    serverAttr.put("numLoginServers", (servers == null) ? 0 : servers.size());
+                    if (servers != null) {
+                        final JSONArray serversJson = new JSONArray();
+                        for (final LoginServerManager.LoginServer server : servers) {
+                            if (server != null) {
+                                serversJson.put(server.url);
+                            }
+                        }
+                        serverAttr.put("loginServers", serversJson);
+                    }
+                    EventBuilderHelper.createAndStoreEventSync("addUser", account, TAG, serverAttr);
+                } catch (JSONException e) {
+                    Log.e(TAG, "Exception thrown while creating JSON", e);
+                }
+            }
+        });
     }
 
     /**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -47,6 +47,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Smart store
@@ -77,7 +79,7 @@ public class SmartStore  {
 
 	// Table to keep track of soup's index specs
     protected static final String SOUP_INDEX_MAP_TABLE = "soup_index_map";
-    
+
     // Table to keep track of status of long operations in flight
     protected static final String LONG_OPERATIONS_STATUS_TABLE = "long_operations_status";
 
@@ -100,7 +102,7 @@ public class SmartStore  {
 	protected static final String TYPE_COL = "type";
     protected static final String DETAILS_COL = "details";
 	protected static final String STATUS_COL = "status";
-	
+
     // JSON fields added to soup element on insert/update
     public static final String SOUP_ENTRY_ID = "_soupEntryId";
     public static final String SOUP_LAST_MODIFIED_DATE = "_soupLastModifiedDate";
@@ -118,6 +120,9 @@ public class SmartStore  {
 
 	// FTS extension to use
 	protected FtsExtension ftsExtension = FtsExtension.fts5;
+
+	// background executor
+	private final ExecutorService threadPool = Executors.newFixedThreadPool(1);
 
 	/**
      * Changes the encryption key on the smartstore.
@@ -155,7 +160,7 @@ public class SmartStore  {
 	        db.execSQL(sb.toString());
 	        // Add index on soup_name column
 	        db.execSQL(String.format("CREATE INDEX %s on %s ( %s )", SOUP_INDEX_MAP_TABLE + "_0", SOUP_INDEX_MAP_TABLE, SOUP_NAME_COL));
-	
+
 	        // Create soup_names table
 	        // The table name for the soup will simply be table_<soupId>
 	        sb = new StringBuilder();
@@ -177,7 +182,7 @@ public class SmartStore  {
 	        createLongOperationsStatusTable(db);
     	}
     }
-    
+
     /**
      * Create long_operations_status table
      * @param db
@@ -253,7 +258,7 @@ public class SmartStore  {
     	}
     	return size;
     }
-    
+
     /**
      * Start transaction
 	 * NB: to avoid deadlock, caller should have synchronized(store.getDatabase()) around the whole transaction
@@ -298,7 +303,7 @@ public class SmartStore  {
 	 * @param soupSpec
 	 * @param indexSpecs
 	 */
-	public void registerSoupWithSpec(SoupSpec soupSpec, IndexSpec[] indexSpecs) {
+	public void registerSoupWithSpec(final SoupSpec soupSpec, final IndexSpec[] indexSpecs) {
 		final SQLiteDatabase db = getDatabase();
 		synchronized(db) {
 			String soupName = soupSpec.getSoupName();
@@ -306,23 +311,6 @@ public class SmartStore  {
 			if (indexSpecs.length == 0) throw new SmartStoreException("No indexSpecs specified for soup: " + soupName);
 			if (IndexSpec.hasJSON1(indexSpecs) && soupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE))  throw new SmartStoreException("Can't have JSON1 index specs in externally stored soup:" + soupName);
 			if (hasSoup(soupName)) return; // soup already exist - do nothing
-			final JSONArray features = new JSONArray();
-			if (IndexSpec.hasJSON1(indexSpecs)) {
-				features.put("JSON1");
-			}
-			if (IndexSpec.hasFTS(indexSpecs)) {
-				features.put("FTS");
-			}
-			if (soupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE)) {
-				features.put("ExternalStorage");
-			}
-			final JSONObject attributes = new JSONObject();
-			try {
-				attributes.put("features", features);
-			} catch (JSONException e) {
-				Log.e(TAG, "Exception thrown while building page object", e);
-			}
-			EventBuilderHelper.createAndStoreEvent("registerSoup", null, TAG, attributes);
 
 			// First get a table name
 			String soupTableName = null;
@@ -346,6 +334,29 @@ public class SmartStore  {
 			} finally {
 				db.endTransaction();
 			}
+			threadPool.execute(new Runnable() {
+				@Override
+				public void run() {
+					final JSONArray features = new JSONArray();
+					if (IndexSpec.hasJSON1(indexSpecs)) {
+						features.put("JSON1");
+					}
+					if (IndexSpec.hasFTS(indexSpecs)) {
+						features.put("FTS");
+					}
+					if (soupSpec.getFeatures().contains(SoupSpec.FEATURE_EXTERNAL_STORAGE)) {
+						features.put("ExternalStorage");
+					}
+					final JSONObject attributes = new JSONObject();
+					try {
+						attributes.put("features", features);
+					} catch (JSONException e) {
+						Log.e(TAG, "Exception thrown while building page object", e);
+					}
+					EventBuilderHelper.createAndStoreEventSync("registerSoup", null, TAG, attributes);
+
+				}
+			});
 		}
 	}
 
@@ -459,7 +470,7 @@ public class SmartStore  {
             db.endTransaction();
         }
     }
-    
+
 	/**
 	 * Finish long operations that were interrupted
 	 */
@@ -475,7 +486,7 @@ public class SmartStore  {
 			}
 		}
 	}
-	
+
 	/**
 	 * @return unfinished long operations
 	 */
@@ -510,14 +521,14 @@ public class SmartStore  {
 		}
 		return longOperations.toArray(new LongOperation[0]);
 	}
-    
+
 	/**
 	 * Alter soup using only soup name without extra soup features.
-	 * 
+	 *
 	 * @param soupName
 	 * @param indexSpecs array of index specs
 	 * @param reIndexData
-	 * @throws JSONException 
+	 * @throws JSONException
 	 */
 	public void alterSoup(String soupName, IndexSpec[] indexSpecs,
 			boolean reIndexData) throws JSONException {
@@ -542,7 +553,7 @@ public class SmartStore  {
 	/**
 	 * Re-index all soup elements for passed indexPaths
 	 * NB: only indexPath that have IndexSpec on them will be indexed
-	 * 
+	 *
 	 * @param soupName
 	 * @param indexPaths
 	 * @param handleTx
@@ -574,7 +585,7 @@ public class SmartStore  {
 			}
 
 			boolean hasFts = IndexSpec.hasFTS(indexSpecs);
-			
+
 			if (handleTx) {
 				db.beginTransaction();
 			}
@@ -612,7 +623,7 @@ public class SmartStore  {
 			        	}
 			        	catch (JSONException e) {
 			        		Log.w("SmartStore.alterSoup", "Could not parse soup element " + soupEntryId, e);
-			        		// Should not have happen - just keep going 
+			        		// Should not have happen - just keep going
 			        	}
 			        }
 			        while (cursor.moveToNext());
@@ -629,7 +640,7 @@ public class SmartStore  {
 
 	/**
 	 * Return indexSpecs of soup
-	 * 
+	 *
 	 * @param soupName
 	 * @return
 	 */
@@ -641,7 +652,7 @@ public class SmartStore  {
 	        return DBHelper.getInstance(db).getIndexSpecs(db, soupName);
     	}
 	}
-	
+
 	/**
 	 * Clear all rows from a soup
 	 * @param soupName
@@ -666,7 +677,7 @@ public class SmartStore  {
 			}
     	}
 	}
-	
+
     /**
      * Check if soup exists
      *
@@ -767,14 +778,14 @@ public class SmartStore  {
 	 * Run a query given by its query Spec, only returned results from selected page
 	 * @param querySpec
 	 * @param pageIndex
-     * @throws JSONException 
+     * @throws JSONException
 	 */
 	public JSONArray query(QuerySpec querySpec, int pageIndex) throws JSONException {
 		final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
 			QueryType qt = querySpec.queryType;
 	    	String sql = convertSmartSql(querySpec.smartSql);
-	
+
 	        // Page
 	        int offsetRows = querySpec.pageSize * pageIndex;
 	        int numberRows = querySpec.pageSize;
@@ -787,7 +798,7 @@ public class SmartStore  {
 	                do {
 	                	// Smart queries
 	                	if (qt == QueryType.smart || querySpec.selectPaths != null) {
-	                		results.put(getDataFromRow(cursor));	
+	                		results.put(getDataFromRow(cursor));
 	                	}
 	            		// Exact/like/range queries
 	                	else {
@@ -849,7 +860,7 @@ public class SmartStore  {
 		}
 		return row;
 	}
-	
+
 	/**
 	 * @param querySpec
 	 * @return count of results for a query
@@ -910,7 +921,7 @@ public class SmartStore  {
 	            }
 	            long now = System.currentTimeMillis();
 	            long soupEntryId = DBHelper.getInstance(db).getNextId(db, soupTableName);
-	
+
 	            // Adding fields to soup element
 	            soupElt.put(SOUP_ENTRY_ID, soupEntryId);
 	            soupElt.put(SOUP_LAST_MODIFIED_DATE, now);
@@ -1199,7 +1210,7 @@ public class SmartStore  {
 	                entryId = lookupSoupEntryId(soupName, externalIdPath, externalIdObj + "");
 	            }
 	        }
-	
+
 	        // If we have an entryId, let's do an update, otherwise let's do a create
 	        if (entryId != -1) {
 	            return update(soupName, soupElt, entryId, handleTx);
@@ -1226,7 +1237,7 @@ public class SmartStore  {
 	        String soupTableName = DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	        if (soupTableName == null) throw new SmartStoreException("Soup: " + soupName + " does not exist");
 	        String columnName = DBHelper.getInstance(db).getColumnNameForPath(db, soupName, fieldPath);
-	
+
 	        Cursor cursor = null;
 	        try {
 	            cursor = db.query(soupTableName, new String[] {ID_COL}, columnName + " = ?", new String[] { fieldValue }, null, null, null);


### PR DESCRIPTION
EventBuilderHelper is doing some not-insignificant work on the same thread it is being called on in many cases from file access to data parsing. This data is not validated to always be compliant, so shouldn't be done in a place that could cause applications to break.

On top of that there are a few methods being called where extra setup work is being done alongside non-eventing code.

RestResponse changes were made because "asString" is not necessarily thread-safe lazy consuming the response body, and in almost all cases if there can be understood that there is data the data would be consumed... so better to have it ready immediately than later.