### PR TITLE
Dev support for Mobile SDK

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -138,7 +138,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
     }
 
     @Override
-    public void onResume(RestClient _) {
+    public void onResume(RestClient c) {
         // Called from delegate with null
 
         // Get client (if already logged in)

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.phonegap.ui;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.CookieManager;
 import android.webkit.WebView;
@@ -49,6 +50,8 @@ import com.salesforce.androidsdk.rest.RestClient.ClientInfo;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.security.PasscodeManager;
+import com.salesforce.androidsdk.ui.SalesforceActivityDelegate;
+import com.salesforce.androidsdk.ui.SalesforceActivityInterface;
 import com.salesforce.androidsdk.util.EventsObservable;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
 import com.salesforce.androidsdk.util.LogoutCompleteReceiver;
@@ -68,24 +71,31 @@ import okhttp3.HttpUrl;
 /**
  * Class that defines the main activity for a PhoneGap-based application.
  */
-public class SalesforceDroidGapActivity extends CordovaActivity {
+public class SalesforceDroidGapActivity extends CordovaActivity implements SalesforceActivityInterface {
 
     private static final String TAG = "SfDroidGapActivity";
+
+    // Delegate
+    private final SalesforceActivityDelegate delegate;
 
     // Rest client
     private RestClient client;
     private ClientManager clientManager;
-    
+
     // Config
     private BootConfig bootconfig;
-    private PasscodeManager passcodeManager;
-    private UserSwitchReceiver userSwitchReceiver;
-    private LogoutCompleteReceiver logoutCompleteReceiver;
 
     // Web app loaded?
     private boolean webAppLoaded = false;
 
-    /** Called when the activity is first created. */
+    public SalesforceDroidGapActivity() {
+        super();
+        delegate = new SalesforceActivityDelegate(this);
+    }
+
+    /**
+     * Called when the activity is first created.
+     */
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -97,15 +107,8 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
         // Get clientManager
         clientManager = buildClientManager();
 
-        // Passcode manager
-        passcodeManager = SalesforceSDKManager.getInstance().getPasscodeManager();
-        userSwitchReceiver = new DroidGapUserSwitchReceiver();
-        registerReceiver(userSwitchReceiver, new IntentFilter(UserAccountManager.USER_SWITCH_INTENT_ACTION));
-        logoutCompleteReceiver = new DroidGapLogoutCompleteReceiver();
-        registerReceiver(logoutCompleteReceiver, new IntentFilter(SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION));
-
-        // Let observers know
-        EventsObservable.get().notifyEvent(EventType.MainActivityCreateComplete, this);
+        // Delegate create
+        delegate.onCreate();
     }
 
     protected ClientManager buildClientManager() {
@@ -130,48 +133,37 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
     @Override
     public void onResume() {
         super.onResume();
-        if (passcodeManager.onResume(this)) {
-
-            // Get client (if already logged in)
-            try {
-                client = clientManager.peekRestClient();
-            } catch (AccountInfoNotFoundException e) {
-                client = null;
-            }
-
-            // Not logged in
-            if (client == null) {
-                onResumeNotLoggedIn();
-            }
-
-            // Logged in
-            else {
-
-                // Web app never loaded
-                if (!webAppLoaded) {
-                    onResumeLoggedInNotLoaded();
-                }
-
-                // Web app already loaded
-                else {
-                    SalesforceHybridLogger.i(TAG, "onResume - already logged in/web app already loaded");
-                }
-            }
-        }
+        delegate.onResume(false);
+        // will call this.onResume(RestClient client) with a null client
     }
 
-    /**
-     * Restarts the activity if the user has been switched.
-     */
-    private void restartIfUserSwitched() {
-        if (client != null) {
-            try {
-                RestClient currentClient = clientManager.peekRestClient();
-                if (currentClient != null && !currentClient.getClientInfo().userId.equals(client.getClientInfo().userId)) {
-                    this.recreate();
-                }
-            } catch (AccountInfoNotFoundException e) {
-                SalesforceHybridLogger.i(TAG, "restartIfUserSwitched - no user account found");
+    @Override
+    public void onResume(RestClient client) {
+        // Called from delegate / client should be null
+
+        // Get client (if already logged in)
+        try {
+            client = clientManager.peekRestClient();
+        } catch (AccountInfoNotFoundException e) {
+            client = null;
+        }
+
+        // Not logged in
+        if (client == null) {
+            onResumeNotLoggedIn();
+        }
+
+        // Logged in
+        else {
+
+            // Web app never loaded
+            if (!webAppLoaded) {
+                onResumeLoggedInNotLoaded();
+            }
+
+            // Web app already loaded
+            else {
+                SalesforceHybridLogger.i(TAG, "onResume - already logged in/web app already loaded");
             }
         }
     }
@@ -262,21 +254,25 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
     @Override
     public void onPause() {
         super.onPause();
-        passcodeManager.onPause(this);
+        delegate.onPause();
     }
 
     @Override
     public void onDestroy() {
-        unregisterReceiver(userSwitchReceiver);
-        unregisterReceiver(logoutCompleteReceiver);
+        delegate.onDestroy();
         super.onDestroy();
     }
 
     @Override
     public void onUserInteraction() {
-        passcodeManager.recordUserInteraction();
+        delegate.onUserInteraction();
     }
-    
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        return delegate.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
+    }
+
     public BootConfig getBootConfig() {
         return bootconfig;
     }
@@ -295,6 +291,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
 
     /**
      * Get a RestClient and refresh the auth token
+     *
      * @param callbackContext when not null credentials/errors are sent through to callbackContext.success()/error()
      */
     public void authenticate(final CallbackContext callbackContext) {
@@ -353,6 +350,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
 
     /**
      * Get json for credentials
+     *
      * @param callbackContext
      */
     public void getAuthCredentials(CallbackContext callbackContext) {
@@ -372,6 +370,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
     /**
      * If an action causes a redirect to the login page, this method will be called.
      * It causes the session to be refreshed and reloads url through the front door.
+     *
      * @param url the page to load once the session has been refreshed.
      */
     public void refresh(final String url) {
@@ -407,7 +406,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
                 }
             }
         });
-    }        
+    }
 
     /**
      * Loads the VF ping page and sets cookies.
@@ -455,7 +454,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
         SalesforceHybridLogger.i(TAG, "loadLocalStartPage called - loading: " + startPage);
         loadUrl("file:///android_asset/www/" + startPage);
         webAppLoaded = true;
-    }		
+    }
 
     /**
      * Load remote start page (front-doored)
@@ -466,6 +465,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
 
     /**
      * Load the remote start page.
+     *
      * @param loadThroughFrontDoor Whether or not to load through front-door.
      */
     private void loadRemoteStartPage(boolean loadThroughFrontDoor) {
@@ -479,11 +479,11 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
         loadUrl(url);
         webAppLoaded = true;
     }
-    
+
     /**
      * Returns the front-doored URL of a URL passed in.
      *
-     * @param url URL to be front-doored.
+     * @param url      URL to be front-doored.
      * @param isAbsUrl True - if the URL should be used as is, False - otherwise.
      * @return Front-doored URL.
      */
@@ -513,9 +513,9 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
         loadUrl(url);
         webAppLoaded = true;
     }
-    
+
     /**
-     * Load error page 
+     * Load error page
      */
     public void loadErrorPage() {
         String errorPage = bootconfig.getErrorPage();
@@ -532,69 +532,55 @@ public class SalesforceDroidGapActivity extends CordovaActivity {
         return appView;
     }
 
-   /**
-    * Set cookies on cookie manager.
-    */
-   private void setSidCookies() {
-       SalesforceHybridLogger.i(TAG, "setSidCookies called");
-       CookieManager cookieMgr = CookieManager.getInstance();
-       cookieMgr.setAcceptCookie(true);  // Required to set additional cookies that the auth process will return.
-       SalesforceSDKManager.getInstance().removeSessionCookies();
-       SystemClock.sleep(250); // removeSessionCookies kicks out a thread - let it finish
-       String accessToken = client.getAuthToken();
-       addSidCookieForInstance(cookieMgr, accessToken);
-       SalesforceSDKManager.getInstance().syncCookies();
-   }
-
-   private void addSidCookieForInstance(CookieManager cookieMgr, String sid) {
-       final ClientInfo clientInfo = SalesforceDroidGapActivity.this.client.getClientInfo();
-       URI instanceUrl = null;
-       if (clientInfo != null) {
-           instanceUrl = clientInfo.getInstanceUrl();
-       }
-       String host = null;
-       if (instanceUrl != null) {
-           host = instanceUrl.getHost();
-       }
-       if (host != null) {
-           addSidCookieForDomain(cookieMgr, host, sid);
-       }
-   }
-
-   private void addSidCookieForDomain(CookieManager cookieMgr, String domain, String sid) {
-       String cookieStr = "sid=" + sid;
-       cookieMgr.setCookie(domain, cookieStr);
-   }
-
     /**
-     * Performs actions on logout complete.
+     * Set cookies on cookie manager.
      */
-    protected void logoutCompleteActions() {
+    private void setSidCookies() {
+        SalesforceHybridLogger.i(TAG, "setSidCookies called");
+        CookieManager cookieMgr = CookieManager.getInstance();
+        cookieMgr.setAcceptCookie(true);  // Required to set additional cookies that the auth process will return.
+        SalesforceSDKManager.getInstance().removeSessionCookies();
+        SystemClock.sleep(250); // removeSessionCookies kicks out a thread - let it finish
+        String accessToken = client.getAuthToken();
+        addSidCookieForInstance(cookieMgr, accessToken);
+        SalesforceSDKManager.getInstance().syncCookies();
     }
 
-    /**
-     * Acts on the user switch event.
-     *
-     * @author bhariharan
-     */
-    private class DroidGapUserSwitchReceiver extends UserSwitchReceiver {
-
-        @Override
-        protected void onUserSwitch() {
-            restartIfUserSwitched();
+    private void addSidCookieForInstance(CookieManager cookieMgr, String sid) {
+        final ClientInfo clientInfo = SalesforceDroidGapActivity.this.client.getClientInfo();
+        URI instanceUrl = null;
+        if (clientInfo != null) {
+            instanceUrl = clientInfo.getInstanceUrl();
+        }
+        String host = null;
+        if (instanceUrl != null) {
+            host = instanceUrl.getHost();
+        }
+        if (host != null) {
+            addSidCookieForDomain(cookieMgr, host, sid);
         }
     }
 
-    /**
-     * Acts on the logout complete event.
-     *
-     * @author bhariharan
-     */
-    private class DroidGapLogoutCompleteReceiver extends LogoutCompleteReceiver {
+    private void addSidCookieForDomain(CookieManager cookieMgr, String domain, String sid) {
+        String cookieStr = "sid=" + sid;
+        cookieMgr.setCookie(domain, cookieStr);
+    }
 
-        @Override
-        protected void onLogoutComplete() {
-            logoutCompleteActions();
+    @Override
+    public void onLogoutComplete() {
+    }
+
+    @Override
+    public void onUserSwitched() {
+        if (client != null) {
+            try {
+                RestClient currentClient = clientManager.peekRestClient();
+                if (currentClient != null && !currentClient.getClientInfo().userId.equals(client.getClientInfo().userId)) {
+                    this.recreate();
+                }
+            } catch (AccountInfoNotFoundException e) {
+                SalesforceHybridLogger.i(TAG, "restartIfUserSwitched - no user account found");
+            }
         }
     }
 }

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -138,8 +138,8 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
     }
 
     @Override
-    public void onResume(RestClient client) {
-        // Called from delegate / client should be null
+    public void onResume(RestClient _) {
+        // Called from delegate with null
 
         // Get client (if already logged in)
         try {

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/app/SalesforceReactSDKManager.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/app/SalesforceReactSDKManager.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.reactnative.app;
 import android.app.Activity;
 import android.content.Context;
 
+import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -38,6 +39,7 @@ import com.salesforce.androidsdk.reactnative.bridge.SalesforceNetReactBridge;
 import com.salesforce.androidsdk.reactnative.bridge.SalesforceOauthReactBridge;
 import com.salesforce.androidsdk.reactnative.bridge.SmartStoreReactBridge;
 import com.salesforce.androidsdk.reactnative.bridge.SmartSyncReactBridge;
+import com.salesforce.androidsdk.reactnative.ui.SalesforceReactActivity;
 import com.salesforce.androidsdk.smartsync.app.SmartSyncSDKManager;
 import com.salesforce.androidsdk.ui.LoginActivity;
 import com.salesforce.androidsdk.util.EventsObservable;
@@ -45,6 +47,7 @@ import com.salesforce.androidsdk.util.EventsObservable.EventType;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -162,4 +165,20 @@ public class SalesforceReactSDKManager extends SmartSyncSDKManager {
 			}
 		};
 	}
+
+	@Override
+	protected LinkedHashMap<String, DevActionHandler> getDevActions(final Activity frontActivity) {
+		LinkedHashMap<String, DevActionHandler> devActions = super.getDevActions(frontActivity);
+
+		devActions.put(
+				"React Native Dev Support", new DevActionHandler() {
+					@Override
+					public void onSelected() {
+						((SalesforceReactActivity) frontActivity).showReactDevOptionsDialog();
+					}
+				});
+
+		return devActions;
+	}
+
 }

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
@@ -107,7 +107,7 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
     }
 
     @Override
-    public void onResume(RestClient _) {
+    public void onResume(RestClient c) {
         // Called from delegate with null
 
         // Get client (if already logged in)

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
@@ -103,11 +103,12 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
         super.onResume();
         delegate.onResume(false);
         // will call this.onResume(RestClient client) with a null client
+        loadReactAppOnceIfReady();
     }
 
     @Override
-    public void onResume(RestClient client) {
-        // Called from delegate / client should be null
+    public void onResume(RestClient _) {
+        // Called from delegate with null
 
         // Get client (if already logged in)
         try {
@@ -124,8 +125,6 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
         else {
             SalesforceReactLogger.i(TAG, "onResume - already logged in");
         }
-
-        loadReactAppOnceIfReady();
     }
 
     /**

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -85,6 +85,11 @@
             android:theme="@style/SalesforceSDK.ActionBarTheme"
             android:exported="false" />
 
+        <!--  Dev info activity -->
+        <activity android:name="com.salesforce.androidsdk.ui.DevInfoActivity"
+            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:exported="false" />
+
         <!-- Google Play Services Push Registration -->
         <!--
             Push notification services and receivers. The 'category' attribute

--- a/libs/SalesforceSDK/res/layout/sf__dev_info.xml
+++ b/libs/SalesforceSDK/res/layout/sf__dev_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ListView android:id="@+id/list" android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -76,4 +76,8 @@
 	<string name="sf__fingerprint_cancel">Use Passcode</string>
 	<string name="sf__fingerprint_success">Success</string>
 	<string name="sf__fingerprint_failed">Fingerprint Authentication Failed</string>
+
+	<!-- Dev support -->
+	<string name="sf__dev_support_title">Mobile SDK Dev Support</string>
+
 </resources>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -47,6 +47,7 @@ import android.provider.Settings;
 import android.text.TextUtils;
 import android.webkit.CookieManager;
 
+import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
@@ -67,6 +68,7 @@ import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.security.PasscodeManager;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.ui.AccountSwitcherActivity;
+import com.salesforce.androidsdk.ui.DevInfoActivity;
 import com.salesforce.androidsdk.ui.LoginActivity;
 import com.salesforce.androidsdk.ui.PasscodeActivity;
 import com.salesforce.androidsdk.ui.SalesforceR;
@@ -75,6 +77,8 @@ import com.salesforce.androidsdk.util.EventsObservable.EventType;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.SortedSet;
@@ -1193,7 +1197,7 @@ public class SalesforceSDKManager {
                                         devActionsDialog = null;
                                     }
                                 })
-                                .setTitle("Mobile SDK Dev Support")
+                                .setTitle(R.string.sf__dev_support_title)
                                 .create();
                 devActionsDialog.show();
             }
@@ -1207,6 +1211,13 @@ public class SalesforceSDKManager {
      */
     protected LinkedHashMap<String,DevActionHandler> getDevActions(final Activity frontActivity) {
         LinkedHashMap<String, DevActionHandler> devActions = new LinkedHashMap<>();
+        devActions.put(
+                "Show dev info", new DevActionHandler() {
+                    @Override
+                    public void onSelected() {
+                        frontActivity.startActivity(new Intent(frontActivity, DevInfoActivity.class));
+                    }
+                });
         devActions.put(
                 "Logout", new DevActionHandler() {
                     @Override
@@ -1242,6 +1253,30 @@ public class SalesforceSDKManager {
         return isDevSupportEnabled;
     }
 
+    /**
+     * @return Dev info (list of name1, value1, name2, value2 etc) to show in DevInfoActivity
+     */
+    public List<String> getDevSupportInfos() {
+
+        return Arrays.asList(
+                "SDK Version", SDK_VERSION,
+                "App Type", getAppType(),
+                "User Agent", getUserAgent(),
+                "Browser Login Enabled", isBrowserLoginEnabled() + "",
+                "Current User", usersToString(getUserAccountManager().getCurrentUser()),
+                "Authenticated Users", usersToString(getUserAccountManager().getAuthenticatedUsers().toArray(new UserAccount[0]))
+        );
+    }
+
+    private String usersToString(UserAccount... userAccounts) {
+        List<String> accountNames = new ArrayList<>();
+        if (userAccounts != null) {
+            for (UserAccount userAccount : userAccounts) {
+                accountNames.add(userAccount.getAccountName());
+            }
+        }
+        return TextUtils.join(", ", accountNames);
+    }
 
     private void sendLogoutCompleteIntent() {
         final Intent intent = new Intent(LOGOUT_COMPLETE_INTENT_ACTION);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -1343,11 +1343,11 @@ public class SalesforceSDKManager {
             Field field = clazz.getField(fieldName);
             return field.get(null);
         } catch (ClassNotFoundException e) {
-            e.printStackTrace();
+            SalesforceSDKLogger.e(TAG, "getBuildConfigValue failed", e);
         } catch (NoSuchFieldException e) {
-            e.printStackTrace();
+            SalesforceSDKLogger.e(TAG, "getBuildConfigValue failed", e);
         } catch (IllegalAccessException e) {
-            e.printStackTrace();
+            SalesforceSDKLogger.e(TAG, "getBuildConfigValue failed", e);
         }
         return null;
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.ui;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.ListView;
+import android.widget.SimpleAdapter;
+
+import com.salesforce.androidsdk.R;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dev support activity showing a lot of useful information
+ */
+public class DevInfoActivity extends Activity {
+
+    public static final String NAME = "name";
+    public static final String VALUE = "value";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Title / layout
+        getActionBar().setTitle(R.string.sf__dev_support_title);
+        setContentView(R.layout.sf__dev_info);
+
+        // Setup list
+        List<Map<String, String>> listData = prepareListData(SalesforceSDKManager.getInstance().getDevSupportInfos());
+        String[] from = new String[] {NAME, VALUE};
+        int[] to = new int[] { android.R.id.text1, android.R.id.text2};
+        ((ListView) findViewById(R.id.list)).setAdapter(new SimpleAdapter(this, listData, android.R.layout.simple_list_item_2, from, to));
+    }
+
+    private List<Map<String, String>> prepareListData(List<String> rawData) {
+        List<Map<String, String>> listData = new ArrayList<>();
+        for (int i=0; i<rawData.size(); i+=2) {
+            Map<String, String> entry = new HashMap<>();
+            entry.put(NAME, rawData.get(i));
+            entry.put(VALUE, rawData.get(i+1));
+            listData.add(entry);
+        }
+        return listData;
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.ui;
 import android.app.Activity;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.view.KeyEvent;
 
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
@@ -120,6 +121,17 @@ public abstract class SalesforceActivity extends Activity {
         unregisterReceiver(logoutCompleteReceiver);
     	super.onDestroy();
     }
+
+    @Override
+	public boolean onKeyUp(int keyCode, KeyEvent event) {
+		if (SalesforceSDKManager.getInstance().isDevSupportEnabled()) {
+			if (keyCode == KeyEvent.KEYCODE_MENU) {
+				SalesforceSDKManager.getInstance().showDevSupportDialog(this);
+				return true;
+			}
+		}
+		return false;
+	}
 
     /**
      * Refreshes the client if the user has been switched.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -51,7 +51,7 @@ public abstract class SalesforceActivity extends Activity implements SalesforceA
 	@Override 
 	public void onResume() {
 		super.onResume();
-		delegate.onResume();
+		delegate.onResume(true);
 	}
 
 	@Override
@@ -73,11 +73,15 @@ public abstract class SalesforceActivity extends Activity implements SalesforceA
 
     @Override
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
-		return delegate.onKeyUp(keyCode, event);
+		return delegate.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
 	}
 
     @Override
-    public void logoutCompleteActions() {
+    public void onLogoutComplete() {
     }
 
+	@Override
+	public void onUserSwitched() {
+		delegate.onResume(true);
+	}
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-present, salesforce.com, inc.
+ * Copyright (c) 2017-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2012-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.ui;
+
+import android.app.Activity;
+import android.content.IntentFilter;
+import android.view.KeyEvent;
+
+import com.salesforce.androidsdk.accounts.UserAccountManager;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.rest.ClientManager;
+import com.salesforce.androidsdk.rest.RestClient;
+import com.salesforce.androidsdk.security.PasscodeManager;
+import com.salesforce.androidsdk.util.EventsObservable;
+import com.salesforce.androidsdk.util.LogoutCompleteReceiver;
+import com.salesforce.androidsdk.util.UserSwitchReceiver;
+
+/**
+ * Class taking care of common behavior of Salesforce*Activity classes
+ */
+
+public class SalesforceActivityDelegate {
+
+    private Activity activity;
+    private PasscodeManager passcodeManager;
+    private UserSwitchReceiver userSwitchReceiver;
+    private LogoutCompleteReceiver logoutCompleteReceiver;
+
+
+    public SalesforceActivityDelegate(Activity activity) {
+        this.activity = activity;
+    }
+
+    public void onCreate() {
+        // Gets an instance of the passcode manager.
+        passcodeManager = SalesforceSDKManager.getInstance().getPasscodeManager();
+        userSwitchReceiver = new ActivityUserSwitchReceiver();
+        activity.registerReceiver(userSwitchReceiver, new IntentFilter(UserAccountManager.USER_SWITCH_INTENT_ACTION));
+        logoutCompleteReceiver = new ActivityLogoutCompleteReceiver();
+        activity.registerReceiver(logoutCompleteReceiver, new IntentFilter(SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION));
+
+        // Lets observers know that activity creation is complete.
+        EventsObservable.get().notifyEvent(EventsObservable.EventType.MainActivityCreateComplete, this);
+    }
+
+    public void onResume() {
+
+        // Brings up the passcode screen if needed.
+        if (passcodeManager.onResume(activity)) {
+
+            // Gets login options.
+            final String accountType = SalesforceSDKManager.getInstance().getAccountType();
+            final ClientManager.LoginOptions loginOptions = SalesforceSDKManager.getInstance().getLoginOptions();
+
+            // Gets a rest client.
+            new ClientManager(activity, accountType, loginOptions,
+                    SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(activity, new ClientManager.RestClientCallback() {
+
+                @Override
+                public void authenticatedRestClient(RestClient client) {
+                    if (client == null) {
+                        SalesforceSDKManager.getInstance().logout(activity);
+                        return;
+                    }
+                    ((SalesforceActivityInterface) activity).onResume(client);
+
+                    // Lets observers know that rendition is complete.
+                    EventsObservable.get().notifyEvent(EventsObservable.EventType.RenditionComplete);
+                }
+            });
+        }
+    }
+
+    public void onUserInteraction() {
+        passcodeManager.recordUserInteraction();
+    }
+
+    public void onPause() {
+        passcodeManager.onPause(activity);
+    }
+
+    public void onDestroy() {
+        activity.unregisterReceiver(userSwitchReceiver);
+        activity.unregisterReceiver(logoutCompleteReceiver);
+    }
+
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (SalesforceSDKManager.getInstance().isDevSupportEnabled()) {
+            if (keyCode == KeyEvent.KEYCODE_MENU) {
+                SalesforceSDKManager.getInstance().showDevSupportDialog(activity);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected void refreshIfUserSwitched() {
+        onResume();
+    }
+
+
+    /**
+     * Acts on the user switch event.
+     */
+    private class ActivityUserSwitchReceiver extends UserSwitchReceiver {
+
+        @Override
+        protected void onUserSwitch() {
+            refreshIfUserSwitched();
+        }
+    }
+
+    /**
+     * Acts on the logout complete event.
+     */
+    private class ActivityLogoutCompleteReceiver extends LogoutCompleteReceiver {
+
+        @Override
+        protected void onLogoutComplete() {
+            ((SalesforceActivityInterface) activity).logoutCompleteActions();
+        }
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
@@ -45,5 +45,11 @@ public interface SalesforceActivityInterface {
     /**
      * Performs actions on logout complete.
      */
-    void logoutCompleteActions();
+    void onLogoutComplete();
+
+    /**
+     * Performs actions on user switched.
+     */
+    void onUserSwitched();
+
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-present, salesforce.com, inc.
+ * Copyright (c) 2017-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -26,58 +26,24 @@
  */
 package com.salesforce.androidsdk.ui;
 
-import android.app.Activity;
-import android.os.Bundle;
-import android.view.KeyEvent;
+
+import com.salesforce.androidsdk.rest.RestClient;
 
 /**
- * Abstract base class for all Salesforce activities.
+ * Interface common to all Salesforce*Activity classes
+ * Used by SalesforceActivityDelegate
  */
-public abstract class SalesforceActivity extends Activity implements SalesforceActivityInterface {
 
-	private final SalesforceActivityDelegate delegate;
+public interface SalesforceActivityInterface {
+    /**
+     * Method that is called after the activity resumes once we have a RestClient.
+     *
+     * @param client RestClient instance.
+     */
+    void onResume(RestClient client);
 
-	public SalesforceActivity() {
-		super();
-		this.delegate = new SalesforceActivityDelegate(this);
-	}
-
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		delegate.onCreate();
-	}
-
-	@Override 
-	public void onResume() {
-		super.onResume();
-		delegate.onResume();
-	}
-
-	@Override
-	public void onUserInteraction() {
-		delegate.onUserInteraction();
-	}
-
-    @Override
-    public void onPause() {
-        super.onPause();
-		delegate.onPause();
-    }
-
-    @Override
-    public void onDestroy() {
-		delegate.onDestroy();
-    	super.onDestroy();
-    }
-
-    @Override
-	public boolean onKeyUp(int keyCode, KeyEvent event) {
-		return delegate.onKeyUp(keyCode, event);
-	}
-
-    @Override
-    public void logoutCompleteActions() {
-    }
-
+    /**
+     * Performs actions on logout complete.
+     */
+    void logoutCompleteActions();
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceExpandableListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceExpandableListActivity.java
@@ -27,159 +27,58 @@
 package com.salesforce.androidsdk.ui;
 
 import android.app.ExpandableListActivity;
-import android.content.IntentFilter;
 import android.os.Bundle;
-
-import com.salesforce.androidsdk.accounts.UserAccountManager;
-import com.salesforce.androidsdk.app.SalesforceSDKManager;
-import com.salesforce.androidsdk.rest.ClientManager;
-import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
-import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback;
-import com.salesforce.androidsdk.rest.RestClient;
-import com.salesforce.androidsdk.security.PasscodeManager;
-import com.salesforce.androidsdk.util.EventsObservable;
-import com.salesforce.androidsdk.util.EventsObservable.EventType;
-import com.salesforce.androidsdk.util.LogoutCompleteReceiver;
-import com.salesforce.androidsdk.util.UserSwitchReceiver;
+import android.view.KeyEvent;
 
 /**
  * Abstract base class for all Salesforce expandable list activities.
  *
  * @author bhariharan
  */
-public abstract class SalesforceExpandableListActivity extends ExpandableListActivity {
+public abstract class SalesforceExpandableListActivity extends ExpandableListActivity implements SalesforceActivityInterface {
 
-	private PasscodeManager passcodeManager;
-    private UserSwitchReceiver userSwitchReceiver;
-    private LogoutCompleteReceiver logoutCompleteReceiver;
+	private final SalesforceActivityDelegate delegate;
 
-	/**
-	 * Method that is called after the activity resumes once we have a RestClient.
-	 *
-	 * @param client RestClient instance.
-	 */
-	public abstract void onResume(RestClient client);
+	public SalesforceExpandableListActivity() {
+		super();
+		delegate = new SalesforceActivityDelegate(this);
+	}
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-
-		// Gets an instance of the passcode manager.
-		passcodeManager = SalesforceSDKManager.getInstance().getPasscodeManager();
-        userSwitchReceiver = new ActivityUserSwitchReceiver();
-        registerReceiver(userSwitchReceiver, new IntentFilter(UserAccountManager.USER_SWITCH_INTENT_ACTION));
-        logoutCompleteReceiver = new ActivityLogoutCompleteReceiver();
-        registerReceiver(logoutCompleteReceiver, new IntentFilter(SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION));
-
-		// Lets observers know that activity creation is complete.
-		EventsObservable.get().notifyEvent(EventType.MainActivityCreateComplete, this);
+		delegate.onCreate();
 	}
 
-	@Override 
+	@Override
 	public void onResume() {
 		super.onResume();
-
-		// Brings up the passcode screen if needed.
-		if (passcodeManager.onResume(this)) {
-
-			// Gets login options.
-			final String accountType = SalesforceSDKManager.getInstance().getAccountType();
-	    	final LoginOptions loginOptions = SalesforceSDKManager.getInstance().getLoginOptions();
-
-			// Gets a rest client.
-			new ClientManager(this, accountType, loginOptions, SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(this, new RestClientCallback() {
-
-				@Override
-				public void authenticatedRestClient(RestClient client) {
-					if (client == null) {
-						SalesforceSDKManager.getInstance().logout(SalesforceExpandableListActivity.this);
-						return;
-					}
-					onResume(client);
-
-					// Lets observers know that rendition is complete.
-					EventsObservable.get().notifyEvent(EventType.RenditionComplete);
-				}
-			});
-		}
+		delegate.onResume();
 	}
 
 	@Override
 	public void onUserInteraction() {
-		passcodeManager.recordUserInteraction();
+		delegate.onUserInteraction();
 	}
 
-    @Override
-    public void onPause() {
-        super.onPause();
-    	passcodeManager.onPause(this);
-    }
-
-    @Override
-    public void onDestroy() {
-    	unregisterReceiver(userSwitchReceiver);
-        unregisterReceiver(logoutCompleteReceiver);
-    	super.onDestroy();
-    }
-
-    /**
-     * Refreshes the client if the user has been switched.
-     */
-	protected void refreshIfUserSwitched() {
-		if (passcodeManager.onResume(this)) {
-
-			// Gets login options.
-			final String accountType = SalesforceSDKManager.getInstance().getAccountType();
-	    	final LoginOptions loginOptions = SalesforceSDKManager.getInstance().getLoginOptions();
-
-			// Gets a rest client.
-			new ClientManager(this, accountType, loginOptions,
-					SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(this, new RestClientCallback() {
-
-				@Override
-				public void authenticatedRestClient(RestClient client) {
-					if (client == null) {
-						SalesforceSDKManager.getInstance().logout(SalesforceExpandableListActivity.this);
-						return;
-					}
-					onResume(client);
-
-					// Lets observers know that rendition is complete.
-					EventsObservable.get().notifyEvent(EventType.RenditionComplete);
-				}
-			});
-		}
+	@Override
+	public void onPause() {
+		super.onPause();
+		delegate.onPause();
 	}
 
-    /**
-     * Performs actions on logout complete.
-     */
-    protected void logoutCompleteActions() {
-    }
+	@Override
+	public void onDestroy() {
+		delegate.onDestroy();
+		super.onDestroy();
+	}
 
-    /**
-     * Acts on the user switch event.
-     *
-     * @author bhariharan
-     */
-    private class ActivityUserSwitchReceiver extends UserSwitchReceiver {
+	@Override
+	public boolean onKeyUp(int keyCode, KeyEvent event) {
+		return delegate.onKeyUp(keyCode, event);
+	}
 
-		@Override
-		protected void onUserSwitch() {
-			refreshIfUserSwitched();
-		}
-    }
-
-	/**
-	 * Acts on the logout complete event.
-	 *
-	 * @author bhariharan
-	 */
-	private class ActivityLogoutCompleteReceiver extends LogoutCompleteReceiver {
-
-		@Override
-		protected void onLogoutComplete() {
-            logoutCompleteActions();
-		}
+	@Override
+	public void logoutCompleteActions() {
 	}
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceExpandableListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceExpandableListActivity.java
@@ -53,7 +53,7 @@ public abstract class SalesforceExpandableListActivity extends ExpandableListAct
 	@Override
 	public void onResume() {
 		super.onResume();
-		delegate.onResume();
+		delegate.onResume(true);
 	}
 
 	@Override
@@ -75,10 +75,15 @@ public abstract class SalesforceExpandableListActivity extends ExpandableListAct
 
 	@Override
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
-		return delegate.onKeyUp(keyCode, event);
+		return delegate.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
 	}
 
 	@Override
-	public void logoutCompleteActions() {
+	public void onLogoutComplete() {
+	}
+
+	@Override
+	public void onUserSwitched() {
+		delegate.onResume(true);
 	}
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
@@ -48,150 +48,50 @@ import com.salesforce.androidsdk.util.UserSwitchReceiver;
  *
  * @author bhariharan
  */
-public abstract class SalesforceListActivity extends ListActivity {
+public abstract class SalesforceListActivity extends ListActivity implements SalesforceActivityInterface {
 
-	private PasscodeManager passcodeManager;
-    private UserSwitchReceiver userSwitchReceiver;
-    private LogoutCompleteReceiver logoutCompleteReceiver;
+	private final SalesforceActivityDelegate delegate;
 
-	/**
-	 * Method that is called after the activity resumes once we have a RestClient.
-	 *
-	 * @param client RestClient instance.
-	 */
-	public abstract void onResume(RestClient client);
+	public SalesforceListActivity() {
+		super();
+		delegate = new SalesforceActivityDelegate(this);
+	}
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-
-		// Gets an instance of the passcode manager.
-		passcodeManager = SalesforceSDKManager.getInstance().getPasscodeManager();
-        userSwitchReceiver = new ActivityUserSwitchReceiver();
-        registerReceiver(userSwitchReceiver, new IntentFilter(UserAccountManager.USER_SWITCH_INTENT_ACTION));
-        logoutCompleteReceiver = new ActivityLogoutCompleteReceiver();
-        registerReceiver(logoutCompleteReceiver, new IntentFilter(SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION));
-
-		// Lets observers know that activity creation is complete.
-		EventsObservable.get().notifyEvent(EventType.MainActivityCreateComplete, this);
+		delegate.onCreate();
 	}
 
-	@Override 
+	@Override
 	public void onResume() {
 		super.onResume();
-
-		// Brings up the passcode screen if needed.
-		if (passcodeManager.onResume(this)) {
-
-			// Gets login options.
-			final String accountType = SalesforceSDKManager.getInstance().getAccountType();
-	    	final LoginOptions loginOptions = SalesforceSDKManager.getInstance().getLoginOptions();
-
-			// Gets a rest client.
-			new ClientManager(this, accountType, loginOptions, SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(this, new RestClientCallback() {
-
-				@Override
-				public void authenticatedRestClient(RestClient client) {
-					if (client == null) {
-						SalesforceSDKManager.getInstance().logout(SalesforceListActivity.this);
-						return;
-					}
-					onResume(client);
-
-					// Lets observers know that rendition is complete.
-					EventsObservable.get().notifyEvent(EventType.RenditionComplete);
-				}
-			});
-		}
+		delegate.onResume();
 	}
 
 	@Override
 	public void onUserInteraction() {
-		passcodeManager.recordUserInteraction();
+		delegate.onUserInteraction();
 	}
 
-    @Override
-    public void onPause() {
-        super.onPause();
-    	passcodeManager.onPause(this);
-    }
+	@Override
+	public void onPause() {
+		super.onPause();
+		delegate.onPause();
+	}
 
-    @Override
-    public void onDestroy() {
-    	unregisterReceiver(userSwitchReceiver);
-        unregisterReceiver(logoutCompleteReceiver);
-    	super.onDestroy();
-    }
+	@Override
+	public void onDestroy() {
+		delegate.onDestroy();
+		super.onDestroy();
+	}
 
 	@Override
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
-		if (SalesforceSDKManager.getInstance().isDevSupportEnabled()) {
-			if (keyCode == KeyEvent.KEYCODE_MENU) {
-				SalesforceSDKManager.getInstance().showDevSupportDialog(this);
-				return true;
-			}
-		}
-		return false;
+		return delegate.onKeyUp(keyCode, event);
 	}
 
-    /**
-     * Refreshes the client if the user has been switched.
-     */
-	protected void refreshIfUserSwitched() {
-		if (passcodeManager.onResume(this)) {
-
-			// Gets login options.
-			final String accountType = SalesforceSDKManager.getInstance().getAccountType();
-	    	final LoginOptions loginOptions = SalesforceSDKManager.getInstance().getLoginOptions();
-
-			// Gets a rest client.
-			new ClientManager(this, accountType, loginOptions,
-					SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(this, new RestClientCallback() {
-
-				@Override
-				public void authenticatedRestClient(RestClient client) {
-					if (client == null) {
-						SalesforceSDKManager.getInstance().logout(SalesforceListActivity.this);
-						return;
-					}
-					onResume(client);
-
-					// Lets observers know that rendition is complete.
-					EventsObservable.get().notifyEvent(EventType.RenditionComplete);
-				}
-			});
-		}
-	}
-
-    /**
-     * Performs actions on logout complete.
-     */
-    protected void logoutCompleteActions() {
-    }
-
-    /**
-     * Acts on the user switch event.
-     *
-     * @author bhariharan
-     */
-    private class ActivityUserSwitchReceiver extends UserSwitchReceiver {
-
-		@Override
-		protected void onUserSwitch() {
-			refreshIfUserSwitched();
-		}
-    }
-
-	/**
-	 * Acts on the logout complete event.
-	 *
-	 * @author bhariharan
-	 */
-	private class ActivityLogoutCompleteReceiver extends LogoutCompleteReceiver {
-
-		@Override
-		protected void onLogoutComplete() {
-            logoutCompleteActions();
-		}
+	@Override
+	public void logoutCompleteActions() {
 	}
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.ui;
 import android.app.ListActivity;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.view.KeyEvent;
 
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
@@ -121,6 +122,17 @@ public abstract class SalesforceListActivity extends ListActivity {
         unregisterReceiver(logoutCompleteReceiver);
     	super.onDestroy();
     }
+
+	@Override
+	public boolean onKeyUp(int keyCode, KeyEvent event) {
+		if (SalesforceSDKManager.getInstance().isDevSupportEnabled()) {
+			if (keyCode == KeyEvent.KEYCODE_MENU) {
+				SalesforceSDKManager.getInstance().showDevSupportDialog(this);
+				return true;
+			}
+		}
+		return false;
+	}
 
     /**
      * Refreshes the client if the user has been switched.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
@@ -27,21 +27,8 @@
 package com.salesforce.androidsdk.ui;
 
 import android.app.ListActivity;
-import android.content.IntentFilter;
 import android.os.Bundle;
 import android.view.KeyEvent;
-
-import com.salesforce.androidsdk.accounts.UserAccountManager;
-import com.salesforce.androidsdk.app.SalesforceSDKManager;
-import com.salesforce.androidsdk.rest.ClientManager;
-import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
-import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback;
-import com.salesforce.androidsdk.rest.RestClient;
-import com.salesforce.androidsdk.security.PasscodeManager;
-import com.salesforce.androidsdk.util.EventsObservable;
-import com.salesforce.androidsdk.util.EventsObservable.EventType;
-import com.salesforce.androidsdk.util.LogoutCompleteReceiver;
-import com.salesforce.androidsdk.util.UserSwitchReceiver;
 
 /**
  * Abstract base class for all Salesforce list activities.
@@ -66,7 +53,7 @@ public abstract class SalesforceListActivity extends ListActivity implements Sal
 	@Override
 	public void onResume() {
 		super.onResume();
-		delegate.onResume();
+		delegate.onResume(true);
 	}
 
 	@Override
@@ -88,10 +75,15 @@ public abstract class SalesforceListActivity extends ListActivity implements Sal
 
 	@Override
 	public boolean onKeyUp(int keyCode, KeyEvent event) {
-		return delegate.onKeyUp(keyCode, event);
+		return delegate.onKeyUp(keyCode, event) || super.onKeyUp(keyCode, event);
 	}
 
 	@Override
-	public void logoutCompleteActions() {
+	public void onLogoutComplete() {
+	}
+
+	@Override
+	public void onUserSwitched() {
+		delegate.onResume(true);
 	}
 }

--- a/libs/SmartStore/AndroidManifest.xml
+++ b/libs/SmartStore/AndroidManifest.xml
@@ -11,6 +11,8 @@
 	<application>
 
         <!--  SmartStore Inspector screen -->
-        <activity android:name="com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity" />
+        <activity android:name="com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity"
+			android:theme="@style/SalesforceSDK.ActionBarTheme"
+			android:exported="false"/>
 	</application>
 </manifest>

--- a/libs/SmartStore/res/layout/sf__inspector.xml
+++ b/libs/SmartStore/res/layout/sf__inspector.xml
@@ -4,6 +4,26 @@
     android:layout_height="match_parent"
     android:orientation="vertical" >
 
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal" >
+
+        <Button
+            style="@style/SmartStore.Inspector.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/sf__inspector_store" />
+
+        <Spinner
+            android:id="@+id/sf__inspector_stores_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </LinearLayout>
+
     <MultiAutoCompleteTextView
         android:id="@+id/sf__inspector_query_text"
         style="@style/SmartStore.Inspector.EditText.Query"

--- a/libs/SmartStore/res/values/sf__strings.xml
+++ b/libs/SmartStore/res/values/sf__strings.xml
@@ -2,6 +2,8 @@
 <resources>
 
     <!--       SmartStore Inspector      -->
+    <string name="sf__inspector_title">Inspect SmartStore</string>
+    <string name="sf__inspector_store">Store</string>
     <string name="sf__inspector_select_button">SELECT</string>
     <string name="sf__inspector_from_button">FROM</string>
     <string name="sf__inspector_where_button">WHERE</string>
@@ -17,7 +19,8 @@
     <string name="sf__inspector_pageindex_hint">Page index (default: 0)</string>    
     <string name="sf__inspector_no_query_specified">No query specified</string>
     <string name="sf__inspector_no_rows_returned">No rows returned</string>
-    
+    <string name="sf__inspector_no_soups_found">No soups found</string>
+
     <string name="sf__inspector_soups_query">select soupName from soup_names</string>
     <string name="sf__inspector_indices_query">select soupName, path, columnType from soup_index_map</string>
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -442,8 +442,8 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
         devSupportInfos.addAll(Arrays.asList(
                 "SQLCipher version", getSmartStore().getSQLCipherVersion(),
                 "SQLCipher Compile Options", TextUtils.join(", ", getSmartStore().getCompileOptions()),
-                "Global Stores", TextUtils.join(", ", getGlobalStoresPrefixList()),
-                "User Stores", TextUtils.join(", ", getUserStoresPrefixList())
+                "User Stores", TextUtils.join(", ", getUserStoresPrefixList()),
+                "Global Stores", TextUtils.join(", ", getGlobalStoresPrefixList())
         ));
         return devSupportInfos;
     }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -37,6 +37,7 @@ import com.salesforce.androidsdk.smartstore.R;
 import com.salesforce.androidsdk.smartstore.config.StoreConfig;
 import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
+import com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity;
 import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 import com.salesforce.androidsdk.ui.LoginActivity;
 import com.salesforce.androidsdk.util.EventsObservable;
@@ -46,6 +47,7 @@ import net.sqlcipher.database.SQLiteOpenHelper;
 
 import org.json.JSONException;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -415,5 +417,20 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
     private void setupStoreFromConfig(SmartStore store, int resourceId) {
         StoreConfig config = new StoreConfig(context, resourceId);
         config.registerSoups(store);
+    }
+
+    @Override
+    protected LinkedHashMap<String, DevActionHandler> getDevActions(final Activity frontActivity) {
+        LinkedHashMap<String, DevActionHandler> devActions = super.getDevActions(frontActivity);
+
+        devActions.put(
+                "Inspect DB", new DevActionHandler() {
+                    @Override
+                    public void onSelected() {
+                        frontActivity.startActivity(SmartStoreInspectorActivity.getIntent(frontActivity, false, DBOpenHelper.DEFAULT_DB_NAME));
+                    }
+                });
+
+        return devActions;
     }
 }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -47,6 +47,8 @@ import net.sqlcipher.database.SQLiteOpenHelper;
 
 import org.json.JSONException;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -424,7 +426,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
         LinkedHashMap<String, DevActionHandler> devActions = super.getDevActions(frontActivity);
 
         devActions.put(
-                "Inspect DB", new DevActionHandler() {
+                "Inspect SmartStore", new DevActionHandler() {
                     @Override
                     public void onSelected() {
                         frontActivity.startActivity(SmartStoreInspectorActivity.getIntent(frontActivity, false, DBOpenHelper.DEFAULT_DB_NAME));
@@ -432,5 +434,17 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
                 });
 
         return devActions;
+    }
+
+    @Override
+    public List<String> getDevSupportInfos() {
+        List<String> devSupportInfos = new ArrayList<>(super.getDevSupportInfos());
+        devSupportInfos.addAll(Arrays.asList(
+                "SQLCipher version", getSmartStore().getSQLCipherVersion(),
+                "SQLCipher Compile Options", TextUtils.join(", ", getSmartStore().getCompileOptions()),
+                "Global Stores", TextUtils.join(", ", getGlobalStoresPrefixList()),
+                "User Stores", TextUtils.join(", ", getUserStoresPrefixList())
+        ));
+        return devSupportInfos;
     }
 }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -28,6 +28,7 @@ package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.ContentValues;
 import android.database.Cursor;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
@@ -1608,4 +1609,39 @@ public class SmartStore  {
 			return DBHelper.getInstance(db).getFeatures(db, soupName).contains(SoupSpec.FEATURE_EXTERNAL_STORAGE);
 		}
 	}
+
+	/**
+	 * Get compile options
+	 *
+	 * @return list of compile options
+	 */
+	public List<String> getCompileOptions() {
+		return queryPragma("compile_options");
+	}
+
+	/**
+	 * Get sqlcipher version
+	 *
+	 * @return sqlcipher version
+	 */
+	public String getSQLCipherVersion() {
+		return TextUtils.join(" ", queryPragma("cipher_version"));
+	}
+
+	@NonNull
+	private List<String> queryPragma(String pragma) {
+		final SQLiteDatabase db = getDatabase();
+		ArrayList<String> results = new ArrayList<>();
+		Cursor c = null;
+		try {
+			c = db.rawQuery("PRAGMA " + pragma, null);
+			while (c.moveToNext()) {
+				results.add(c.getString(0));
+			}
+		} finally {
+			safeClose(c);
+		}
+		return results;
+	}
+
 }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
@@ -33,16 +33,20 @@ import android.os.Bundle;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.view.animation.GridLayoutAnimationController;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.GridView;
 import android.widget.MultiAutoCompleteTextView;
 import android.widget.MultiAutoCompleteTextView.Tokenizer;
+import android.widget.Spinner;
 
+import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.smartstore.R;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
@@ -56,10 +60,11 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-public class SmartStoreInspectorActivity extends Activity {
+public class SmartStoreInspectorActivity extends Activity implements AdapterView.OnItemSelectedListener {
 
 	// Keys for extras bundle
 	private static final String IS_GLOBAL_STORE = "isGlobalStore";
@@ -69,13 +74,18 @@ public class SmartStoreInspectorActivity extends Activity {
 	// Default page size / index
 	private static final int DEFAULT_PAGE_SIZE = 10;
 	private static final int DEFAULT_PAGE_INDEX = 0;
+	public static final String USER_STORE = " (user store)";
+	public static final String GLOBAL_STORE = " (global store)";
+	public static final String DEFAULT_STORE = "default";
 
 	// Store
 	private String dbName;
 	private boolean isGlobal;
 	private SmartStore smartStore;
+	private List<String> allStores;
 
 	// View elements
+	private Spinner spinner;
 	private MultiAutoCompleteTextView queryText;
 	private EditText pageSizeText;
 	private EditText pageIndexText;
@@ -109,20 +119,20 @@ public class SmartStoreInspectorActivity extends Activity {
 		super.onCreate(savedInstanceState);
 		readExtras();
 		setContentView(R.layout.sf__inspector);
-		queryText = (MultiAutoCompleteTextView) findViewById(R.id.sf__inspector_query_text);
-		pageSizeText = (EditText) findViewById(R.id.sf__inspector_pagesize_text);
-		pageIndexText = (EditText) findViewById(R.id.sf__inspector_pageindex_text);
-		resultGrid = (GridView) findViewById(R.id.sf__inspector_result_grid);
+		getActionBar().setTitle(R.string.sf__inspector_title);
+		spinner = findViewById(R.id.sf__inspector_stores_spinner);
+		queryText = findViewById(R.id.sf__inspector_query_text);
+		pageSizeText = findViewById(R.id.sf__inspector_pagesize_text);
+		pageIndexText = findViewById(R.id.sf__inspector_pageindex_text);
+		resultGrid = findViewById(R.id.sf__inspector_result_grid);
+		setupSpinner();
 	}
+
 
 	@Override
 	protected void onResume() {
 		super.onResume();
-		final SmartStoreSDKManager manager = SmartStoreSDKManager.getInstance();
-		smartStore = isGlobal
-				? manager.getGlobalSmartStore(dbName)
-				: manager.getSmartStore(dbName, manager.getUserAccountManager().getCurrentUser(), null);
-		setupAutocomplete(queryText);
+		setupStore(isGlobal, dbName);
 	}
 
 	private void readExtras() {
@@ -130,6 +140,68 @@ public class SmartStoreInspectorActivity extends Activity {
 		isGlobal = bundle == null ? false : bundle.getBoolean(IS_GLOBAL_STORE, false);
 		dbName = bundle == null ? DBOpenHelper.DEFAULT_DB_NAME : bundle.getString(DB_NAME, DBOpenHelper.DEFAULT_DB_NAME);
 	}
+
+	private void setupSpinner() {
+		SmartStoreSDKManager mgr = SmartStoreSDKManager.getInstance();
+		allStores = new ArrayList<>();
+		for (String dbName : mgr.getUserStoresPrefixList()) allStores.add(getDisplayNameForStore(false, dbName));
+		for (String dbName : mgr.getGlobalStoresPrefixList()) allStores.add(getDisplayNameForStore(true, dbName));
+		int selectedStoreIndex = allStores.indexOf(getDisplayNameForStore(this.isGlobal, this.dbName));
+		spinner.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, allStores));
+		spinner.setSelection(selectedStoreIndex);
+		spinner.setOnItemSelectedListener(this);
+	}
+
+	private String getDisplayNameForStore(boolean isGlobal, String dbName) {
+		return (dbName.equals(DBOpenHelper.DEFAULT_DB_NAME) ? DEFAULT_STORE : dbName) + (isGlobal ? GLOBAL_STORE : USER_STORE);
+	}
+
+	private Pair<Boolean, String> getStoreFromDisplayName(String storeDisplayName) {
+		boolean isGlobal;
+		String dbName;
+		if (storeDisplayName.endsWith(GLOBAL_STORE)) {
+			isGlobal = true;
+			dbName = storeDisplayName.substring(0, storeDisplayName.length() - GLOBAL_STORE.length());
+		}
+		else {
+			isGlobal = false;
+			dbName = storeDisplayName.substring(0, storeDisplayName.length() - USER_STORE.length());
+		}
+		dbName =  dbName.equals(DEFAULT_STORE) ? DBOpenHelper.DEFAULT_DB_NAME : dbName;
+		return new Pair<>(isGlobal, dbName);
+	}
+
+	private void setupStore(boolean isGlobal, String dbName) {
+		SmartStoreSDKManager mgr = SmartStoreSDKManager.getInstance();
+		UserAccount currentUser = mgr.getUserAccountManager().getCurrentUser();
+		this.isGlobal = isGlobal;
+		this.dbName = dbName;
+		smartStore = isGlobal ? mgr.getGlobalSmartStore(dbName) : mgr.getSmartStore(dbName, currentUser, null);
+		setupAutocomplete(queryText);
+	}
+
+	/**
+	 * Called when item selected in stores drop down
+	 * @param adapterView
+	 * @param view
+	 * @param i
+	 * @param l
+	 */
+	@Override
+	public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+		Pair<Boolean, String> selectedStore = getStoreFromDisplayName(allStores.get(i));
+		setupStore(selectedStore.first, selectedStore.second);
+	}
+
+	/**
+	 * Called when no item is selected in stores drop down
+	 * @param adapterView
+	 */
+	@Override
+	public void onNothingSelected(AdapterView<?> adapterView) {
+
+	}
+
 
 	/**
 	 * Called when "Clear" button is clicked
@@ -190,6 +262,11 @@ public class SmartStoreInspectorActivity extends Activity {
 	 */
 	public void onSoupsClick(View v) {
 		List<String> names = smartStore.getAllSoupNames();
+
+		if (names.size() == 0) {
+			showAlert(null, getString(R.string.sf__inspector_no_soups_found));
+			return;
+		}
 
 		if (names.size() > 10) {
 			queryText.setText(getString(R.string.sf__inspector_soups_query));

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
@@ -174,10 +174,12 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 	private void setupStore(boolean isGlobal, String dbName) {
 		SmartStoreSDKManager mgr = SmartStoreSDKManager.getInstance();
 		UserAccount currentUser = mgr.getUserAccountManager().getCurrentUser();
-		this.isGlobal = isGlobal;
-		this.dbName = dbName;
-		smartStore = isGlobal ? mgr.getGlobalSmartStore(dbName) : mgr.getSmartStore(dbName, currentUser, null);
-		setupAutocomplete(queryText);
+		if (this.isGlobal != isGlobal || !this.dbName.equals(dbName) || smartStore == null) {
+			this.isGlobal = isGlobal;
+			this.dbName = dbName;
+			smartStore = isGlobal ? mgr.getGlobalSmartStore(dbName) : mgr.getSmartStore(dbName, currentUser, null);
+			setupAutocomplete(queryText);
+		}
 	}
 
 	/**

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreInspectorActivityTest.java
@@ -26,14 +26,6 @@
  */
 package com.salesforce.androidsdk.store;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import net.sqlcipher.database.SQLiteOpenHelper;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import android.content.Context;
 import android.test.ActivityInstrumentationTestCase2;
 import android.view.View;
@@ -42,6 +34,7 @@ import android.widget.ListAdapter;
 import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
 
+import com.salesforce.androidsdk.analytics.EventBuilderHelper;
 import com.salesforce.androidsdk.smartstore.R;
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
 import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
@@ -49,6 +42,14 @@ import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 import com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity;
+
+import net.sqlcipher.database.SQLiteOpenHelper;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Tests for ServerPickerActivity
@@ -71,6 +72,7 @@ public class SmartStoreInspectorActivityTest extends
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
+		EventBuilderHelper.enableDisable(false);
 		setActivityInitialTouchMode(false);
 		targetContext = getInstrumentation().getTargetContext();
 		createStore();

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
@@ -30,6 +30,7 @@ import android.database.Cursor;
 import android.os.SystemClock;
 
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
+import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec.Order;
@@ -44,7 +45,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -80,18 +80,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	 * Checking compile options
 	 */
 	public void testCompileOptions() {
-		ArrayList<String> compileOptions = new ArrayList<String>();
-		Cursor c = null;
-		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
-			c = db.rawQuery("PRAGMA compile_options", null);
-            while(c.moveToNext()) {
-				compileOptions.add(c.getString(0));
-			}
-		}
-		finally {
-			safeClose(c);
-		}
+		List<String> compileOptions = store.getCompileOptions();
 
 		assertTrue("ENABLE_FTS4 flag not found in compile options", compileOptions.contains("ENABLE_FTS4"));
 		assertTrue("ENABLE_FTS3_PARENTHESIS flag not found in compile options", compileOptions.contains("ENABLE_FTS3_PARENTHESIS"));

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/ExplorerActivity.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/ExplorerActivity.java
@@ -26,10 +26,8 @@
  */
 package com.salesforce.samples.restexplorer;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.IntentFilter;
 import android.os.Bundle;
 import android.text.method.ScrollingMovementMethod;
 import android.view.View;
@@ -42,11 +40,8 @@ import android.widget.RadioGroup;
 import android.widget.TabHost;
 import android.widget.TextView;
 
-import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
-import com.salesforce.androidsdk.rest.ClientManager;
-import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback;
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.rest.RestClient.AsyncRequestCallback;
 import com.salesforce.androidsdk.rest.RestRequest;
@@ -54,6 +49,7 @@ import com.salesforce.androidsdk.rest.RestRequest.RestMethod;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.rest.files.FileRequests;
 import com.salesforce.androidsdk.security.PasscodeManager;
+import com.salesforce.androidsdk.ui.SalesforceActivity;
 import com.salesforce.androidsdk.util.EventsObservable;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
 import com.salesforce.androidsdk.util.UserSwitchReceiver;
@@ -78,7 +74,7 @@ import okhttp3.RequestBody;
 /**
  * Main activity for REST explorer.
  */
-public class ExplorerActivity extends Activity {
+public class ExplorerActivity extends SalesforceActivity {
 
 	private static final String DOUBLE_LINE = "==============================================================================";
 	private static final String SINGLE_LINE = "------------------------------------------------------------------------------";
@@ -87,7 +83,6 @@ public class ExplorerActivity extends Activity {
 	private String apiVersion;
 	private RestClient client;
 	private TextView resultText;
-    private UserSwitchReceiver userSwitchReceiver;
     private TabHost tabHost;
     private LogoutDialogFragment logoutConfirmationDialog;
 
@@ -133,57 +128,15 @@ public class ExplorerActivity extends Activity {
 		// Makes the result area scrollable.
 		resultText = (TextView) findViewById(R.id.result_text);
 		resultText.setMovementMethod(new ScrollingMovementMethod());
-        userSwitchReceiver = new ExplorerUserSwitchReceiver();
-        registerReceiver(userSwitchReceiver, new IntentFilter(UserAccountManager.USER_SWITCH_INTENT_ACTION));
         logoutConfirmationDialog = new LogoutDialogFragment();
 	}
 
-	@Override 
-	public void onResume() {
-		super.onResume();
-		
-		// Hides everything until we are logged in.
-		findViewById(R.id.root).setVisibility(View.INVISIBLE);
-		
-		// Brings up the passcode screen if needed.
-		if (passcodeManager.onResume(this)) {
-			String accountType = SalesforceSDKManager.getInstance().getAccountType();
-
-			// Gets a rest client.
-			new ClientManager(this, accountType, SalesforceSDKManager.getInstance().getLoginOptions(),
-					SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(this, new RestClientCallback() {
-
-				@Override
-				public void authenticatedRestClient(RestClient client) {
-					if (client == null) {
-						SalesforceSDKManager.getInstance().logout(ExplorerActivity.this);
-						return;
-					}
-					ExplorerActivity.this.client = client;
-					
-					// Shows everything.
-					findViewById(R.id.root).setVisibility(View.VISIBLE);				
-				}
-			});
-		}
-	}
-
-    @Override
-    public void onPause() {
-    	super.onPause();
-    	passcodeManager.onPause(this);
-    }
-
-    @Override
-    public void onDestroy() {
-    	unregisterReceiver(userSwitchReceiver);
-    	super.onDestroy();
-    }
-
 	@Override
-	public void onUserInteraction() {
-		passcodeManager.recordUserInteraction();
+	public void onResume(RestClient client) {
+		this.client = client;
 	}
+
+
 
 	/**
 	 * Returns the logout dialog fragment (used mainly by tests).
@@ -859,39 +812,4 @@ public class ExplorerActivity extends Activity {
 		}
 	}
 
-    /**
-     * Refreshes the client if the user has been switched.
-     */
-	private void refreshIfUserSwitched() {
-		if (passcodeManager.onResume(this)) {
-			final String accountType = SalesforceSDKManager.getInstance().getAccountType();
-
-			// Gets a rest client.
-			new ClientManager(this, accountType, SalesforceSDKManager.getInstance().getLoginOptions(),
-					SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(this, new RestClientCallback() {
-
-				@Override
-				public void authenticatedRestClient(RestClient client) {
-					if (client == null) {
-						SalesforceSDKManager.getInstance().logout(ExplorerActivity.this);
-						return;
-					}
-					ExplorerActivity.this.client = client;
-				}
-			});
-		}
-	}
-
-    /**
-     * Acts on the user switch event.
-     *
-     * @author bhariharan
-     */
-    private class ExplorerUserSwitchReceiver extends UserSwitchReceiver {
-
-		@Override
-		protected void onUserSwitch() {
-			refreshIfUserSwitched();
-		}
-    }
 }

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
@@ -40,7 +40,6 @@ public class SmartSyncExplorerApp extends Application {
 	public void onCreate() {
 		super.onCreate();
 		SmartSyncSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
-		SmartSyncSDKManager.getInstance().setDevSupportEnabled(BuildConfig.DEBUG);
 
         /*
          * Uncomment the following line to enable browser based login. This will use a

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
@@ -40,6 +40,7 @@ public class SmartSyncExplorerApp extends Application {
 	public void onCreate() {
 		super.onCreate();
 		SmartSyncSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
+		SmartSyncSDKManager.getInstance().setDevSupportEnabled(BuildConfig.DEBUG);
 
         /*
          * Uncomment the following line to enable browser based login. This will use a

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/MainActivity.java
@@ -128,7 +128,7 @@ public class MainActivity extends SalesforceListActivity implements
 	}
 
 	@Override
-	protected void logoutCompleteActions() {
+	public void logoutCompleteActions() {
 		super.logoutCompleteActions();
 		// If refresh token is revoked - ClientManager does a logout that doesn't finish top activity activity or show login
 		if (!isChild()) {

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/ui/MainActivity.java
@@ -128,8 +128,8 @@ public class MainActivity extends SalesforceListActivity implements
 	}
 
 	@Override
-	public void logoutCompleteActions() {
-		super.logoutCompleteActions();
+	public void onLogoutComplete() {
+		super.onLogoutComplete();
 		// If refresh token is revoked - ClientManager does a logout that doesn't finish top activity activity or show login
 		if (!isChild()) {
             recreate();


### PR DESCRIPTION
Overview of changes:
* SalesforceSDKManager has a new flag `isDevSupportEnabled`.
It defaults to `BuildConfig.DEBUG`.
When `true`, the menu button keyboard shortcut will bring up a dialog when in a `Salesforce*Activity`.

* The list of actions in the dialog comes  from the method `getDevActions(..)` in `SalesforceSDKManager`. Subclasses of `SalesforceSDKManager` can (and some do) provide more actions.

* Also added a new screen `DevInfoActivity` that shows interesting infos for developers. It can be launched from the new dev support dialog. The data shown comes from the method`getDevSupportInfos()` in `SalesforceSDKManager`. 
Subclasses of `SalesforceSDKManager` can (and some do) provide more data.

Current dev support actions:
* All apps: "Show dev info", "Logout", "Switch User"
* Apps using SmartStore: the ones above and "Inspect SmartStore"
* Apps using React: the ones above and "React Native Dev Support" (to bring the React Native dev support dialog).

Current def info data:
* All apps: "SDK version", "App Type", "User Agent", "Browser Login Enabled", "Current User" (account name), "Authenticated Users" (account names).
* Apps using SmartStore: the ones above and "SQLCipher version", "SQLCipher Compile Options", "User Stores" (names), "Global Stores" (names).

NB: To prevent code duplication, I introduced a new class `SalesforceActivityDelegate` and refactored all `Salesforce*Activity` classes (including `SalesforceDroidGapActivity` and `SalesforceReactActivity`) to use it.