### PR TITLE
Added check for null okHttpClient before publishing log lines

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AILTNPublisher.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AILTNPublisher.java
@@ -113,6 +113,11 @@ public class AILTNPublisher implements AnalyticsPublisher {
                     ApiVersionStrings.getVersionNumber(SalesforceSDKManager.getInstance().getAppContext()));
             final RestClient restClient = SalesforceSDKManager.getInstance().getClientManager().peekRestClient();
 
+            if (restClient.getOkHttpClient() == null) {
+                // Rest client is not ready
+                return false;
+            }
+
             /*
              * There's no easy way to get content length using GZIP interceptors. Some trickery is
              * required to achieve this by adding an additional interceptor to determine content length.


### PR DESCRIPTION
There are some cases when publishLogLines may be called before RestClient has
an okHttpClient. In these cases, lets return early and publish logs later when its ready.