### PR TITLE
Removing meaningless code

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -288,18 +288,7 @@ public class Encryptor {
         final SecretKeySpec skeySpec = new SecretKeySpec(key, cipher.getAlgorithm());
         final IvParameterSpec ivSpec = new IvParameterSpec(initVector);
         cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivSpec);
-        byte[] padded = cipher.doFinal(meat, 0, meatLen);
-        byte[] result = padded;
-        byte paddingValue = padded[padded.length - 1];
-        if (0 <= paddingValue) {
-            if (paddingValue < (byte) 16) {
-                byte compare = padded[padded.length - paddingValue];
-                if (compare == paddingValue) {
-                    result = new byte[padded.length - paddingValue];
-                    System.arraycopy(padded, 0, result, 0, result.length);
-                }
-            }
-        }
+        byte[] result = cipher.doFinal(meat, 0, meatLen);
         return result;
     }
 }


### PR DESCRIPTION
Once upon a time, we used to pad with the number of pad bytes. https://github.com/forcedotcom/SalesforceMobileSDK-Android/commit/d65974a70df81eed6d88109af96f36f937f55fee

Then we stopped doing that. https://github.com/forcedotcom/SalesforceMobileSDK-Android/commit/7becd771898d87843dc444dd758d93449199c824
But only the encrypt() method was updated, not the decrypt method.

We were left with that meaningless and actually dangerous code that can throw ArrayIndexOutOfBoundException.
NB: Such exception happened sometimes and a superficial change was made (see https://github.com/forcedotcom/SalesforceMobileSDK-Android/commit/8d9ef6bb45d3129f5a312688bbeee700fef28334).