### PR TITLE
Adding helpers for IDP initiated auth flow

### DIFF
--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -90,6 +90,15 @@
             android:theme="@style/SalesforceSDK.ActionBarTheme"
             android:exported="false" />
 
+        <!-- Receiver for IDP initiated login flow -->
+        <receiver android:name="com.salesforce.androidsdk.auth.idp.IDPInititatedLoginReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.salesforce.IDP_LOGIN_REQUEST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
+
         <!-- Google Play Services Push Registration -->
         <!--
             Push notification services and receivers. The 'category' attribute
@@ -110,12 +119,14 @@
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
             </intent-filter>
         </service>
+
         <service android:name="com.salesforce.androidsdk.push.SFDCInstanceIDListenerService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.android.gms.iid.InstanceID" />
             </intent-filter>
         </service>
+
         <service android:name="com.salesforce.androidsdk.push.SFDCRegistrationIntentService"
             android:exported="false">
         </service>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPInititatedLoginReceiver.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPInititatedLoginReceiver.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.idp;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
+
+/**
+ * This class receives a request to login from an IDP app and triggers the
+ * IDP login flow from within the SP app based on the 'user_hint' passed in.
+ *
+ * @author bhariharan
+ */
+public class IDPInititatedLoginReceiver extends BroadcastReceiver {
+
+    public static final String IDP_LOGIN_REQUEST_ACTION = "com.salesforce.IDP_LOGIN_REQUEST";
+    public static final String USER_HINT_KEY = "user_hint";
+    public static final String IDP_INIT_LOGIN_KEY = "idp_init_login";
+
+    private String userHint;
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent != null) {
+            if (IDP_LOGIN_REQUEST_ACTION.equals(intent.getAction())) {
+                final Bundle extras = intent.getExtras();
+                if (extras != null) {
+                    userHint = extras.getString(USER_HINT_KEY);
+                }
+                launchLoginActivity();
+            }
+        }
+    }
+
+    private void launchLoginActivity() {
+        final Bundle options = SalesforceSDKManager.getInstance().getLoginOptions().asBundle();
+        final Intent intent = new Intent(SalesforceSDKManager.getInstance().getAppContext(),
+                SalesforceSDKManager.getInstance().getLoginActivityClass());
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.putExtras(options);
+        intent.putExtra(USER_HINT_KEY, userHint);
+        intent.putExtra(IDP_INIT_LOGIN_KEY, true);
+        SalesforceSDKManager.getInstance().getAppContext().startActivity(intent);
+    }
+}


### PR DESCRIPTION
IDP initiated flow works end-to-end now.

Here's the code you need on the IDP side to trigger this flow:
```
final Intent intent = new Intent(IDPInititatedLoginReceiver.IDP_LOGIN_REQUEST_ACTION);
intent.putExtra(IDPInititatedLoginReceiver.USER_HINT_KEY, userHint);
sendBroadcast(intent);
```

This will be in the IDP template app.