### PR TITLE
First stab at rewriting SalesforceAnalytics tests with new testing framework

### DIFF
--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -15,6 +15,8 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api 'com.squareup:tape:1.2.3'
+    androidTestApi 'com.android.support.test:runner:1.0.1'
+    androidTestApi 'com.android.support.test:rules:1.0.1'
 }
 
 android {
@@ -46,7 +48,7 @@ android {
   }
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.analytics.tests"
-    testInstrumentationRunner "com.salesforce.androidsdk.analytics.util.test.JUnitReportTestRunner"
+    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/util/test/JUnitReportTestRunner.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/util/test/JUnitReportTestRunner.java
@@ -34,7 +34,10 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * This extends the report runner that generates a standard junit report file, with the timerun cap.
+ *
+ * @deprecated Will be removed in Mobile SDK 7.0. Use the standard Android test runner instead.
  */
+@Deprecated
 public class JUnitReportTestRunner extends InstrumentationTestRunner {
 
     @Override

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/util/test/TimeLimitedTestRunner.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/util/test/TimeLimitedTestRunner.java
@@ -41,7 +41,10 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * A TestRunner that limits the lifetime of the test run.
+ *
+ * @deprecated Will be removed in Mobile SDK 7.0. Use the standard Android test runner instead.
  */
+@Deprecated
 public class TimeLimitedTestRunner extends AndroidTestRunner {
 
     private static final String TAG = "TimeLimitedTestRunner";

--- a/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
+++ b/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
@@ -9,9 +9,6 @@
 		<uses-library android:name="android.test.runner" />
 	</application>
 
-	<instrumentation android:targetPackage="com.salesforce.androidsdk.analytics.tests"
-		android:name="com.salesforce.androidsdk.analytics.util.test.JUnitReportTestRunner" />
-
     <uses-sdk android:minSdkVersion="21"
         android:targetSdkVersion="27" />
 </manifest>

--- a/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
+++ b/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.analytics.tests" 
-	android:versionCode="1"
-	android:versionName="1.0">
-
-	<application android:label="@string/app_name">
-		<uses-library android:name="android.test.runner" />
-	</application>
+	package="com.salesforce.androidsdk.analytics.tests">
 
     <uses-sdk android:minSdkVersion="21"
         android:targetSdkVersion="27" />
+
+	<application />
 </manifest>

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
@@ -27,7 +27,16 @@
 package com.salesforce.androidsdk.analytics.logger;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +46,9 @@ import java.util.List;
  *
  * @author bhariharan
  */
-public class FileLoggerTest extends InstrumentationTestCase {
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class FileLoggerTest {
 
     private static final String COMPONENT_NAME = "FileLoggerTest";
     private static final String TEST_LOG_LINE_1 = "This is test log line 1!";
@@ -49,22 +60,20 @@ public class FileLoggerTest extends InstrumentationTestCase {
     private Context targetContext;
     private FileLogger fileLogger;
 
-    @Override
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
-        targetContext = getInstrumentation().getTargetContext();
+        targetContext = InstrumentationRegistry.getTargetContext();
         FileLogger.resetFileLoggerPrefs(targetContext);
         fileLogger = new FileLogger(targetContext, COMPONENT_NAME);
         fileLogger.flushLog();
         int size = fileLogger.getSize();
-        assertEquals("Log file should be empty", 0, size);
+        Assert.assertEquals("Log file should be empty", 0, size);
     }
 
-    @Override
+    @After
     public void tearDown() throws Exception {
         FileLogger.resetFileLoggerPrefs(targetContext);
         fileLogger.flushLog();
-        super.tearDown();
     }
 
     /**
@@ -74,11 +83,11 @@ public class FileLoggerTest extends InstrumentationTestCase {
      */
     public void testSetMaxSize() throws Exception {
         int maxSize = fileLogger.getMaxSize();
-        assertEquals("Max size didn't match expected max size", DEFAULT_MAX_SIZE, maxSize);
+        Assert.assertEquals("Max size didn't match expected max size", DEFAULT_MAX_SIZE, maxSize);
         int newMaxSize = 2000;
         fileLogger.setMaxSize(newMaxSize);
         maxSize = fileLogger.getMaxSize();
-        assertEquals("Max size didn't match expected max size", newMaxSize, maxSize);
+        Assert.assertEquals("Max size didn't match expected max size", newMaxSize, maxSize);
     }
 
     /**
@@ -86,13 +95,14 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testFlushLogFile() throws Exception {
         fileLogger.addLogLine(TEST_LOG_LINE_1);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 1 entry", 1, size);
+        Assert.assertEquals("Log file should have 1 entry", 1, size);
         fileLogger.flushLog();
         size = fileLogger.getSize();
-        assertEquals("Log file should be empty", 0, size);
+        Assert.assertEquals("Log file should be empty", 0, size);
     }
 
     /**
@@ -100,10 +110,11 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAddLogLine() throws Exception {
         fileLogger.addLogLine(TEST_LOG_LINE_1);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 1 entry", 1, size);
+        Assert.assertEquals("Log file should have 1 entry", 1, size);
     }
 
     /**
@@ -111,6 +122,7 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAddListOfLogLines() throws Exception {
         final List<String> logLines = new ArrayList<>();
         logLines.add(TEST_LOG_LINE_1);
@@ -118,7 +130,7 @@ public class FileLoggerTest extends InstrumentationTestCase {
         logLines.add(TEST_LOG_LINE_3);
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
     }
 
     /**
@@ -126,11 +138,12 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAddArrayOfLogLines() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
     }
 
     /**
@@ -138,13 +151,14 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testRemoveLogLine() throws Exception {
         fileLogger.addLogLine(TEST_LOG_LINE_1);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 1 entry", 1, size);
+        Assert.assertEquals("Log file should have 1 entry", 1, size);
         fileLogger.removeLogLine();
         size = fileLogger.getSize();
-        assertEquals("Log file should be empty", 0, size);
+        Assert.assertEquals("Log file should be empty", 0, size);
     }
 
     /**
@@ -152,14 +166,15 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testRemoveNumLogLines() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         fileLogger.removeLogLines(2);
         size = fileLogger.getSize();
-        assertEquals("Log file should have 1 entry", 1, size);
+        Assert.assertEquals("Log file should have 1 entry", 1, size);
     }
 
     /**
@@ -167,16 +182,17 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testOrderOfRemoval() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         fileLogger.removeLogLines(2);
         size = fileLogger.getSize();
-        assertEquals("Log file should have 1 entry", 1, size);
+        Assert.assertEquals("Log file should have 1 entry", 1, size);
         final String logLineRead = fileLogger.readLogLine();
-        assertEquals("Incorrect log lines were removed", TEST_LOG_LINE_3, logLineRead);
+        Assert.assertEquals("Incorrect log lines were removed", TEST_LOG_LINE_3, logLineRead);
     }
 
     /**
@@ -184,12 +200,13 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testReadLogLine() throws Exception {
         fileLogger.addLogLine(TEST_LOG_LINE_1);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 1 entry", 1, size);
+        Assert.assertEquals("Log file should have 1 entry", 1, size);
         final String logLineRead = fileLogger.readLogLine();
-        assertEquals("Incorrect log line read", TEST_LOG_LINE_1, logLineRead);
+        Assert.assertEquals("Incorrect log line read", TEST_LOG_LINE_1, logLineRead);
     }
 
     /**
@@ -197,6 +214,7 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testReadAndRemoveLogLinesAsList() throws Exception {
         final List<String> logLines = new ArrayList<>();
         logLines.add(TEST_LOG_LINE_1);
@@ -204,10 +222,10 @@ public class FileLoggerTest extends InstrumentationTestCase {
         logLines.add(TEST_LOG_LINE_3);
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         final List<String> logLinesRead = fileLogger.readAndRemoveLogLinesAsList(3);
-        assertEquals("Number of log lines read should be 3", 3, logLinesRead.size());
-        assertEquals("Log lines read are different from expected log lines", logLines, logLinesRead);
+        Assert.assertEquals("Number of log lines read should be 3", 3, logLinesRead.size());
+        Assert.assertEquals("Log lines read are different from expected log lines", logLines, logLinesRead);
     }
 
     /**
@@ -215,16 +233,17 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testReadAndRemoveLogLinesAsArray() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         final String[] logLinesRead = fileLogger.readAndRemoveLogLinesAsArray(3);
-        assertEquals("Number of log lines read should be 3", 3, logLinesRead.length);
-        assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_1, logLinesRead[0]);
-        assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_2, logLinesRead[1]);
-        assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_3, logLinesRead[2]);
+        Assert.assertEquals("Number of log lines read should be 3", 3, logLinesRead.length);
+        Assert.assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_1, logLinesRead[0]);
+        Assert.assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_2, logLinesRead[1]);
+        Assert.assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_3, logLinesRead[2]);
     }
 
     /**
@@ -232,6 +251,7 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testReadAndRemoveFileAsList() throws Exception {
         final List<String> logLines = new ArrayList<>();
         logLines.add(TEST_LOG_LINE_1);
@@ -239,12 +259,12 @@ public class FileLoggerTest extends InstrumentationTestCase {
         logLines.add(TEST_LOG_LINE_3);
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         final List<String> logLinesRead = fileLogger.readAndRemoveFileAsList();
-        assertEquals("Number of log lines read should be 3", 3, logLinesRead.size());
-        assertEquals("Log lines read are different from expected log lines", logLines, logLinesRead);
+        Assert.assertEquals("Number of log lines read should be 3", 3, logLinesRead.size());
+        Assert.assertEquals("Log lines read are different from expected log lines", logLines, logLinesRead);
         size = fileLogger.getSize();
-        assertEquals("Log file should have no entries", 0, size);
+        Assert.assertEquals("Log file should have no entries", 0, size);
     }
 
     /**
@@ -252,18 +272,19 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testReadAndRemoveFileAsArray() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         final String[] logLinesRead = fileLogger.readAndRemoveFileAsArray();
-        assertEquals("Number of log lines read should be 3", 3, logLinesRead.length);
-        assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_1, logLinesRead[0]);
-        assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_2, logLinesRead[1]);
-        assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_3, logLinesRead[2]);
+        Assert.assertEquals("Number of log lines read should be 3", 3, logLinesRead.length);
+        Assert.assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_1, logLinesRead[0]);
+        Assert.assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_2, logLinesRead[1]);
+        Assert.assertEquals("Log line read is different from expected log line", TEST_LOG_LINE_3, logLinesRead[2]);
         size = fileLogger.getSize();
-        assertEquals("Log file should have no entries", 0, size);
+        Assert.assertEquals("Log file should have no entries", 0, size);
     }
 
     /**
@@ -271,13 +292,14 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testOrderOfReading() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         final String logLineRead = fileLogger.readLogLine();
-        assertEquals("Incorrect log line was read", TEST_LOG_LINE_1, logLineRead);
+        Assert.assertEquals("Incorrect log line was read", TEST_LOG_LINE_1, logLineRead);
     }
 
     /**
@@ -285,19 +307,20 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testWriteAfterMaxSizeReached() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         fileLogger.setMaxSize(1);
         int maxSize = fileLogger.getMaxSize();
-        assertEquals("Max size should be 1", 1, maxSize);
+        Assert.assertEquals("Max size should be 1", 1, maxSize);
         fileLogger.addLogLine(TEST_LOG_LINE_4);
         size = fileLogger.getSize();
-        assertEquals("Log file should have 1 entry", 1, size);
+        Assert.assertEquals("Log file should have 1 entry", 1, size);
         final String logLineRead = fileLogger.readLogLine();
-        assertEquals("Incorrect log line read", TEST_LOG_LINE_4, logLineRead);
+        Assert.assertEquals("Incorrect log line read", TEST_LOG_LINE_4, logLineRead);
     }
 
     /**
@@ -305,16 +328,17 @@ public class FileLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testWriteForMaxSizeZero() throws Exception {
         final String[] logLines = new String[] {TEST_LOG_LINE_1, TEST_LOG_LINE_2, TEST_LOG_LINE_3};
         fileLogger.addLogLines(logLines);
         int size = fileLogger.getSize();
-        assertEquals("Log file should have 3 entries", 3, size);
+        Assert.assertEquals("Log file should have 3 entries", 3, size);
         fileLogger.setMaxSize(0);
         int maxSize = fileLogger.getMaxSize();
-        assertEquals("Max size should be 0", 0, maxSize);
+        Assert.assertEquals("Max size should be 0", 0, maxSize);
         fileLogger.addLogLine(TEST_LOG_LINE_4);
         size = fileLogger.getSize();
-        assertEquals("Log file should have no entries", 0, size);
+        Assert.assertEquals("Log file should have no entries", 0, size);
     }
 }

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
@@ -81,6 +81,7 @@ public class FileLoggerTest {
      *
      * @throws Exception
      */
+    @Test
     public void testSetMaxSize() throws Exception {
         int maxSize = fileLogger.getMaxSize();
         Assert.assertEquals("Max size didn't match expected max size", DEFAULT_MAX_SIZE, maxSize);

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
@@ -27,7 +27,16 @@
 package com.salesforce.androidsdk.analytics.logger;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Set;
 
@@ -36,28 +45,28 @@ import java.util.Set;
  *
  * @author bhariharan
  */
-public class SalesforceLoggerTest extends InstrumentationTestCase {
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class SalesforceLoggerTest {
 
     private static final String TEST_COMPONENT_1 = "TestComponent1";
     private static final String TEST_COMPONENT_2 = "TestComponent2";
 
     private Context targetContext;
 
-    @Override
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
-        targetContext = getInstrumentation().getTargetContext();
+        targetContext = InstrumentationRegistry.getTargetContext();
         SalesforceLogger.flushComponents();
         SalesforceLogger.resetLoggerPrefs(targetContext);
         final Set<String> components = SalesforceLogger.getComponents();
-        assertNull("No components should be returned", components);
+        Assert.assertNull("No components should be returned", components);
     }
 
-    @Override
+    @After
     public void tearDown() throws Exception {
         SalesforceLogger.flushComponents();
         SalesforceLogger.resetLoggerPrefs(targetContext);
-        super.tearDown();
     }
 
     /**
@@ -65,11 +74,12 @@ public class SalesforceLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAddSingleComponent() throws Exception {
         final SalesforceLogger logger = SalesforceLogger.getLogger(TEST_COMPONENT_1, targetContext);
-        assertNotNull("SalesforceLogger instance should not be null", logger);
+        Assert.assertNotNull("SalesforceLogger instance should not be null", logger);
         final Set<String> components = SalesforceLogger.getComponents();
-        assertEquals("Number of components should be 1", 1, components.size());
+        Assert.assertEquals("Number of components should be 1", 1, components.size());
     }
 
     /**
@@ -77,15 +87,16 @@ public class SalesforceLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAddMultipleComponents() throws Exception {
         SalesforceLogger logger = SalesforceLogger.getLogger(TEST_COMPONENT_1, targetContext);
-        assertNotNull("SalesforceLogger instance should not be null", logger);
+        Assert.assertNotNull("SalesforceLogger instance should not be null", logger);
         logger = SalesforceLogger.getLogger(TEST_COMPONENT_2, targetContext);
-        assertNotNull("SalesforceLogger instance should not be null", logger);
+        Assert.assertNotNull("SalesforceLogger instance should not be null", logger);
         final Set<String> components = SalesforceLogger.getComponents();
-        assertEquals("Number of components should be 2", 2, components.size());
-        assertTrue("Component should be present in results", components.contains(TEST_COMPONENT_1));
-        assertTrue("Component should be present in results", components.contains(TEST_COMPONENT_2));
+        Assert.assertEquals("Number of components should be 2", 2, components.size());
+        Assert.assertTrue("Component should be present in results", components.contains(TEST_COMPONENT_1));
+        Assert.assertTrue("Component should be present in results", components.contains(TEST_COMPONENT_2));
     }
 
     /**
@@ -93,13 +104,14 @@ public class SalesforceLoggerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testSetLogLevel() throws Exception {
         final SalesforceLogger logger = SalesforceLogger.getLogger(TEST_COMPONENT_1, targetContext);
-        assertNotNull("SalesforceLogger instance should not be null", logger);
+        Assert.assertNotNull("SalesforceLogger instance should not be null", logger);
         SalesforceLogger.Level logLevel = logger.getLogLevel();
-        assertNotSame("Log levels should not be same", SalesforceLogger.Level.VERBOSE, logLevel);
+        Assert.assertNotSame("Log levels should not be same", SalesforceLogger.Level.VERBOSE, logLevel);
         logger.setLogLevel(SalesforceLogger.Level.VERBOSE);
         logLevel = logger.getLogLevel();
-        assertEquals("Log levels should be the same", SalesforceLogger.Level.VERBOSE, logLevel);
+        Assert.assertEquals("Log levels should be the same", SalesforceLogger.Level.VERBOSE, logLevel);
     }
 }

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/model/InstrumentationEventBuilderTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/model/InstrumentationEventBuilderTest.java
@@ -27,7 +27,9 @@
 package com.salesforce.androidsdk.analytics.model;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -37,6 +39,10 @@ import com.salesforce.androidsdk.analytics.security.Encryptor;
 import junit.framework.Assert;
 
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.UUID;
 
@@ -45,7 +51,9 @@ import java.util.UUID;
  *
  * @author bhariharan
  */
-public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class InstrumentationEventBuilderTest {
 
     private static final String TAG = "EventBuilderTest";
     private static final String TEST_ENCRYPTION_KEY = Encryptor.hash("test_encryption_key", "key");
@@ -60,19 +68,17 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
     private Context targetContext;
     private AnalyticsManager analyticsManager;
 
-    @Override
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
-        targetContext = getInstrumentation().getTargetContext();
+        targetContext = InstrumentationRegistry.getTargetContext();
         uniqueId = UUID.randomUUID().toString();
         analyticsManager = new AnalyticsManager(uniqueId,
                 targetContext, TEST_ENCRYPTION_KEY, TEST_DEVICE_APP_ATTRIBUTES);
     }
 
-    @Override
+    @After
     public void tearDown() throws Exception {
         analyticsManager.reset();
-        super.tearDown();
     }
 
     /**
@@ -80,6 +86,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testMissingSchemaType() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -104,6 +111,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testMissingEventTypeInInteraction() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -127,6 +135,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testMissingEventTypeInError() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -143,7 +152,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
         } catch (InstrumentationEventBuilder.EventBuilderException e) {
             Assert.fail("Exception should not have been thrown");
         }
-        assertNotNull("Event should not be null", event);
+        Assert.assertNotNull("Event should not be null", event);
     }
 
     /**
@@ -151,6 +160,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testMissingPage() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -175,6 +185,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testMissingName() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -198,6 +209,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testMissingDeviceAppAttributes() throws Exception {
         analyticsManager.reset();
         analyticsManager = new AnalyticsManager(uniqueId, targetContext, TEST_ENCRYPTION_KEY, null);
@@ -227,6 +239,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAutoPopulateStartTime() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -240,7 +253,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
         eventBuilder.page(new JSONObject());
         final InstrumentationEvent event = eventBuilder.buildEvent();
         long startTime = event.getStartTime();
-        assertTrue("Start time should have been auto populated", startTime > 0);
+        Assert.assertTrue("Start time should have been auto populated", startTime > 0);
     }
 
     /**
@@ -248,6 +261,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAutoPopulateEventId() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -262,7 +276,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
         eventBuilder.page(new JSONObject());
         final InstrumentationEvent event = eventBuilder.buildEvent();
         final String eventId = event.getEventId();
-        assertFalse("Event ID should have been auto populated", TextUtils.isEmpty(eventId));
+        Assert.assertFalse("Event ID should have been auto populated", TextUtils.isEmpty(eventId));
     }
 
     /**
@@ -270,6 +284,7 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testAutoPopulateSequenceId() throws Exception {
         final InstrumentationEventBuilder eventBuilder = InstrumentationEventBuilder.getInstance(analyticsManager, targetContext);
         long curTime = System.currentTimeMillis();
@@ -284,8 +299,8 @@ public class InstrumentationEventBuilderTest extends InstrumentationTestCase {
         eventBuilder.page(new JSONObject());
         final InstrumentationEvent event = eventBuilder.buildEvent();
         int sequenceId = event.getSequenceId();
-        assertTrue("Sequence ID should have been auto populated", sequenceId > 0);
+        Assert.assertTrue("Sequence ID should have been auto populated", sequenceId > 0);
         int globalSequenceId = analyticsManager.getGlobalSequenceId();
-        assertEquals("Global sequence ID should have been updated", 0, globalSequenceId - sequenceId);
+        Assert.assertEquals("Global sequence ID should have been updated", 0, globalSequenceId - sequenceId);
     }
 }

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
@@ -27,14 +27,24 @@
 package com.salesforce.androidsdk.analytics.security;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * Tests for Encryptor.
  *
  * @author bhariharan
  */
-public class EncryptorTest extends InstrumentationTestCase {
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class EncryptorTest {
 
 	private static final String[] TEST_KEYS = new String[] {
 			null,
@@ -46,45 +56,42 @@ public class EncryptorTest extends InstrumentationTestCase {
             "fake-token"
     };
 
-	@Override
+	@Before
 	public void setUp() throws Exception {
-		super.setUp();
-		final Context targetContext = getInstrumentation().getTargetContext();
+		final Context targetContext = InstrumentationRegistry.getTargetContext();
 		Encryptor.init(targetContext);
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-        super.tearDown();
 	}
 
 	/**
 	 * Test to make sure that encrypt does nothing when given a null key.
 	 */
+    @Test
 	public void testEncryptWithNullKey() {
 		for (final String data : TEST_DATA) {
-			assertEquals("Encrypt should have left the string unchanged", data, Encryptor.encrypt(data, null));
+            Assert.assertEquals("Encrypt should have left the string unchanged", data, Encryptor.encrypt(data, null));
 		}
 	}
 	
 	/**
 	 * Test to make sure that decrypt does nothing when given a null key.
 	 */
+    @Test
 	public void testDecryptWithNullKey() {
 		for (final String data : TEST_DATA) {
-			assertEquals("Decrypt should have left the string unchanged", data, Encryptor.decrypt(data, null));
+            Assert.assertEquals("Decrypt should have left the string unchanged", data, Encryptor.decrypt(data, null));
 		}
 	}
 
     /**
      * Test to ensure encryption and decryption work as expected.
      */
+    @Test
 	public void testEncryptDecrypt() {
 		for (String key : TEST_KEYS) {
 			for (String data : TEST_DATA) {
 				String encryptedData = Encryptor.encrypt(data, key);
 				String decryptedData = Encryptor.decrypt(encryptedData, key);
-				assertEquals("Decrypt should restore original", data, decryptedData);
+                Assert.assertEquals("Decrypt should restore original", data, decryptedData);
 			}
 		}
 	}
@@ -93,11 +100,12 @@ public class EncryptorTest extends InstrumentationTestCase {
 	 * Test to make sure encrypt returns a string different from the original
      * and that decrypt restores the original.
 	 */
+    @Test
 	public void testEncryptDecryptWithDifferentData() {
 		final String key = makeKey("123456");
 		for (final String data : TEST_DATA) {
-			assertFalse("Encrypted string should be different from original", data.equals(Encryptor.encrypt(data, key)));
-			assertEquals("Decrypt should restore original", data, Encryptor.decrypt(Encryptor.encrypt(data, key), key));
+            Assert.assertFalse("Encrypted string should be different from original", data.equals(Encryptor.encrypt(data, key)));
+            Assert.assertEquals("Decrypt should restore original", data, Encryptor.decrypt(Encryptor.encrypt(data, key), key));
 			for (final String otherData : TEST_DATA) {
                 final String encryptedA = Encryptor.encrypt(data, key);
                 final String decryptedA = Encryptor.decrypt(encryptedA, key);
@@ -105,7 +113,7 @@ public class EncryptorTest extends InstrumentationTestCase {
                 final String decryptedB = Encryptor.decrypt(encryptedB, key);
 				boolean sameDecrypted = decryptedA.equals(decryptedB); 
 				boolean sameData = data.equals(otherData);
-				assertEquals("Decrypted strings '" 
+                Assert.assertEquals("Decrypted strings '"
 						+ decryptedA + "','" + decryptedB 
 						+ "'  should be different for different strings '"
 						+ data +"','" + otherData + "'", 
@@ -117,10 +125,11 @@ public class EncryptorTest extends InstrumentationTestCase {
 	/**
 	 * Test to make sure that encrypting with different keys produces different results.
 	 */
+    @Test
 	public void testEncryptDecryptWithDifferentKeys() {
 		final String data = "fake-token";
 		for (final String key : TEST_KEYS) {
-			assertEquals("Decrypt should restore original", data, Encryptor.decrypt(Encryptor.encrypt(data, key), key));
+            Assert.assertEquals("Decrypt should restore original", data, Encryptor.decrypt(Encryptor.encrypt(data, key), key));
 			for (final String otherKey : TEST_KEYS) {
 				boolean sameKey = (key == null && otherKey == null) || (key != null && key.equals(otherKey));
 				if (!sameKey) {
@@ -128,9 +137,9 @@ public class EncryptorTest extends InstrumentationTestCase {
                     final String decryptedA = Encryptor.decrypt(encryptedA, key);
                     final String encryptedB = Encryptor.encrypt(data, otherKey);
                     final String decryptedB = Encryptor.decrypt(encryptedB, otherKey);
-					assertEquals("Decrypted values should be the same", decryptedA, decryptedB);
-					boolean sameEncrypted = encryptedA.equals(encryptedB); 
-					assertEquals("Encrypted strings '" 
+                    Assert.assertEquals("Decrypted values should be the same", decryptedA, decryptedB);
+					boolean sameEncrypted = encryptedA.equals(encryptedB);
+                    Assert.assertEquals("Encrypted strings '"
 							+ encryptedA + "','" + encryptedB 
 							+ "'  should be different for different keys '"
 							+ key +"','" + otherKey + "'", 

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/store/EventStoreManagerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/store/EventStoreManagerTest.java
@@ -27,7 +27,9 @@
 package com.salesforce.androidsdk.analytics.store;
 
 import android.content.Context;
-import android.test.InstrumentationTestCase;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.analytics.manager.AnalyticsManager;
 import com.salesforce.androidsdk.analytics.model.DeviceAppAttributes;
@@ -35,7 +37,13 @@ import com.salesforce.androidsdk.analytics.model.InstrumentationEvent;
 import com.salesforce.androidsdk.analytics.model.InstrumentationEventBuilder;
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 
+import junit.framework.Assert;
+
 import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +54,9 @@ import java.util.UUID;
  *
  * @author bhariharan
  */
-public class EventStoreManagerTest extends InstrumentationTestCase {
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class EventStoreManagerTest {
 
     private static final String TEST_FILENAME_SUFFIX = "_test_filename_suffix";
     private static final String TEST_ENCRYPTION_KEY = Encryptor.hash("test_encryption_key", "key");
@@ -57,26 +67,23 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
     private static final String TEST_SENDER_ID = "TEST_SENDER_ID";
     private static final String TEST_SESSION_ID = "TEST_SESSION_ID";
 
-    private String uniqueId;
     private Context targetContext;
     private EventStoreManager storeManager;
     private AnalyticsManager analyticsManager;
 
-    @Override
+    @Before
     public void setUp() throws Exception {
-        super.setUp();
-        targetContext = getInstrumentation().getTargetContext();
-        uniqueId = UUID.randomUUID().toString();
+        targetContext = InstrumentationRegistry.getTargetContext();
+        final String uniqueId = UUID.randomUUID().toString();
         analyticsManager = new AnalyticsManager(uniqueId,
                 targetContext, TEST_ENCRYPTION_KEY, TEST_DEVICE_APP_ATTRIBUTES);
         storeManager = new EventStoreManager(TEST_FILENAME_SUFFIX, targetContext, TEST_ENCRYPTION_KEY);
     }
 
-    @Override
+    @After
     public void tearDown() throws Exception {
         storeManager.deleteAllEvents();
         analyticsManager.reset();
-        super.tearDown();
     }
 
     /**
@@ -84,14 +91,15 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testStoreOneEvent() throws Exception {
         final InstrumentationEvent event = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event);
+        Assert.assertNotNull("Generated event stored should not be null", event);
         storeManager.storeEvent(event);
         final List<InstrumentationEvent> events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 1", 1, events.size());
-        assertTrue("Stored event should be the same as generated event", event.equals(events.get(0)));
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 1", 1, events.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event.equals(events.get(0)));
     }
 
     /**
@@ -99,20 +107,21 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testStoreMultipleEvents() throws Exception {
         final InstrumentationEvent event1 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event1);
+        Assert.assertNotNull("Generated event stored should not be null", event1);
         final InstrumentationEvent event2 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event2);
+        Assert.assertNotNull("Generated event stored should not be null", event2);
         final List<InstrumentationEvent> genEvents = new ArrayList<InstrumentationEvent>();
         genEvents.add(event1);
         genEvents.add(event2);
         storeManager.storeEvents(genEvents);
         final List<InstrumentationEvent> events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 2", 2, events.size());
-        assertTrue("Stored event should be the same as generated event", event1.equals(events.get(0)));
-        assertTrue("Stored event should be the same as generated event", event2.equals(events.get(1)));
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 2", 2, events.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event1.equals(events.get(0)));
+        Assert.assertTrue("Stored event should be the same as generated event", event2.equals(events.get(1)));
     }
 
     /**
@@ -120,14 +129,15 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testFetchOneEvent() throws Exception {
         final InstrumentationEvent event = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event);
+        Assert.assertNotNull("Generated event stored should not be null", event);
         final String eventId = event.getEventId();
         storeManager.storeEvent(event);
         final InstrumentationEvent storedEvent = storeManager.fetchEvent(eventId);
-        assertNotNull("Event stored should not be null", storedEvent);
-        assertTrue("Stored event should be the same as generated event", event.equals(storedEvent));
+        Assert.assertNotNull("Event stored should not be null", storedEvent);
+        Assert.assertTrue("Stored event should be the same as generated event", event.equals(storedEvent));
     }
 
     /**
@@ -135,18 +145,19 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testFetchAllEvents() throws Exception {
         final InstrumentationEvent event1 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event1);
+        Assert.assertNotNull("Generated event stored should not be null", event1);
         storeManager.storeEvent(event1);
         final InstrumentationEvent event2 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event2);
+        Assert.assertNotNull("Generated event stored should not be null", event2);
         storeManager.storeEvent(event2);
         final List<InstrumentationEvent> events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 2", 2, events.size());
-        assertTrue("Stored event should be the same as generated event", event1.equals(events.get(0)));
-        assertTrue("Stored event should be the same as generated event", event2.equals(events.get(1)));
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 2", 2, events.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event1.equals(events.get(0)));
+        Assert.assertTrue("Stored event should be the same as generated event", event2.equals(events.get(1)));
     }
 
     /**
@@ -154,19 +165,20 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testDeleteOneEvent() throws Exception {
         final InstrumentationEvent event = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event);
+        Assert.assertNotNull("Generated event stored should not be null", event);
         final String eventId = event.getEventId();
         storeManager.storeEvent(event);
         final List<InstrumentationEvent> eventsBeforeDel = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", eventsBeforeDel);
-        assertEquals("Number of events stored should be 1", 1, eventsBeforeDel.size());
-        assertTrue("Stored event should be the same as generated event", event.equals(eventsBeforeDel.get(0)));
+        Assert.assertNotNull("List of events stored should not be null", eventsBeforeDel);
+        Assert.assertEquals("Number of events stored should be 1", 1, eventsBeforeDel.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event.equals(eventsBeforeDel.get(0)));
         storeManager.deleteEvent(eventId);
         final List<InstrumentationEvent> eventsAfterDel = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", eventsAfterDel);
-        assertEquals("Number of events stored should be 0", 0, eventsAfterDel.size());
+        Assert.assertNotNull("List of events stored should not be null", eventsAfterDel);
+        Assert.assertEquals("Number of events stored should be 0", 0, eventsAfterDel.size());
     }
 
     /**
@@ -174,29 +186,30 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testDeleteMultipleEvents() throws Exception {
         final InstrumentationEvent event1 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event1);
+        Assert.assertNotNull("Generated event stored should not be null", event1);
         final String eventId1 = event1.getEventId();
         final InstrumentationEvent event2 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event2);
+        Assert.assertNotNull("Generated event stored should not be null", event2);
         final String eventId2 = event2.getEventId();
         final List<InstrumentationEvent> genEvents = new ArrayList<InstrumentationEvent>();
         genEvents.add(event1);
         genEvents.add(event2);
         storeManager.storeEvents(genEvents);
         final List<InstrumentationEvent> eventsBeforeDel = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", eventsBeforeDel);
-        assertEquals("Number of events stored should be 2", 2, eventsBeforeDel.size());
-        assertTrue("Stored event should be the same as generated event", event1.equals(eventsBeforeDel.get(0)));
-        assertTrue("Stored event should be the same as generated event", event2.equals(eventsBeforeDel.get(1)));
+        Assert.assertNotNull("List of events stored should not be null", eventsBeforeDel);
+        Assert.assertEquals("Number of events stored should be 2", 2, eventsBeforeDel.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event1.equals(eventsBeforeDel.get(0)));
+        Assert.assertTrue("Stored event should be the same as generated event", event2.equals(eventsBeforeDel.get(1)));
         final List<String> eventIds = new ArrayList<String>();
         eventIds.add(eventId1);
         eventIds.add(eventId2);
         storeManager.deleteEvents(eventIds);
         final List<InstrumentationEvent> eventsAfterDel = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", eventsAfterDel);
-        assertEquals("Number of events stored should be 0", 0, eventsAfterDel.size());
+        Assert.assertNotNull("List of events stored should not be null", eventsAfterDel);
+        Assert.assertEquals("Number of events stored should be 0", 0, eventsAfterDel.size());
     }
 
     /**
@@ -204,24 +217,25 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testDeleteAllEvents() throws Exception {
         final InstrumentationEvent event1 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event1);
+        Assert.assertNotNull("Generated event stored should not be null", event1);
         final InstrumentationEvent event2 = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event2);
+        Assert.assertNotNull("Generated event stored should not be null", event2);
         final List<InstrumentationEvent> genEvents = new ArrayList<InstrumentationEvent>();
         genEvents.add(event1);
         genEvents.add(event2);
         storeManager.storeEvents(genEvents);
         final List<InstrumentationEvent> eventsBeforeDel = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", eventsBeforeDel);
-        assertEquals("Number of events stored should be 2", 2, eventsBeforeDel.size());
-        assertTrue("Stored event should be the same as generated event", event1.equals(eventsBeforeDel.get(0)));
-        assertTrue("Stored event should be the same as generated event", event2.equals(eventsBeforeDel.get(1)));
+        Assert.assertNotNull("List of events stored should not be null", eventsBeforeDel);
+        Assert.assertEquals("Number of events stored should be 2", 2, eventsBeforeDel.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event1.equals(eventsBeforeDel.get(0)));
+        Assert.assertTrue("Stored event should be the same as generated event", event2.equals(eventsBeforeDel.get(1)));
         storeManager.deleteAllEvents();
         final List<InstrumentationEvent> eventsAfterDel = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", eventsAfterDel);
-        assertEquals("Number of events stored should be 0", 0, eventsAfterDel.size());
+        Assert.assertNotNull("List of events stored should not be null", eventsAfterDel);
+        Assert.assertEquals("Number of events stored should be 0", 0, eventsAfterDel.size());
     }
 
     /**
@@ -229,14 +243,15 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testDisablingLogging() throws Exception {
         final InstrumentationEvent event = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event);
+        Assert.assertNotNull("Generated event stored should not be null", event);
         storeManager.enableLogging(false);
         storeManager.storeEvent(event);
         final List<InstrumentationEvent> events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 0", 0, events.size());
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 0", 0, events.size());
     }
 
     /**
@@ -244,20 +259,21 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testEnablingLogging() throws Exception {
         final InstrumentationEvent event = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event);
+        Assert.assertNotNull("Generated event stored should not be null", event);
         storeManager.enableLogging(false);
         storeManager.storeEvent(event);
         List<InstrumentationEvent> events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 0", 0, events.size());
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 0", 0, events.size());
         storeManager.enableLogging(true);
         storeManager.storeEvent(event);
         events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 1", 1, events.size());
-        assertTrue("Stored event should be the same as generated event", event.equals(events.get(0)));
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 1", 1, events.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event.equals(events.get(0)));
     }
 
     /**
@@ -265,14 +281,15 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testEventLimitExceeded() throws Exception {
         final InstrumentationEvent event = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event);
+        Assert.assertNotNull("Generated event stored should not be null", event);
         storeManager.setMaxEvents(0);
         storeManager.storeEvent(event);
         final List<InstrumentationEvent> events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 0", 0, events.size());
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 0", 0, events.size());
     }
 
     /**
@@ -280,20 +297,21 @@ public class EventStoreManagerTest extends InstrumentationTestCase {
      *
      * @throws Exception
      */
+    @Test
     public void testEventLimitNotExceeded() throws Exception {
         final InstrumentationEvent event = createTestEvent();
-        assertNotNull("Generated event stored should not be null", event);
+        Assert.assertNotNull("Generated event stored should not be null", event);
         storeManager.setMaxEvents(0);
         storeManager.storeEvent(event);
         List<InstrumentationEvent> events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 0", 0, events.size());
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 0", 0, events.size());
         storeManager.setMaxEvents(1);
         storeManager.storeEvent(event);
         events = storeManager.fetchAllEvents();
-        assertNotNull("List of events stored should not be null", events);
-        assertEquals("Number of events stored should be 1", 1, events.size());
-        assertTrue("Stored event should be the same as generated event", event.equals(events.get(0)));
+        Assert.assertNotNull("List of events stored should not be null", events);
+        Assert.assertEquals("Number of events stored should be 1", 1, events.size());
+        Assert.assertTrue("Stored event should be the same as generated event", event.equals(events.get(0)));
     }
 
     private InstrumentationEvent createTestEvent() throws Exception {


### PR DESCRIPTION
`InstrumentationTestCase` has been deprecated. We should be using `InstrumentationRegistry` and the test support library instead - it's faster and more efficient.