### PR TITLE
Restart app / show login if refresh token revoked

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -551,6 +551,11 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
      * Performs actions on logout complete.
      */
     protected void logoutCompleteActions() {
+        // NB: without this code a refresh token revoke does not restart app
+        // If this is not the desired behavior in your application, simply override this method
+        if (!isChild()) {
+            recreate();
+        }
     }
 
     /**

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
@@ -254,6 +254,11 @@ public abstract class SalesforceReactActivity extends ReactActivity {
      * Performs actions on logout complete.
      */
     protected void logoutCompleteActions() {
+        // NB: without this code a refresh token revoke does not restart app
+        // If this is not the desired behavior in your application, simply override this method
+        if (!isChild()) {
+            recreate();
+        }
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -154,6 +154,11 @@ public abstract class SalesforceActivity extends Activity {
      * Performs actions on logout complete.
      */
     protected void logoutCompleteActions() {
+		// NB: without this code a refresh token revoke does not restart app
+		// If this is not the desired behavior in your application, simply override this method
+		if (!isChild()) {
+			recreate();
+		}
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceExpandableListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceExpandableListActivity.java
@@ -155,6 +155,11 @@ public abstract class SalesforceExpandableListActivity extends ExpandableListAct
      * Performs actions on logout complete.
      */
     protected void logoutCompleteActions() {
+		// NB: without this code a refresh token revoke does not restart app
+		// If this is not the desired behavior in your application, simply override this method
+		if (!isChild()) {
+			recreate();
+		}
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
@@ -155,6 +155,11 @@ public abstract class SalesforceListActivity extends ListActivity {
      * Performs actions on logout complete.
      */
     protected void logoutCompleteActions() {
+		// NB: without this code a refresh token revoke does not restart app
+		// If this is not the desired behavior in your application, simply override this method
+		if (!isChild()) {
+			recreate();
+		}
     }
 
     /**

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/MainActivity.java
@@ -132,15 +132,6 @@ public class MainActivity extends SalesforceListActivity implements
 	}
 
 	@Override
-	protected void logoutCompleteActions() {
-		super.logoutCompleteActions();
-		// If refresh token is revoked - ClientManager does a logout that doesn't finish top activity activity or show login
-		if (!isChild()) {
-            recreate();
-        }
-	}
-
-	@Override
 	public void onResume(RestClient client) {
 		curAccount = SmartSyncSDKManager.getInstance().getUserAccountManager().getCurrentUser();
 		Account account = null;


### PR DESCRIPTION
This is the default behavior on iOS but was not the default behavior on Android.
If this is not the desired behavior, a dev simply needs to override logoutCompleteActions.