### PR TITLE
Marking KeyInterface deprecated for 7.0 and related cleanup

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/HybridApp.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/HybridApp.java
@@ -28,18 +28,15 @@ package com.salesforce.androidsdk.phonegap.app;
 
 import android.app.Application;
 
-import com.salesforce.androidsdk.analytics.security.Encryptor;
-import com.salesforce.androidsdk.app.SalesforceSDKManager.KeyInterface;
-
 /**
- * Application class used by hybrid applications
+ * Application class used by hybrid applications.
  */
 public class HybridApp extends Application {
 
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		SalesforceHybridSDKManager.initHybrid(getApplicationContext(), new HybridKeyImpl());
+		SalesforceHybridSDKManager.initHybrid(getApplicationContext());
 
 		/*
          * Uncomment the following line to enable IDP login flow. This will allow the user to
@@ -54,13 +51,5 @@ public class HybridApp extends Application {
          * to uncomment a few lines of code in SalesforceSDK library project's AndroidManifest.xml.
          */
 		// SalesforceHybridSDKManager.getInstance().setBrowserLoginEnabled(true);
-	}
-}
-
-class HybridKeyImpl implements KeyInterface {
-
-	@Override
-	public String getKey(String name) {
-        return Encryptor.hash(name + "12s9adpahk;n12-97sdainkasd=012", name + "12kl0dsakj4-cxh1qewkjasdol8");
 	}
 }

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
@@ -49,7 +49,7 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
     private static final String TAG = "SalesforceHybridSDKManager";
 
     /**
-     Paths to the assets files containing configs for SmartStore / SmartSync in hybrid apps
+     * Paths to the assets files containing configs for SmartStore / SmartSync in hybrid apps
      */
     private enum ConfigAssetPath {
 
@@ -58,7 +58,6 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
         globalSyncs("globalsyncs.json"),
         userSyncs("usersyncs.json");
 
-
         String path;
 
         ConfigAssetPath(String fileName) {
@@ -66,14 +65,28 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
         }
     }
 
+    /**
+     * Protected constructor.
+     *
+     * @param context Application context.
+     * @param mainActivity Activity that should be launched after the login flow.
+     * @param loginActivity Login activity.
+     */
+    protected SalesforceHybridSDKManager(Context context, Class<? extends Activity> mainActivity,
+                                         Class<? extends Activity> loginActivity) {
+        this(context, null, mainActivity, loginActivity);
+    }
 
     /**
      * Protected constructor.
+	 *
      * @param context Application context.
      * @param keyImpl Implementation of KeyInterface.
 	 * @param mainActivity Activity that should be launched after the login flow.
 	 * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #SalesforceHybridSDKManager(Context, Class, Class)} instead.
 	 */
+    @Deprecated
     protected SalesforceHybridSDKManager(Context context, KeyInterface keyImpl,
 								  Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
     	super(context, keyImpl, mainActivity, loginActivity);
@@ -100,16 +113,15 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
         EventsObservable.get().notifyEvent(EventType.AppCreateComplete);
 	}
 
-	/**
-	 * Initializes components required for this class
-	 * to properly function. This method should be called
-	 * by hybrid apps using the Salesforce Mobile SDK.
-	 *
-	 * @param context Application context.
-     * @param keyImpl Implementation of KeyInterface.
-	 */
-    public static void initHybrid(Context context, KeyInterface keyImpl) {
-		SalesforceHybridSDKManager.init(context, keyImpl, SalesforceDroidGapActivity.class,
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by hybrid apps using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     */
+    public static void initHybrid(Context context) {
+        SalesforceHybridSDKManager.init(context, null, SalesforceDroidGapActivity.class,
                 LoginActivity.class);
     }
 
@@ -120,12 +132,56 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
 	 *
 	 * @param context Application context.
      * @param keyImpl Implementation of KeyInterface.
-     * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initHybrid(Context)} instead.
 	 */
+	@Deprecated
+    public static void initHybrid(Context context, KeyInterface keyImpl) {
+		SalesforceHybridSDKManager.init(context, keyImpl, SalesforceDroidGapActivity.class,
+                LoginActivity.class);
+    }
+
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by hybrid apps using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     * @param loginActivity Login activity.
+     */
+    public static void initHybrid(Context context, Class<? extends Activity> loginActivity) {
+        SalesforceHybridSDKManager.init(context, null, SalesforceDroidGapActivity.class,
+                loginActivity);
+    }
+
+	/**
+	 * Initializes components required for this class
+	 * to properly function. This method should be called
+	 * by hybrid apps using the Salesforce Mobile SDK.
+	 *
+	 * @param context Application context.
+     * @param keyImpl Implementation of KeyInterface.
+     * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initHybrid(Context, Class)} instead.
+	 */
+	@Deprecated
     public static void initHybrid(Context context, KeyInterface keyImpl,
     		Class<? extends Activity> loginActivity) {
 		SalesforceHybridSDKManager.init(context, keyImpl, SalesforceDroidGapActivity.class,
 				loginActivity);
+    }
+
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by hybrid apps that use a subclass of SalesforceDroidGapActivity.
+     *
+     * @param context Application context.
+     * @param mainActivity Main activity.
+     * @param loginActivity Login activity.
+     */
+    public static void initHybrid(Context context, Class<? extends SalesforceDroidGapActivity> mainActivity,
+                                  Class<? extends Activity> loginActivity) {
+        SalesforceHybridSDKManager.init(context, null, mainActivity, loginActivity);
     }
 
 	/**
@@ -137,7 +193,9 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
      * @param keyImpl Implementation of KeyInterface.
      * @param mainActivity Main activity.
      * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initHybrid(Context, Class, Class)} instead.
 	 */
+	@Deprecated
     public static void initHybrid(Context context, KeyInterface keyImpl,
     		Class<? extends SalesforceDroidGapActivity> mainActivity,
     		Class<? extends Activity> loginActivity) {

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
@@ -74,7 +74,7 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
      */
     protected SalesforceHybridSDKManager(Context context, Class<? extends Activity> mainActivity,
                                          Class<? extends Activity> loginActivity) {
-        this(context, null, mainActivity, loginActivity);
+        super(context, mainActivity, loginActivity);
     }
 
     /**
@@ -211,7 +211,7 @@ public class SalesforceHybridSDKManager extends SmartSyncSDKManager {
     	if (INSTANCE != null) {
     		return (SmartSyncSDKManager) INSTANCE;
     	} else {
-            throw new RuntimeException("Applications need to call SmartSyncSDKManager.init() first.");
+            throw new RuntimeException("Applications need to call SalesforceHybridSDKManager.init() first.");
     	}
     }
 

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/app/SalesforceReactSDKManager.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/app/SalesforceReactSDKManager.java
@@ -29,7 +29,6 @@ package com.salesforce.androidsdk.reactnative.app;
 import android.app.Activity;
 import android.content.Context;
 
-import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -55,13 +54,28 @@ import java.util.List;
  */
 public class SalesforceReactSDKManager extends SmartSyncSDKManager {
 
+	/**
+	 * Protected constructor.
+	 *
+	 * @param context Application context.
+	 * @param mainActivity Activity that should be launched after the login flow.
+	 * @param loginActivity Login activity.
+	 */
+	protected SalesforceReactSDKManager(Context context, Class<? extends Activity> mainActivity,
+                                        Class<? extends Activity> loginActivity) {
+		super(context, mainActivity, loginActivity);
+	}
+
     /**
      * Protected constructor.
+     *
      * @param context Application context.
      * @param keyImpl Implementation of KeyInterface.
 	 * @param mainActivity Activity that should be launched after the login flow.
 	 * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #SalesforceReactSDKManager(Context, Class, Class)} instead.
 	 */
+    @Deprecated
     protected SalesforceReactSDKManager(Context context, KeyInterface keyImpl,
 								  Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
     	super(context, keyImpl, mainActivity, loginActivity);
@@ -71,6 +85,7 @@ public class SalesforceReactSDKManager extends SmartSyncSDKManager {
 	 * Initializes components required for this class
 	 * to properly function. This method should be called
 	 * by apps using the Salesforce Mobile SDK.
+     *
 	 * @param context Application context.
      * @param keyImpl Implementation of KeyInterface.
 	 * @param mainActivity Activity that should be launched after the login flow.
@@ -88,6 +103,18 @@ public class SalesforceReactSDKManager extends SmartSyncSDKManager {
         EventsObservable.get().notifyEvent(EventType.AppCreateComplete);
 	}
 
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by react native apps using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     * @param mainActivity Activity that should be launched after the login flow.
+     */
+    public static void initReactNative(Context context, Class<? extends Activity> mainActivity) {
+        SalesforceReactSDKManager.init(context, null, mainActivity, LoginActivity.class);
+    }
+
 	/**
 	 * Initializes components required for this class
 	 * to properly function. This method should be called
@@ -96,11 +123,27 @@ public class SalesforceReactSDKManager extends SmartSyncSDKManager {
 	 * @param context Application context.
 	 * @param keyImpl Implementation of KeyInterface.
 	 * @param mainActivity Activity that should be launched after the login flow.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initReactNative(Context, Class)} instead.
 	 */
+	@Deprecated
 	public static void initReactNative(Context context, KeyInterface keyImpl,
 								  Class<? extends Activity> mainActivity) {
 		SalesforceReactSDKManager.init(context, keyImpl, mainActivity, LoginActivity.class);
 	}
+
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by react native apps using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     * @param mainActivity Activity that should be launched after the login flow.
+     * @param loginActivity Login activity.
+     */
+    public static void initReactNative(Context context, Class<? extends Activity> mainActivity,
+                                       Class<? extends Activity> loginActivity) {
+        SalesforceReactSDKManager.init(context, null, mainActivity, loginActivity);
+    }
 
 	/**
 	 * Initializes components required for this class
@@ -111,7 +154,9 @@ public class SalesforceReactSDKManager extends SmartSyncSDKManager {
 	 * @param keyImpl Implementation of KeyInterface.
 	 * @param mainActivity Activity that should be launched after the login flow.
 	 * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initReactNative(Context, Class, Class)} instead.
 	 */
+	@Deprecated
 	public static void initReactNative(Context context, KeyInterface keyImpl,
 								  Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
 		SalesforceReactSDKManager.init(context, keyImpl, mainActivity, loginActivity);
@@ -126,7 +171,7 @@ public class SalesforceReactSDKManager extends SmartSyncSDKManager {
     	if (INSTANCE != null) {
     		return (SalesforceReactSDKManager) INSTANCE;
     	} else {
-            throw new RuntimeException("Applications need to call SmartSyncSDKManager.init() first.");
+            throw new RuntimeException("Applications need to call SalesforceReactSDKManager.init() first.");
     	}
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -636,7 +636,13 @@ public class SalesforceSDKManager {
      * @return True - if IDP login flow is enabled, False - otherwise.
      */
     public boolean isIDPLoginFlowEnabled() {
-        return !TextUtils.isEmpty(idpAppURIScheme);
+        boolean isIDPFlowEnabled = !TextUtils.isEmpty(idpAppURIScheme);
+        if (isIDPFlowEnabled) {
+            SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_APP_IS_SP);
+        } else {
+            SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_APP_IS_SP);
+        }
+        return isIDPFlowEnabled;
     }
 
     /**
@@ -645,18 +651,16 @@ public class SalesforceSDKManager {
      */
     private boolean isIdentityProvider() {
         try {
-            PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_ACTIVITIES);
+            PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(),
+                    PackageManager.GET_ACTIVITIES);
             for (ActivityInfo activityInfo : packageInfo.activities) {
                 if (activityInfo.name.equals(IDPAccountPickerActivity.class.getName())) {
                     return true;
                 }
             }
-
-
         } catch (NameNotFoundException e) {
             SalesforceSDKLogger.e(TAG, "Exception occurred while examining application info", e);
         }
-
         return false;
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -225,11 +225,26 @@ public class SalesforceSDKManager {
 
     /**
      * Protected constructor.
+     *
+     * @param context Application context.
+     * @param mainActivity Activity that should be launched after the login flow.
+     * @param loginActivity Login activity.
+     */
+    protected SalesforceSDKManager(Context context, Class<? extends Activity> mainActivity,
+                                   Class<? extends Activity> loginActivity) {
+        this(context, null, mainActivity, loginActivity);
+    }
+
+    /**
+     * Protected constructor.
+     *
      * @param context Application context.
      * @param keyImpl Implementation for KeyInterface.
      * @param mainActivity Activity that should be launched after the login flow.
      * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #SalesforceSDKManager(Context, Class, Class)} instead.
      */
+    @Deprecated
     protected SalesforceSDKManager(Context context, KeyInterface keyImpl,
                                    Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
         this.uid = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
@@ -300,9 +315,12 @@ public class SalesforceSDKManager {
     	}
     }
 
-    /*
-     * TODO: Mark this deprecated and remove it in Mobile SDK 7.0.
+    /**
+     * @deprecated This interface has been deprecated in Mobile SDK 6.1 and will be removed
+     * in Mobile SDK 7.0. This is required to upgrade an app built on an older version of
+     * Mobile SDK to Mobile SDK 6.x.
      */
+    @Deprecated
     public interface KeyInterface {
 
         /**
@@ -326,7 +344,11 @@ public class SalesforceSDKManager {
          *
          * @param name The name associated with the key.
          * @return The key used for encrypting salts and keys.
+         * @deprecated This interface has been deprecated in Mobile SDK 6.1 and will be removed
+         * in Mobile SDK 7.0. This is required to upgrade an app built on an older version of
+         * Mobile SDK to Mobile SDK 6.x.
          */
+        @Deprecated
         public String getKey(String name);
     }
 
@@ -348,10 +370,11 @@ public class SalesforceSDKManager {
      *
      * @param name The name associated with the key.
      * @return The key used for encrypting salts and keys.
+     * @deprecated This interface has been deprecated in Mobile SDK 6.1 and will be removed
+     * in Mobile SDK 7.0. This is required to upgrade an app built on an older version of
+     * Mobile SDK to Mobile SDK 6.x.
      */
-    /*
-     * TODO: Mark this deprecated and remove it in Mobile SDK 7.0.
-     */
+    @Deprecated
     public String getKey(String name) {
     	String key = null;
     	if (keyImpl != null) {
@@ -447,11 +470,37 @@ public class SalesforceSDKManager {
      * this method before using the Salesforce Mobile SDK.
      *
      * @param context Application context.
-     * @param keyImpl Implementation of KeyInterface.
      * @param mainActivity Activity that should be launched after the login flow.
      */
+    public static void initNative(Context context, Class<? extends Activity> mainActivity) {
+        SalesforceSDKManager.init(context, null, mainActivity, LoginActivity.class);
+    }
+
+    /**
+     * Initializes required components. Native apps must call one overload of
+     * this method before using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     * @param keyImpl Implementation of KeyInterface.
+     * @param mainActivity Activity that should be launched after the login flow.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initNative(Context, Class)} instead.
+     */
+    @Deprecated
     public static void initNative(Context context, KeyInterface keyImpl, Class<? extends Activity> mainActivity) {
         SalesforceSDKManager.init(context, keyImpl, mainActivity, LoginActivity.class);
+    }
+
+    /**
+     * Initializes required components. Native apps must call one overload of
+     * this method before using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     * @param mainActivity Activity that should be launched after the login flow.
+     * @param loginActivity Login activity.
+     */
+    public static void initNative(Context context, Class<? extends Activity> mainActivity,
+                                  Class<? extends Activity> loginActivity) {
+        SalesforceSDKManager.init(context, null, mainActivity, loginActivity);
     }
 
     /**
@@ -462,7 +511,9 @@ public class SalesforceSDKManager {
      * @param keyImpl Implementation of KeyInterface.
      * @param mainActivity Activity that should be launched after the login flow.
      * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initNative(Context, Class, Class)} instead.
      */
+    @Deprecated
     public static void initNative(Context context, KeyInterface keyImpl,
                                   Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
         SalesforceSDKManager.init(context, keyImpl, mainActivity, loginActivity);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -66,10 +66,24 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * Protected constructor.
      *
      * @param context       Application context.
-     * @param keyImpl       Implementation of KeyInterface.
      * @param mainActivity  Activity that should be launched after the login flow.
      * @param loginActivity Login activity.
      */
+    protected SmartStoreSDKManager(Context context, Class<? extends Activity> mainActivity,
+                                   Class<? extends Activity> loginActivity) {
+        this(context, null, mainActivity, loginActivity);
+    }
+
+    /**
+     * Protected constructor.
+     *
+     * @param context       Application context.
+     * @param keyImpl       Implementation of KeyInterface.
+     * @param mainActivity  Activity that should be launched after the login flow.
+     * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #SmartStoreSDKManager(Context, Class, Class)} instead.
+     */
+    @Deprecated
     protected SmartStoreSDKManager(Context context, KeyInterface keyImpl,
                                    Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
         super(context, keyImpl, mainActivity, loginActivity);
@@ -103,13 +117,39 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * by native apps using the Salesforce Mobile SDK.
      *
      * @param context      Application context.
-     * @param keyImpl      Implementation of KeyInterface.
      * @param mainActivity Activity that should be launched after the login flow.
      */
-    public static void initNative(Context context, KeyInterface keyImpl,
-                                  Class<? extends Activity> mainActivity) {
-        SmartStoreSDKManager.init(context, keyImpl, mainActivity,
-                LoginActivity.class);
+    public static void initNative(Context context, Class<? extends Activity> mainActivity) {
+        SmartStoreSDKManager.init(context, null, mainActivity, LoginActivity.class);
+    }
+
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by native apps using the Salesforce Mobile SDK.
+     *
+     * @param context      Application context.
+     * @param keyImpl      Implementation of KeyInterface.
+     * @param mainActivity Activity that should be launched after the login flow.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initNative(Context, Class)} instead.
+     */
+    @Deprecated
+    public static void initNative(Context context, KeyInterface keyImpl, Class<? extends Activity> mainActivity) {
+        SmartStoreSDKManager.init(context, keyImpl, mainActivity, LoginActivity.class);
+    }
+
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by native apps using the Salesforce Mobile SDK.
+     *
+     * @param context       Application context.
+     * @param mainActivity  Activity that should be launched after the login flow.
+     * @param loginActivity Login activity.
+     */
+    public static void initNative(Context context, Class<? extends Activity> mainActivity,
+                                  Class<? extends Activity> loginActivity) {
+        SmartStoreSDKManager.init(context, null, mainActivity, loginActivity);
     }
 
     /**
@@ -121,7 +161,9 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * @param keyImpl       Implementation of KeyInterface.
      * @param mainActivity  Activity that should be launched after the login flow.
      * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initNative(Context, Class, Class)} instead.
      */
+    @Deprecated
     public static void initNative(Context context, KeyInterface keyImpl,
                                   Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
         SmartStoreSDKManager.init(context, keyImpl, mainActivity, loginActivity);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -71,7 +71,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      */
     protected SmartStoreSDKManager(Context context, Class<? extends Activity> mainActivity,
                                    Class<? extends Activity> loginActivity) {
-        this(context, null, mainActivity, loginActivity);
+        super(context, mainActivity, loginActivity);
     }
 
     /**

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
@@ -59,7 +59,7 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
 	 */
 	protected SmartSyncSDKManager(Context context, Class<? extends Activity> mainActivity,
                                   Class<? extends Activity> loginActivity) {
-		this(context, null, mainActivity, loginActivity);
+		super(context, mainActivity, loginActivity);
 	}
 
 	/**

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
@@ -51,12 +51,27 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
 	private static final String TAG = "SmartSyncSDKManager";
 
 	/**
+	 * Protected constructor.
+     *
+	 * @param context Application context.
+	 * @param mainActivity Activity that should be launched after the login flow.
+	 * @param loginActivity Login activity.
+	 */
+	protected SmartSyncSDKManager(Context context, Class<? extends Activity> mainActivity,
+                                  Class<? extends Activity> loginActivity) {
+		this(context, null, mainActivity, loginActivity);
+	}
+
+	/**
      * Protected constructor.
+     *
      * @param context Application context.
      * @param keyImpl Implementation of KeyInterface.
 	 * @param mainActivity Activity that should be launched after the login flow.
 	 * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #SmartSyncSDKManager(Context, Class, Class)} instead.
 	 */
+	@Deprecated
     protected SmartSyncSDKManager(Context context, KeyInterface keyImpl,
 								  Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
     	super(context, keyImpl, mainActivity, loginActivity);
@@ -66,6 +81,7 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
 	 * Initializes components required for this class
 	 * to properly function. This method should be called
 	 * by apps using the Salesforce Mobile SDK.
+     *
 	 * @param context Application context.
      * @param keyImpl Implementation of KeyInterface.
 	 * @param mainActivity Activity that should be launched after the login flow.
@@ -83,6 +99,18 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
         EventsObservable.get().notifyEvent(EventType.AppCreateComplete);
 	}
 
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by native apps using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     * @param mainActivity Activity that should be launched after the login flow.
+     */
+    public static void initNative(Context context, Class<? extends Activity> mainActivity) {
+        SmartSyncSDKManager.init(context, null, mainActivity, LoginActivity.class);
+    }
+
 	/**
 	 * Initializes components required for this class
 	 * to properly function. This method should be called
@@ -91,10 +119,26 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
 	 * @param context Application context.
      * @param keyImpl Implementation of KeyInterface.
      * @param mainActivity Activity that should be launched after the login flow.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initNative(Context, Class)} instead.
 	 */
+	@Deprecated
     public static void initNative(Context context, KeyInterface keyImpl,
     		Class<? extends Activity> mainActivity) {
     	SmartSyncSDKManager.init(context, keyImpl, mainActivity, LoginActivity.class);
+    }
+
+    /**
+     * Initializes components required for this class
+     * to properly function. This method should be called
+     * by native apps using the Salesforce Mobile SDK.
+     *
+     * @param context Application context.
+     * @param mainActivity Activity that should be launched after the login flow.
+     * @param loginActivity Login activity.
+     */
+    public static void initNative(Context context, Class<? extends Activity> mainActivity,
+                                  Class<? extends Activity> loginActivity) {
+        SmartSyncSDKManager.init(context, null, mainActivity, loginActivity);
     }
 
 	/**
@@ -106,7 +150,9 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
      * @param keyImpl Implementation of KeyInterface.
      * @param mainActivity Activity that should be launched after the login flow.
      * @param loginActivity Login activity.
+     * @deprecated Will be removed in Mobile SDK 7.0. Use {@link #initNative(Context, Class, Class)} instead.
 	 */
+	@Deprecated
     public static void initNative(Context context, KeyInterface keyImpl,
     		Class<? extends Activity> mainActivity, Class<? extends Activity> loginActivity) {
     	SmartSyncSDKManager.init(context, keyImpl, mainActivity, loginActivity);
@@ -169,5 +215,4 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
 		SyncsConfig config = new SyncsConfig(context, resourceId);
 		config.createSyncs(store);
 	}
-
 }

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridTestApp.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridTestApp.java
@@ -39,6 +39,7 @@ public class SalesforceHybridTestApp extends Application {
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		SalesforceHybridSDKManager.initHybrid(getApplicationContext(), null, SalesforceHybridTestActivity.class, LoginActivity.class);
+		SalesforceHybridSDKManager.initHybrid(getApplicationContext(),
+				SalesforceHybridTestActivity.class, LoginActivity.class);
 	}
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/TestForceApp.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/TestForceApp.java
@@ -39,7 +39,7 @@ public class TestForceApp extends Application {
 
     @Override
     public void onCreate() {
-    	SalesforceSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
+    	SalesforceSDKManager.initNative(getApplicationContext(), MainActivity.class);
     	super.onCreate();
     	SalesforceSDKManager.getInstance().setIsTestRun(true);
     }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/TestForceApp.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/TestForceApp.java
@@ -40,7 +40,7 @@ public class TestForceApp extends Application {
 
     @Override
     public void onCreate() {
-    	SmartStoreSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
+    	SmartStoreSDKManager.initNative(getApplicationContext(), MainActivity.class);
     	super.onCreate();
     	SalesforceSDKManager.getInstance().setIsTestRun(true);
     }

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/TestForceApp.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/TestForceApp.java
@@ -39,7 +39,7 @@ public class TestForceApp extends Application {
 
     @Override
     public void onCreate() {
-    	SmartSyncSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
+    	SmartSyncSDKManager.initNative(getApplicationContext(), MainActivity.class);
     	super.onCreate();
     	SmartSyncSDKManager.getInstance().setIsTestRun(true);
     }

--- a/native/NativeSampleApps/ConfiguredApp/src/com/salesforce/samples/configuredapp/ConfiguredApp.java
+++ b/native/NativeSampleApps/ConfiguredApp/src/com/salesforce/samples/configuredapp/ConfiguredApp.java
@@ -39,7 +39,7 @@ public class ConfiguredApp extends Application {
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		SalesforceSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
+		SalesforceSDKManager.initNative(getApplicationContext(), MainActivity.class);
 
 		/*
          * Uncomment the following line to enable IDP login flow. This will allow the user to
@@ -56,5 +56,3 @@ public class ConfiguredApp extends Application {
 		// SalesforceSDKManager.getInstance().setBrowserLoginEnabled(true);
 	}
 }
-
-

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
@@ -38,7 +38,7 @@ public class RestExplorerApp extends Application {
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		SalesforceSDKManager.initNative(getApplicationContext(), null, ExplorerActivity.class);
+		SalesforceSDKManager.initNative(getApplicationContext(), ExplorerActivity.class);
 
 		/*
          * Uncomment the following line to enable IDP login flow. This will allow the user to

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
@@ -39,7 +39,7 @@ public class SmartSyncExplorerApp extends Application {
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		SmartSyncSDKManager.initNative(getApplicationContext(), null, MainActivity.class);
+		SmartSyncSDKManager.initNative(getApplicationContext(), MainActivity.class);
 
 		/*
          * Uncomment the following line to enable IDP login flow. This will allow the user to


### PR DESCRIPTION
In `Mobile SDK 6.0` we decoupled encryption from the passcode, thereby making `KeyInterface` unused. It was required in `6.0` for the upgrade. In this PR I'm marking it deprecated, to be removed in `Mobile SDK 7.0`. I have added equivalent `init` methods in the `SDKManager` classes that don't take `KeyInterface` in and marked the existing ones that take `KeyInterface` in deprecated. Also updated the corresponding calls from sample apps and tests. No code changes really.