### PR TITLE
Deprecating SalesforceR and removing all usage of it

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -389,7 +389,9 @@ public class SalesforceSDKManager {
      *
      * Since 1.3, SalesforceSDK is packaged as a library project, so the SalesforceR subclass is no longer needed.
      * @return SalesforceR object which allows reference to resources living outside the SDK.
+     * @deprecated Will be removed in Mobile SDK 7.0. Resources can be referenced directly in a library project.
      */
+    @Deprecated
     public SalesforceR getSalesforceR() {
         return salesforceR;
     }
@@ -1178,7 +1180,7 @@ public class SalesforceSDKManager {
      * @return Account type string.
      */
     public String getAccountType() {
-        return context.getString(getSalesforceR().stringAccountType());
+        return context.getString(R.string.account_type);
     }
 
     @Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
@@ -32,9 +32,8 @@ import android.content.SharedPreferences.Editor;
 import android.content.res.XmlResourceParser;
 import android.text.TextUtils;
 
-import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.config.RuntimeConfig.ConfigKey;
-import com.salesforce.androidsdk.ui.SalesforceR;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
 import org.xmlpull.v1.XmlPullParserException;
@@ -289,12 +288,11 @@ public class LoginServerManager {
 	 * (only called when servers.xml is missing).
 	 */
 	private List<LoginServer> getLegacyLoginServers() {
-		final SalesforceR salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
 		final List<LoginServer> loginServers = new ArrayList<LoginServer>();
-		final LoginServer productionServer = new LoginServer(ctx.getString(salesforceR.stringAuthLoginProduction()),
+		final LoginServer productionServer = new LoginServer(ctx.getString(R.string.sf__auth_login_production),
 				PRODUCTION_LOGIN_URL, false);
 		loginServers.add(productionServer);
-		final LoginServer sandboxServer = new LoginServer(ctx.getString(salesforceR.stringAuthLoginSandbox()),
+		final LoginServer sandboxServer = new LoginServer(ctx.getString(R.string.sf__auth_login_sandbox),
 				SANDBOX_LOGIN_URL, false);
 		loginServers.add(sandboxServer);
 		return loginServers;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/AccountSwitcherActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/AccountSwitcherActivity.java
@@ -31,6 +31,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.RadioGroup;
 
+import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
@@ -46,15 +47,13 @@ import java.util.List;
  */
 public class AccountSwitcherActivity extends Activity {
 
-	protected SalesforceR salesforceR;
 	protected UserAccountManager userAccMgr;
 
 	@Override
 	public void onCreate(Bundle savedInstance) {
 		super.onCreate(savedInstance);
-        salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
 		userAccMgr = SalesforceSDKManager.getInstance().getUserAccountManager();
-		setContentView(salesforceR.layoutAccountSwitcher());
+		setContentView(R.layout.sf__account_switcher);
 	}
 
 	@Override
@@ -71,7 +70,7 @@ public class AccountSwitcherActivity extends Activity {
 	 * @param v View that was clicked.
 	 */
 	public void switchToExistingAccount(View v) {
-        final RadioGroup radioGroup = findViewById(salesforceR.idAccountListGroup());
+        final RadioGroup radioGroup = findViewById(R.id.sf__accounts_group);
         int checkedId = radioGroup.getCheckedRadioButtonId();
 		final SalesforceAccountRadioButton rb = radioGroup.findViewById(checkedId);
 		if (rb != null) {
@@ -122,7 +121,7 @@ public class AccountSwitcherActivity extends Activity {
     }
 
 	private void buildAccountList() {
-        final RadioGroup radioGroup = findViewById(salesforceR.idAccountListGroup());
+        final RadioGroup radioGroup = findViewById(R.id.sf__accounts_group);
         radioGroup.removeAllViews();
         UserAccount curAccount = userAccMgr.getCurrentUser();
         final List<UserAccount> accounts = getAccounts();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/CustomServerUrlEditor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/CustomServerUrlEditor.java
@@ -41,6 +41,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.config.LoginServerManager;
 
@@ -50,7 +51,6 @@ import com.salesforce.androidsdk.config.LoginServerManager;
 public class CustomServerUrlEditor extends DialogFragment {
 
 	boolean isDefault;
-	private SalesforceR salesforceR;
 	private LoginServerManager loginServerManager;
 	private Context context;
 	private View rootView;
@@ -61,9 +61,6 @@ public class CustomServerUrlEditor extends DialogFragment {
 	public CustomServerUrlEditor() {
 		context = SalesforceSDKManager.getInstance().getAppContext();
 
-		// Object which allows reference to resources living outside the SDK.
-		salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
-
 		// Login server manager.
 		loginServerManager = SalesforceSDKManager.getInstance().getLoginServerManager();
 	}
@@ -71,31 +68,31 @@ public class CustomServerUrlEditor extends DialogFragment {
 	@Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
-        rootView = inflater.inflate(salesforceR.layoutCustomServerUrl(), container);
-        final String label = getEditDefaultValue((salesforceR.idPickerCustomLabel()));
-		final String urlValue = getEditDefaultValue((salesforceR.idPickerCustomUrl()));
-		isDefault = urlValue.equals(getString(salesforceR.stringServerUrlDefaultCustomUrl()));
+        rootView = inflater.inflate(R.layout.sf__custom_server_url, container);
+        final String label = getEditDefaultValue(R.id.sf__picker_custom_label);
+		final String urlValue = getEditDefaultValue(R.id.sf__picker_custom_url);
+		isDefault = urlValue.equals(getString(R.string.sf__server_url_default_custom_url));
 		if (isDefault) {
-			getDialog().setTitle(salesforceR.stringServerUrlAddTitle());
+			getDialog().setTitle(R.string.sf__server_url_add_title);
 		} else {
-			getDialog().setTitle(salesforceR.stringServerUrlEditTitle());
+			getDialog().setTitle(R.string.sf__server_url_edit_title);
 		}
-		setEditText(salesforceR.idPickerCustomLabel(), label);
-		setEditText(salesforceR.idPickerCustomUrl(), urlValue);
+		setEditText(R.id.sf__picker_custom_label, label);
+		setEditText(R.id.sf__picker_custom_url, urlValue);
 
 		/*
 		 * Sets handlers in the code for the dialog. 
 		 */
-		final Button applyBtn = (Button) rootView.findViewById(salesforceR.idApplyButton());
+		final Button applyBtn = rootView.findViewById(R.id.sf__apply_button);
 		applyBtn.setOnClickListener(new View.OnClickListener() {
 
 			@Override
 			public void onClick(View v) {
-				final String lbl = validateInput(salesforceR.idPickerCustomLabel());
+				final String lbl = validateInput(R.id.sf__picker_custom_label);
 				if (lbl == null) {
 					return;
 				}
-				final String val = validateInput(salesforceR.idPickerCustomUrl());
+				final String val = validateInput(R.id.sf__picker_custom_url);
 				if (val == null) {
 					return;
 				}
@@ -105,7 +102,7 @@ public class CustomServerUrlEditor extends DialogFragment {
 				dismiss();
 			}
 		});
-		final Button cancelBtn = (Button) rootView.findViewById(salesforceR.idCancelButton());
+		final Button cancelBtn = rootView.findViewById(R.id.sf__cancel_button);
 		cancelBtn.setOnClickListener(new View.OnClickListener() {
 
 			@Override
@@ -137,7 +134,7 @@ public class CustomServerUrlEditor extends DialogFragment {
 		if (value == null) {
 			throw new RuntimeException("Value cannot be null");
 		}
-		final EditText et = (EditText) rootView.findViewById(editId);
+		final EditText et = rootView.findViewById(editId);
 		final SpannableString labelSpan = new SpannableString(value);
 		if (et != null) {
 			et.setText(labelSpan);
@@ -152,10 +149,10 @@ public class CustomServerUrlEditor extends DialogFragment {
 						if (hasFocus && isDefaultValue) {
 							et.getText().clear();
 						} else if (!hasFocus && et.getText().toString().equals("")) {
-							if (et.getId() == salesforceR.idPickerCustomLabel()) {
-								setEditText(salesforceR.idPickerCustomLabel(), getEditDefaultValue(et.getId()));
+							if (et.getId() == R.id.sf__picker_custom_label) {
+								setEditText(R.id.sf__picker_custom_label, getEditDefaultValue(et.getId()));
 							} else {
-								setEditText(salesforceR.idPickerCustomUrl(), getEditDefaultValue(et.getId()));
+								setEditText(R.id.sf__picker_custom_url, getEditDefaultValue(et.getId()));
 							}
 						}
 					}
@@ -165,7 +162,7 @@ public class CustomServerUrlEditor extends DialogFragment {
 	}
 
 	private String validateInput(int editId) {
-		final EditText et = (EditText) rootView.findViewById(editId);
+		final EditText et = rootView.findViewById(editId);
 		final Editable etVal = et.getText();
 		boolean isInvalidValue = etVal.toString().equals(getEditDefaultValue(editId))
 				|| etVal.toString().equals("");
@@ -173,10 +170,10 @@ public class CustomServerUrlEditor extends DialogFragment {
 		/*
 		 * Ensures that the URL is a 'https://' URL, since OAuth requires 'https://'.
 		 */
-		if (editId == salesforceR.idPickerCustomUrl()) {
+		if (editId == R.id.sf__picker_custom_url) {
 			isInvalidValue = !URLUtil.isHttpsUrl(etVal.toString());
 			if (isInvalidValue) {
-				Toast.makeText(context, getString(salesforceR.stringInvalidServerUrl()),
+				Toast.makeText(context, getString(R.string.sf__invalid_server_url),
 						Toast.LENGTH_SHORT).show();
 			}
 		}
@@ -189,10 +186,10 @@ public class CustomServerUrlEditor extends DialogFragment {
 	}
 
 	private String getEditDefaultValue(int editId) {
-		if (editId == salesforceR.idPickerCustomLabel()) {
-			return getString(salesforceR.stringServerUrlDefaultCustomLabel());
+		if (editId == R.id.sf__picker_custom_label) {
+			return getString(R.string.sf__server_url_default_custom_label);
 		} else { 
-			return getString(salesforceR.stringServerUrlDefaultCustomUrl());
+			return getString(R.string.sf__server_url_default_custom_url);
 		}
 	}
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
@@ -47,7 +47,7 @@ import android.view.Window;
 import android.widget.Button;
 import android.widget.TextView;
 
-import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.R;
 
 import javax.crypto.Cipher;
 
@@ -60,7 +60,6 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
 
     private Button mCancelButton;
     private TextView mStatusText;
-    private SalesforceR salesforceR;
     private Cipher mCipher;
     private PasscodeActivity mContext;
 
@@ -70,7 +69,6 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
         // Do not create a new Fragment when the Activity is re-created such as orientation changes.
         setRetainInstance(true);
         setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);
-        salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
     }
 
     @Override
@@ -83,6 +81,7 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
                 return;
             }
             fingerprintManager.authenticate(new CryptoObject(mCipher), null, 0, new AuthenticationCallback() {
+
                 @Override
                 public void onAuthenticationError(int errorCode, CharSequence errString) {
                     super.onAuthenticationError(errorCode, errString);
@@ -92,7 +91,7 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
                 public void onAuthenticationSucceeded(AuthenticationResult result) {
                     super.onAuthenticationSucceeded(result);
                     if (mStatusText != null) {
-                        mStatusText.setText(salesforceR.idFingerprintSuccessString());
+                        mStatusText.setText(R.string.sf__fingerprint_success);
                         mStatusText.setTextColor(Color.GREEN);
                     }
                     if (FingerprintAuthDialogFragment.this.getFragmentManager() != null) {
@@ -105,7 +104,7 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
                 public void onAuthenticationFailed() {
                     super.onAuthenticationFailed();
                     if (mStatusText != null) {
-                        mStatusText.setText(salesforceR.idFingerprintFailureString());
+                        mStatusText.setText(R.string.sf__fingerprint_failed);
                         mStatusText.setTextColor(Color.RED);
                     }
                 }
@@ -124,8 +123,7 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Dialog dialog =  super.onCreateDialog(savedInstanceState);
-        //Hide the title from the dialog
+        final Dialog dialog =  super.onCreateDialog(savedInstanceState);
         dialog.getWindow().requestFeature(Window.FEATURE_NO_TITLE);
         return dialog;
     }
@@ -133,15 +131,15 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
-        View v = inflater.inflate(salesforceR.idFingerprintDialog(), container, false);
-        mCancelButton = (Button) v.findViewById(salesforceR.idFingerprintCancelButton());
+        final View v = inflater.inflate(R.layout.sf__fingerprint_dialog, container, false);
+        mCancelButton = v.findViewById(R.id.sf__use_password_button);
         mCancelButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 dismiss();
             }
         });
-        mStatusText = (TextView) v.findViewById(salesforceR.idFingerprintStatusText());
+        mStatusText = (TextView) v.findViewById(R.id.sf__fingerprint_status);
         return v;
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -84,7 +84,6 @@ public class LoginActivity extends AccountAuthenticatorActivity
     public static final int PICK_SERVER_REQUEST_CODE = 10;
     private static final String TAG = "LoginActivity";
 
-    private SalesforceR salesforceR;
 	private boolean wasBackgrounded;
 	private OAuthWebviewHelper webviewHelper;
     private ChangeServerReceiver changeServerReceiver;
@@ -99,9 +98,6 @@ public class LoginActivity extends AccountAuthenticatorActivity
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-        // Object which allows reference to resources living outside the SDK
-        salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
-
         // Getting login options from intent's extras
         final LoginOptions loginOptions = LoginOptions.fromBundle(getIntent().getExtras());
 
@@ -110,14 +106,14 @@ public class LoginActivity extends AccountAuthenticatorActivity
                 WindowManager.LayoutParams.FLAG_SECURE);
 
         // Setup content view
-        setContentView(salesforceR.layoutLogin());
+        setContentView(R.layout.sf__login);
 		if (SalesforceSDKManager.getInstance().isIDPLoginFlowEnabled()) {
             final Button button = findViewById(R.id.sf__idp_login_button);
             button.setVisibility(View.VISIBLE);
         }
 
         // Setup the WebView.
-        final WebView webView = findViewById(salesforceR.idLoginWebView());
+        final WebView webView = findViewById(R.id.sf__oauth_webview);
         final WebSettings webSettings = webView.getSettings();
         webSettings.setUseWideViewPort(true);
         webSettings.setLayoutAlgorithm(LayoutAlgorithm.NORMAL);
@@ -290,20 +286,20 @@ public class LoginActivity extends AccountAuthenticatorActivity
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(salesforceR.menuLogin(), menu);
+        getMenuInflater().inflate(R.menu.sf__login, menu);
         return super.onCreateOptionsMenu(menu);
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         int itemId = item.getItemId();
-		if (itemId == salesforceR.idItemClearCookies()) {
+		if (itemId == R.id.sf__menu_clear_cookies) {
         	onClearCookiesClick(null);
         	return true;
-        } else if (itemId == salesforceR.idItemPickServer()) {
+        } else if (itemId == R.id.sf__menu_pick_server) {
         	onPickServerClick(null);
         	return true;
-        } else if (itemId == salesforceR.idItemReload()) {
+        } else if (itemId == R.id.sf__menu_reload) {
         	onReloadClick(null);
         	return true;
         } else {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
@@ -31,6 +31,7 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 
+import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
 /**
@@ -41,14 +42,12 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
  */
 public class ManageSpaceActivity extends Activity {
 
-	private SalesforceR salesforceR;
 	private AlertDialog manageSpaceDialog;
 
 	@Override
 	public void onCreate(Bundle savedState) {
 		super.onCreate(savedState);
-		salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
-		setContentView(salesforceR.layoutManageSpace());
+		setContentView(R.layout.sf__manage_space);
 		manageSpaceDialog = buildManageSpaceDialog();
 		manageSpaceDialog.show();
 	}
@@ -68,15 +67,15 @@ public class ManageSpaceActivity extends Activity {
 	 */
     protected AlertDialog buildManageSpaceDialog() {
         return new AlertDialog.Builder(this)
-        .setMessage(salesforceR.stringManageSpaceConfirmation())
-        .setPositiveButton(getString(salesforceR.stringPasscodeLogoutYes()),
+        .setMessage(R.string.sf__manage_space_confirmation)
+        .setPositiveButton(getString(R.string.sf__passcode_logout_yes),
         new DialogInterface.OnClickListener() {
 
         	@Override
         	public void onClick(DialogInterface dialog, int which) {
         		SalesforceSDKManager.getInstance().logout(ManageSpaceActivity.this, false);
         	}
-        }).setNegativeButton(getString(salesforceR.stringPasscodeLogoutNo()),
+        }).setNegativeButton(getString(R.string.sf__passcode_logout_no),
         new DialogInterface.OnClickListener() {
 
         	@Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -274,7 +274,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
     protected void showError(Exception exception) {
         Toast.makeText(getContext(),
-                getContext().getString(SalesforceSDKManager.getInstance().getSalesforceR().stringGenericError(), exception.toString()),
+                getContext().getString(R.string.sf__generic_error, exception.toString()),
                 Toast.LENGTH_LONG).show();
     }
 
@@ -449,19 +449,16 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
         @Override
         public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
             int primError = error.getPrimaryError();
-
-            // Figuring out string resource id
-            SalesforceR r = SalesforceSDKManager.getInstance().getSalesforceR();
-            int primErrorStringId = r.stringSSLUnknownError();
+            int primErrorStringId = R.string.sf__ssl_unknown_error;
             switch (primError) {
-                case SslError.SSL_EXPIRED:      primErrorStringId = r.stringSSLExpired(); break;
-                case SslError.SSL_IDMISMATCH:   primErrorStringId = r.stringSSLIdMismatch(); break;
-                case SslError.SSL_NOTYETVALID:  primErrorStringId = r.stringSSLNotYetValid(); break;
-                case SslError.SSL_UNTRUSTED:    primErrorStringId = r.stringSSLUntrusted(); break;
+                case SslError.SSL_EXPIRED:      primErrorStringId = R.string.sf__ssl_expired; break;
+                case SslError.SSL_IDMISMATCH:   primErrorStringId = R.string.sf__ssl_id_mismatch; break;
+                case SslError.SSL_NOTYETVALID:  primErrorStringId = R.string.sf__ssl_not_yet_valid; break;
+                case SslError.SSL_UNTRUSTED:    primErrorStringId = R.string.sf__ssl_untrusted; break;
             }
 
             // Building text message to show
-            String text = getContext().getString(r.stringSSLError(), getContext().getString(primErrorStringId));
+            String text = getContext().getString(R.string.sf__ssl_error, getContext().getString(primErrorStringId));
             SalesforceSDKLogger.e(TAG, "Received SSL error for server: " + text);
 
             // Bringing up toast
@@ -516,8 +513,8 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
         private void handleJWTError() {
             final SalesforceSDKManager mgr = SalesforceSDKManager.getInstance();
-            onAuthFlowError(getContext().getString(mgr.getSalesforceR().stringGenericAuthenticationErrorTitle()),
-                    getContext().getString(mgr.getSalesforceR().stringJWTAuthenticationErrorBody()), backgroundException);
+            onAuthFlowError(getContext().getString(R.string.sf__generic_authentication_error_title),
+                    getContext().getString(R.string.sf__jwt_authentication_error), backgroundException);
         }
     }
 
@@ -553,16 +550,16 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             // Failure cases.
             if (backgroundException != null) {
                 SalesforceSDKLogger.w(TAG, "Exception thrown while retrieving token response", backgroundException);
-                onAuthFlowError(getContext().getString(mgr.getSalesforceR().stringGenericAuthenticationErrorTitle()),
-                        getContext().getString(mgr.getSalesforceR().stringGenericAuthenticationErrorBody()), backgroundException);
+                onAuthFlowError(getContext().getString(R.string.sf__generic_authentication_error_title),
+                        getContext().getString(R.string.sf__generic_authentication_error), backgroundException);
                 callback.finish(null);
                 return;
             }
             if (id.customPermissions != null) {
                 final boolean mustBeManagedApp = id.customPermissions.optBoolean(MUST_BE_MANAGED_APP_PERM);
                 if (mustBeManagedApp && !RuntimeConfig.getRuntimeConfig(getContext()).isManagedApp()) {
-                    onAuthFlowError(getContext().getString(mgr.getSalesforceR().stringGenericAuthenticationErrorTitle()),
-                            getContext().getString(mgr.getSalesforceR().stringManagedAppError()), backgroundException);
+                    onAuthFlowError(getContext().getString(R.string.sf__generic_authentication_error_title),
+                            getContext().getString(R.string.sf__managed_app_error), backgroundException);
                     callback.finish(null);
                     return;
                 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
@@ -49,6 +49,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
+import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
@@ -74,7 +75,6 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
     private EditText entry;
     private PasscodeManager passcodeManager;
     private String firstPasscode;
-    private SalesforceR salesforceR;
     private boolean logoutEnabled;
     private AlertDialog logoutAlertDialog;
     private boolean isLogoutAlertShowing;
@@ -91,9 +91,6 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        // Object which allows reference to resources living outside the SDK.
-        salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
 
         // Protect against screenshots.
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
@@ -266,6 +263,9 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
         return false;
     }
 
+    /*
+     * TODO: Remove this method, along with the one in UpgradeManager, in Mobile SDK 7.0.
+     */
     private void performUpgradeStep(String passcode) {
         final String oldKey = passcodeManager.getLegacyEncryptionKey(passcode);
         final String newKey = SalesforceSDKManager.getEncryptionKey();
@@ -305,87 +305,93 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
     }
 
     protected int getLayoutId() {
-        return salesforceR.layoutPasscode();
+        return R.layout.sf__passcode;
     }
 
     protected TextView getTitleView() {
-        return (TextView) findViewById(salesforceR.idPasscodeTitle());
+        return (TextView) findViewById(R.id.sf__passcode_title);
     }
 
     protected TextView getForgotPasscodeView() {
-        return (TextView) findViewById(salesforceR.idPasscodeForgot());
+        return (TextView) findViewById(R.id.sf__passcode_forgot);
     }
 
     protected TextView getErrorView() {
-        return (TextView) findViewById(salesforceR.idPasscodeError());
+        return (TextView) findViewById(R.id.sf__passcode_error);
     }
 
     protected TextView getInstructionsView() {
-        return (TextView) findViewById(salesforceR.idPasscodeInstructions());
+        return (TextView) findViewById(R.id.sf__passcode_instructions);
     }
 
     protected EditText getEntryView() {
-        return (EditText) findViewById(salesforceR.idPasscodeText());
+        return (EditText) findViewById(R.id.sf__passcode_text);
     }
 
     protected String getCreateTitle() {
-    	return String.format(getString(salesforceR.stringPasscodeCreateTitle()), SalesforceSDKManager.getInstance().getAppDisplayString());
+    	return String.format(getString(R.string.sf__passcode_create_title),
+                SalesforceSDKManager.getInstance().getAppDisplayString());
     }
 
     protected String getEnterTitle() {
-    	return String.format(getString(salesforceR.stringPasscodeEnterTitle()), SalesforceSDKManager.getInstance().getAppDisplayString());
+    	return String.format(getString(R.string.sf__passcode_enter_title),
+                SalesforceSDKManager.getInstance().getAppDisplayString());
     }
 
     protected String getConfirmTitle() {
-    	return String.format(getString(salesforceR.stringPasscodeConfirmTitle()), SalesforceSDKManager.getInstance().getAppDisplayString());
+    	return String.format(getString(R.string.sf__passcode_confirm_title),
+                SalesforceSDKManager.getInstance().getAppDisplayString());
     }
 
     protected String getEnterInstructions() {
-    	return String.format(getString(salesforceR.stringPasscodeEnterInstructions()), SalesforceSDKManager.getInstance().getAppDisplayString());
+    	return String.format(getString(R.string.sf__passcode_enter_instructions),
+                SalesforceSDKManager.getInstance().getAppDisplayString());
     }
 
     protected String getForgotPasscodeString() {
-        return getString(salesforceR.stringPasscodeForgot());
+        return getString(R.string.sf__passcode_forgot_string);
     }
 
     protected String getLogoutConfirmationString() {
-        return getString(salesforceR.stringPasscodeLogoutConfirmation());
+        return getString(R.string.sf__passcode_logout_confirmation);
     }
 
     protected String getLogoutYesString() {
-        return getString(salesforceR.stringPasscodeLogoutYes());
+        return getString(R.string.sf__passcode_logout_yes);
     }
 
     protected String getLogoutNoString() {
-        return getString(salesforceR.stringPasscodeLogoutNo());
+        return getString(R.string.sf__passcode_logout_no);
     }
 
     protected String getCreateInstructions() {
-    	return String.format(getString(salesforceR.stringPasscodeCreateInstructions()), SalesforceSDKManager.getInstance().getAppDisplayString());
+    	return String.format(getString(R.string.sf__passcode_create_instructions),
+                SalesforceSDKManager.getInstance().getAppDisplayString());
     }
 
     protected String getChangeInstructions() {
-    	return getString(salesforceR.stringPasscodeChangeInstructions());
+    	return getString(R.string.sf__passcode_change_instructions);
     }
 
     protected String getConfirmInstructions() {
-    	return String.format(getString(salesforceR.stringPasscodeConfirmInstructions()), SalesforceSDKManager.getInstance().getAppDisplayString());
+    	return String.format(getString(R.string.sf__passcode_confirm_instructions),
+                SalesforceSDKManager.getInstance().getAppDisplayString());
     }
 
     protected String getMinLengthInstructions(int minPasscodeLength) {
-        return getString(salesforceR.stringPasscodeMinLength(), minPasscodeLength);
+        return getString(R.string.sf__passcode_min_length, minPasscodeLength);
     }
 
     protected String getPasscodeTryAgainError(int countAttemptsLeft) {
-        return getString(salesforceR.stringPasscodeTryAgain(), countAttemptsLeft);
+        return getString(R.string.sf__passcode_try_again, countAttemptsLeft);
     }
 
     protected String getPasscodeFinalAttemptError() {
-        return getString(salesforceR.stringPasscodeFinal());
+        return getString(R.string.sf__passcode_final);
     }
 
     protected String getPasscodesDontMatchError() {
-        return getString(salesforceR.stringPasscodesDontMatch());
+        return getString(R.string.sf__passcodes_dont_match);
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceR.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceR.java
@@ -35,8 +35,9 @@ import com.salesforce.androidsdk.R;
  * Since 1.3, SalesforceSDK is packaged as a library project and therefore contains its resources.
  * We are only keeping this class for backward compatibility reason, for projects that use the SDK as a jar or that have
  * provided custom screens (login, passcode etc) and used SalesforceR to point to their own screens.
+ * @deprecated Will be removed in Mobile SDK 7.0. Resources can be referenced directly in a library project.
  */
-
+@Deprecated
 public class SalesforceR {
 	/* Login */
 	public int stringAccountType() { return R.string.account_type; }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -58,7 +58,6 @@ public class ServerPickerActivity extends Activity implements
     private static final String SERVER_DIALOG_NAME = "custom_server_dialog";
 
     private CustomServerUrlEditor urlEditDialog;
-    private SalesforceR salesforceR;
     private LoginServerManager loginServerManager;
 
     /**
@@ -82,7 +81,7 @@ public class ServerPickerActivity extends Activity implements
     @Override
     public void onCheckedChanged(RadioGroup group, int checkedId) {
     	if (group != null) {
-    		final SalesforceServerRadioButton rb = (SalesforceServerRadioButton) group.findViewById(checkedId);
+    		final SalesforceServerRadioButton rb = group.findViewById(checkedId);
     		if (rb != null) {
     			final String name = rb.getName();
     			final String url = rb.getUrl();
@@ -108,27 +107,26 @@ public class ServerPickerActivity extends Activity implements
      * @return Server list group ID.
      */
     protected int getServerListGroupId() {
-        return salesforceR.idServerListGroup();
+        return R.id.sf__server_list_group;
     }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
     	super.onCreate(savedInstanceState);
-        salesforceR = SalesforceSDKManager.getInstance().getSalesforceR();
         loginServerManager = SalesforceSDKManager.getInstance().getLoginServerManager();
-        setContentView(salesforceR.layoutServerPicker());
+        setContentView(R.layout.sf__server_picker);
 
         /*
          * Hides the 'Add Connection' button if the MDM variable to disable
          * adding of custom hosts is set.
          */
-        final Button addConnectionButton = (Button) findViewById(R.id.sf__show_custom_url_edit);
+        final Button addConnectionButton = findViewById(R.id.sf__show_custom_url_edit);
         if (addConnectionButton != null) {
             if (RuntimeConfig.getRuntimeConfig(this).getBoolean(RuntimeConfig.ConfigKey.OnlyShowAuthorizedHosts)) {
                 addConnectionButton.setVisibility(View.GONE);
             }
         }
-        final RadioGroup radioGroup = (RadioGroup) findViewById(getServerListGroupId());
+        final RadioGroup radioGroup = findViewById(getServerListGroupId());
         radioGroup.setOnCheckedChangeListener(this);
     	urlEditDialog = new CustomServerUrlEditor();
     	urlEditDialog.setRetainInstance(true);
@@ -142,7 +140,7 @@ public class ServerPickerActivity extends Activity implements
 
     @Override
     public void onDestroy() {
-        final RadioGroup radioGroup = (RadioGroup) findViewById(getServerListGroupId());
+        final RadioGroup radioGroup = findViewById(getServerListGroupId());
         radioGroup.setOnCheckedChangeListener(null);
         urlEditDialog = null;
         super.onDestroy();
@@ -150,13 +148,13 @@ public class ServerPickerActivity extends Activity implements
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(salesforceR.menuClearCustomUrl(), menu);
+        getMenuInflater().inflate(R.menu.sf__clear_custom_url, menu);
         return super.onCreateOptionsMenu(menu);
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == salesforceR.idMenuClearCustomUrl()) {
+        if (item.getItemId() == R.id.sf__menu_clear_custom_url) {
             clearCustomUrlSetting();
             return true;
         } else {
@@ -216,7 +214,7 @@ public class ServerPickerActivity extends Activity implements
      * Controls the elements in the layout based on past user choices.
      */
     protected void setupRadioButtons() {
-        final RadioGroup radioGroup = (RadioGroup) findViewById(getServerListGroupId());
+        final RadioGroup radioGroup = findViewById(getServerListGroupId());
         final List<LoginServer> servers = loginServerManager.getLoginServers();
         if (servers != null) {
             for (final LoginServer currentServer : servers) {
@@ -229,7 +227,7 @@ public class ServerPickerActivity extends Activity implements
      * Rebuilds the display.
      */
     public void rebuildDisplay() {
-        final RadioGroup radioGroup = (RadioGroup) findViewById(getServerListGroupId());
+        final RadioGroup radioGroup = findViewById(getServerListGroupId());
         radioGroup.removeAllViews();
         setupRadioButtons();
 


### PR DESCRIPTION
`SalesforceR` is a legacy artifact that we used prior to `Mobile SDK 1.3` (yes, `1.3`) to access resources when we used to ship a `.jar` file. Since then we've switched to shipping as an `Android` library project which includes resources. This PR removes all usage of `SalesforceR` and accesses resources directly instead. It also marks `SalesforceR` deprecated (to be removed in `Mobile SDK 7.0`) -> long overdue.