### PR TITLE
Logger crash bug fix

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/util/SalesforceHybridLogger.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/util/SalesforceHybridLogger.java
@@ -27,7 +27,7 @@
 package com.salesforce.androidsdk.phonegap.util;
 
 import com.salesforce.androidsdk.analytics.logger.SalesforceLogger;
-import com.salesforce.androidsdk.phonegap.app.SalesforceHybridSDKManager;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
 /**
  * A simple logger util class for the SalesforceHybrid library. This class simply acts
@@ -155,6 +155,6 @@ public class SalesforceHybridLogger {
 
     private static SalesforceLogger getLogger() {
         return SalesforceLogger.getLogger(COMPONENT_NAME,
-                SalesforceHybridSDKManager.getInstance().getAppContext());
+                SalesforceSDKManager.getInstance().getAppContext());
     }
 }

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/util/SalesforceReactLogger.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/util/SalesforceReactLogger.java
@@ -27,7 +27,7 @@
 package com.salesforce.androidsdk.reactnative.util;
 
 import com.salesforce.androidsdk.analytics.logger.SalesforceLogger;
-import com.salesforce.androidsdk.reactnative.app.SalesforceReactSDKManager;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
 /**
  * A simple logger util class for the SalesforceReact library. This class simply acts
@@ -155,6 +155,6 @@ public class SalesforceReactLogger {
 
     private static SalesforceLogger getLogger() {
         return SalesforceLogger.getLogger(COMPONENT_NAME,
-                SalesforceReactSDKManager.getInstance().getAppContext());
+                SalesforceSDKManager.getInstance().getAppContext());
     }
 }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/util/SmartStoreLogger.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/util/SmartStoreLogger.java
@@ -27,7 +27,7 @@
 package com.salesforce.androidsdk.smartstore.util;
 
 import com.salesforce.androidsdk.analytics.logger.SalesforceLogger;
-import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
 /**
  * A simple logger util class for the SmartStore library. This class simply acts
@@ -155,6 +155,6 @@ public class SmartStoreLogger {
 
     private static SalesforceLogger getLogger() {
         return SalesforceLogger.getLogger(COMPONENT_NAME,
-                SmartStoreSDKManager.getInstance().getAppContext());
+                SalesforceSDKManager.getInstance().getAppContext());
     }
 }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SmartSyncLogger.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SmartSyncLogger.java
@@ -27,8 +27,8 @@
 package com.salesforce.androidsdk.smartsync.util;
 
 import com.salesforce.androidsdk.analytics.logger.SalesforceLogger;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.rest.RestResponse;
-import com.salesforce.androidsdk.smartsync.app.SmartSyncSDKManager;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -224,7 +224,7 @@ public class SmartSyncLogger {
 
     private static SalesforceLogger getLogger() {
         return SalesforceLogger.getLogger(COMPONENT_NAME,
-                SmartSyncSDKManager.getInstance().getAppContext());
+                SalesforceSDKManager.getInstance().getAppContext());
     }
 
     private static String toString(Object obj) {


### PR DESCRIPTION
There could be cases where the app extends `SalesforceSDKManager` but uses some hybrid components. If we automatically typecast to `SmartSyncSDKManager`, this would cause a crash. Besides, `appContext` is in the lowest level of the hierarchy anyway.