### PR TITLE
Adding persistence of logging preferences

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/FileLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/FileLogger.java
@@ -27,6 +27,7 @@
 package com.salesforce.androidsdk.analytics.logger;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -47,9 +48,12 @@ public class FileLogger {
     private static final String LOG_SUFFIX = "_log";
     private static final String UTF8 = "UTF-8";
     private static final String ASCII = "US-ASCII";
+    private static final String FILE_LOGGER_PREFS = "sf_file_logger_prefs";
     private static final String TAG = "FileLogger";
     private static final int MAX_SIZE = 10000;
 
+    private Context context;
+    private String componentName;
     private QueueFile file;
     private int maxSize;
 
@@ -61,9 +65,11 @@ public class FileLogger {
      * @throws IOException If file initialization was unsuccessful.
      */
     public FileLogger(Context context, String componentName) throws IOException {
+        this.context = context;
+        this.componentName = componentName;
+        readFileLoggerPrefs();
         final File filename = new File(context.getFilesDir(), componentName + LOG_SUFFIX);
         file = new QueueFile(filename);
-        maxSize = MAX_SIZE;
     }
 
     /**
@@ -102,11 +108,11 @@ public class FileLogger {
      *
      * @param size Maximum number of log lines.
      */
-    public synchronized void setMaxSize(int size) {
+    public void setMaxSize(int size) {
         if (size < 0) {
             size = 0;
         }
-        maxSize = size;
+        storeFileLoggerPrefs(size);
     }
 
     /**
@@ -253,5 +259,21 @@ public class FileLogger {
         for (int i = 0; i < linesToRemove; i++) {
             removeLogLine();
         }
+    }
+
+    private synchronized void storeFileLoggerPrefs(int maxSize) {
+        final SharedPreferences sp = context.getSharedPreferences(FILE_LOGGER_PREFS, Context.MODE_PRIVATE);
+        final SharedPreferences.Editor e = sp.edit();
+        e.putInt(componentName, maxSize);
+        e.commit();
+        this.maxSize = maxSize;
+    }
+
+    private void readFileLoggerPrefs() {
+        final SharedPreferences sp = context.getSharedPreferences(FILE_LOGGER_PREFS, Context.MODE_PRIVATE);
+        if (!sp.contains(componentName)) {
+            storeFileLoggerPrefs(MAX_SIZE);
+        }
+        maxSize = sp.getInt(componentName, MAX_SIZE);
     }
 }

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/FileLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/FileLogger.java
@@ -276,4 +276,16 @@ public class FileLogger {
         }
         maxSize = sp.getInt(componentName, MAX_SIZE);
     }
+
+    /**
+     * Resets the stored file logger prefs. Should be used ONLY by tests.
+     *
+     * @param context Context.
+     */
+    public synchronized static void resetFileLoggerPrefs(Context context) {
+        final SharedPreferences sp = context.getSharedPreferences(FILE_LOGGER_PREFS, Context.MODE_PRIVATE);
+        final SharedPreferences.Editor e = sp.edit();
+        e.clear();
+        e.commit();
+    }
 }

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
@@ -54,7 +54,7 @@ public class SalesforceLogger {
     private static final String TAG = "SalesforceLogger";
     private static final String LOG_LINE_FORMAT = "TIME: %s, LEVEL: %s, TAG: %s, MESSAGE: %s";
     private static final String LOG_LINE_FORMAT_WITH_EXCEPTION = "TIME: %s, LEVEL: %s, TAG: %s, MESSAGE: %s, EXCEPTION: %s";
-    private static final String US_DATE_FORMAT = "yyyy.MM.dd G 'at' HH:mm:ss z";
+    private static final String US_DATE_FORMAT = "MM-dd HH:mm:ss.SSS";
     private static final String SF_LOGGER_PREFS = "sf_logger_prefs";
     private static final ExecutorService THREAD_POOL = Executors.newFixedThreadPool(1);
     private static Map<String, SalesforceLogger> LOGGERS;

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
@@ -56,7 +56,7 @@ public class SalesforceLogger {
     private static final String LOG_LINE_FORMAT_WITH_EXCEPTION = "TIME: %s, LEVEL: %s, TAG: %s, MESSAGE: %s, EXCEPTION: %s";
     private static final String US_DATE_FORMAT = "yyyy.MM.dd G 'at' HH:mm:ss z";
     private static final String SF_LOGGER_PREFS = "sf_logger_prefs";
-    private static final ExecutorService THREAD_POOL = Executors.newFixedThreadPool(3);
+    private static final ExecutorService THREAD_POOL = Executors.newFixedThreadPool(1);
     private static Map<String, SalesforceLogger> LOGGERS;
 
     /**

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
@@ -321,4 +321,16 @@ public class SalesforceLogger {
         final String logLevelString = sp.getString(componentName, level.toString());
         logLevel = Level.valueOf(logLevelString);
     }
+
+    /**
+     * Resets the stored logger prefs. Should be used ONLY by tests.
+     *
+     * @param context Context.
+     */
+    public synchronized static void resetLoggerPrefs(Context context) {
+        final SharedPreferences sp = context.getSharedPreferences(SF_LOGGER_PREFS, Context.MODE_PRIVATE);
+        final SharedPreferences.Editor e = sp.edit();
+        e.clear();
+        e.commit();
+    }
 }

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
@@ -53,6 +53,7 @@ public class FileLoggerTest extends InstrumentationTestCase {
     public void setUp() throws Exception {
         super.setUp();
         targetContext = getInstrumentation().getTargetContext();
+        FileLogger.resetFileLoggerPrefs(targetContext);
         fileLogger = new FileLogger(targetContext, COMPONENT_NAME);
         fileLogger.flushLog();
         int size = fileLogger.getSize();
@@ -61,6 +62,7 @@ public class FileLoggerTest extends InstrumentationTestCase {
 
     @Override
     public void tearDown() throws Exception {
+        FileLogger.resetFileLoggerPrefs(targetContext);
         fileLogger.flushLog();
         super.tearDown();
     }

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
@@ -44,7 +44,7 @@ public class FileLoggerTest extends InstrumentationTestCase {
     private static final String TEST_LOG_LINE_2 = "This is test log line 2!";
     private static final String TEST_LOG_LINE_3 = "This is test log line 3!";
     private static final String TEST_LOG_LINE_4 = "This is test log line 4!";
-    private static final int DEFAULT_MAX_SIZE = 1000;
+    private static final int DEFAULT_MAX_SIZE = 10000;
 
     private Context targetContext;
     private FileLogger fileLogger;

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
@@ -48,6 +48,7 @@ public class SalesforceLoggerTest extends InstrumentationTestCase {
         super.setUp();
         targetContext = getInstrumentation().getTargetContext();
         SalesforceLogger.flushComponents();
+        SalesforceLogger.resetLoggerPrefs(targetContext);
         final Set<String> components = SalesforceLogger.getComponents();
         assertNull("No components should be returned", components);
     }
@@ -55,6 +56,7 @@ public class SalesforceLoggerTest extends InstrumentationTestCase {
     @Override
     public void tearDown() throws Exception {
         SalesforceLogger.flushComponents();
+        SalesforceLogger.resetLoggerPrefs(targetContext);
         super.tearDown();
     }
 

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
@@ -40,9 +40,8 @@ public class SalesforceLoggerTest extends InstrumentationTestCase {
 
     private static final String TEST_COMPONENT_1 = "TestComponent1";
     private static final String TEST_COMPONENT_2 = "TestComponent2";
-    private static final String TEST_COMPONENT_3 = "TestComponent3";
+
     private Context targetContext;
-    private SalesforceLogger logger;
 
     @Override
     public void setUp() throws Exception {


### PR DESCRIPTION
This stores the log levels and file size per component in `SharedPreferences`, so that these preferences are used even if the app is swapped out of memory or the device is restarted.