### PR TITLE
Removing setter for IDP login flow

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/HybridApp.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/HybridApp.java
@@ -42,11 +42,10 @@ public class HybridApp extends Application {
 		SalesforceHybridSDKManager.initHybrid(getApplicationContext(), new HybridKeyImpl());
 
 		/*
-         * Uncomment the following lines to enable IDP login flow. This will allow the user to
+         * Uncomment the following line to enable IDP login flow. This will allow the user to
          * either authenticate using the current app or use a designated IDP app for login.
          * Replace 'idpAppURIScheme' with the URI scheme of the IDP app meant to be used.
          */
-		// SalesforceHybridSDKManager.getInstance().setIDPLoginFlowEnabled(true);
         // SalesforceHybridSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
 
         /*

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -162,7 +162,6 @@ public class SalesforceSDKManager {
     private List<String> additionalOauthKeys;
     private String loginBrand;
     private boolean browserLoginEnabled;
-    private boolean idpLoginFlowEnabled;
     private String idpAppURIScheme;
     private boolean idpAppLoginFlowActive;
 
@@ -262,7 +261,6 @@ public class SalesforceSDKManager {
         final RuntimeConfig runtimeConfig = RuntimeConfig.getRuntimeConfig(context);
         final String idpAppUrlScheme = runtimeConfig.getString(RuntimeConfig.ConfigKey.IDPAppURLScheme);
         if (!TextUtils.isEmpty(idpAppUrlScheme)) {
-            setIDPLoginFlowEnabled(true);
             this.idpAppURIScheme = idpAppUrlScheme;
         }
     }
@@ -632,21 +630,7 @@ public class SalesforceSDKManager {
      * @return True - if IDP login flow is enabled, False - otherwise.
      */
     public boolean isIDPLoginFlowEnabled() {
-        return idpLoginFlowEnabled;
-    }
-
-    /**
-     * Sets whether IDP login flow is enabled.
-     *
-     * @param idpLoginFlowEnabled True - if IDP login flow is enabled, False - otherwise.
-     */
-    public synchronized void setIDPLoginFlowEnabled(boolean idpLoginFlowEnabled) {
-        this.idpLoginFlowEnabled = idpLoginFlowEnabled;
-        if (idpLoginFlowEnabled) {
-            SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_APP_IS_SP);
-        } else {
-            SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_APP_IS_SP);
-        }
+        return !TextUtils.isEmpty(idpAppURIScheme);
     }
 
     /**

--- a/native/NativeSampleApps/ConfiguredApp/src/com/salesforce/samples/configuredapp/ConfiguredApp.java
+++ b/native/NativeSampleApps/ConfiguredApp/src/com/salesforce/samples/configuredapp/ConfiguredApp.java
@@ -42,11 +42,10 @@ public class ConfiguredApp extends Application {
 		SalesforceSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
 
 		/*
-         * Uncomment the following lines to enable IDP login flow. This will allow the user to
+         * Uncomment the following line to enable IDP login flow. This will allow the user to
          * either authenticate using the current app or use a designated IDP app for login.
          * Replace 'idpAppURIScheme' with the URI scheme of the IDP app meant to be used.
          */
-		// SalesforceSDKManager.getInstance().setIDPLoginFlowEnabled(true);
         // SalesforceSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
 
 		/*

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
@@ -41,11 +41,10 @@ public class RestExplorerApp extends Application {
 		SalesforceSDKManager.initNative(getApplicationContext(), null, ExplorerActivity.class);
 
 		/*
-         * Uncomment the following lines to enable IDP login flow. This will allow the user to
+         * Uncomment the following line to enable IDP login flow. This will allow the user to
          * either authenticate using the current app or use a designated IDP app for login.
          * Replace 'idpAppURIScheme' with the URI scheme of the IDP app meant to be used.
          */
-		// SalesforceSDKManager.getInstance().setIDPLoginFlowEnabled(true);
         // SalesforceSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
 
 		/*

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
@@ -42,11 +42,10 @@ public class SmartSyncExplorerApp extends Application {
 		SmartSyncSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
 
 		/*
-         * Uncomment the following lines to enable IDP login flow. This will allow the user to
+         * Uncomment the following line to enable IDP login flow. This will allow the user to
          * either authenticate using the current app or use a designated IDP app for login.
          * Replace 'idpAppURIScheme' with the URI scheme of the IDP app meant to be used.
          */
-		// SmartSyncSDKManager.getInstance().setIDPLoginFlowEnabled(true);
         // SmartSyncSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
 
         /*


### PR DESCRIPTION
Use the presence or absence of `idpAppURIScheme` directly to establish if the flow is enabled.