### PR TITLE
Fixing an issue with AccMgrAuthTokenProvider

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -606,12 +606,12 @@ public class ClientManager {
      */
     public static class AccMgrAuthTokenProvider implements RestClient.AuthTokenProvider {
 
-        private static boolean gettingAuthToken;
-        private static final Object lock = new Object();
+        private boolean gettingAuthToken;
+        private final Object lock = new Object();
         private final ClientManager clientManager;
-        private static String lastNewAuthToken;
+        private String lastNewAuthToken;
         private final String refreshToken;
-        private static String lastNewInstanceUrl;
+        private String lastNewInstanceUrl;
         private long lastRefreshTime = -1 /* never refreshed */;
 
         /**


### PR DESCRIPTION
This class shouldn't be using static private properties.  It is crucial that they are instance properties for each Provider created, otherwise if you attempt to have RestClients that are associated with different logged in accounts any but the main account will be completely unable to authenticate. 