### PR TITLE
Removing deprecated APIs

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -288,18 +288,6 @@ public class LoginActivity extends AccountAuthenticatorActivity
 	}
 
 	@Override
-	public void onLoadingProgress(int totalProgress) {
-		onIndeterminateProgress(false);
-		setProgress(totalProgress);
-	}
-
-	@Override
-	public void onIndeterminateProgress(boolean show) {
-		setProgressBarIndeterminateVisibility(show);
-		setProgressBarIndeterminate(show);
-	}
-
-	@Override
 	public void onAccountAuthenticatorResult(Bundle authResult) {
 		setAccountAuthenticatorResult(authResult);
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -124,15 +124,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
         /** we're starting to load this login page into the webview */
         void loadingLoginPage(String loginUrl);
 
-        /**
-         * progress update of loading the webview, totalProgress will go from
-         * 0..10000 (you can pass this directly to the activity progressbar)
-         */
-        void onLoadingProgress(int totalProgress);
-
-        /** We're doing something that takes some unknown amount of time */
-        void onIndeterminateProgress(boolean show);
-
         /** We've completed the auth process and here's the resulting Authentication Result bundle to return to the Authenticator */
         void onAccountAuthenticatorResult(Bundle authResult);
 
@@ -225,7 +216,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
     /** Factory method for the WebChromeClient, you can replace this with something else if you need to */
     protected WebChromeClient makeWebChromeClient() {
-        return new AuthWebChromeClient();
+        return new WebChromeClient();
     }
 
     protected Context getContext() {
@@ -632,7 +623,8 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                     callback.finish();
                 }
             }
-            // No screen lock required or no mobile policy specified
+
+            // No screen lock required or no mobile policy specified.
             else {
                 final PasscodeManager passcodeManager = mgr.getPasscodeManager();
                 passcodeManager.storeMobilePolicyForOrg(account, 0, PasscodeManager.MIN_PASSCODE_LENGTH);
@@ -647,11 +639,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 SalesforceSDKLogger.w(TAG, "Exception thrown", ex);
             }
             backgroundException = ex;
-        }
-
-        @Override
-        protected void onProgressUpdate(Boolean... values) {
-            callback.onIndeterminateProgress(values[0]);
         }
     }
 
@@ -778,17 +765,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     protected String buildAccountName(String username, String instanceServer) {
         return String.format("%s (%s) (%s)", username, instanceServer,
         		SalesforceSDKManager.getInstance().getApplicationName());
-    }
-
-    /**
-     * WebChromeClient used to report back loading progress.
-     */
-    protected class AuthWebChromeClient extends WebChromeClient {
-
-        @Override
-        public void onProgressChanged(WebView view, int newProgress) {
-            callback.onLoadingProgress(newProgress * 100);
-        }
     }
 
     /**


### PR DESCRIPTION
These APIs do nothing on `API 21` and higher. Since we bumped up our `minVersion` to `API 21`, we don't need them anymore.