### PR TITLE
Moving LoginActivity declarations to app's Manifest

### DIFF
--- a/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
@@ -31,6 +31,41 @@
             </intent-filter>
         </activity>
 
+        <!-- Login activity -->
+        <!--
+            Launch mode of "singleInstance" ensures that the activity isn't restarted
+            by a callback from Chrome custom tab when auth flow is complete. This is
+            required for the Chrome custom tab auth flow to work correctly.
+        -->
+        <!--
+            To enable browser based authentication, uncomment the lines below and replace
+            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+
+            For example, if the callback URL of your connected app is
+            "testsfdc:///mobilesdk/detect/oauth/done",
+            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'path' would be "/mobilesdk/detect/oauth/done".
+
+            If the callback URL is "sfdc://login.salesforce.com/oauth/done",
+            'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
+            and 'path' would be "/oauth/done".
+        -->
+        <!--
+        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:launchMode="singleInstance">
+
+            <intent-filter>
+                <data android:scheme="testsfdc"
+                    android:host="*"
+                    android:path="/mobilesdk/detect/oauth/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        -->
+
         <!-- IDP account picker activity -->
         <!--
             To enable this app as an IDP app that's capable of handling authentication

--- a/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
@@ -31,6 +31,41 @@
             </intent-filter>
         </activity>
 
+        <!-- Login activity -->
+        <!--
+            Launch mode of "singleInstance" ensures that the activity isn't restarted
+            by a callback from Chrome custom tab when auth flow is complete. This is
+            required for the Chrome custom tab auth flow to work correctly.
+        -->
+        <!--
+            To enable browser based authentication, uncomment the lines below and replace
+            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+
+            For example, if the callback URL of your connected app is
+            "testsfdc:///mobilesdk/detect/oauth/done",
+            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'path' would be "/mobilesdk/detect/oauth/done".
+
+            If the callback URL is "sfdc://login.salesforce.com/oauth/done",
+            'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
+            and 'path' would be "/oauth/done".
+        -->
+        <!--
+        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:launchMode="singleInstance">
+
+            <intent-filter>
+                <data android:scheme="testsfdc"
+                    android:host="*"
+                    android:path="/mobilesdk/detect/oauth/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        -->
+
         <!-- IDP account picker activity -->
         <!--
             To enable this app as an IDP app that's capable of handling authentication

--- a/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/AndroidManifest.xml
@@ -31,6 +31,41 @@
             </intent-filter>
         </activity>
 
+        <!-- Login activity -->
+        <!--
+            Launch mode of "singleInstance" ensures that the activity isn't restarted
+            by a callback from Chrome custom tab when auth flow is complete. This is
+            required for the Chrome custom tab auth flow to work correctly.
+        -->
+        <!--
+            To enable browser based authentication, uncomment the lines below and replace
+            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+
+            For example, if the callback URL of your connected app is
+            "testsfdc:///mobilesdk/detect/oauth/done",
+            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'path' would be "/mobilesdk/detect/oauth/done".
+
+            If the callback URL is "sfdc://login.salesforce.com/oauth/done",
+            'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
+            and 'path' would be "/oauth/done".
+        -->
+        <!--
+        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:launchMode="singleInstance">
+
+            <intent-filter>
+                <data android:scheme="testsfdc"
+                    android:host="*"
+                    android:path="/mobilesdk/detect/oauth/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        -->
+
         <!-- IDP account picker activity -->
         <!--
             To enable this app as an IDP app that's capable of handling authentication

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -32,32 +32,7 @@
         -->
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK.ActionBarTheme"
-            android:launchMode="singleInstance">
-
-            <!--
-                To enable browser based authentication, uncomment the lines below and replace
-                'scheme', 'host' and 'path' with their corresponding values from your connected app.
-
-                For example, if the callback URL of your connected app is
-                "testsfdc:///mobilesdk/detect/oauth/done",
-                'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
-                'path' would be "/mobilesdk/detect/oauth/done".
-
-                If the callback URL is "sfdc://login.salesforce.com/oauth/done",
-                'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
-                and 'path' would be "/oauth/done".
-            -->
-            <!--
-            <intent-filter>
-                <data android:scheme="testsfdc"
-                    android:host="*"
-                    android:path="/mobilesdk/detect/oauth/done" />
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-            -->
-        </activity>
+            android:launchMode="singleInstance" />
 
         <!-- Passcode activity -->
         <activity android:name="com.salesforce.androidsdk.ui.PasscodeActivity"

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -154,6 +154,12 @@ public class LoginActivity extends AccountAuthenticatorActivity
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
 
+        // If this is a callback from Chrome, processes it and does nothing else.
+        if (isChromeCallback(intent)) {
+            completeAuthFlow(intent);
+            return;
+        }
+
         // Reloads login page for every new intent to ensure the correct login server is selected.
         webviewHelper.loadLoginPage();
 
@@ -169,9 +175,6 @@ public class LoginActivity extends AccountAuthenticatorActivity
                     onIDPLoginClick(null);
                 }
             }
-        }
-        if (isChromeCallback(intent)) {
-            completeAuthFlow(intent);
         }
     }
 

--- a/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
+++ b/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
@@ -26,6 +26,41 @@
 			</intent-filter>
 		</activity>
 
+		<!-- Login activity -->
+		<!--
+            Launch mode of "singleInstance" ensures that the activity isn't restarted
+            by a callback from Chrome custom tab when auth flow is complete. This is
+            required for the Chrome custom tab auth flow to work correctly.
+        -->
+		<!--
+            To enable browser based authentication, uncomment the lines below and replace
+            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+
+            For example, if the callback URL of your connected app is
+            "testsfdc:///mobilesdk/detect/oauth/done",
+            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'path' would be "/mobilesdk/detect/oauth/done".
+
+            If the callback URL is "sfdc://login.salesforce.com/oauth/done",
+            'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
+            and 'path' would be "/oauth/done".
+        -->
+		<!--
+        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:launchMode="singleInstance">
+
+            <intent-filter>
+                <data android:scheme="testsfdc"
+                    android:host="*"
+                    android:path="/mobilesdk/detect/oauth/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        -->
+
 		<!-- IDP account picker activity -->
 		<!--
             To enable this app as an IDP app that's capable of handling authentication

--- a/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
@@ -22,6 +22,41 @@
 			</intent-filter>
 		</activity>
 
+		<!-- Login activity -->
+		<!--
+            Launch mode of "singleInstance" ensures that the activity isn't restarted
+            by a callback from Chrome custom tab when auth flow is complete. This is
+            required for the Chrome custom tab auth flow to work correctly.
+        -->
+		<!--
+            To enable browser based authentication, uncomment the lines below and replace
+            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+
+            For example, if the callback URL of your connected app is
+            "testsfdc:///mobilesdk/detect/oauth/done",
+            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'path' would be "/mobilesdk/detect/oauth/done".
+
+            If the callback URL is "sfdc://login.salesforce.com/oauth/done",
+            'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
+            and 'path' would be "/oauth/done".
+        -->
+		<!--
+        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:launchMode="singleInstance">
+
+            <intent-filter>
+                <data android:scheme="testsfdc"
+                    android:host="*"
+                    android:path="/mobilesdk/detect/oauth/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        -->
+
         <!-- IDP account picker activity -->
         <!--
             To enable this app as an IDP app that's capable of handling authentication

--- a/native/NativeSampleApps/SmartSyncExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/SmartSyncExplorer/AndroidManifest.xml
@@ -22,6 +22,41 @@
 			</intent-filter>
 		</activity>
 
+        <!-- Login activity -->
+        <!--
+            Launch mode of "singleInstance" ensures that the activity isn't restarted
+            by a callback from Chrome custom tab when auth flow is complete. This is
+            required for the Chrome custom tab auth flow to work correctly.
+        -->
+        <!--
+            To enable browser based authentication, uncomment the lines below and replace
+            'scheme', 'host' and 'path' with their corresponding values from your connected app.
+
+            For example, if the callback URL of your connected app is
+            "testsfdc:///mobilesdk/detect/oauth/done",
+            'scheme' would be "testsfdc", 'host' would be "*" since it doesn't exist, and
+            'path' would be "/mobilesdk/detect/oauth/done".
+
+            If the callback URL is "sfdc://login.salesforce.com/oauth/done",
+            'scheme' would be "sfdc", 'host' would be "login.salesforce.com",
+            and 'path' would be "/oauth/done".
+        -->
+        <!--
+        <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
+            android:theme="@style/SalesforceSDK.ActionBarTheme"
+            android:launchMode="singleInstance">
+
+            <intent-filter>
+                <data android:scheme="testsfdc"
+                    android:host="*"
+                    android:path="/mobilesdk/detect/oauth/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        -->
+
         <!-- IDP account picker activity -->
         <!--
             To enable this app as an IDP app that's capable of handling authentication


### PR DESCRIPTION
This allows apps that consume through `Maven` to enable browser-based auth as well. Manifest merger will take care of merging this when `Gradle` is used to build.