### PR TITLE
Large scale OAuth cleanup

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -56,7 +56,6 @@ public class UserAccount {
 	public static final String USER_ID = "userId";
 	public static final String USERNAME = "username";
 	public static final String ACCOUNT_NAME = "accountName";
-	public static final String CLIENT_ID = "clientId";
 	public static final String COMMUNITY_ID = "communityId";
 	public static final String COMMUNITY_URL = "communityUrl";
 	public static final String INTERNAL_COMMUNITY_ID = "000000000000000AAA";
@@ -82,7 +81,6 @@ public class UserAccount {
 	private String userId;
 	private String username;
 	private String accountName;
-	private String clientId;
 	private String communityId;
 	private String communityUrl;
     private String firstName;
@@ -105,34 +103,6 @@ public class UserAccount {
 	 * @param userId User ID.
 	 * @param username Username.
 	 * @param accountName Account name.
-	 * @param clientId Client ID.
-	 * @param communityId Community ID.
-	 * @param communityUrl Community URL.
-	 */
-    public UserAccount(String authToken, String refreshToken,
-                       String loginServer, String idUrl, String instanceServer,
-                       String orgId, String userId, String username, String accountName,
-                       String clientId, String communityId, String communityUrl) {
-        this(authToken, refreshToken,
-                loginServer, idUrl, instanceServer,
-                orgId, userId, username, accountName,
-                clientId, communityId, communityUrl,
-                null, null, null, null, null, null, null);
-    }
-
-	/**
-	 * Parameterized constructor.
-	 *
-	 * @param authToken Auth token.
-	 * @param refreshToken Refresh token.
-	 * @param loginServer Login server.
-	 * @param idUrl Identity URL.
-	 * @param instanceServer Instance server.
-	 * @param orgId Org ID.
-	 * @param userId User ID.
-	 * @param username Username.
-	 * @param accountName Account name.
-	 * @param clientId Client ID.
 	 * @param communityId Community ID.
 	 * @param communityUrl Community URL.
 	 * @param firstName First Name.
@@ -146,8 +116,8 @@ public class UserAccount {
 	public UserAccount(String authToken, String refreshToken,
 					   String loginServer, String idUrl, String instanceServer,
 					   String orgId, String userId, String username, String accountName,
-					   String clientId, String communityId, String communityUrl,
-					   String firstName, String lastName, String displayName, String email, String photoUrl,
+					   String communityId, String communityUrl, String firstName, String lastName,
+                       String displayName, String email, String photoUrl,
 					   String thumbnailUrl, Map<String, String> additionalOauthValues) {
 		this.authToken = authToken;
 		this.refreshToken = refreshToken;
@@ -158,7 +128,6 @@ public class UserAccount {
 		this.userId = userId;
 		this.username = username;
 		this.accountName = accountName;
-		this.clientId = clientId;
 		this.communityId = communityId;
 		this.communityUrl = communityUrl;
 		this.firstName = firstName;
@@ -186,7 +155,6 @@ public class UserAccount {
 			orgId = object.optString(ORG_ID, null);
 			userId = object.optString(USER_ID, null);
 			username = object.optString(USERNAME, null);
-			clientId = object.optString(CLIENT_ID, null);
 			if (!TextUtils.isEmpty(username) && !TextUtils.isEmpty(instanceServer)) {
 				accountName = String.format("%s (%s) (%s)", username, instanceServer,
 						SalesforceSDKManager.getInstance().getApplicationName());
@@ -219,7 +187,6 @@ public class UserAccount {
 			orgId = bundle.getString(ORG_ID);
 			userId = bundle.getString(USER_ID);
 			username = bundle.getString(USERNAME);
-			clientId = bundle.getString(CLIENT_ID);
 			accountName = bundle.getString(ACCOUNT_NAME);
 			communityId = bundle.getString(COMMUNITY_ID);
 			communityUrl = bundle.getString(COMMUNITY_URL);
@@ -313,15 +280,6 @@ public class UserAccount {
 	 */
 	public String getAccountName() {
 		return accountName;
-	}
-
-	/**
-	 * Returns the client ID for this user account.
-	 *
-	 * @return Client ID.
-	 */
-	public String getClientId() {
-		return clientId;
 	}
 
 	/**
@@ -598,7 +556,6 @@ public class UserAccount {
         	object.put(ORG_ID, orgId);
         	object.put(USER_ID, userId);
         	object.put(USERNAME, username);
-        	object.put(CLIENT_ID, clientId);
         	object.put(COMMUNITY_ID, communityId);
         	object.put(COMMUNITY_URL, communityUrl);
             object.put(FIRST_NAME, firstName);
@@ -630,7 +587,6 @@ public class UserAccount {
         object.putString(ORG_ID, orgId);
         object.putString(USER_ID, userId);
         object.putString(USERNAME, username);
-        object.putString(CLIENT_ID, clientId);
         object.putString(ACCOUNT_NAME, accountName);
         object.putString(COMMUNITY_ID, communityId);
         object.putString(COMMUNITY_URL, communityUrl);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -442,7 +442,7 @@ public class UserAccountManager {
 			return null;
 		}
 		return new UserAccount(authToken, refreshToken, loginServer, idUrl,
-				instanceServer, orgId, userId, username, accountName, clientId,
+				instanceServer, orgId, userId, username, accountName,
 				communityId, communityUrl, firstName, lastName, displayName, email, photoUrl,
 				thumbnailUrl, additionalOauthValues);
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -375,10 +375,10 @@ public class SalesforceSDKManager {
             final BootConfig config = BootConfig.getBootConfig(context);
             if (TextUtils.isEmpty(jwt)) {
                 loginOptions = new LoginOptions(url, config.getOauthRedirectURI(),
-                        config.getRemoteAccessConsumerKey(), config.getOauthScopes(), null);
+                        config.getRemoteAccessConsumerKey(), config.getOauthScopes());
             } else {
                 loginOptions = new LoginOptions(url, config.getOauthRedirectURI(),
-                        config.getRemoteAccessConsumerKey(), config.getOauthScopes(), null, jwt);
+                        config.getRemoteAccessConsumerKey(), config.getOauthScopes(), jwt);
             }
         } else {
             loginOptions.setJwt(jwt);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
@@ -252,11 +252,6 @@ public class SalesforceSDKUpgradeManager {
                             }
                         }
                     }
-                    final String encClientSecret = acctManager.getUserData(account, AuthenticatorService.KEY_CLIENT_SECRET);
-                    String clientSecret = null;
-                    if (encClientSecret != null) {
-                        clientSecret = Encryptor.decrypt(encClientSecret, oldKey);
-                    }
                     final String encCommunityId = acctManager.getUserData(account, AuthenticatorService.KEY_COMMUNITY_ID);
                     String communityId = null;
                     if (encCommunityId != null) {
@@ -299,9 +294,6 @@ public class SalesforceSDKUpgradeManager {
                                 acctManager.setUserData(account, key, Encryptor.encrypt(value, newKey));
                             }
                         }
-                    }
-                    if (clientSecret != null) {
-                        acctManager.setUserData(account, AuthenticatorService.KEY_CLIENT_SECRET, Encryptor.encrypt(clientSecret, newKey));
                     }
                     if (communityId != null) {
                         acctManager.setUserData(account, AuthenticatorService.KEY_COMMUNITY_ID, Encryptor.encrypt(communityId, newKey));

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -63,7 +63,6 @@ public class AuthenticatorService extends Service {
     public static final String KEY_ORG_ID = "orgId";
     public static final String KEY_USERNAME = "username";
     public static final String KEY_ID_URL = "id";
-    public static final String KEY_CLIENT_SECRET = "clientSecret";
     public static final String KEY_COMMUNITY_ID = "communityId";
     public static final String KEY_COMMUNITY_URL = "communityUrl";
     public static final String KEY_EMAIL = "email";
@@ -152,11 +151,6 @@ public class AuthenticatorService extends Service {
             if (encThumbnailUrl != null) {
                 thumbnailUrl = SalesforceSDKManager.decrypt(encThumbnailUrl);
             }
-            final String encClientSecret = mgr.getUserData(account, AuthenticatorService.KEY_CLIENT_SECRET);
-            String clientSecret = null;
-            if (encClientSecret != null) {
-                clientSecret = SalesforceSDKManager.decrypt(encClientSecret);
-            }
             final List<String> additionalOauthKeys = SalesforceSDKManager.getInstance().getAdditionalOauthKeys();
             Map<String, String> values = null;
             if (additionalOauthKeys != null && !additionalOauthKeys.isEmpty()) {
@@ -183,7 +177,7 @@ public class AuthenticatorService extends Service {
             final Bundle resBundle = new Bundle();
             try {
                 final TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT,
-                        new URI(loginServer), clientId, refreshToken, clientSecret, addlParamsMap);
+                        new URI(loginServer), clientId, refreshToken, addlParamsMap);
 
                 // Handle the case where the org has been migrated to a new instance, or has turned on my domains.
                 if (!instServer.equalsIgnoreCase(tr.instanceUrl)) {
@@ -247,11 +241,6 @@ public class AuthenticatorService extends Service {
                     }
                 }
                 resBundle.putString(AuthenticatorService.KEY_THUMBNAIL_URL, encrThumbnailUrl);
-                String encrClientSecret = null;
-                if (clientSecret != null) {
-                    encrClientSecret = SalesforceSDKManager.encrypt(clientSecret);
-                }
-                resBundle.putString(AuthenticatorService.KEY_CLIENT_SECRET, encrClientSecret);
                 String encrCommunityId = null;
                 if (communityId != null) {
                 	encrCommunityId = SalesforceSDKManager.encrypt(communityId);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -54,11 +54,11 @@ import okhttp3.Response;
 /**
  * Helper methods for common OAuth2 requests.
  *
- * The typical OAuth2 flow is;
+ * The typical OAuth2 flow is:
  *
  * <ol>
  * <li> The authorization flow is started by presenting the web-based
- * authorization screen to the user.  This will prompt him/her to login and to
+ * authorization screen to the user. This will prompt him/her to login and to
  * authorize our application. The result will be a callback with an
  * authorization code, or an error.</li>
  *
@@ -76,11 +76,9 @@ import okhttp3.Response;
  *
  * <li> If the refresh token becomes invalid, go back to the beginning.</li>
  * </ol>
- *
  */
 public class OAuth2 {
 
-    // Misc constants: strings appearing in requests or responses
     private static final String ACCESS_TOKEN = "access_token";
     private static final String CLIENT_ID = "client_id";
     private static final String CLIENT_SECRET = "client_secret";
@@ -119,99 +117,48 @@ public class OAuth2 {
     private static final String FRONTDOOR = "/secur/frontdoor.jsp?";
     private static final String SID = "sid";
     private static final String RETURL = "retURL";
-    private static final String AUTHORIZATION_CODE = "authorization_code";
     private static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
     private static final String ASSERTION = "assertion";
     private static final String JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
-    private static final String TAG = "OAuth2";
-
-    // Login paths
     private static final String OAUTH_AUTH_PATH = "/services/oauth2/authorize";
     private static final String OAUTH_DISPLAY_PARAM = "?display=";
     private static final String OAUTH_TOKEN_PATH = "/services/oauth2/token";
     private static final String OAUTH_REVOKE_PATH = "/services/oauth2/revoke?token=";
-    public static final String EMPTY_STRING = "";
+    private static final String EMPTY_STRING = "";
+    private static final String TAG = "OAuth2";
 
     /**
-     * Build the URL to the authorization web page for this login server.
-     * You need not provide refresh_token, as it is provided automatically.
+     * Builds the URL to the authorization web page for this login server.
+     * You need not provide the 'refresh_token' scope, as it is provided automatically.
      *
-     * @param loginServer
-     *            the base protocol and server to use (e.g.
-     *            https://login.salesforce.com)
-     * @param clientId
-     *            OAuth client ID
-     * @param callbackUrl
-     *            OAuth callback url
-     * @param scopes A list of OAuth scopes to request (eg {"visualforce","api"}). If null, the default OAuth scope is provided.
+     * @param loginServer Base protocol and server to use (e.g. https://login.salesforce.com).
+     * @param clientId OAuth client ID.
+     * @param callbackUrl OAuth callback URL or redirect URL.
+     * @param scopes A list of OAuth scopes to request (e.g. {"visualforce", "api"}). If null,
+     *               the default OAuth scope is provided.
+     * @param clientSecret OAuth client secret. If null, 'response_type' is set to 'token'.
+     * @param displayType OAuth display type. If null, the default of 'touch' is used.
+     * @param addlParams Any additional parameters that may be added to the request.
      * @return A URL to start the OAuth flow in a web browser/view.
      *
      * @see <a href="https://help.salesforce.com/apex/HTViewHelpDoc?language=en&id=remoteaccess_oauth_scopes.htm">RemoteAccess OAuth Scopes</a>
-     *
      */
-    public static URI getAuthorizationUrl(URI loginServer, String clientId,
-                                          String callbackUrl, String[] scopes) {
-        return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, null, null);
-    }
-
-    /**
-     * Build the URL to the authorization web page for this login server.
-     * @param loginServer
-     * @param clientId
-     * @param callbackUrl
-     * @param scopes
-     * @param clientSecret
-     * @return
-     */
-    public static URI getAuthorizationUrl(URI loginServer, String clientId,
-                                          String callbackUrl, String[] scopes, String clientSecret) {
-        return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, clientSecret, null);
-    }
-
-    /**
-     * Build the URL to the authorization web page for this login server.
-     * @param loginServer
-     * @param clientId
-     * @param callbackUrl
-     * @param scopes
-     * @param clientSecret
-     * @param displayType
-     * @return
-     */
-
-    public static URI getAuthorizationUrl(URI loginServer, String clientId,
-                                          String callbackUrl, String[] scopes, String clientSecret, String displayType) {
-        return getAuthorizationUrl(loginServer, clientId,
-                callbackUrl, scopes, clientSecret, displayType,null);
-    }
-
-    /**
-     * Build the URL to the authorization web page for this login server.
-     * @param loginServer
-     * @param clientId
-     * @param callbackUrl
-     * @param scopes
-     * @param clientSecret
-     * @param displayType
-     * @param addlParams
-     * @return
-     */
-    public static URI getAuthorizationUrl(URI loginServer, String clientId,
-                                          String callbackUrl, String[] scopes, String clientSecret, String displayType,
+    public static URI getAuthorizationUrl(URI loginServer, String clientId, String callbackUrl,
+                                          String[] scopes, String clientSecret, String displayType,
                                           Map<String,String> addlParams) {
         final StringBuilder sb = new StringBuilder(loginServer.toString());
         sb.append(OAUTH_AUTH_PATH).append(getBrandedLoginPath());
         sb.append(OAUTH_DISPLAY_PARAM).append(displayType == null ? TOUCH : displayType);
         sb.append(AND).append(RESPONSE_TYPE).append(EQUAL).append(clientSecret == null ? TOKEN : ACTIVATED_CLIENT_CODE);
         sb.append(AND).append(CLIENT_ID).append(EQUAL).append(Uri.encode(clientId));
-        if (scopes != null && scopes.length > 0)
+        if (scopes != null && scopes.length > 0) {
             sb.append(AND).append(SCOPE).append(EQUAL).append(Uri.encode(computeScopeParameter(scopes)));
+        }
         sb.append(AND).append(REDIRECT_URI).append(EQUAL).append(callbackUrl);
-
-        if(addlParams !=null && addlParams.size() > 0) {
-            for(Map.Entry<String,String> entry : addlParams.entrySet()) {
-                String value = entry.getValue()==null?EMPTY_STRING :entry.getValue();
+        if (addlParams != null && addlParams.size() > 0) {
+            for (final Map.Entry<String,String> entry : addlParams.entrySet()) {
+                final String value = entry.getValue() == null ? EMPTY_STRING : entry.getValue();
                 sb.append(AND).append(entry.getKey()).append(EQUAL).append(Uri.encode(value));
             }
         }
@@ -235,53 +182,39 @@ public class OAuth2 {
     }
 
     /**
-     * Build the URL to the authorization web page for this login server.
-     * @param loginServer
-     * @param clientId
-     * @param callbackUrl
-     * @param scopes
-     * @param clientSecret
-     * @param displayType
-     * @param accessToken
-     * @param instanceURL
-     * @return
+     * Builds the URL to the authorization web page for this login server.
+     * You need not provide the 'refresh_token' scope, as it is provided automatically.
+     *
+     * @param loginServer Base protocol and server to use (e.g. https://login.salesforce.com).
+     * @param clientId OAuth client ID.
+     * @param callbackUrl OAuth callback URL or redirect URL.
+     * @param scopes A list of OAuth scopes to request (e.g. {"visualforce", "api"}). If null,
+     *               the default OAuth scope is provided.
+     * @param clientSecret OAuth client secret. If null, 'response_type' is set to 'token'.
+     * @param displayType OAuth display type. If null, the default of 'touch' is used.
+     * @param accessToken Access token.
+     * @param instanceURL Instance URL.
+     * @param addlParams Any additional parameters that may be added to the request.
+     * @return A URL to start the OAuth flow in a web browser/view.
+     *
+     * @see <a href="https://help.salesforce.com/apex/HTViewHelpDoc?language=en&id=remoteaccess_oauth_scopes.htm">RemoteAccess OAuth Scopes</a>
      */
-    public static URI getAuthorizationUrl(URI loginServer, String clientId,
-                                          String callbackUrl, String[] scopes, String clientSecret,
-                                          String displayType, String accessToken, String instanceURL) {
-        return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, clientSecret,
-                displayType, accessToken, instanceURL,null);
-    }
-
-    /**
-     * Build the URL to the authorization web page for this login server.
-     * @param loginServer
-     * @param clientId
-     * @param callbackUrl
-     * @param scopes
-     * @param clientSecret
-     * @param displayType
-     * @param accessToken
-     * @param instanceURL
-     * @param addlParams
-     * @return
-     */
-    public static URI getAuthorizationUrl(URI loginServer, String clientId,
-                                          String callbackUrl, String[] scopes, String clientSecret,
-                                          String displayType, String accessToken, String instanceURL,
-                                          Map<String,String> addlParams) {
-        if(accessToken == null || instanceURL == null) {
-            return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, clientSecret, displayType, addlParams);
+    public static URI getAuthorizationUrl(URI loginServer, String clientId, String callbackUrl,
+                                          String[] scopes, String clientSecret, String displayType,
+                                          String accessToken, String instanceURL,
+                                          Map<String, String> addlParams) {
+        if (accessToken == null || instanceURL == null) {
+            return getAuthorizationUrl(loginServer, clientId, callbackUrl, scopes, clientSecret,
+                    displayType, addlParams);
         }
         final StringBuilder sb = new StringBuilder(instanceURL);
         sb.append(FRONTDOOR);
         sb.append(SID).append(EQUAL).append(accessToken);
-        sb.append(AND).append(RETURL).append(EQUAL).append(Uri.encode(getAuthorizationUrl(loginServer,clientId,callbackUrl,
-                scopes, clientSecret, displayType).toString()));
-
-        if(addlParams != null && addlParams.size() > 0) {
-            for(Map.Entry<String,String> entry : addlParams.entrySet()) {
-                String value = entry.getValue()==null? EMPTY_STRING :entry.getValue();
+        sb.append(AND).append(RETURL).append(EQUAL).append(Uri.encode(getAuthorizationUrl(loginServer,
+                clientId, callbackUrl, scopes, clientSecret, displayType, null).toString()));
+        if (addlParams != null && addlParams.size() > 0) {
+            for (final Map.Entry<String,String> entry : addlParams.entrySet()) {
+                final String value = entry.getValue() == null ? EMPTY_STRING : entry.getValue();
                 sb.append(AND).append(entry.getKey()).append(EQUAL).append(Uri.encode(value));
             }
         }
@@ -290,76 +223,44 @@ public class OAuth2 {
 
     private static String computeScopeParameter(String[] scopes) {
         final List<String> scopesList = Arrays.asList(scopes == null ? new String[]{} : scopes);
-        Set<String> scopesSet = new TreeSet<String>(scopesList); // sorted set to make tests easier
+        final Set<String> scopesSet = new TreeSet<String>(scopesList); // sorted set to make tests easier
         scopesSet.add(REFRESH_TOKEN);
         return TextUtils.join(" ", scopesSet.toArray(new String[]{}));
     }
 
     /**
-     * Get a new auth token using the refresh token.
+     * Gets a new auth token using the refresh token.
      *
-     * @param httpAccessor
-     * @param loginServer
-     * @param clientId
-     * @param refreshToken
-     * @return
+     * @param httpAccessor HttpAccess instance.
+     * @param loginServer Login server.
+     * @param clientId Client ID.
+     * @param refreshToken Refresh token.
+     * @param clientSecret Client secret.
+     * @param addlParams Additional parameters.
+     * @return Token response.
+     *
      * @throws OAuthFailedException
      * @throws IOException
      */
-    public static TokenEndpointResponse refreshAuthToken(
-            HttpAccess httpAccessor, URI loginServer, String clientId,
-            String refreshToken) throws OAuthFailedException, IOException {
-        return refreshAuthToken(httpAccessor, loginServer, clientId, refreshToken, null);
-    }
-
-    /**
-     * Get a new auth token using the refresh token.
-     *
-     * @param httpAccessor
-     * @param loginServer
-     * @param clientId
-     * @param refreshToken
-     * @param clientSecret
-     * @return
-     * @throws OAuthFailedException
-     * @throws IOException
-     */
-    public static TokenEndpointResponse refreshAuthToken(
-            HttpAccess httpAccessor, URI loginServer, String clientId,
-            String refreshToken, String clientSecret) throws OAuthFailedException, IOException {
-        return  refreshAuthToken(httpAccessor, loginServer, clientId, refreshToken, clientSecret,null);
-    }
-
-    /**
-     * Get a new auth token using the refresh token.
-     *
-     * @param httpAccessor
-     * @param loginServer
-     * @param clientId
-     * @param refreshToken
-     * @param clientSecret
-     * @param addlParams
-     * @return
-     * @throws OAuthFailedException
-     * @throws IOException
-     */
-    public static TokenEndpointResponse refreshAuthToken(
-            HttpAccess httpAccessor, URI loginServer, String clientId,
-            String refreshToken, String clientSecret,Map<String,String> addlParams) throws OAuthFailedException, IOException {
-        FormBody.Builder formBodyBuilder = makeTokenEndpointParams(REFRESH_TOKEN,
+    public static TokenEndpointResponse refreshAuthToken(HttpAccess httpAccessor, URI loginServer,
+                                                         String clientId, String refreshToken,
+                                                         String clientSecret,
+                                                         Map<String,String> addlParams)
+            throws OAuthFailedException, IOException {
+        final FormBody.Builder formBodyBuilder = makeTokenEndpointParams(REFRESH_TOKEN,
                 clientId, clientSecret, addlParams);
         formBodyBuilder.add(REFRESH_TOKEN, refreshToken);
         formBodyBuilder.add(FORMAT, JSON);
-        TokenEndpointResponse tr = makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder);
-        return tr;
+        return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder);
     }
 
     /**
      * Revokes the existing refresh token.
      *
-     * @param httpAccessor
-     * @param loginServer
-     * @param refreshToken
+     * @param httpAccessor HttpAccess instance.
+     * @param loginServer Login server.
+     * @param refreshToken Refresh token.
+     *
      * @throws OAuthFailedException
      * @throws IOException
      */
@@ -367,10 +268,7 @@ public class OAuth2 {
         final StringBuilder sb = new StringBuilder(loginServer.toString());
         sb.append(OAUTH_REVOKE_PATH);
         sb.append(Uri.encode(refreshToken));
-        Request request = new Request.Builder()
-                .url(sb.toString())
-                .get()
-                .build();
+        final Request request = new Request.Builder().url(sb.toString()).get().build();
         try {
             httpAccessor.getOkHttpClient().newCall(request).execute();
         } catch (IOException e) {
@@ -378,99 +276,69 @@ public class OAuth2 {
         }
     }
 
-     /** @returns a TokenEndointResponse from the give authorization code, this is typically the first step after
-     * receiving an authorization code from the oAuth authorization UI flow.
-     * In addition, this will also call the Identity service to fetch & populate the username field.
+    /**
+     * Swaps a JWT for regular OAuth tokens. This is typically the first step after
+     * receiving a JWT from a link. In addition, this will also call the identity
+     * service to populate the username field.
      *
-     * @param loginServerUrl  the protocol & host (e.g. https://login.salesforce.com) that the authCode was generated from
-     * @param clientSecret the client secret if there is one (e.g. for IP/IC bypass)
-     * @param authCode     the authorization code issued by the oauth authorization flow.
-     *
-     * @throws IOException
-     * @throws URISyntaxException
-     * @throws OAuthFailedException
-     *
-     */
-    public static TokenEndpointResponse swapAuthCodeForTokens(HttpAccess httpAccessor, URI loginServerUrl, String clientSecret,
-            String authCode, String clientId, String callbackUrl) throws IOException, URISyntaxException, OAuthFailedException {
-        // call the token endpoint, and swap our authorization code for a refresh & access tokens.
-        FormBody.Builder formBodyBuilder = makeTokenEndpointParams(AUTHORIZATION_CODE, clientId, clientSecret);
-        formBodyBuilder.add(REDIRECT_URI, callbackUrl);
-        TokenEndpointResponse tr = makeTokenEndpointRequest(httpAccessor, loginServerUrl, formBodyBuilder);
-        return tr;
-    }
-
-    /** @returns a TokenEndointResponse from the give JWT, this is typically the first step after
-     * receiving a JWT from email link.
-     * In addition, this will also call the Identity service to fetch & populate the username field.
-     *
-     * @param loginServerUrl  the protocol & host (e.g. https://login.salesforce.com) that the authCode was generated from
-     * @param jwt     the jwt issued by the oauth authorization flow.
+     * @param httpAccessor HttpAccess instance.
+     * @param loginServerUrl The server (e.g. https://login.salesforce.com) that
+     *                       the auth code was generated from.
+     * @param jwt JWT issued by the OAuth authorization flow.
      *
      * @throws IOException
      * @throws URISyntaxException
      * @throws OAuthFailedException
-     *
      */
     public static TokenEndpointResponse swapJWTForTokens(HttpAccess httpAccessor, URI loginServerUrl,
-                                                              String jwt) throws IOException, URISyntaxException, OAuthFailedException {
-        // call the token endpoint, and swap jwt for an access tokens.
-        FormBody.Builder formBodyBuilder = new FormBody.Builder()
-                .add(GRANT_TYPE, JWT_BEARER)
+                                                              String jwt) throws IOException,
+            URISyntaxException, OAuthFailedException {
+        final FormBody.Builder formBodyBuilder = new FormBody.Builder().add(GRANT_TYPE, JWT_BEARER)
                 .add(ASSERTION, jwt);
         return makeTokenEndpointRequest(httpAccessor, loginServerUrl, formBodyBuilder);
     }
 
     /**
-     * Call the identity service to determine the username of the user and the mobile policy, given
+     * Calls the identity service to determine the username of the user and the mobile policy, given
      * their identity service ID and an access token.
      *
-     * @param httpAccessor
-     * @param identityServiceIdUrl
-     * @param authToken
-     * @return
+     * @param httpAccessor HttpAccessor instance.
+     * @param identityServiceIdUrl Identity service URL.
+     * @param authToken Access token.
+     * @return IdServiceResponse instance.
+     *
      * @throws IOException
      * @throws URISyntaxException
      */
-    public static final IdServiceResponse callIdentityService(
-            HttpAccess httpAccessor, String identityServiceIdUrl,
-            String authToken) throws IOException, URISyntaxException {
-        Request.Builder builder = new Request.Builder()
-                .url(identityServiceIdUrl)
-                .get();
+    public static final IdServiceResponse callIdentityService(HttpAccess httpAccessor,
+                                                              String identityServiceIdUrl,
+                                                              String authToken)
+            throws IOException, URISyntaxException {
+        final Request.Builder builder = new Request.Builder().url(identityServiceIdUrl).get();
         addAuthorizationHeader(builder, authToken);
-        Request request = builder.build();
-        Response response = httpAccessor.getOkHttpClient().newCall(request).execute();
+        final Request request = builder.build();
+        final Response response = httpAccessor.getOkHttpClient().newCall(request).execute();
         return new IdServiceResponse(response);
     }
 
     /**
-     * Add authorization header to request builder
-     * @param builder
-     * @param authToken
+     * Adds the authorization header to request builder.
+     *
+     * @param builder Builder instance.
+     * @param authToken Access token.
      */
     public static final Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken) {
         return builder.header(AUTHORIZATION, BEARER + authToken);
     }
 
-    /**
-     * @param httpAccessor
-     * @param loginServer
-     * @param formBodyBuilder
-     * @return
-     * @throws OAuthFailedException
-     * @throws IOException
-     */
-    private static TokenEndpointResponse makeTokenEndpointRequest(
-            HttpAccess httpAccessor, URI loginServer, FormBody.Builder formBodyBuilder)
+    private static TokenEndpointResponse makeTokenEndpointRequest(HttpAccess httpAccessor,
+                                                                  URI loginServer,
+                                                                  FormBody.Builder formBodyBuilder)
             throws OAuthFailedException, IOException {
         final String refreshPath = loginServer.toString() + OAUTH_TOKEN_PATH;
         final RequestBody body = formBodyBuilder.build();
-        Request request = new Request.Builder()
-                .url(refreshPath)
-                .post(body)
-                .build();
-        Response response = httpAccessor.getOkHttpClient().newCall(request).execute();
+        final Request request = new Request.Builder().url(refreshPath).post(body).build();
+        final Response response = httpAccessor.getOkHttpClient().newCall(request).execute();
         if (response.isSuccessful()) {
             return new TokenEndpointResponse(response);
         } else {
@@ -478,34 +346,15 @@ public class OAuth2 {
         }
     }
 
-    /**
-     * @param grantType
-     * @param clientId
-     * @return
-     */
-    private static FormBody.Builder makeTokenEndpointParams(
-            String grantType, String clientId, String clientSecret) {
-        return makeTokenEndpointParams(grantType, clientId, clientSecret, null);
-    }
-
-    /**
-     *
-     * @param grantType
-     * @param clientId
-     * @param clientSecret
-     * @param addlParams
-     * @return
-     */
-    private static FormBody.Builder makeTokenEndpointParams(
-            String grantType, String clientId, String clientSecret, Map<String,String> addlParams) {
-        FormBody.Builder builder = new FormBody.Builder()
-                .add(GRANT_TYPE, grantType)
-                .add(CLIENT_ID, clientId);
+    private static FormBody.Builder makeTokenEndpointParams(String grantType, String clientId,
+                                                            String clientSecret,
+                                                            Map<String,String> addlParams) {
+        final FormBody.Builder builder = new FormBody.Builder().add(GRANT_TYPE, grantType).add(CLIENT_ID, clientId);
         if (clientSecret != null) {
             builder.add(CLIENT_SECRET, clientSecret);
         }
-        if(addlParams != null ) {
-            for(Map.Entry<String,String> entry : addlParams.entrySet()) {
+        if (addlParams != null ) {
+            for (final Map.Entry<String,String> entry : addlParams.entrySet()) {
                 builder.add(entry.getKey(),entry.getValue());
             }
         }
@@ -514,7 +363,7 @@ public class OAuth2 {
 
 
     /**
-     * Exception thrown when refresh fails.
+     * Exception thrown when the refresh flow fails.
      */
     public static class OAuthFailedException extends Exception {
 
@@ -527,6 +376,11 @@ public class OAuth2 {
         final TokenErrorResponse response;
         final int httpStatusCode;
 
+        /**
+         * Returns if the refresh token is valid.
+         *
+         * @return True - if refresh token is valid, False - otherwise.
+         */
         public boolean isRefreshTokenInvalid() {
             return httpStatusCode == HttpURLConnection.HTTP_UNAUTHORIZED
                     || httpStatusCode == HttpURLConnection.HTTP_FORBIDDEN
@@ -554,12 +408,6 @@ public class OAuth2 {
         private static final long serialVersionUID = 1L;
     }
 
-    /**************************************************************************************************
-     *
-     * Helper classes to parse responses
-     *
-     **************************************************************************************************/
-
     /**
      * Helper class to parse an identity service response.
      */
@@ -577,6 +425,11 @@ public class OAuth2 {
         public JSONObject customAttributes;
         public JSONObject customPermissions;
 
+        /**
+         * Parameterized constructor built from identity service response.
+         *
+         * @param response Identity service response.
+         */
         public IdServiceResponse(Response response) {
             try {
                 final JSONObject parsedResponse = (new RestResponse(response)).asJSONObject();
@@ -610,12 +463,16 @@ public class OAuth2 {
         public String error;
         public String errorDescription;
 
+        /**
+         * Parameterized constructor built from an error response.
+         *
+         * @param response Error response.
+         */
         public TokenErrorResponse(Response response) {
             try {
                 final JSONObject parsedResponse = (new RestResponse(response)).asJSONObject();
                 error = parsedResponse.getString(ERROR);
-                errorDescription = parsedResponse
-                        .getString(ERROR_DESCRIPTION);
+                errorDescription = parsedResponse.getString(ERROR_DESCRIPTION);
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token error response", e);
             }
@@ -645,8 +502,9 @@ public class OAuth2 {
         public Map<String, String> additionalOauthValues;
 
         /**
-         * Constructor used during login flow
-         * @param callbackUrlParams
+         * Parameterized constructor built during login flow.
+         *
+         * @param callbackUrlParams Callback URL parameters.
          */
         public TokenEndpointResponse(Map<String, String> callbackUrlParams) {
             try {
@@ -676,8 +534,9 @@ public class OAuth2 {
         }
 
         /**
-         * Constructor used during refresh flow
-         * @param response
+         * Parameterized constructor built from refresh flow response.
+         *
+         * @param response Token endpoint response.
          */
         public TokenEndpointResponse(Response response) {
             try {
@@ -717,7 +576,7 @@ public class OAuth2 {
 
         private void computeOtherFields() throws URISyntaxException {
             idUrlWithInstance = idUrl.replace(new URI(idUrl).getHost(), new URI(instanceUrl).getHost());
-            String[] idUrlFragments = idUrl.split("/");
+            final String[] idUrlFragments = idUrl.split("/");
             userId = idUrlFragments[idUrlFragments.length - 1];
             orgId = idUrlFragments[idUrlFragments.length - 2];
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
@@ -342,9 +342,9 @@ public class PushService extends IntentService {
     		try {
     	        final AccMgrAuthTokenProvider authTokenProvider = new AccMgrAuthTokenProvider(cm,
 						account.getInstanceServer(), account.getAuthToken(), account.getRefreshToken());
-    			final ClientInfo clientInfo = new ClientInfo(account.getClientId(),
-    					new URI(account.getInstanceServer()), new URI(account.getLoginServer()),
-    					new URI(account.getIdUrl()), account.getAccountName(), account.getUsername(),
+    			final ClientInfo clientInfo = new ClientInfo(new URI(account.getInstanceServer()),
+						new URI(account.getLoginServer()), new URI(account.getIdUrl()),
+                        account.getAccountName(), account.getUsername(),
     	        		account.getUserId(), account.getOrgId(),
     	        		account.getCommunityId(), account.getCommunityUrl(),
 						account.getFirstName(), account.getLastName(), account.getDisplayName(), account.getEmail(),

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -59,7 +59,6 @@ public class RestClient {
 	private static final String INSTANCE_URL = "instanceUrl";
 	private static final String LOGIN_URL = "loginUrl";
 	private static final String IDENTITY_URL = "identityUrl";
-	private static final String CLIENT_ID = "clientId";
 	private static final String ORG_ID = "orgId";
 	private static final String USER_ID = "userId";
 	private static final String REFRESH_TOKEN = "refreshToken";
@@ -248,7 +247,6 @@ public class RestClient {
 		data.put(REFRESH_TOKEN, getRefreshToken());
 		data.put(USER_ID, clientInfo.userId);
 		data.put(ORG_ID, clientInfo.orgId);
-		data.put(CLIENT_ID, clientInfo.clientId);
 		data.put(LOGIN_URL, clientInfo.loginUrl.toString());
 		data.put(IDENTITY_URL, clientInfo.identityUrl.toString());
 		data.put(INSTANCE_URL, clientInfo.instanceUrl.toString());
@@ -397,7 +395,6 @@ public class RestClient {
 	 */
 	public static class ClientInfo {
 
-		public final String clientId;
 		public final URI instanceUrl;
 		public final URI loginUrl;
 		public final URI identityUrl;
@@ -418,7 +415,6 @@ public class RestClient {
 		/**
 		 * Parameterized constructor.
 		 *
-		 * @param clientId Client ID.
 		 * @param instanceUrl Instance URL.
 		 * @param loginUrl Login URL.
 		 * @param identityUrl Identity URL.
@@ -436,12 +432,11 @@ public class RestClient {
          * @param thumbnailUrl Thumbnail URL.
          * @param additionalOauthValues Additional OAuth values.
 		 */
-		public ClientInfo(String clientId, URI instanceUrl, URI loginUrl,
+		public ClientInfo(URI instanceUrl, URI loginUrl,
 				URI identityUrl, String accountName, String username,
 				String userId, String orgId, String communityId, String communityUrl,
 				String firstName, String lastName, String displayName, String email,
 				String photoUrl, String thumbnailUrl, Map<String, String> additionalOauthValues) {
-			this.clientId = clientId;
 			this.instanceUrl = instanceUrl;
 			this.loginUrl = loginUrl;
 			this.identityUrl = identityUrl;
@@ -572,7 +567,7 @@ public class RestClient {
         public static final String NOUSER = "nouser";
 
         public UnauthenticatedClientInfo() {
-            super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         }
 
         @Override
@@ -751,7 +746,7 @@ public class RestClient {
                 if (!clientInfo.instanceUrl.toString().equalsIgnoreCase(instanceUrl)) {
                     try {
                         // Create a new ClientInfo
-                        clientInfo = new ClientInfo(clientInfo.clientId, new URI(instanceUrl),
+                        clientInfo = new ClientInfo(new URI(instanceUrl),
                                 clientInfo.loginUrl, clientInfo.identityUrl,
                                 clientInfo.accountName, clientInfo.username,
                                 clientInfo.userId, clientInfo.orgId, clientInfo.communityId,
@@ -785,5 +780,4 @@ public class RestClient {
 			super(msg, cause);
 		}
 	}
-
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -371,24 +371,21 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
     protected URI getAuthorizationUrl(Boolean jwtFlow) throws URISyntaxException {
         if (jwtFlow) {
-            return OAuth2.getAuthorizationUrl(
-                    new URI(loginOptions.getLoginUrl()),
+            return OAuth2.getAuthorizationUrl(new URI(loginOptions.getLoginUrl()),
                     getOAuthClientId(),
                     loginOptions.getOauthCallbackUrl(),
                     loginOptions.getOauthScopes(),
-                    null,
                     getAuthorizationDisplayType(),
                     loginOptions.getJwt(),
                     loginOptions.getLoginUrl(),
                     loginOptions.getAdditionalParameters());
         }
-        return OAuth2.getAuthorizationUrl(
-                new URI(loginOptions.getLoginUrl()),
+        return OAuth2.getAuthorizationUrl(new URI(loginOptions.getLoginUrl()),
                 getOAuthClientId(),
                 loginOptions.getOauthCallbackUrl(),
                 loginOptions.getOauthScopes(),
-                null,
-                getAuthorizationDisplayType(),loginOptions.getAdditionalParameters());
+                getAuthorizationDisplayType(),
+                loginOptions.getAdditionalParameters());
     }
 
     protected URI getAuthorizationUrl() throws URISyntaxException {
@@ -581,9 +578,9 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                     accountOptions.identityUrl, accountOptions.instanceUrl,
                     accountOptions.orgId, accountOptions.userId,
                     accountOptions.username, buildAccountName(accountOptions.username,
-                    accountOptions.instanceUrl), loginOptions.getClientSecret(),
-                    accountOptions.communityId, accountOptions.communityUrl,
-                    accountOptions.firstName, accountOptions.lastName, accountOptions.displayName,
+                    accountOptions.instanceUrl), accountOptions.communityId,
+                    accountOptions.communityUrl, accountOptions.firstName,
+                    accountOptions.lastName, accountOptions.displayName,
                     accountOptions.email, accountOptions.photoUrl,
                     accountOptions.thumbnailUrl, accountOptions.additionalOauthValues);
             if (id.customAttributes != null) {
@@ -675,7 +672,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 getOAuthClientId(),
                 accountOptions.orgId,
                 accountOptions.userId,
-                loginOptions.getClientSecret(),
                 accountOptions.communityId,
                 accountOptions.communityUrl,
                 accountOptions.firstName,
@@ -697,11 +693,11 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 accountOptions.refreshToken, loginOptions.getLoginUrl(),
                 accountOptions.identityUrl, accountOptions.instanceUrl,
                 accountOptions.orgId, accountOptions.userId,
-                accountOptions.username, accountName,
-                loginOptions.getClientSecret(), accountOptions.communityId,
+                accountOptions.username, accountName, accountOptions.communityId,
                 accountOptions.communityUrl, accountOptions.firstName,
                 accountOptions.lastName, accountOptions.displayName, accountOptions.email,
-                accountOptions.photoUrl, accountOptions.thumbnailUrl, accountOptions.additionalOauthValues);
+                accountOptions.photoUrl, accountOptions.thumbnailUrl,
+                accountOptions.additionalOauthValues);
         if (!TextUtils.isEmpty(pushNotificationId)) {
             PushMessaging.register(appContext, account);
         }

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ui/SalesforceHybridTestActivity.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ui/SalesforceHybridTestActivity.java
@@ -56,7 +56,7 @@ public class SalesforceHybridTestActivity extends SalesforceDroidGapActivity {
         		authToken, instanceUrl,
         		loginUrl, identityUrl,
         		loginOptions.getOauthClientId(), orgId,
-        		userId, null, null, null, null, null, null, null, null, null, null);
+        		userId, null, null, null, null, null, null, null, null, null);
 		return clientManager;
 	}
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
@@ -72,8 +72,7 @@ public class UserAccountManagerTest extends InstrumentationTestCase {
         loginOptions = new LoginOptions(ClientManagerTest.TEST_LOGIN_URL,
         		ClientManagerTest.TEST_CALLBACK_URL,
         		ClientManagerTest.TEST_CLIENT_ID,
-				ClientManagerTest.TEST_SCOPES,
-                null);
+				ClientManagerTest.TEST_SCOPES);
         clientManager = new ClientManager(targetContext,
         		ClientManagerTest.TEST_ACCOUNT_TYPE, loginOptions, true);
         accMgr = clientManager.getAccountManager();
@@ -165,14 +164,14 @@ public class UserAccountManagerTest extends InstrumentationTestCase {
         		ClientManagerTest.TEST_IDENTITY_URL, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_ORG_ID, ClientManagerTest.TEST_USER_ID,
         		ClientManagerTest.TEST_USERNAME, ClientManagerTest.TEST_ACCOUNT_NAME,
-        		ClientManagerTest.TEST_CLIENT_ID, null, null);
+        		null, null, null, null, null, null, null, null, null);
     	assertTrue("User account should exist", userAccMgr.doesUserAccountExist(userAcc));
     	userAcc = new UserAccount(ClientManagerTest.TEST_AUTH_TOKEN,
         		ClientManagerTest.TEST_REFRESH_TOKEN, ClientManagerTest.TEST_LOGIN_URL,
         		ClientManagerTest.TEST_IDENTITY_URL, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_ORG_ID_2, ClientManagerTest.TEST_USER_ID_2,
         		ClientManagerTest.TEST_OTHER_USERNAME, ClientManagerTest.TEST_OTHER_ACCOUNT_NAME,
-        		ClientManagerTest.TEST_CLIENT_ID, null, null);
+        		null, null, null, null, null, null, null, null, null);
     	assertFalse("User account should not exist", userAccMgr.doesUserAccountExist(userAcc));
     }
 
@@ -209,8 +208,8 @@ public class UserAccountManagerTest extends InstrumentationTestCase {
         		ClientManagerTest.TEST_IDENTITY_URL, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_ORG_ID, ClientManagerTest.TEST_USER_ID,
         		ClientManagerTest.TEST_USERNAME, ClientManagerTest.TEST_ACCOUNT_NAME,
-        		ClientManagerTest.TEST_CLIENT_ID, null, null);
-    	userAccMgr.signoutUser(userAcc, null, false);
+				null, null, null, null, null, null, null, null, null);
+		userAccMgr.signoutUser(userAcc, null, false);
     	eq.waitForEvent(EventType.LogoutComplete, 30000);
     	users = userAccMgr.getAuthenticatedUsers();
     	assertEquals("There should be 1 authenticated user", 1, users.size());
@@ -234,7 +233,7 @@ public class UserAccountManagerTest extends InstrumentationTestCase {
         		ClientManagerTest.TEST_AUTH_TOKEN, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_LOGIN_URL, ClientManagerTest.TEST_IDENTITY_URL,
         		ClientManagerTest.TEST_CLIENT_ID, ClientManagerTest.TEST_ORG_ID,
-        		ClientManagerTest.TEST_USER_ID, null, null, null, null, null, null, null, null, null, null);
+        		ClientManagerTest.TEST_USER_ID, null, null, null, null, null, null, null, null, null);
     }
 
     /**
@@ -248,6 +247,6 @@ public class UserAccountManagerTest extends InstrumentationTestCase {
         		ClientManagerTest.TEST_AUTH_TOKEN, ClientManagerTest.TEST_INSTANCE_URL,
         		ClientManagerTest.TEST_LOGIN_URL, ClientManagerTest.TEST_IDENTITY_URL,
         		ClientManagerTest.TEST_CLIENT_ID, ClientManagerTest.TEST_ORG_ID_2,
-        		ClientManagerTest.TEST_USER_ID_2, null, null, null, null, null, null, null, null, null, null);
+        		ClientManagerTest.TEST_USER_ID_2, null, null, null, null, null, null, null, null, null);
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -107,7 +107,7 @@ public class UserAccountTest extends InstrumentationTestCase {
         final UserAccount account = new UserAccount(TEST_AUTH_TOKEN,
                 TEST_REFRESH_TOKEN, TEST_LOGIN_URL, TEST_IDENTITY_URL, TEST_INSTANCE_URL,
                 TEST_ORG_ID, TEST_USER_ID, TEST_USERNAME, TEST_ACCOUNT_NAME,
-                TEST_CLIENT_ID, TEST_COMMUNITY_ID, TEST_COMMUNITY_URL, TEST_FIRST_NAME,
+                TEST_COMMUNITY_ID, TEST_COMMUNITY_URL, TEST_FIRST_NAME,
                 TEST_LAST_NAME, TEST_DISPLAY_NAME, TEST_EMAIL, TEST_PHOTO_URL, TEST_THUMBNAIL_URL,
                 createAdditionalOauthValues());
         final Bundle bundle = account.toBundle();
@@ -129,7 +129,6 @@ public class UserAccountTest extends InstrumentationTestCase {
         assertEquals("Org ID should match", TEST_ORG_ID, account.getOrgId());
         assertEquals("User ID should match", TEST_USER_ID, account.getUserId());
         assertEquals("User name should match", TEST_USERNAME, account.getUsername());
-        assertEquals("Client ID should match", TEST_CLIENT_ID, account.getClientId());
         assertEquals("Account name should match", TEST_ACCOUNT_NAME, account.getAccountName());
         assertEquals("Community ID should match", TEST_COMMUNITY_ID, account.getCommunityId());
         assertEquals("Community URL should match", TEST_COMMUNITY_URL, account.getCommunityUrl());
@@ -156,7 +155,6 @@ public class UserAccountTest extends InstrumentationTestCase {
         assertEquals("Org ID should match", TEST_ORG_ID, account.getOrgId());
         assertEquals("User ID should match", TEST_USER_ID, account.getUserId());
         assertEquals("User name should match", TEST_USERNAME, account.getUsername());
-        assertEquals("Client ID should match", TEST_CLIENT_ID, account.getClientId());
         assertEquals("Community ID should match", TEST_COMMUNITY_ID, account.getCommunityId());
         assertEquals("Community URL should match", TEST_COMMUNITY_URL, account.getCommunityUrl());
         assertEquals("First name should match", TEST_FIRST_NAME, account.getFirstName());
@@ -186,7 +184,6 @@ public class UserAccountTest extends InstrumentationTestCase {
         object.put(UserAccount.ORG_ID, TEST_ORG_ID);
         object.put(UserAccount.USER_ID, TEST_USER_ID);
         object.put(UserAccount.USERNAME, TEST_USERNAME);
-        object.put(UserAccount.CLIENT_ID, TEST_CLIENT_ID);
         object.put(UserAccount.ACCOUNT_NAME, TEST_ACCOUNT_NAME);
         object.put(UserAccount.COMMUNITY_ID, TEST_COMMUNITY_ID);
         object.put(UserAccount.COMMUNITY_URL, TEST_COMMUNITY_URL);
@@ -215,7 +212,6 @@ public class UserAccountTest extends InstrumentationTestCase {
         object.putString(UserAccount.ORG_ID, TEST_ORG_ID);
         object.putString(UserAccount.USER_ID, TEST_USER_ID);
         object.putString(UserAccount.USERNAME, TEST_USERNAME);
-        object.putString(UserAccount.CLIENT_ID, TEST_CLIENT_ID);
         object.putString(UserAccount.ACCOUNT_NAME, TEST_ACCOUNT_NAME);
         object.putString(UserAccount.COMMUNITY_ID, TEST_COMMUNITY_ID);
         object.putString(UserAccount.COMMUNITY_URL, TEST_COMMUNITY_URL);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
@@ -110,7 +110,7 @@ public class SalesforceSDKManagerTest extends InstrumentationTestCase {
                 ClientManagerTest.TEST_INSTANCE_URL, ClientManagerTest.TEST_LOGIN_URL,
                 ClientManagerTest.TEST_IDENTITY_URL, ClientManagerTest.TEST_CLIENT_ID,
                 ClientManagerTest.TEST_ORG_ID, ClientManagerTest.TEST_USER_ID,
-                null, null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null, null);
         final AccountManager accMgr = AccountManager.get(targetContext);
         final UserAccount curUser = userAccMgr.getCurrentUser();
         assertNotNull("Current user should NOT be null", curUser);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
@@ -65,7 +65,9 @@ public class HttpAccessTest extends InstrumentationTestCase {
 		httpAccess = new HttpAccess(null, "dummy-agent");
 		okHttpClient = httpAccess.getOkHttpClient();
 		resourcesUrl = HttpUrl.parse(TestCredentials.INSTANCE_URL + "/services/data/" + TestCredentials.API_VERSION + "/");
-		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
+		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
+				new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+                TestCredentials.REFRESH_TOKEN, null);
 		headers = new Headers.Builder()
 				.add("Content-Type", "application/json")
 				.add("Authorization", "OAuth " + refreshResponse.authToken)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
@@ -65,7 +65,7 @@ public class HttpAccessTest extends InstrumentationTestCase {
 		httpAccess = new HttpAccess(null, "dummy-agent");
 		okHttpClient = httpAccess.getOkHttpClient();
 		resourcesUrl = HttpUrl.parse(TestCredentials.INSTANCE_URL + "/services/data/" + TestCredentials.API_VERSION + "/");
-		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN);
+		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
 		headers = new Headers.Builder()
 				.add("Content-Type", "application/json")
 				.add("Authorization", "OAuth " + refreshResponse.authToken)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -74,13 +74,13 @@ public class OAuth2Test extends InstrumentationTestCase {
 	public void testGetAuthorizationUrl() throws URISyntaxException {
 		String callbackUrl = "sfdc://callback";
 		URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null);
 		URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
 		assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
 		authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, "touch", null);
 		expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -99,7 +99,7 @@ public class OAuth2Test extends InstrumentationTestCase {
 		params.put("param2", "val2");
 		params.put("param3", null);
 		URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, params);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, params);
 		assertTrue("Wrong authorization url", authorizationUrl.getRawQuery().indexOf("&param1=val1") > 0);
 		assertTrue("Wrong authorization url", authorizationUrl.getRawQuery().indexOf("&param2=val2") > 0);
 		assertTrue("Wrong authorization url", authorizationUrl.getRawQuery().indexOf("&param3=") > 0);
@@ -115,13 +115,13 @@ public class OAuth2Test extends InstrumentationTestCase {
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
         assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
         authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, "touch", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -138,13 +138,13 @@ public class OAuth2Test extends InstrumentationTestCase {
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
         assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
         authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, "touch", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -161,13 +161,13 @@ public class OAuth2Test extends InstrumentationTestCase {
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
         assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
         authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, "touch", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -177,7 +177,7 @@ public class OAuth2Test extends InstrumentationTestCase {
     private void tryScopes(String[] scopes, String expectedScopeParamValue) throws URISyntaxException {
         String callbackUrl = "sfdc://callback";
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID,callbackUrl, scopes, null, null, null);
+                TestCredentials.CLIENT_ID,callbackUrl, scopes, null, null);
         HttpUrl url = HttpUrl.get(authorizationUrl);
         boolean scopesFound = false;
         for (int i = 0, size = url.querySize(); i < size; i++) {
@@ -227,7 +227,9 @@ public class OAuth2Test extends InstrumentationTestCase {
 	public void testRefreshAuthToken() throws IOException, OAuthFailedException, URISyntaxException {
 
 		// Get an auth token using the refresh token
-		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
+		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
+				new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+                TestCredentials.REFRESH_TOKEN, null);
 		assertNotNull("Auth token should not be null", refreshResponse.authToken);
 		
 		// Let's try it out
@@ -255,7 +257,8 @@ public class OAuth2Test extends InstrumentationTestCase {
 
 		// Get an auth token using the refresh token
 		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
-                new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
+                new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+                TestCredentials.REFRESH_TOKEN, null);
 		assertNotNull("Auth token should not be null", refreshResponse.authToken);
 
 		// Now let's call the identity service

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -74,13 +74,13 @@ public class OAuth2Test extends InstrumentationTestCase {
 	public void testGetAuthorizationUrl() throws URISyntaxException {
 		String callbackUrl = "sfdc://callback";
 		URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
 		URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
 		assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
 		authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch");
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
 		expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -115,13 +115,13 @@ public class OAuth2Test extends InstrumentationTestCase {
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
         assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
         authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch");
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -138,13 +138,13 @@ public class OAuth2Test extends InstrumentationTestCase {
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
         assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
         authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch");
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -161,13 +161,13 @@ public class OAuth2Test extends InstrumentationTestCase {
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null);
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
         assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
         authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch");
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, "touch", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl);
@@ -177,7 +177,7 @@ public class OAuth2Test extends InstrumentationTestCase {
     private void tryScopes(String[] scopes, String expectedScopeParamValue) throws URISyntaxException {
         String callbackUrl = "sfdc://callback";
         URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
-                TestCredentials.CLIENT_ID,callbackUrl, scopes);
+                TestCredentials.CLIENT_ID,callbackUrl, scopes, null, null, null);
         HttpUrl url = HttpUrl.get(authorizationUrl);
         boolean scopesFound = false;
         for (int i = 0, size = url.querySize(); i < size; i++) {
@@ -227,7 +227,7 @@ public class OAuth2Test extends InstrumentationTestCase {
 	public void testRefreshAuthToken() throws IOException, OAuthFailedException, URISyntaxException {
 
 		// Get an auth token using the refresh token
-		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN);
+		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
 		assertNotNull("Auth token should not be null", refreshResponse.authToken);
 		
 		// Let's try it out
@@ -255,7 +255,7 @@ public class OAuth2Test extends InstrumentationTestCase {
 
 		// Get an auth token using the refresh token
 		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
-                new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN);
+                new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
 		assertNotNull("Auth token should not be null", refreshResponse.authToken);
 
 		// Now let's call the identity service

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
@@ -102,7 +102,7 @@ public class ClientManagerTest extends InstrumentationTestCase {
         getInstrumentation().callApplicationOnCreate(app);
         TestCredentials.init(getInstrumentation().getContext());
         loginOptions = new LoginOptions(TEST_LOGIN_URL, TEST_CALLBACK_URL,
-                TEST_CLIENT_ID, TEST_SCOPES, null);
+                TEST_CLIENT_ID, TEST_SCOPES);
         clientManager = new ClientManager(targetContext, TEST_ACCOUNT_TYPE,
         		loginOptions, true);
         accountManager = clientManager.getAccountManager();
@@ -148,7 +148,7 @@ public class ClientManagerTest extends InstrumentationTestCase {
         additionalParams.put("p2","v2");
         additionalParams.put("p3",null);
         LoginOptions loginOptions = new LoginOptions(TEST_LOGIN_URL,
-                TEST_CALLBACK_URL, TEST_CLIENT_ID, TEST_SCOPES, null, null, additionalParams);
+                TEST_CALLBACK_URL, TEST_CLIENT_ID, TEST_SCOPES, null, additionalParams);
         assertNotNull("LoginOptions must not be null",loginOptions);
         assertNotNull("LoginOptions must not be null",loginOptions.getAdditionalParameters());
         assertEquals("# of LoginOptions must be correct",additionalParams.size(),loginOptions.getAdditionalParameters().size());
@@ -498,8 +498,8 @@ public class ClientManagerTest extends InstrumentationTestCase {
     private Bundle createTestAccount() {
         return clientManager.createNewAccount(TEST_ACCOUNT_NAME, TEST_USERNAME, TEST_REFRESH_TOKEN,
                 TEST_AUTH_TOKEN, TEST_INSTANCE_URL, TEST_LOGIN_URL, TEST_IDENTITY_URL, TEST_CLIENT_ID,
-                TEST_ORG_ID, TEST_USER_ID, null, null, null, TEST_FIRST_NAME,
-                TEST_LAST_NAME, TEST_DISPLAY_NAME, TEST_EMAIL, TEST_PHOTO_URL, TEST_THUMBNAIL_URL, testOauthValues);
+                TEST_ORG_ID, TEST_USER_ID, null, null, TEST_FIRST_NAME, TEST_LAST_NAME,
+                TEST_DISPLAY_NAME, TEST_EMAIL, TEST_PHOTO_URL, TEST_THUMBNAIL_URL, testOauthValues);
     }
 
     /**
@@ -510,7 +510,7 @@ public class ClientManagerTest extends InstrumentationTestCase {
         return clientManager.createNewAccount(TEST_OTHER_ACCOUNT_NAME, TEST_OTHER_USERNAME,
                 TEST_REFRESH_TOKEN, TEST_AUTH_TOKEN, TEST_INSTANCE_URL, TEST_LOGIN_URL,
                 TEST_IDENTITY_URL, TEST_CLIENT_ID, TEST_ORG_ID_2, TEST_USER_ID_2,
-                null, null, null, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_DISPLAY_NAME, TEST_EMAIL, TEST_PHOTO_URL,
+                null, null, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_DISPLAY_NAME, TEST_EMAIL, TEST_PHOTO_URL,
                 TEST_THUMBNAIL_URL, testOauthValues);
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -100,7 +100,7 @@ public class RestClientTest extends InstrumentationTestCase {
         super.setUp();
         TestCredentials.init(getInstrumentation().getContext());
         httpAccess = new HttpAccess(null, "dummy-agent");
-        TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN);
+        TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
         authToken = refreshResponse.authToken;
         instanceUrl = refreshResponse.instanceUrl;
         testOauthKeys = new ArrayList<>();

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -100,7 +100,9 @@ public class RestClientTest extends InstrumentationTestCase {
         super.setUp();
         TestCredentials.init(getInstrumentation().getContext());
         httpAccess = new HttpAccess(null, "dummy-agent");
-        TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess, new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN, null, null);
+        TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
+                new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+                TestCredentials.REFRESH_TOKEN, null);
         authToken = refreshResponse.authToken;
         instanceUrl = refreshResponse.instanceUrl;
         testOauthKeys = new ArrayList<>();
@@ -108,8 +110,7 @@ public class RestClientTest extends InstrumentationTestCase {
         testOauthValues = new HashMap<>();
         testOauthValues.put(TEST_CUSTOM_KEY, TEST_CUSTOM_VALUE);
         SalesforceSDKManager.getInstance().setAdditionalOauthKeys(testOauthKeys);
-        clientInfo = new ClientInfo(TestCredentials.CLIENT_ID,
-        		new URI(TestCredentials.INSTANCE_URL),
+        clientInfo = new ClientInfo(new URI(TestCredentials.INSTANCE_URL),
         		new URI(TestCredentials.LOGIN_URL),
         		new URI(TestCredentials.IDENTITY_URL),
         		TestCredentials.ACCOUNT_NAME, TestCredentials.USERNAME,
@@ -132,7 +133,6 @@ public class RestClientTest extends InstrumentationTestCase {
      * @throws URISyntaxException
      */
     public void testGetClientInfo() throws URISyntaxException {
-        assertEquals("Wrong client id", TestCredentials.CLIENT_ID, restClient.getClientInfo().clientId);
         assertEquals("Wrong instance url", new URI(TestCredentials.INSTANCE_URL), restClient.getClientInfo().instanceUrl);
         assertEquals("Wrong login url", new URI(TestCredentials.LOGIN_URL), restClient.getClientInfo().loginUrl);
         assertEquals("Wrong account name", TestCredentials.ACCOUNT_NAME, restClient.getClientInfo().accountName);
@@ -161,8 +161,7 @@ public class RestClientTest extends InstrumentationTestCase {
     }
 
     public void testClientInfoResolveUrlForCommunityUrl() throws Exception {
-        final ClientInfo info = new ClientInfo(TestCredentials.CLIENT_ID,
-        		new URI(TestCredentials.INSTANCE_URL),
+        final ClientInfo info = new ClientInfo(new URI(TestCredentials.INSTANCE_URL),
         		new URI(TestCredentials.LOGIN_URL),
         		new URI(TestCredentials.IDENTITY_URL),
         		TestCredentials.ACCOUNT_NAME, TestCredentials.USERNAME,
@@ -173,8 +172,7 @@ public class RestClientTest extends InstrumentationTestCase {
     }
 
     public void testGetInstanceUrlForCommunity() throws Exception {
-        final ClientInfo info = new ClientInfo(TestCredentials.CLIENT_ID,
-        		new URI(TestCredentials.INSTANCE_URL),
+        final ClientInfo info = new ClientInfo(new URI(TestCredentials.INSTANCE_URL),
         		new URI(TestCredentials.LOGIN_URL),
         		new URI(TestCredentials.IDENTITY_URL),
         		TestCredentials.ACCOUNT_NAME, TestCredentials.USERNAME,

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
@@ -143,7 +143,7 @@ abstract public class ManagerTestCase extends InstrumentationTestCase {
         httpAccess = new HttpAccess(null, "dummy-agent");
         final TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
         		new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
-        		TestCredentials.REFRESH_TOKEN);
+        		TestCredentials.REFRESH_TOKEN, null, null);
         final String authToken = refreshResponse.authToken;
         final ClientInfo clientInfo = new ClientInfo(TestCredentials.CLIENT_ID,
         		new URI(TestCredentials.INSTANCE_URL),

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
@@ -145,8 +145,7 @@ abstract public class ManagerTestCase extends InstrumentationTestCase {
         		new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
         		TestCredentials.REFRESH_TOKEN, null);
         final String authToken = refreshResponse.authToken;
-        final ClientInfo clientInfo = new ClientInfo(TestCredentials.CLIENT_ID,
-        		new URI(TestCredentials.INSTANCE_URL),
+        final ClientInfo clientInfo = new ClientInfo(new URI(TestCredentials.INSTANCE_URL),
         		new URI(TestCredentials.LOGIN_URL),
         		new URI(TestCredentials.IDENTITY_URL),
         		TestCredentials.ACCOUNT_NAME, TestCredentials.USERNAME,

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
@@ -100,7 +100,7 @@ abstract public class ManagerTestCase extends InstrumentationTestCase {
             eq.waitForEvent(EventType.AppCreateComplete, 5000);
         }
         final LoginOptions loginOptions = new LoginOptions(TestCredentials.LOGIN_URL,
-        		TEST_CALLBACK_URL, TestCredentials.CLIENT_ID, TEST_SCOPES, null);
+        		TEST_CALLBACK_URL, TestCredentials.CLIENT_ID, TEST_SCOPES);
         final ClientManager clientManager = new ClientManager(targetContext,
         		TestCredentials.ACCOUNT_TYPE, loginOptions, true);
         clientManager.createNewAccount(TestCredentials.ACCOUNT_NAME,
@@ -108,7 +108,7 @@ abstract public class ManagerTestCase extends InstrumentationTestCase {
         		TEST_AUTH_TOKEN, TestCredentials.INSTANCE_URL,
         		TestCredentials.LOGIN_URL, TestCredentials.IDENTITY_URL,
         		TestCredentials.CLIENT_ID, TestCredentials.ORG_ID,
-        		TestCredentials.USER_ID, null, null, null, null, null, null, null, null, null, null);
+        		TestCredentials.USER_ID, null, null, null, null, null, null, null, null, null);
     	MetadataManager.reset(null);
     	CacheManager.hardReset(null);
     	SyncManager.reset();
@@ -143,7 +143,7 @@ abstract public class ManagerTestCase extends InstrumentationTestCase {
         httpAccess = new HttpAccess(null, "dummy-agent");
         final TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
         		new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
-        		TestCredentials.REFRESH_TOKEN, null, null);
+        		TestCredentials.REFRESH_TOKEN, null);
         final String authToken = refreshResponse.authToken;
         final ClientInfo clientInfo = new ClientInfo(TestCredentials.CLIENT_ID,
         		new URI(TestCredentials.INSTANCE_URL),

--- a/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/ExplorerActivityTest.java
+++ b/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/ExplorerActivityTest.java
@@ -128,7 +128,7 @@ public class ExplorerActivityTest extends
         clientManager = new ClientManager(targetContext, targetContext.getString(R.string.account_type), null, SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked());
         clientManager.createNewAccount(TEST_ACCOUNT_NAME, TEST_USERNAME, TEST_REFRESH_TOKEN,
                 TEST_ACCESS_TOKEN, TEST_INSTANCE_URL, TEST_LOGIN_URL, TEST_IDENTITY_URL, TEST_CLIENT_ID,
-                TEST_ORG_ID, TEST_USER_ID, null, null, null, null, null, null, null, null, null, null);
+                TEST_ORG_ID, TEST_USER_ID, null, null, null, null, null, null, null, null, null);
         SalesforceSDKManager.getInstance().getPasscodeManager().setTimeoutMs(0);
         final AccountManager accountManager = AccountManager.get(targetContext);
 


### PR DESCRIPTION
Before I send the IDP and SP pull requests out, I wanted to clean up our legacy `OAuth` implementation and start off with a clean base, so I've sent that portion out separately as a pull request.

**Since this PR is large and probably not reviewable, here's a summary of changes I made:**
- Consolidated a bunch of overridden methods that we had accumulated over the years as we added more parameters for features. Most of them were unnecessary and confusing for consumers.
- Removed `client_secret` in any shape, size or form from our codebase, since this is a legacy `OAuth` flow that doesn't apply anymore.
- Removed `clientId` from the `UserAccount` object. This field was never getting populated anyway because we were (incorrectly) assigning the value of `client_secret` to this field.
- All the other changes are simply rippling effects of the API changes.

**Testing:**
- All libraries and sample apps compile successfully.
- Ran the following sample apps and tested various scenarios including revoking tokens, refresh flow, multi-user login, switching users and log out. Works fine.
    - [x] `SmartSyncExplorer`.
    - [x] `RestAPIExplorer`.
    - [x] `SmartSyncExplorerHybrid`.
- Running tests:
    - [x] `SmartSync` tests - 100% passing.
    - [x] `SmartStore` tests - 100% passing.
    - [x] `SalesforceHybrid` tests - 100% passing.
    - [x] `SalesforceSDK` tests - 100% passing.
- Emulators used:
    - [x] `API 25`.
    - [x] `API 23`.

Should be good to go!