### PR TITLE
Caching auth token right away

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -61,6 +61,7 @@ import com.salesforce.androidsdk.push.PushMessaging;
 import com.salesforce.androidsdk.push.PushNotificationInterface;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
+import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.security.PasscodeManager;
 import com.salesforce.androidsdk.ui.AccountSwitcherActivity;
 import com.salesforce.androidsdk.ui.LoginActivity;
@@ -627,6 +628,7 @@ public class SalesforceSDKManager {
     protected void cleanUp(Activity frontActivity, Account account) {
         final UserAccount userAccount = UserAccountManager.getInstance().buildUserAccount(account);
         SalesforceAnalyticsManager.reset(userAccount);
+        RestClient.clearCaches(userAccount.getOrgId(), userAccount.getUserId());
         final List<UserAccount> users = getUserAccountManager().getAuthenticatedUsers();
 
         // Finishes front activity if specified, and if this is the last account.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -369,6 +369,11 @@ public class ClientManager {
         }
         Account acc = new Account(accountName, getAccountType());
         accountManager.addAccountExplicitly(acc, SalesforceSDKManager.encrypt(refreshToken), new Bundle());
+
+        // Caching auth token otherwise the first call to accountManager.getAuthToken will go to the AuthenticatorService which will do a refresh
+        // That is problematic when the refresh token is set to expire immediately
+        accountManager.setAuthToken(acc, AccountManager.KEY_AUTHTOKEN, SalesforceSDKManager.encrypt(authToken));
+
         // There is a bug in AccountManager::addAccountExplicitly() that sometimes causes user data to not be
         // saved when the user data is passed in through that method. The work-around is to call setUserData()
         // for all the user data manually after passing in empty user data into addAccountExplicitly().

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -67,14 +67,18 @@ public class RestClient {
 	private static final String COMMUNITY_URL = "communityUrl";
 	private static final String TAG = "RestClient";
 
-	private static Map<String, OkHttpClient.Builder> OK_CLIENT_BUILDERS;
-    private static Map<String, OkHttpClient> OK_CLIENTS;
+	private static Map<String, OAuthRefreshInterceptor> OAUTH_REFRESH_INTERCEPTORS = new HashMap<>();
+	private static Map<String, OkHttpClient.Builder> OK_CLIENT_BUILDERS = new HashMap<>();
+    private static Map<String, OkHttpClient> OK_CLIENTS = new HashMap<>();
+
+	private ClientInfo clientInfo;
     private HttpAccess httpAccessor;
+	private AuthTokenProvider authTokenProvider;
     private OAuthRefreshInterceptor oAuthRefreshInterceptor;
 	private OkHttpClient.Builder okHttpClientBuilder;
 	private OkHttpClient okHttpClient;
 
-	/** 
+	/**
 	 * AuthTokenProvider interface.
 	 * RestClient will call its authTokenProvider to refresh its authToken once it has expired. 
 	 */
@@ -132,29 +136,57 @@ public class RestClient {
      * @param authTokenProvider
 	 */
 	public RestClient(ClientInfo clientInfo, String authToken, HttpAccess httpAccessor, AuthTokenProvider authTokenProvider) {
-		this(httpAccessor, new OAuthRefreshInterceptor(clientInfo, authToken, authTokenProvider));
-	}
-
-	public RestClient(HttpAccess httpAccessor, OAuthRefreshInterceptor httpInterceptor) {
+		this.clientInfo = clientInfo;
         this.httpAccessor = httpAccessor;
-		this.oAuthRefreshInterceptor = httpInterceptor;
+		this.authTokenProvider = authTokenProvider;
+		setOAuthRefreshInterceptor(authToken);
 		setOkHttpClientBuilder();
 		setOkHttpClient(null);
 	}
 
 	/**
-	 * Clear cache of org-id/user-id to OkHttpClient.Builder
+	 * Remove cached OkHttpClient.Builder, OkHttpClient and OAuthRefreshInterceptor for the given org id, user id
 	 */
-	public static void clearOkClientBuildersCache() {
-		OK_CLIENT_BUILDERS = null;
+	public synchronized static void clearCaches(String orgId, String userId) {
+		String cacheKey = computeCacheKey(orgId, userId);
+		OAUTH_REFRESH_INTERCEPTORS.remove(cacheKey);
+		OK_CLIENT_BUILDERS.remove(cacheKey);
+		OkHttpClient client = OK_CLIENTS.remove(cacheKey);
+		if (client != null) {
+			client.dispatcher().cancelAll();
+		}
 	}
 
-    /**
-     * Clear cache of org-id/user-id to OkHttpClient
-     */
-    public static void clearOkClientsCache() {
-        OK_CLIENTS = null;
+	/**
+	 * Clear caches of org-id/user-id to OkHttpClient.Builder, OkHttpClient and OAuthRefreshInterceptor
+	 */
+	public synchronized static void clearCaches() {
+		OAUTH_REFRESH_INTERCEPTORS.clear();
+		OK_CLIENT_BUILDERS.clear();
+		OK_CLIENTS.clear();
     }
+
+	private String getCacheKey() {
+		return computeCacheKey(clientInfo.orgId, clientInfo.userId);
+	}
+
+	private static String computeCacheKey(String orgId, String userId) {
+		return orgId != null && userId != null ? orgId + "-" + userId : "unauthenticated";
+	}
+
+	/**
+	 * Sets the OAuthRefreshInterceptor associated with this user account.
+	 */
+    private synchronized void setOAuthRefreshInterceptor(String authToken) {
+		final String cacheKey = getCacheKey();
+		OAuthRefreshInterceptor oAuthRefreshInterceptor = OAUTH_REFRESH_INTERCEPTORS.get(cacheKey);
+		// If none cached, create new one
+		if (oAuthRefreshInterceptor == null) {
+			oAuthRefreshInterceptor = new OAuthRefreshInterceptor(clientInfo, authToken, authTokenProvider);
+			OAUTH_REFRESH_INTERCEPTORS.put(cacheKey, oAuthRefreshInterceptor);
+		}
+		this.oAuthRefreshInterceptor = oAuthRefreshInterceptor;
+	}
 
 	/**
 	 * Sets the OkHttpclient.Builder associated with this user account. The OkHttpclient.Builder
@@ -162,18 +194,13 @@ public class RestClient {
 	 * switch occurs, to prevent multiple threads being spawned unnecessarily.
 	 */
 	private synchronized void setOkHttpClientBuilder() {
-		if (OK_CLIENT_BUILDERS == null) {
-			OK_CLIENT_BUILDERS = new HashMap<>();
-		}
-		final String uniqueId = this.oAuthRefreshInterceptor.clientInfo.buildUniqueId();
-		OkHttpClient.Builder okHttpClientBuilder = null;
-		if (uniqueId != null) {
-			okHttpClientBuilder = OK_CLIENT_BUILDERS.get(uniqueId);
-			if (okHttpClientBuilder == null) {
-				okHttpClientBuilder = httpAccessor.getOkHttpClientBuilder()
-						.addInterceptor(oAuthRefreshInterceptor);
-				OK_CLIENT_BUILDERS.put(uniqueId, okHttpClientBuilder);
-			}
+		final String cacheKey = getCacheKey();
+		OkHttpClient.Builder okHttpClientBuilder = OK_CLIENT_BUILDERS.get(cacheKey);
+		// If none cached, create new one
+		if (okHttpClientBuilder == null) {
+			okHttpClientBuilder = httpAccessor.getOkHttpClientBuilder()
+					.addInterceptor(getOAuthRefreshInterceptor());
+			OK_CLIENT_BUILDERS.put(getCacheKey(), okHttpClientBuilder);
 		}
 		this.okHttpClientBuilder = okHttpClientBuilder;
 	}
@@ -184,23 +211,20 @@ public class RestClient {
 	 * switch occurs, to prevent multiple threads being spawned unnecessarily.
 	 */
 	public synchronized void setOkHttpClient(OkHttpClient okHttpClient) {
-		if (OK_CLIENTS == null) {
-			OK_CLIENTS = new HashMap<>();
+		final String cacheKey = getCacheKey();
+
+		// If a valid client passed in, caches it.
+		if (okHttpClient != null) {
+			OK_CLIENTS.put(cacheKey, okHttpClient);
 		}
-		final String uniqueId = this.oAuthRefreshInterceptor.clientInfo.buildUniqueId();
-        if (uniqueId == null) {
-            return;
-        }
 
-        // If a valid client passed in, caches it. If not, creates a new one.
-        if (okHttpClient != null) {
-            OK_CLIENTS.put(uniqueId, okHttpClient);
-        } else if (!OK_CLIENTS.containsKey(uniqueId)) {
-            OK_CLIENTS.put(uniqueId, getOkHttpClientBuilder().build());
-        }
-
-        // Uses the cached client.
-		this.okHttpClient = OK_CLIENTS.get(uniqueId);
+		okHttpClient = OK_CLIENTS.get(cacheKey);
+		// If none cached, create new one
+		if (okHttpClient == null) {
+			okHttpClient = getOkHttpClientBuilder().build();
+			OK_CLIENTS.put(cacheKey, okHttpClient);
+		}
+		this.okHttpClient = okHttpClient;
 	}
 
 	/**
@@ -208,7 +232,7 @@ public class RestClient {
 	 * @param clientInfo The new client info to set
 	 */
 	public void setClientInfo(final ClientInfo clientInfo) {
-		oAuthRefreshInterceptor.setClientInfo(clientInfo);
+		getOAuthRefreshInterceptor().setClientInfo(clientInfo);
 	}
 
 	/**
@@ -263,6 +287,13 @@ public class RestClient {
 	 */
 	public ClientInfo getClientInfo() {
 		return oAuthRefreshInterceptor.clientInfo;
+	}
+
+	/**
+	 * @return underlying OAuthRefreshInterceptor
+	 */
+	public OAuthRefreshInterceptor getOAuthRefreshInterceptor() {
+		return oAuthRefreshInterceptor;
 	}
 
 	/**


### PR DESCRIPTION
Also fixing issues with RestClient caches
- no point building a fresh oauth refresh interceptor if a cached ok http client ends up being used
- cleaning cache on logout