### PR TITLE
Adding support for unauthenticatedStartPage hybrid configuration

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -203,7 +203,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                 // Remote
                 else {
                     SalesforceHybridLogger.w(TAG, "onResumeNotLoggedIn - should not authenticate/remote start page - loading web app");
-                    loadRemoteStartPage(!bootconfig.isStartPageAbsoluteUrl());
+                    loadRemoteStartPage(bootconfig.getUnauthenticatedStartPage(), false);
                 }
             }
         } catch (BootConfig.BootConfigException e) {
@@ -231,7 +231,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
             // Online
             if (SalesforceSDKManager.getInstance().hasNetwork()) {
                 SalesforceHybridLogger.i(TAG, "onResumeLoggedInNotLoaded - remote start page/online - loading web app");
-                loadRemoteStartPage(!bootconfig.isStartPageAbsoluteUrl());
+                loadRemoteStartPage(bootconfig.getStartPage(), true);
             }
 
             // Offline
@@ -460,20 +460,19 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
      * Load remote start page (front-doored)
      */
     public void loadRemoteStartPage() {
-        loadRemoteStartPage(true);
+        loadRemoteStartPage(bootconfig.getStartPage(), true);
     }
 
     /**
      * Load the remote start page.
-     *
+     * @param startPageUrl The start page to load.
      * @param loadThroughFrontDoor Whether or not to load through front-door.
      */
-    private void loadRemoteStartPage(boolean loadThroughFrontDoor) {
+    private void loadRemoteStartPage(String startPageUrl, boolean loadThroughFrontDoor) {
         assert !bootconfig.isLocal();
-        String startPage = bootconfig.getStartPage();
-        String url = startPage;
+        String url = startPageUrl;
         if (loadThroughFrontDoor) {
-            url = getFrontDoorUrl(url, false);
+            url = getFrontDoorUrl(url, BootConfig.isAbsoluteUrl(url));
         }
         SalesforceHybridLogger.i(TAG, "loadRemoteStartPage called - loading: " + url);
         loadUrl(url);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/BootConfig.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/BootConfig.java
@@ -147,14 +147,12 @@ public class BootConfig {
 			}
 
 			// Lack of unauthenticatedStartPage with remote deferred authentication is an error.
-			if (!config.isLocal() && !config.shouldAuthenticate()
-					&& (config.getUnauthenticatedStartPage() == null || config.getUnauthenticatedStartPage().length() == 0)) {
+			if (!config.isLocal() && !config.shouldAuthenticate() && TextUtils.isEmpty(config.getUnauthenticatedStartPage())) {
 				throw new BootConfigException(UNAUTHENTICATED_START_PAGE + " required for remote app with deferred authentication.");
 			}
 
 			// unauthenticatedStartPage, if present, must be an absolute URL.
-			if (config.getUnauthenticatedStartPage() != null
-					&& config.getUnauthenticatedStartPage().length() > 0
+			if (!TextUtils.isEmpty(config.getUnauthenticatedStartPage())
 					&& !BootConfig.isAbsoluteUrl(config.getUnauthenticatedStartPage())) {
 				throw new BootConfigException(UNAUTHENTICATED_START_PAGE + " should be absolute URL.");
 			}

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_absoluteStartPage.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_absoluteStartPage.json
@@ -1,0 +1,11 @@
+{
+    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
+    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "oauthScopes": ["api","web"],
+    "isLocal": true,
+    "startPage": "https://www.salesforce.com/test.html",
+    "errorPage": "error.html",
+    "shouldAuthenticate": true,
+    "attemptOfflineLoad": true,
+    "androidPushNotificationClientId": ""
+}

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_relativeUnauthenticatedStartPage.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_relativeUnauthenticatedStartPage.json
@@ -1,0 +1,12 @@
+{
+    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
+    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "oauthScopes": ["api","web"],
+    "isLocal": false,
+    "startPage": "/apex/TestPage",
+    "errorPage": "error.html",
+    "shouldAuthenticate": false,
+    "unauthenticatedStartPage": "/RelativeStartPage.html",
+    "attemptOfflineLoad": true,
+    "androidPushNotificationClientId": ""
+}

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_remoteDeferredAuthNoUnauthenticatedStartPage.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_remoteDeferredAuthNoUnauthenticatedStartPage.json
@@ -1,0 +1,11 @@
+{
+    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
+    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "oauthScopes": ["api","web"],
+    "isLocal": false,
+    "startPage": "/apex/TestPage",
+    "errorPage": "error.html",
+    "shouldAuthenticate": false,
+    "attemptOfflineLoad": true,
+    "androidPushNotificationClientId": ""
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
@@ -42,12 +42,14 @@ public class BootConfigTest extends InstrumentationTestCase {
 
     @Override
     public void setUp() throws Exception {
+        super.setUp();
         testContext = getInstrumentation().getContext();
     }
 
     @Override
     public void tearDown() throws Exception {
         testContext = null;
+        super.tearDown();
     }
 
     public void testNoBootConfig() {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
@@ -26,13 +26,8 @@
  */
 package com.salesforce.androidsdk.config;
 
+import android.content.Context;
 import android.test.InstrumentationTestCase;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.Arrays;
 
 /**
  * Tests for BootConfig.
@@ -42,14 +37,17 @@ import java.util.Arrays;
 
 public class BootConfigTest extends InstrumentationTestCase {
 
+    private static final String BOOTCONFIG_ASSETS_PATH_PREFIX = "www" + System.getProperty("file.separator");
+    private Context testContext;
+
     @Override
     public void setUp() throws Exception {
-
+        testContext = getInstrumentation().getContext();
     }
 
     @Override
     public void tearDown() throws Exception {
-
+        testContext = null;
     }
 
     public void testNoBootConfig() {
@@ -62,17 +60,17 @@ public class BootConfigTest extends InstrumentationTestCase {
     }
 
     public void testAbsoluteStartPage() {
-        BootConfig config = createHybridBootConfig(true, "https://www.salesforce.com/test.html", true, null);
+        BootConfig config = BootConfig.getHybridBootConfig(testContext, BOOTCONFIG_ASSETS_PATH_PREFIX + "bootconfig_absoluteStartPage.json");
         validateBootConfig(config, "Validation should fail with absolute URL start page.");
     }
 
     public void testRemoteDeferredAuthNoUnauthenticatedStartPage() {
-        BootConfig config = createHybridBootConfig(false, "/apex/TestPage", false, null);
+        BootConfig config = BootConfig.getHybridBootConfig(testContext, BOOTCONFIG_ASSETS_PATH_PREFIX + "bootconfig_remoteDeferredAuthNoUnauthenticatedStartPage.json");
         validateBootConfig(config, "Validation should fail with no unauthenticatedStartPage value in remote deferred auth.");
     }
 
     public void testRelativeUnauthenticatedStartPage() {
-        BootConfig config = createHybridBootConfig(false, "/apex/TestPage", false, "/RelativeStartPage.html");
+        BootConfig config = BootConfig.getHybridBootConfig(testContext, BOOTCONFIG_ASSETS_PATH_PREFIX + "bootconfig_relativeUnauthenticatedStartPage.json");
         validateBootConfig(config, "Validation should fail with relative unauthenticatedStartPage value.");
     }
 
@@ -83,25 +81,6 @@ public class BootConfigTest extends InstrumentationTestCase {
             fail(errorMessage);
         } catch (BootConfig.BootConfigException e) {
             // Expected
-        }
-    }
-
-    private BootConfig createHybridBootConfig(boolean isLocal, String startPage, boolean shouldAuthenticate, String unauthenticatedStartPage) {
-        try {
-            JSONObject obj = new JSONObject();
-            obj.put("remoteAccessConsumerKey", "TestConsumerKey");
-            obj.put("oauthRedirectURI", "testRedirect:///uri/test");
-            obj.put("oauthScopes", new JSONArray(Arrays.asList(new String[] { "api", "web" })));
-            obj.put("isLocal", isLocal);
-            obj.put("startPage", startPage);
-            obj.put("errorPage", "TestErrorPage.html");
-            obj.put("shouldAuthenticate", shouldAuthenticate);
-            obj.put("attemptOfflineLoad", true);
-            obj.put("unauthenticatedStartPage", unauthenticatedStartPage);
-            return new BootConfig(obj, true);
-        } catch (JSONException e) {
-            fail("Error creating JSON boot config: " + e.getMessage());
-            return null;
         }
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2017-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.config;
+
+import android.test.InstrumentationTestCase;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+
+/**
+ * Tests for BootConfig.
+ *
+ * @author khawkins
+ */
+
+public class BootConfigTest extends InstrumentationTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+
+    }
+
+    public void testNoBootConfig() {
+        try {
+            BootConfig.validateBootConfig(null);
+            fail("Validation should fail with no boot config.");
+        } catch (BootConfig.BootConfigException e) {
+            // Expected
+        }
+    }
+
+    public void testAbsoluteStartPage() {
+        BootConfig config = createHybridBootConfig(true, "https://www.salesforce.com/test.html", true, null);
+        validateBootConfig(config, "Validation should fail with absolute URL start page.");
+    }
+
+    public void testRemoteDeferredAuthNoUnauthenticatedStartPage() {
+        BootConfig config = createHybridBootConfig(false, "/apex/TestPage", false, null);
+        validateBootConfig(config, "Validation should fail with no unauthenticatedStartPage value in remote deferred auth.");
+    }
+
+    public void testRelativeUnauthenticatedStartPage() {
+        BootConfig config = createHybridBootConfig(false, "/apex/TestPage", false, "/RelativeStartPage.html");
+        validateBootConfig(config, "Validation should fail with relative unauthenticatedStartPage value.");
+    }
+
+    private void validateBootConfig(BootConfig config, String errorMessage) {
+        assertNotNull("Boot config should not be null.", config);
+        try {
+            BootConfig.validateBootConfig(config);
+            fail(errorMessage);
+        } catch (BootConfig.BootConfigException e) {
+            // Expected
+        }
+    }
+
+    private BootConfig createHybridBootConfig(boolean isLocal, String startPage, boolean shouldAuthenticate, String unauthenticatedStartPage) {
+        try {
+            JSONObject obj = new JSONObject();
+            obj.put("remoteAccessConsumerKey", "TestConsumerKey");
+            obj.put("oauthRedirectURI", "testRedirect:///uri/test");
+            obj.put("oauthScopes", new JSONArray(Arrays.asList(new String[] { "api", "web" })));
+            obj.put("isLocal", isLocal);
+            obj.put("startPage", startPage);
+            obj.put("errorPage", "TestErrorPage.html");
+            obj.put("shouldAuthenticate", shouldAuthenticate);
+            obj.put("attemptOfflineLoad", true);
+            obj.put("unauthenticatedStartPage", unauthenticatedStartPage);
+            return new BootConfig(obj, true);
+        } catch (JSONException e) {
+            fail("Error creating JSON boot config: " + e.getMessage());
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Per our updated requirements for deferred authentication in hybrid remote apps:

- New property introduced to bootconfig: `unauthenticatedStartPage`.
    - Required for deferred authentication in hybrid remote apps.
    - Ignored in other configurations (local, remote apps with authentication configured.  Framework will log a warning message in these cases).
    - Must be an absolute URL, if present.
    - Use of `unauthenticatedStartPage` vs. `startPage` in a remote app with deferred authentication will be based on the internal authentication state of a user.
        - If a user has not authenticated, the unauthenticated page will be loaded.
        - If the user has authenticated, the original start page will be used.
- Existing `startPage` property represents the "authenticated" path for remote apps, and all paths for local apps.
    - This property is always required.
    - The URL value must be relative.