### PR TITLE
Fix for memory bloat on temporary objects

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -26,13 +26,8 @@
  */
 package com.salesforce.androidsdk.analytics.security;
 
-import android.app.Service;
-import android.app.admin.DevicePolicyManager;
-import android.content.Context;
-import android.text.TextUtils;
-import android.util.Base64;
-import android.util.Log;
-
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -42,6 +37,13 @@ import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+
+import android.app.Service;
+import android.app.admin.DevicePolicyManager;
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Base64;
+import android.util.Log;
 
 /**
  * Helper class for encryption/decryption/hash computations.
@@ -135,11 +137,14 @@ public class Encryptor {
     }
 
     public static String decrypt(byte[] data, String key) {
-        if (data == null || data.length == 0) {
-            return null;
+        if (TextUtils.isEmpty(key)) {
+            if (data != null) {
+                return new String(data, Charset.forName(UTF8));
+            } else {
+                return null;
+            }
         }
         try {
-
             // Decodes with Base64.
             byte[] keyBytes = Base64.decode(key, Base64.DEFAULT);
             byte[] dataBytes = Base64.decode(data, Base64.DEFAULT);
@@ -164,19 +169,42 @@ public class Encryptor {
         if (TextUtils.isEmpty(key) || data == null) {
             return data;
         }
+        byte[] bytes = encryptBytes(data, key);
+        if (bytes == null) {
+            return null;
+        }
         try {
+            // do as Base64.encodeToString does... return US-ASCII string with the already Base64 encoded bytes.
+            return new String(bytes, "US-ASCII");
+        } catch (UnsupportedEncodingException e) {
+            Log.w(TAG, "Error during encryption", e);
+        }
+        return null;
+    }
 
+    /**
+     * Encrypts data with key using AES-256. Returns Base64 byte[] array.
+     * @param data
+     * @param key
+     * @return
+     */
+    public static byte[] encryptBytes(String data, String key) {
+        if (TextUtils.isEmpty(key)) {
+            if (data == null) {
+                return null;
+            } else {
+                return data.getBytes();
+            }
+        }
+        try {
             // Encrypts with our preferred cipher.
             byte[] keyBytes = Base64.decode(key, Base64.DEFAULT);
             byte[] dataBytes = data.getBytes(UTF8);
-            byte[] encryptedData = encrypt(dataBytes, keyBytes);
-
-            // Encodes with Base64.
-            return Base64.encodeToString(encryptedData, Base64.DEFAULT);
+            return Base64.encode(encrypt(dataBytes, keyBytes), Base64.DEFAULT);
         } catch (Exception ex) {
             Log.w(TAG, "Error during encryption", ex);
-            return null;
         }
+        return null;
     }
 
     /**

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -131,6 +131,13 @@ public class Encryptor {
         if (TextUtils.isEmpty(key) || data == null) {
             return data;
         }
+        return decrypt(data.getBytes(), key);
+    }
+
+    public static String decrypt(byte[] data, String key) {
+        if (data == null || data.length == 0) {
+            return null;
+        }
         try {
 
             // Decodes with Base64.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
@@ -26,12 +26,6 @@
  */
 package com.salesforce.androidsdk.rest;
 
-import android.util.Log;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -39,9 +33,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import okhttp3.MediaType;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+
+import android.util.Log;
 
 /**
  * RestResponse: Class to represent any REST response.
@@ -63,7 +63,6 @@ public class RestResponse {
 	private String responseAsString;
 	private JSONObject responseAsJSONObject;
 	private JSONArray responseAsJSONArray;
-	private Map<String, String> headers;
 
 	/**
 	 * Constructor
@@ -72,7 +71,6 @@ public class RestResponse {
 	 */
 	public RestResponse(Response response) {
 		this.response = response;
-		consumeQuietly();
 	}
 
 	/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -65,7 +65,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	public static final int DB_VERSION = 3;
 	public static final String DEFAULT_DB_NAME = "smartstore";
 	public static final String SOUP_ELEMENT_PREFIX = "soupelt_";
-    private static final String TAG = "DBOpenHelper";
+	private static final String TAG = "DBOpenHelper";
 	private static final String DB_NAME_SUFFIX = ".db";
 	private static final String ORG_KEY_PREFIX = "00D";
 	private static final String EXTERNAL_BLOBS_SUFFIX = "_external_soup_blobs/";
@@ -94,7 +94,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 * @return List of Database names(prefixes).
 	 */
 	public static synchronized List<String> getUserDatabasePrefixList(Context ctx,
-																	  UserAccount account, String communityId) {
+			UserAccount account, String communityId) {
 		List<String> result = new ArrayList<>();
 		if(account==null) return  result;
 
@@ -120,16 +120,16 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 * @return List of Database names(prefixes).
 	 */
 	public static synchronized List<String> getGlobalDatabasePrefixList(Context ctx,
-																	  UserAccount account, String communityId) {
+			UserAccount account, String communityId) {
 		List<String> result = new ArrayList<>();
-        String accountSuffix = null;
+		String accountSuffix = null;
 		String orgId = null;
-        if (account != null) {
-            accountSuffix = account.getCommunityLevelFilenameSuffix(communityId);
+		if (account != null) {
+			accountSuffix = account.getCommunityLevelFilenameSuffix(communityId);
 			orgId = account.getOrgId();
-        }
+		}
 		SmartStoreGlobalFileFilter globalFileFilter = new SmartStoreGlobalFileFilter(accountSuffix,
-                orgId);
+																					 orgId);
 		final String dbPath = ctx.getApplicationInfo().dataDir + "/databases";
 		final File dir = new File(dbPath);
 		String[] fileNames = dir.list(globalFileFilter);
@@ -173,7 +173,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 *
 	 * @param ctx Context.
 	 * @param dbNamePrefix The database name. This must be a valid file name without a
-     *                     filename extension such as ".db".
+	 *                     filename extension such as ".db".
 	 * @param account User account. If this method is called before authentication,
 	 * 				we will simply return the smart store DB, which is not associated
 	 * 				with any user account. Otherwise, we will return a unique
@@ -196,25 +196,25 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		final String fullDBName = dbName.toString();
 		DBOpenHelper helper = openHelpers.get(fullDBName);
 		if (helper == null) {
-            List<String> numDbs = null;
-            String key = "numGlobalStores";
-            String eventName = "globalSmartStoreInit";
-            if (account == null) {
-                numDbs = getGlobalDatabasePrefixList(ctx, account, communityId);
-            } else {
-                key = "numUserStores";
-                eventName = "userSmartStoreInit";
-                numDbs = getUserDatabasePrefixList(ctx, account, communityId);
-            }
-            int numStores = (numDbs == null) ? 0 : numDbs.size();
-            final JSONObject storeAttributes = new JSONObject();
-            try {
-                storeAttributes.put(key, numStores);
-            } catch (JSONException e) {
-                Log.e(TAG, "Error occurred while creating JSON", e);
-            }
-            EventBuilderHelper.createAndStoreEvent(eventName, account, TAG, storeAttributes);
-            helper = new DBOpenHelper(ctx, fullDBName);
+			List<String> numDbs = null;
+			String key = "numGlobalStores";
+			String eventName = "globalSmartStoreInit";
+			if (account == null) {
+				numDbs = getGlobalDatabasePrefixList(ctx, account, communityId);
+			} else {
+				key = "numUserStores";
+				eventName = "userSmartStoreInit";
+				numDbs = getUserDatabasePrefixList(ctx, account, communityId);
+			}
+			int numStores = (numDbs == null) ? 0 : numDbs.size();
+			final JSONObject storeAttributes = new JSONObject();
+			try {
+				storeAttributes.put(key, numStores);
+			} catch (JSONException e) {
+				Log.e(TAG, "Error occurred while creating JSON", e);
+			}
+			EventBuilderHelper.createAndStoreEvent(eventName, account, TAG, storeAttributes);
+			helper = new DBOpenHelper(ctx, fullDBName);
 			openHelpers.put(fullDBName, helper);
 		}
 		return helper;
@@ -227,9 +227,9 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		dataDir = context.getApplicationInfo().dataDir;
 	}
 
-    protected void loadLibs(Context context) {
-        SqliteLibraryLoader.loadSqlCipher(context);
-    }
+	protected void loadLibs(Context context) {
+		SqliteLibraryLoader.loadSqlCipher(context);
+	}
 
 	@Override
 	public void onCreate(SQLiteDatabase db) {
@@ -265,7 +265,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		if (oldVersion < 3) {
 			// DB versions before 3 used soup_names, which has changed to soup_attrs
 			SmartStore.updateTableNameAndAddColumns(db, SmartStore.SOUP_NAMES_TABLE,
-                    SmartStore.SOUP_ATTRS_TABLE, new String[] { SoupSpec.FEATURE_EXTERNAL_STORAGE });
+													SmartStore.SOUP_ATTRS_TABLE, new String[] { SoupSpec.FEATURE_EXTERNAL_STORAGE });
 		}
 	}
 
@@ -302,7 +302,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 *
 	 * @param ctx Context.
 	 * @param dbNamePrefix The database name. This must be a valid file name without a
-     *                     filename extension such as ".db".
+	 *                     filename extension such as ".db".
 	 * @param account User account.
 	 * @param communityId Community ID.
 	 */
@@ -336,7 +336,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 				StringBuffer communityDBNamePrefix = new StringBuffer(dbNamePrefix);
 				String accountSuffix = account.getUserLevelFilenameSuffix();
 				communityDBNamePrefix.append(accountSuffix);
-		    	deleteFiles(ctx, communityDBNamePrefix.toString());
+				deleteFiles(ctx, communityDBNamePrefix.toString());
 			}
 
 			// Delete external blobs directory
@@ -399,7 +399,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		public void preKey(SQLiteDatabase database) {
 			database.execSQL("PRAGMA cipher_default_kdf_iter = '4000'");
 			// the new default for sqlcipher 3.x (64000) is too slow
-            // also that way we can open 2.x databases without any migration
+			// also that way we can open 2.x databases without any migration
 		}
 
 		public void postKey(SQLiteDatabase database) {
@@ -408,38 +408,38 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 
 	private static void deleteFiles(Context ctx, String prefix) {
 		final String dbPath = ctx.getApplicationInfo().dataDir + "/databases";
-    	final File dir = new File(dbPath);
-    	if (dir != null) {
-        	final SmartStoreFileFilter fileFilter = new SmartStoreFileFilter(prefix);
-        	final File[] fileList = dir.listFiles();
-        	if (fileList != null) {
-            	for (final File file : fileList) {
-            		if (file != null && fileFilter.accept(dir, file.getName())) {
-            			file.delete();
-            			openHelpers.remove(file.getName());
-            		}
-            	}
-        	}
-    	}
+		final File dir = new File(dbPath);
+		if (dir != null) {
+			final SmartStoreFileFilter fileFilter = new SmartStoreFileFilter(prefix);
+			final File[] fileList = dir.listFiles();
+			if (fileList != null) {
+				for (final File file : fileList) {
+					if (file != null && fileFilter.accept(dir, file.getName())) {
+						file.delete();
+						openHelpers.remove(file.getName());
+					}
+				}
+			}
+		}
 	}
 
-    /**
-     * This class acts as a filter to identify only the relevant SmartStore files.
-     *
-     * @author bhariharan
-     */
-    private static class SmartStoreFileFilter implements FilenameFilter {
+	/**
+	 * This class acts as a filter to identify only the relevant SmartStore files.
+	 *
+	 * @author bhariharan
+	 */
+	private static class SmartStoreFileFilter implements FilenameFilter {
 
-    	private String dbNamePrefix;
+		private String dbNamePrefix;
 
-    	/**
-    	 * Parameterized constructor.
-    	 *
-    	 * @param dbNamePrefix Database name prefix pattern.
-    	 */
-    	public SmartStoreFileFilter(String dbNamePrefix) {
-    		this.dbNamePrefix = dbNamePrefix;
-    	}
+		/**
+		 * Parameterized constructor.
+		 *
+		 * @param dbNamePrefix Database name prefix pattern.
+		 */
+		public SmartStoreFileFilter(String dbNamePrefix) {
+			this.dbNamePrefix = dbNamePrefix;
+		}
 
 		@Override
 		public boolean accept(File dir, String filename) {
@@ -452,7 +452,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		String getDbNamePrefix(){
 			return  dbNamePrefix;
 		}
-    }
+	}
 
 	private static class SmartStoreGlobalFileFilter extends SmartStoreFileFilter {
 
@@ -494,7 +494,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 * @param subDir Subdirectory to determine size of. Use null for top-level directory.
 	 *
 	 * @return Size of all files in all subdirectories.
-     */
+	 */
 	public int getSizeOfDir(File subDir) {
 		int size = 0;
 		if (subDir == null) {
@@ -521,7 +521,7 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 *
 	 * @param dir Directory to remove all files and folders recursively.
 	 * @return True if all delete operations were successful. False otherwise.
-     */
+	 */
 	public static boolean removeAllFiles(File dir) {
 		if (dir != null && dir.exists()) {
 			boolean success = true;
@@ -621,33 +621,32 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 * @return True if operation was successful, false otherwise.
 	 */
 	public boolean saveSoupBlob(String soupTableName, long soupEntryId, JSONObject soupElt, String passcode) {
-        return saveSoupBlobFromString(soupTableName, soupEntryId, soupElt.toString(), passcode);
+		return saveSoupBlobFromString(soupTableName, soupEntryId, soupElt.toString(), passcode);
 	}
 
-    /**
-     * Places the soup blob on file storage. The name and folder are determined by the soup and soup entry id.
-     *
-     * @param soupTableName Name of the soup that the blob belongs to.
-     * @param soupEntryId Entry id for the soup blob.
-     * @param soupEltStr Blob to store on file storage as a String.
-     * @param passcode Key with which to encrypt the data.
-     *
-     * @return True if operation was successful, false otherwise.
-     */
-    public boolean saveSoupBlobFromString(String soupTableName, long soupEntryId, String soupEltStr, String passcode) {
-        FileOutputStream outputStream;
-        File file = getSoupBlobFile(soupTableName, soupEntryId);
-
-        try {
-            outputStream = new FileOutputStream(file, false);
-            outputStream.write(Encryptor.encrypt(soupEltStr, passcode).getBytes());
-            outputStream.close();
-            return true;
-        } catch (IOException ex) {
-            Log.e(TAG, "Exception occurred while attempting to write external soup blob.", ex);
-        }
-        return false;
-    }
+	/**
+	 * Places the soup blob on file storage. The name and folder are determined by the soup and soup entry id.
+	 *
+	 * @param soupTableName Name of the soup that the blob belongs to.
+	 * @param soupEntryId Entry id for the soup blob.
+	 * @param soupEltStr Blob to store on file storage as a String.
+	 * @param passcode Key with which to encrypt the data.
+	 *
+	 * @return True if operation was successful, false otherwise.
+	 */
+	public boolean saveSoupBlobFromString(String soupTableName, long soupEntryId, String soupEltStr, String passcode) {
+		File file = getSoupBlobFile(soupTableName, soupEntryId);
+		try (FileOutputStream outputStream = new FileOutputStream(file, false)) {
+			byte[] data = Encryptor.encryptBytes(soupEltStr, passcode);
+			if (data != null) {
+				outputStream.write(data);
+				return true;
+			}
+		} catch (IOException ex) {
+			Log.e(TAG, "Exception occurred while attempting to write external soup blob.", ex);
+		}
+		return false;
+	}
 
 	/**
 	 * Retrieves the soup blob for the given soup entry id from file storage.
@@ -681,19 +680,17 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	 * @return The blob from file storage represented as String. Returns null if there was an error.
 	 */
 	public String loadSoupBlobAsString(String soupTableName, long soupEntryId, String passcode) {
-		String result = null;
-		try {
-			File file = getSoupBlobFile(soupTableName, soupEntryId);
-			FileInputStream f = new FileInputStream(file);
+		File file = getSoupBlobFile(soupTableName, soupEntryId);
+		try (FileInputStream f = new FileInputStream(file)) {
 			DataInputStream data = new DataInputStream(f);
-			byte[] bytes = new byte[(int)file.length()];
+			byte[] bytes = new byte[(int) file.length()];
 			data.readFully(bytes);
-			result = Encryptor.decrypt(bytes, passcode);
+			return Encryptor.decrypt(bytes, passcode);
 
 		} catch (IOException ex) {
 			Log.e(TAG, "Exception occurred while attempting to read external soup blob.", ex);
 		}
-		return result;
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
loadSoupBlobAsString creates an incredible amount of temporary objects if used to pick up large json files from the file system.  Immediately after reading the entire file it would then be converted into bytes to be decrypted.

Change skips the initial creation of the string, passing in the bytes directly to decrypt.  On average testing this has flatlined memory use on an app that uses this functionality often.