### PR TITLE
Names for syncs 

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
@@ -193,7 +193,6 @@ public class SyncManager {
         INSTANCES.keySet().removeAll(keysToRemove);
     }
 
-
     /**
      * Get details of a sync state
      * @param syncId
@@ -227,7 +226,7 @@ public class SyncManager {
      * @throws JSONException
      */
     public SyncState syncDown(SyncDownTarget target, SyncOptions options, String soupName, SyncUpdateCallback callback) throws JSONException {
-    	SyncState sync = SyncState.createSyncDown(smartStore, target, options, soupName);
+    	SyncState sync = SyncState.createSyncDown(smartStore, target, options, soupName, null);
         SmartSyncLogger.d(TAG, "syncDown called", sync);
         runSync(sync, callback);
 		return sync;
@@ -298,7 +297,7 @@ public class SyncManager {
      * @throws JSONException
      */
     public SyncState syncUp(SyncUpTarget target, SyncOptions options, String soupName, SyncUpdateCallback callback) throws JSONException {
-    	SyncState sync = SyncState.createSyncUp(smartStore, target, options, soupName);
+    	SyncState sync = SyncState.createSyncUp(smartStore, target, options, soupName, null);
         SmartSyncLogger.d(TAG, "syncUp called", sync);
         runSync(sync, callback);
     	return sync;

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncState.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/util/SyncState.java
@@ -44,7 +44,8 @@ import org.json.JSONObject;
 public class SyncState {
 	// SmartStore
 	public static final String SYNCS_SOUP = "syncs_soup";
-	
+
+	public static final String SYNC_NAME = "name";
 	public static final String SYNC_TYPE = "type";
 	public static final String SYNC_TARGET = "target";
 	public static final String SYNC_OPTIONS = "options";
@@ -58,6 +59,7 @@ public class SyncState {
 
 	private long id;
 	private Type type;
+	private String name;
 	private SyncTarget target;
 	private SyncOptions options;
 	private String soupName;
@@ -76,23 +78,46 @@ public class SyncState {
 	 * @param store
 	 */
 	public static void setupSyncsSoupIfNeeded(SmartStore store) {
-    	if (store.hasSoup(SYNCS_SOUP)) 
-    		return;
-    	
-    	final IndexSpec[] indexSpecs = {
-    			new IndexSpec(SYNC_TYPE, SmartStore.Type.string)
-    	};    	
-		store.registerSoup(SYNCS_SOUP, indexSpecs);
+    	if (store.hasSoup(SYNCS_SOUP) && store.getSoupIndexSpecs(SYNCS_SOUP).length == 2) {
+			return;
+		}
+
+		final IndexSpec[] indexSpecs = {
+			new IndexSpec(SYNC_TYPE, SmartStore.Type.string),
+			new IndexSpec(SYNC_NAME, SmartStore.Type.string)
+		};
+
+		// Syncs soup exists but doesn't have all the required indexes
+		if (store.hasSoup(SYNCS_SOUP)) {
+			try {
+				store.alterSoup(SYNCS_SOUP, indexSpecs, false);
+			}
+			catch (JSONException e) {
+				throw new SyncManager.SmartSyncException(e);
+			}
+		}
+		// Syncs soup does not exist
+		else {
+			store.registerSoup(SYNCS_SOUP, indexSpecs);
+		}
 	}
 	
 	/**
 	 * Create sync state in database for a sync down and return corresponding SyncState
+	 * NB: Throws exception if there is already a sync with the same name (when name is not null)
+	 *
+	 * @param store
+	 * @param target
+	 * @param options
+	 * @param soupName
+	 * @param name
 	 * @return
-	 * @throws JSONException 
+	 * @throws JSONException
 	 */
-	public static SyncState  createSyncDown(SmartStore store, SyncDownTarget target, SyncOptions options, String soupName) throws JSONException {
+	public static SyncState  createSyncDown(SmartStore store, SyncDownTarget target, SyncOptions options, String soupName, String name) throws JSONException {
     	JSONObject sync = new JSONObject();
     	sync.put(SYNC_TYPE, Type.syncDown);
+		if (name != null) sync.put(SYNC_NAME, name);
     	sync.put(SYNC_TARGET, target.asJSON());
         sync.put(SYNC_OPTIONS, options.asJSON());
     	sync.put(SYNC_SOUP_NAME, soupName);
@@ -102,6 +127,10 @@ public class SyncState {
         sync.put(SYNC_MAX_TIME_STAMP, -1);
 		sync.put(SYNC_START_TIME, 0);
 		sync.put(SYNC_END_TIME, 0);
+
+		if (name != null && hasSyncWithName(store, name)) {
+			throw new SyncManager.SmartSyncException("Failed to create sync down: there is already a sync with name:" + name);
+		}
 
     	sync = store.upsert(SYNCS_SOUP, sync);
 		if (sync == null) {
@@ -114,12 +143,20 @@ public class SyncState {
 	
 	/**
 	 * Create sync state in database for a sync up and return corresponding SyncState
+	 * NB: Throws exception if there is already a sync with the same name (when name is not null)
+	 *
+	 * @param store
+	 * @param target
+	 * @param options
+	 * @param soupName
+	 * @param name
 	 * @return
-	 * @throws JSONException 
+	 * @throws JSONException
 	 */
-	public static SyncState createSyncUp(SmartStore store, SyncUpTarget target, SyncOptions options, String soupName) throws JSONException {
+	public static SyncState createSyncUp(SmartStore store, SyncUpTarget target, SyncOptions options, String soupName, String name) throws JSONException {
     	JSONObject sync = new JSONObject();
     	sync.put(SYNC_TYPE, Type.syncUp);
+		if (name != null) sync.put(SYNC_NAME, name);
         sync.put(SYNC_TARGET, target.asJSON());
     	sync.put(SYNC_SOUP_NAME, soupName);
     	sync.put(SYNC_OPTIONS, options.asJSON());
@@ -129,6 +166,10 @@ public class SyncState {
         sync.put(SYNC_MAX_TIME_STAMP, -1);
 		sync.put(SYNC_START_TIME, 0);
 		sync.put(SYNC_END_TIME, 0);
+
+		if (name != null && hasSyncWithName(store, name)) {
+			throw new SyncManager.SmartSyncException("Failed to create sync up: there is already a sync with name:" + name);
+		}
 
     	sync = store.upsert(SYNCS_SOUP, sync);
 		if (sync == null) {
@@ -147,6 +188,7 @@ public class SyncState {
 		SyncState state = new SyncState();
 		state.id = sync.getLong(SmartStore.SOUP_ENTRY_ID);
 		state.type = Type.valueOf(sync.getString(SYNC_TYPE));
+		state.name = sync.optString(SYNC_NAME);
         final JSONObject jsonTarget = sync.optJSONObject(SYNC_TARGET);
         state.target = (state.type == Type.syncDown ? SyncDownTarget.fromJSON(jsonTarget) : SyncUpTarget.fromJSON(jsonTarget));
 		state.options = SyncOptions.fromJSON(sync.optJSONObject(SYNC_OPTIONS));
@@ -161,7 +203,8 @@ public class SyncState {
 	}
 	
 	/**
-	 * Build SyncState from store sync given by id
+	 * Get sync state of sync given by id
+	 *
 	 * @param store
 	 * @param id
 	 * @return
@@ -175,7 +218,75 @@ public class SyncState {
     	
     	return SyncState.fromJSON(syncs.getJSONObject(0));
 	}
-	
+
+	/**
+	 * Get sync state of sync given by name
+	 *
+	 * @param store
+	 * @param name
+	 * @return
+	 * @throws JSONException
+	 */
+	public static SyncState byName(SmartStore store, String name) throws JSONException {
+		if (name == null) {
+			throw new SyncManager.SmartSyncException("name must not be null");
+		}
+
+		long syncId = store.lookupSoupEntryId(SYNCS_SOUP, SYNC_NAME, name);
+
+		if (syncId < 0)
+			return null;
+
+		return byId(store, syncId);
+	}
+
+	/**
+	 * Delete row for sync given by id
+	 *
+	 * @param store
+	 * @param id
+	 */
+	public static void deleteById(SmartStore store, long id) {
+		store.delete(SYNCS_SOUP, id);
+	}
+
+	/**
+	 * Delete row for sync given by name
+	 *
+	 * @param store
+	 * @param name
+	 */
+	public static void deleteByName(SmartStore store, String name) {
+		if (name == null) {
+			throw new SyncManager.SmartSyncException("name must not be null");
+		}
+
+		long syncId = store.lookupSoupEntryId(SYNCS_SOUP, SYNC_NAME, name);
+
+		if (syncId < 0)
+			return;
+
+		deleteById(store, syncId);
+	}
+
+	/**
+	 * Return true if there is a sync with the given name
+	 * NB: Throws exception if more than one sync is found with given name
+	 *
+	 * @param store
+	 * @param name
+	 * @return
+	 */
+	public static boolean hasSyncWithName(SmartStore store, String name) {
+		if (name == null) {
+			throw new SyncManager.SmartSyncException("name must not be null");
+		}
+
+		long syncId = store.lookupSoupEntryId(SYNCS_SOUP, SYNC_NAME, name);
+
+		return syncId != -1;
+	}
+
 	/**
 	 * @return json representation of sync
 	 * @throws JSONException
@@ -184,6 +295,7 @@ public class SyncState {
 		JSONObject sync = new JSONObject();
 		sync.put(SmartStore.SOUP_ENTRY_ID, id);
 		sync.put(SYNC_TYPE, type.name());
+		if (name != null) sync.put(SYNC_NAME, name);
 		if (target != null) sync.put(SYNC_TARGET, target.asJSON());
 		if (options != null) sync.put(SYNC_OPTIONS, options.asJSON());
 		sync.put(SYNC_SOUP_NAME, soupName);

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -42,6 +42,7 @@ import com.salesforce.androidsdk.smartsync.util.SyncOptions;
 import com.salesforce.androidsdk.smartsync.util.SyncState;
 import com.salesforce.androidsdk.smartsync.util.SyncState.MergeMode;
 import com.salesforce.androidsdk.smartsync.util.SyncUpdateCallbackQueue;
+import com.salesforce.androidsdk.util.test.JSONTestHelper;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -1082,6 +1083,111 @@ public class SyncManagerTest extends SyncManagerTestCase {
             idToFieldsExpectedOnServer.put(id, expectedFields);
         }
         checkServer(idToFieldsExpectedOnServer, Constants.ACCOUNT);
+    }
+
+    /**
+     * Create sync down, get it by id, delete it by id, make sure it's gone
+     */
+    public void testCreateGetDeleteSyncDownById() throws JSONException {
+        // Create
+        SyncState sync = SyncState.createSyncDown(smartStore, new SoqlSyncDownTarget("SELECT Id, Name from Account"), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, null);
+        long syncId = sync.getId();
+        // Get by id
+        SyncState fetchedSync = SyncState.byId(smartStore, syncId);
+        JSONTestHelper.assertSameJSON("Wrong sync state", sync.asJSON(), fetchedSync.asJSON());
+        // Delete by id
+        SyncState.deleteById(smartStore, syncId);
+        assertNull("Sync should be gone", SyncState.byId(smartStore, syncId));
+    }
+
+    /**
+     * Create sync down with a name, get it by name, delete it by name, make sure it's gone
+     */
+    public void testCreateGetDeleteSyncDownWithName() throws JSONException {
+        // Create a named sync down
+        String syncName = "MyNamedSyncDown";
+        SyncState sync = SyncState.createSyncDown(smartStore, new SoqlSyncDownTarget("SELECT Id, Name from Account"), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, syncName);
+        long syncId = sync.getId();
+        // Get by name
+        SyncState fetchedSync = SyncState.byName(smartStore, syncName);
+        JSONTestHelper.assertSameJSON("Wrong sync state", sync.asJSON(), fetchedSync.asJSON());
+        // Delete by name
+        SyncState.deleteByName(smartStore, syncName);
+        assertNull("Sync should be gone", SyncState.byId(smartStore, syncId));
+        assertNull("Sync should be gone", SyncState.byName(smartStore, syncName));
+    }
+
+    /**
+     * Create sync up, get it by id, delete it by id, make sure it's gone
+     */
+    public void testCreateGetDeleteSyncUpById() throws JSONException {
+        // Create
+        SyncState sync = SyncState.createSyncUp(smartStore, new SyncUpTarget(), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, null);
+        long syncId = sync.getId();
+        // Get by id
+        SyncState fetchedSync = SyncState.byId(smartStore, syncId);
+        JSONTestHelper.assertSameJSON("Wrong sync state", sync.asJSON(), fetchedSync.asJSON());
+        // Delete by id
+        SyncState.deleteById(smartStore, syncId);
+        assertNull("Sync should be gone", SyncState.byId(smartStore, syncId));
+    }
+
+    /**
+     * Create sync up with a name, get it by name, delete it by name, make sure it's gone
+     */
+    public void testCreateGetDeleteSyncUpWithName() throws JSONException {
+        // Create a named sync up
+        String syncName = "MyNamedSyncUp";
+        SyncState sync = SyncState.createSyncUp(smartStore, new SyncUpTarget(), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, syncName);
+        long syncId = sync.getId();
+        // Get by name
+        SyncState fetchedSync = SyncState.byName(smartStore, syncName);
+        JSONTestHelper.assertSameJSON("Wrong sync state", sync.asJSON(), fetchedSync.asJSON());
+        // Delete by name
+        SyncState.deleteByName(smartStore, syncName);
+        assertNull("Sync should be gone", SyncState.byId(smartStore, syncId));
+        assertNull("Sync should be gone", SyncState.byName(smartStore, syncName));
+    }
+
+    /**
+     * Create sync with a name, make sure a new sync down with the same name cannot be created
+     */
+    public void testCreateSyncDownWithExistingName() throws JSONException {
+        // Create a named sync
+        String syncName = "MyNamedSync";
+        SyncState.createSyncUp(smartStore, new SyncUpTarget(), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, syncName);
+        // Try to create a sync down with the same name
+        try {
+            SyncState.createSyncDown(smartStore, new SoqlSyncDownTarget("SELECT Id, Name from Account"), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, syncName);
+            fail("SmartSyncException should have been thrown");
+        }
+        catch (SyncManager.SmartSyncException e) {
+            assertTrue(e.getMessage().contains("already a sync with name"));
+        }
+        // Delete by name
+        SyncState.deleteByName(smartStore, syncName);
+        assertNull("Sync should be gone", SyncState.byName(smartStore, syncName));
+    }
+
+    /**
+     * Create sync with a name, make sure a new sync up with the same name cannot be created
+     */
+    public void testCreateSyncUpWithExistingName() throws JSONException {
+        // Create a named sync
+        String syncName = "MyNamedSync";
+        SyncState.createSyncDown(smartStore, new SoqlSyncDownTarget("SELECT Id, Name from Account"), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, syncName);
+        // Try to create a sync down with the same name
+        try {
+            SyncState.createSyncUp(smartStore, new SyncUpTarget(), SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED), ACCOUNTS_SOUP, syncName);
+            fail("SmartSyncException should have been thrown");
+        }
+        catch (SyncManager.SmartSyncException e) {
+            assertTrue(e.getMessage().contains("already a sync with name"));
+        }
+        // Delete by name
+        SyncState.deleteByName(smartStore, syncName);
+        assertNull("Sync should be gone", SyncState.byName(smartStore, syncName));
+
     }
 
     /**

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -722,7 +722,7 @@ public class SyncManagerTest extends SyncManagerTestCase {
         // Create sync
         SlowSoqlSyncDownTarget target = new SlowSoqlSyncDownTarget("SELECT Id, Name, LastModifiedDate FROM Account WHERE Id IN " + makeInClause(idToFields.keySet()));
         SyncOptions options = SyncOptions.optionsForSyncDown(MergeMode.LEAVE_IF_CHANGED);
-        SyncState sync = SyncState.createSyncDown(smartStore, target, options, ACCOUNTS_SOUP);
+        SyncState sync = SyncState.createSyncDown(smartStore, target, options, ACCOUNTS_SOUP, null);
         long syncId = sync.getId();
         checkStatus(sync, SyncState.Type.syncDown, syncId, target, options, SyncState.Status.NEW, 0, -1);
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
@@ -159,7 +159,7 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
      */
     protected long trySyncDown(SyncState.MergeMode mergeMode, SyncDownTarget target, String soupName, int totalSize, int numberFetches) throws JSONException {
         final SyncOptions options = SyncOptions.optionsForSyncDown(mergeMode);
-        final SyncState sync = SyncState.createSyncDown(smartStore, target, options, soupName);
+        final SyncState sync = SyncState.createSyncDown(smartStore, target, options, soupName, null);
         long syncId = sync.getId();
         checkStatus(sync, SyncState.Type.syncDown, syncId, target, options, SyncState.Status.NEW, 0, -1);
 
@@ -503,7 +503,7 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
      */
     protected void trySyncUp(SyncUpTarget target, int numberChanges, SyncOptions options, boolean expectSyncFailure) throws JSONException {
         // Create sync
-		SyncState sync = SyncState.createSyncUp(smartStore, target, options, ACCOUNTS_SOUP);
+		SyncState sync = SyncState.createSyncUp(smartStore, target, options, ACCOUNTS_SOUP, null);
 		long syncId = sync.getId();
 		checkStatus(sync, SyncState.Type.syncUp, syncId, target, options, SyncState.Status.NEW, 0, -1);
 


### PR DESCRIPTION
* The syncs soup has a new indexed field (NB: the upgrade scenario is handled by `setupSyncsSoupIfNeeded()` in `SyncState.java`).
* The `createSyncUp(...)` and `createSyncDown(...)` in `SyncState.java` take a new argument `name`. It can be null, but when it is not null, it cannot be the name of an existing sync.
* There is  a new method for getting a sync by name :`byName(...)` in `SyncState.java`
* There are also new methods for deleting a sync by id or name: `deleteById(...)` in `deleteByName(...)` in `SyncState.java`.
* There are tests for the new capabilities in `SyncManagerTest.java`

In the next PR, I will add the ability to get sync by names and also delete syncs from hybrid and react native apps.
In the PR after that, I will add the ability to define syncs from a config file.