### PR TITLE
Fix poor rendering of OAuth login screens

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -42,6 +42,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
 import android.webkit.WebSettings;
+import android.webkit.WebSettings.LayoutAlgorithm;
 import android.webkit.WebView;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
@@ -106,6 +107,8 @@ public class LoginActivity extends AccountAuthenticatorActivity
         // Setup the WebView.
         final WebView webView = (WebView) findViewById(salesforceR.idLoginWebView());
         final WebSettings webSettings = webView.getSettings();
+        webSettings.setUseWideViewPort(true);
+        webSettings.setLayoutAlgorithm(LayoutAlgorithm.NORMAL);
         webSettings.setJavaScriptEnabled(true);
         webSettings.setAllowFileAccessFromFileURLs(true);
         webSettings.setJavaScriptCanOpenWindowsAutomatically(true);


### PR DESCRIPTION
Changes to WebView settings corrects issues with rendering certain 3rd party login screens (e.g., Facebook) See issue #1510.