### PR TITLE
Binary download support

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
@@ -128,9 +128,8 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
                             result.put(ENCODED_BODY, Base64.encodeToString(response.asBytes(), Base64.DEFAULT));
                             callbackContext.success(result);
                         }
-                        // JSON response
-                        else if (response.getContentType().contains(CONTENT_TYPE_JSON)) {
-
+                        // Some response
+                        else if (response.asBytes().length > 0) {
                             // Is it a JSONObject?
                             final JSONObject responseAsJSONObject = parseResponseAsJSONObject(response);
                             if (responseAsJSONObject != null) {

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
@@ -71,7 +71,7 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
     private static final String FILE_MIME_TYPE_KEY = "fileMimeType";
     private static final String FILE_URL_KEY = "fileUrl";
     private static final String FILE_NAME_KEY = "fileName";
-    private static final String RETURN_RESPONSE_AS_BLOB = "returnResponseAsBlob";
+    private static final String RETURN_BINARY = "returnBinary";
     private static final String ENCODED_BODY = "encodedBody";
     private static final String CONTENT_TYPE = "contentType";
 
@@ -108,7 +108,7 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
     protected void sendRequest(JSONArray args, final CallbackContext callbackContext) {
         try {
             final RestRequest request = prepareRestRequest(args);
-            final boolean returnResponseAsBlob = ((JSONObject) args.get(0)).optBoolean(RETURN_RESPONSE_AS_BLOB, false);
+            final boolean returnBinary = ((JSONObject) args.get(0)).optBoolean(RETURN_BINARY, false);
 
             // Sends the request.
             final RestClient restClient = getRestClient();
@@ -121,7 +121,7 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
                 public void onSuccess(RestRequest request, RestResponse response) {
                     try {
                         // Binary response
-                        if (returnResponseAsBlob) {
+                        if (returnBinary) {
                             JSONObject result = new JSONObject();
                             result.put(CONTENT_TYPE, response.getContentType());
                             result.put(ENCODED_BODY, Base64.encodeToString(response.asBytes(), Base64.DEFAULT));

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
@@ -72,7 +72,6 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
     private static final String FILE_URL_KEY = "fileUrl";
     private static final String FILE_NAME_KEY = "fileName";
     private static final String RETURN_RESPONSE_AS_BLOB = "returnResponseAsBlob";
-    private static final String CONTENT_TYPE_JSON = "application/json";
     private static final String ENCODED_BODY = "encodedBody";
     private static final String CONTENT_TYPE = "contentType";
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
@@ -50,7 +50,6 @@ import okhttp3.ResponseBody;
 public class RestResponse {
 
     private static final String CONTENT_TYPE_HEADER_KEY = "Content-Type";
-    private static final String CONTENT_TYPE_HEADER_VALUE = "application/json";
 	private static final String TAG = "RestResponse";
 
 	private final Response response;
@@ -155,32 +154,12 @@ public class RestResponse {
 		return responseAsBytes;
 	}
 
-    /**
-     * Checks if the response has a body.
-     *
-     * @return True - if response body is present, False - otherwise.
-     */
-	public boolean hasResponseBody() {
-
-        /*
-         * Parses the response headers to determine how to treat the response body,
-         * if it exists. Typically, there's no response body for a POST.
-         */
-        boolean hasResponseBody = false;
-        final Map<String, List<String>> responseHeaders = getAllHeaders();
-        if (responseHeaders != null) {
-            if (responseHeaders.containsKey(CONTENT_TYPE_HEADER_KEY)) {
-                final List<String> contentTypes = responseHeaders.get(CONTENT_TYPE_HEADER_KEY);
-                if (contentTypes != null) {
-                    for (final String contentType : contentTypes) {
-                        if (contentType != null && contentType.contains(CONTENT_TYPE_HEADER_VALUE)) {
-                            hasResponseBody = true;
-                        }
-                    }
-                }
-            }
-        }
-        return hasResponseBody;
+	/**
+	 * Return content type
+	 * @return value of content-type header or null if header not found
+	 */
+	public String getContentType() {
+		return response.header(CONTENT_TYPE_HEADER_KEY);
 	}
 
 	/**


### PR DESCRIPTION
New flag returnBinary (default false) in network plugin sendRequest method.

The native side of the network plugin will send back the base64 encoded body and the content type.