### PR TITLE
 Using junit4's parametrized tests in hybrid tests

### DIFF
--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ForceJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ForceJSTest.java
@@ -27,11 +27,12 @@
 package com.salesforce.androidsdk.phonegap;
 
 import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,82 +40,38 @@ import java.util.List;
 /**
  * Running javascript tests for force.js.
  */
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 @SmallTest
 public class ForceJSTest extends JSTestCase {
 
-	public ForceJSTest() {
-		super("ForceJSTestSuite");
-	}
+    private static final String JS_SUITE = "ForceJSTestSuite";
 
-    @Before
-    public void setUp() throws Exception {
-	    super.setUp();
-    }
+    @Parameterized.Parameter
+	public String testName;
 
-	@Override
-	public List<String> getTestNames() {
-		return Arrays.asList(new String[] {
-				"testParseUrl",
-				"testComputeEndPointIfMissing",
-				"testOwnedFilesList",
+    @Parameterized.Parameters(name = "{0}")
+    public static Iterable<String> data() {
+        return Arrays.asList(new String[]{
+                "testParseUrl",
+                "testComputeEndPointIfMissing",
+                "testOwnedFilesList",
                 "testFilesInUsersGroups",
-				"testFilesSharedWithUser",
+                "testFilesSharedWithUser",
                 "testFileDetails",
-				"testBatchFileDetails",
+                "testBatchFileDetails",
                 "testFileShares",
                 "testAddFileShare",
-				"testDeleteFileShare"
-		});
-	}
+                "testDeleteFileShare"
+        });
+    }
+
+    @BeforeClass
+    public static void runJSTestSuite() throws InterruptedException {
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 5);
+    }
 
     @Test
-	public void testParseUrl() {
-		runTest("testParseUrl");
-	}
-
-    @Test
-	public void testComputeEndPointIfMissing() {
-		runTest("testComputeEndPointIfMissing");
-	}
-
-    @Test
-	public void testOwnedFilesList() {
-		runTest("testOwnedFilesList");
-	}
-
-    @Test
-	public void testFilesInUsersGroups() {
-		runTest("testFilesInUsersGroups");
-	}
-
-    @Test
-	public void testFilesSharedWithUser() {
-		runTest("testFilesSharedWithUser");
-	}
-
-    @Test
-	public void testFileDetails() {
-		runTest("testFileDetails");
-	}
-
-    @Test
-	public void testBatchFileDetails() {
-		runTest("testBatchFileDetails");
-	}
-
-    @Test
-	public void testFileShares() {
-		runTest("testFileShares");
-	}
-
-    @Test
-	public void testAddFileShare() {
-		runTest("testAddFileShare");
-	}
-
-    @Test
-	public void testDeleteFileShare() {
-		runTest("testDeleteFileShare");
-	}
+    public void test() {
+        runTest(JS_SUITE, testName);
+    }
 }

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ForceJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ForceJSTest.java
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk.phonegap;
 
 import android.support.test.filters.SmallTest;
-import android.util.Log;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,7 +34,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
-import java.util.List;
 
 /**
  * Running javascript tests for force.js.

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoJSTest.java
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk.phonegap;
 
 import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoJSTest.java
@@ -29,9 +29,10 @@ package com.salesforce.androidsdk.phonegap;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,26 +40,29 @@ import java.util.List;
 /**
  * Running javascript tests for SDKInfo plugin.
  */
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 @SmallTest
 public class SDKInfoJSTest extends JSTestCase {
 
-    public SDKInfoJSTest() {
-        super("SDKInfoTestSuite");
+    private static final String JS_SUITE = "SDKInfoTestSuite";
+
+    @Parameterized.Parameter
+    public String testName;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<String> data() {
+        return Arrays.asList(new String[]{
+                "testGetInfo"
+        });
     }
 
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
-    public List<String> getTestNames() {
-    	return Arrays.asList("testGetInfo");
+    @BeforeClass
+    public static void runJSTestSuite() throws InterruptedException {
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 5);
     }
 
     @Test
-    public void testGetInfo()  {
-    	runTest("testGetInfo");
+    public void test() {
+        runTest(JS_SUITE, testName);
     }
 }

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
@@ -108,7 +108,7 @@ public class SmartStoreJSTest extends JSTestCase {
 
     @BeforeClass
     public static void runJSTestSuite() throws InterruptedException {
-        JSTestCase.runJSTestSuite(JS_SUITE, data(), 5);
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 30);
     }
 
     @Test

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
@@ -26,12 +26,12 @@
  */
 package com.salesforce.androidsdk.phonegap;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
+import android.support.test.filters.MediumTest;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,27 +39,18 @@ import java.util.List;
 /**
  * Running javascript tests for SmartStore plugin.
  */
-@RunWith(AndroidJUnit4.class)
-@LargeTest
+@RunWith(Parameterized.class)
+@MediumTest
 public class SmartStoreJSTest extends JSTestCase {
 
-    public SmartStoreJSTest() {
-        super("SmartStoreTestSuite");
-    }
+    private static final String JS_SUITE = "SmartStoreTestSuite";
 
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
+    @Parameterized.Parameter
+    public String testName;
 
-    @Override
-    protected int getMaxRuntimeInSecondsForTest(String testName) {
-        return 30;
-    }
-
-    @Override
-    public List<String> getTestNames() {
-        return Arrays.asList(new String[] {
+    @Parameterized.Parameters(name = "{0}")
+    public static List<String> data() {
+        return Arrays.asList(new String[]{
                 "testGetDatabaseSize",
                 "testRegisterRemoveSoup",
                 "testRegisterWithSpec",
@@ -115,263 +106,13 @@ public class SmartStoreJSTest extends JSTestCase {
         });
     }
 
-    @Test
-    public void testGetDatabaseSize() {
-        runTest("testGetDatabaseSize");
+    @BeforeClass
+    public static void runJSTestSuite() throws InterruptedException {
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 5);
     }
 
     @Test
-    public void testRegisterRemoveSoup()  {
-        runTest("testRegisterRemoveSoup");
-    }
-
-    @Test
-    public void testRegisterWithSpec()  {
-        runTest("testRegisterRemoveSoup");
-    }
-
-    @Test
-    public void testRegisterRemoveSoupGlobalStore() {
-        runTest("testRegisterRemoveSoupGlobalStore");
-    }
-
-    @Test
-    public void testRegisterBogusSoup()  {
-        runTest("testRegisterBogusSoup");
-    }
-
-    @Test
-    public void testRegisterSoupNoIndices()  {
-        runTest("testRegisterSoupNoIndices");
-    }
-
-    @Test
-    public void testUpsertSoupEntries()  {
-        runTest("testUpsertSoupEntries");
-    }
-
-    @Test
-    public void testUpsertSoupEntriesWithExternalId() {
-        runTest("testUpsertSoupEntriesWithExternalId");
-    }
-
-    @Test
-    public void testUpsertToNonexistentSoup()  {
-        runTest("testUpsertToNonexistentSoup");
-    }
-
-    @Test
-    public void testRetrieveSoupEntries()  {
-        runTest("testRetrieveSoupEntries");
-    }
-
-    @Test
-    public void testRemoveFromSoup()  {
-        runTest("testRemoveFromSoup");
-    }
-
-    @Test
-    public void testRemoveFromSoupByQuery()  {
-        runTest("testRemoveFromSoupByQuery");
-    }
-
-    @Test
-    public void testQuerySoupWithExactQuery()  {
-        runTest("testQuerySoupWithExactQuery");
-    }
-
-    @Test
-    public void testQuerySoupWithAllQueryDescending() {
-        runTest("testQuerySoupWithAllQueryDescending");
-    }
-
-    @Test
-    public void testQuerySoupWithRangeQueryWithOrderPath() {
-        runTest("testQuerySoupWithRangeQueryWithOrderPath");
-    }
-
-    @Test
-    public void testQuerySoupBadQuerySpec()  {
-        runTest("testQuerySoupBadQuerySpec");
-    }
-
-    @Test
-    public void testQuerySoupEndKeyNoBeginKey()  {
-        runTest("testQuerySoupEndKeyNoBeginKey");
-    }
-
-    @Test
-    public void testQuerySoupBeginKeyNoEndKey()  {
-        runTest("testQuerySoupBeginKeyNoEndKey");
-    }
-
-    @Test
-    public void testManipulateCursor()  {
-        runTest("testManipulateCursor");
-    }
-
-    @Test
-    public void testMoveCursorToPreviousPageFromFirstPage() {
-        runTest("testMoveCursorToPreviousPageFromFirstPage");
-    }
-
-    @Test
-    public void testMoveCursorToNextPageFromLastPage() {
-        runTest("testMoveCursorToNextPageFromLastPage");
-    }
-
-    @Test
-    public void testArbitrarySoupNames()  {
-        runTest("testArbitrarySoupNames");
-    }
-
-    @Test
-    public void testQuerySpecFactories()  {
-        runTest("testQuerySpecFactories");
-    }
-
-    @Test
-    public void testLikeQuerySpecStartsWith()  {
-        runTest("testLikeQuerySpecStartsWith");
-    }
-
-    @Test
-    public void testLikeQuerySpecEndsWith()  {
-        runTest("testLikeQuerySpecEndsWith");
-    }
-
-    @Test
-    public void testLikeQueryInnerText()  {
-        runTest("testLikeQueryInnerText");
-    }
-
-    @Test
-    public void testFullTextSearch() {
-        runTest("testFullTextSearch");
-    }
-
-    @Test
-    public void testCompoundQueryPath()  {
-        runTest("testCompoundQueryPath");
-    }
-
-    @Test
-    public void testEmptyQuerySpec()  {
-        runTest("testEmptyQuerySpec");
-    }
-
-    @Test
-    public void testIntegerQuerySpec()  {
-        runTest("testIntegerQuerySpec");
-    }
-
-    @Test
-    public void testSmartQueryWithCount() {
-        runTest("testSmartQueryWithCount");
-    }
-
-    @Test
-    public void testSmartQueryWithSpecialFields() {
-        runTest("testSmartQueryWithSpecialFields");
-    }
-
-    @Test
-    public void testSmartQueryWithIntegerCompare() {
-        runTest("testSmartQueryWithIntegerCompare");
-    }
-
-    @Test
-    public void testSmartQueryWithMultipleFieldsAndWhereInClause() {
-        runTest("testSmartQueryWithMultipleFieldsAndWhereInClause");
-    }
-
-    @Test
-    public void testSmartQueryWithSingleFieldAndWhereInClause() {
-        runTest("testSmartQueryWithSingleFieldAndWhereInClause");
-    }
-
-    @Test
-    public void testSmartQueryWithWhereLikeClause() {
-        runTest("testSmartQueryWithWhereLikeClause");
-    }
-
-    @Test
-    public void testSmartQueryWithWhereLikeClauseOrdered() {
-        runTest("testSmartQueryWithWhereLikeClauseOrdered");
-    }
-
-    @Test
-    public void testGetSoupIndexSpecs() {
-        runTest("testGetSoupIndexSpecs");
-    }
-
-    @Test
-    public void testGetSoupIndexSpecsWithBogusSoupName() {
-        runTest("testGetSoupIndexSpecsWithBogusSoupName");
-    }
-
-    @Test
-    public void testAlterSoupNoReIndexing() {
-        runTest("testAlterSoupNoReIndexing");
-    }
-
-    @Test
-    public void testAlterSoupWithReIndexing() {
-        runTest("testAlterSoupWithReIndexing");
-    }
-
-    @Test
-    public void testAlterSoupWithSpecNoReIndexing() {
-        runTest("testAlterSoupWithSpecNoReIndexing");
-    }
-
-    @Test
-    public void testAlterSoupWithSpecWithReIndexing() {
-        runTest("testAlterSoupWithSpecWithReIndexing");
-    }
-
-    @Test
-    public void testAlterSoupWithBogusSoupName() {
-        runTest("testAlterSoupWithBogusSoupName");
-    }
-
-    @Test
-    public void testReIndexSoup() {
-        runTest("testReIndexSoup");
-    }
-
-    @Test
-    public void testClearSoup() {
-        runTest("testClearSoup");
-    }
-
-    @Test
-    public void testFullTextSearchAgainstArrayNode() {
-        runTest("testFullTextSearchAgainstArrayNode");
-    }
-
-    @Test
-    public void testLikeQueryAgainstArrayNode() {
-        runTest("testLikeQueryAgainstArrayNode");
-    }
-
-    @Test
-    public void testExactQueryAgainstArrayNode() {
-        runTest("testExactQueryAgainstArrayNode");
-    }
-
-    @Test
-    public void testSmartQueryAgainstArrayNode() {
-        runTest("testSmartQueryAgainstArrayNode");
-    }
-
-    @Test
-    public void testCreateMultipleGlobalStores() {
-        runTest("testCreateMultipleGlobalStores");
-    }
-
-    @Test
-    public void testCreateMultipleUserStores() {
-        runTest("testCreateMultipleUserStores");
+    public void test() {
+        runTest(JS_SUITE, testName);
     }
 }

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreLoadJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreLoadJSTest.java
@@ -27,11 +27,11 @@
 package com.salesforce.androidsdk.phonegap;
 
 import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,63 +39,35 @@ import java.util.List;
 /**
  * Running javascript tests for SmartStore plugin.
  */
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 @LargeTest
 public class SmartStoreLoadJSTest extends JSTestCase {
 
-    public SmartStoreLoadJSTest() {
-        super("SmartStoreLoadTestSuite");
-    }
+    private static final String JS_SUITE = "SmartStoreLoadTestSuite";
 
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
+    @Parameterized.Parameter
+    public String testName;
 
-    @Override
-    protected int getMaxRuntimeInSecondsForTest(String testName) {
-    	return 60;
-    }
-
-    @Override
-    public List<String> getTestNames() {
-    	return Arrays.asList(new String[] {
+    @Parameterized.Parameters(name = "{0}")
+    public static List<String> data() {
+        return Arrays.asList(new String[]{
                 "testNumerousFields",
                 "testIncreasingFieldLength",
                 "testAddAndRetrieveManyEntries",
                 "testUpsertManyEntries",
                 "testUpsertAndQueryEntries",
                 "testUpsertConcurrentEntries"
+
         });
     }
 
-    @Test
-    public void testNumerousFields()  {
-    	runTest("testNumerousFields");
+    @BeforeClass
+    public static void runJSTestSuite() throws InterruptedException {
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 60);
     }
 
     @Test
-    public void testIncreasingFieldLength() {
-    	runTest("testIncreasingFieldLength");
-    }
-
-    @Test
-    public void testAddAndRetrieveManyEntries()  {
-    	runTest("testAddAndRetrieveManyEntries");
-    }
-
-    @Test
-    public void testUpsertManyEntries()  {
-    	runTest("testUpsertManyEntries");
-    }
-
-    @Test
-    public void testUpsertAndQueryEntries()  {
-    	runTest("testUpsertAndQueryEntries");
-    }
-
-    @Test
-    public void testUpsertConcurrentEntries() {
-    	runTest("testUpsertConcurrentEntries");
+    public void test() {
+        runTest(JS_SUITE, testName);
     }
 }

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk.phonegap;
 
 import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
@@ -117,7 +117,7 @@ public class SmartSyncJSTest extends JSTestCase {
 
     @BeforeClass
     public static void runJSTestSuite() throws InterruptedException {
-        JSTestCase.runJSTestSuite(JS_SUITE, data(), 30);
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 60);
     }
 
     @Test

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
@@ -29,9 +29,10 @@ package com.salesforce.androidsdk.phonegap;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,27 +40,18 @@ import java.util.List;
 /**
  * Running javascript tests for smart sync plugin.
  */
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 @LargeTest
 public class SmartSyncJSTest extends JSTestCase {
 
-    public SmartSyncJSTest() {
-        super("SmartSyncTestSuite");
-    }
+    private static final String JS_SUITE = "SmartSyncTestSuite";
 
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-    }
+    @Parameterized.Parameter
+    public String testName;
 
-    @Override
-    protected int getMaxRuntimeInSecondsForTest(String testName) {
-        return 30;
-    }
-
-    @Override
-    public List<String> getTestNames() {
-        return Arrays.asList(new String[] {
+    @Parameterized.Parameters(name = "{0}")
+    public static List<String> data() {
+        return Arrays.asList(new String[]{
                 "testStoreCacheInit",
                 "testStoreCacheRetrieve",
                 "testStoreCacheSave",
@@ -121,311 +113,16 @@ public class SmartSyncJSTest extends JSTestCase {
                 "testSyncDownGetSyncDeleteSyncByName",
                 "testSyncUpGetSyncDeleteSyncById",
                 "testSyncUpGetSyncDeleteSyncByName"
-            });
+        });
+    }
+
+    @BeforeClass
+    public static void runJSTestSuite() throws InterruptedException {
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 30);
     }
 
     @Test
-    public void testStoreCacheInit() {
-        runTest("testStoreCacheInit");
-    }
-
-    @Test
-    public void testStoreCacheRetrieve() {
-        runTest("testStoreCacheRetrieve");
-    }
-
-    @Test
-    public void testStoreCacheSave() {
-        runTest("testStoreCacheSave");
-    }
-
-    @Test
-    public void testStoreCacheSaveAll() {
-        runTest("testStoreCacheSaveAll");
-    }
-
-    @Test
-    public void testStoreCacheRemove() {
-        runTest("testStoreCacheRemove");
-    }
-
-    @Test
-    public void testStoreCacheFind() {
-        runTest("testStoreCacheFind");
-    }
-
-    @Test
-    public void testStoreCacheAddLocalFields() {
-        runTest("testStoreCacheAddLocalFields");
-    }
-
-    @Test
-    public void testStoreCacheWithGlobalStore() {
-        runTest("testStoreCacheWithGlobalStore");
-    }
-
-    @Test
-    public void testSObjectTypeDescribe() {
-        runTest("testSObjectTypeDescribe");
-    }
-
-    @Test
-    public void testSObjectTypeGetMetadata() {
-        runTest("testSObjectTypeGetMetadata");
-    }
-
-    @Test
-    public void testSObjectTypeDescribeLayout() {
-        runTest("testSObjectTypeDescribeLayout");
-    }
-
-    @Test
-    public void testSObjectTypeCacheOnlyMode() {
-        runTest("testSObjectTypeCacheOnlyMode");
-    }
-
-    @Test
-    public void testSObjectTypeCacheMerge() {
-        runTest("testSObjectTypeCacheMerge");
-    }
-
-    @Test
-    public void testMultiSObjectTypes() {
-        runTest("testMultiSObjectTypes");
-    }
-
-    @Test
-    public void testSObjectTypeReset() {
-        runTest("testSObjectTypeReset");
-    }
-
-    @Test
-    public void testSyncRemoteObjectWithCacheCreate() {
-        runTest("testSyncRemoteObjectWithCacheCreate");
-    }
-
-    @Test
-    public void testSyncRemoteObjectWithCacheRead() {
-        runTest("testSyncRemoteObjectWithCacheRead");
-    }
-
-    @Test
-    public void testSyncRemoteObjectWithCacheUpdate() {
-        runTest("testSyncRemoteObjectWithCacheUpdate");
-    }
-
-    @Test
-    public void testSyncRemoteObjectWithCacheDelete() {
-        runTest("testSyncRemoteObjectWithCacheDelete");
-    }
-
-    @Test
-    public void testSyncSObjectWithServerCreate() {
-        runTest("testSyncSObjectWithServerCreate");
-    }
-
-    @Test
-    public void testSyncSObjectWithServerRead() {
-        runTest("testSyncSObjectWithServerRead");
-    }
-
-    @Test
-    public void testSyncSObjectWithServerUpdate() {
-        runTest("testSyncSObjectWithServerUpdate");
-    }
-
-    @Test
-    public void testSyncSObjectWithServerDelete() {
-        runTest("testSyncSObjectWithServerDelete");
-    }
-
-    @Test
-    public void testSyncSObjectCreate() {
-        runTest("testSyncSObjectCreate");
-    }
-
-    @Test
-    public void testSyncSObjectRetrieve() {
-        runTest("testSyncSObjectRetrieve");
-    }
-
-    @Test
-    public void testSyncSObjectUpdate() {
-        runTest("testSyncSObjectUpdate");
-    }
-
-    @Test
-    public void testSyncSObjectDelete() {
-        runTest("testSyncSObjectDelete");
-    }
-
-    @Test
-    public void testSyncSObjectDetectConflictCreate() {
-        runTest("testSyncSObjectDetectConflictCreate");
-    }
-
-    @Test
-    public void testSyncSObjectDetectConflictRetrieve() {
-        runTest("testSyncSObjectDetectConflictRetrieve");
-    }
-
-    @Test
-    public void testSyncSObjectDetectConflictUpdate() {
-        runTest("testSyncSObjectDetectConflictUpdate");
-    }
-
-    @Test
-    public void testSyncSObjectDetectConflictDelete() {
-        runTest("testSyncSObjectDetectConflictDelete");
-    }
-
-    @Test
-    public void testSObjectFetch() {
-        runTest("testSObjectFetch");
-    }
-
-    @Test
-    public void testSObjectSave() {
-        runTest("testSObjectSave");
-    }
-
-    @Test
-    public void testSObjectDestroy() {
-        runTest("testSObjectDestroy");
-    }
-
-    @Test
-    public void testSyncApexRestObjectWithServerCreate() {
-        runTest("testSyncApexRestObjectWithServerCreate");
-    }
-
-    @Test
-    public void testSyncApexRestObjectWithServerRead() {
-        runTest("testSyncApexRestObjectWithServerRead");
-    }
-
-    @Test
-    public void testSyncApexRestObjectWithServerUpdate() {
-        runTest("testSyncApexRestObjectWithServerUpdate");
-    }
-
-    @Test
-    public void testSyncApexRestObjectWithServerDelete() {
-        runTest("testSyncApexRestObjectWithServerDelete");
-    }
-
-    @Test
-    public void testFetchApexRestObjectsFromServer() {
-        runTest("testFetchApexRestObjectsFromServer");
-    }
-
-    @Test
-    public void testFetchSObjectsFromServer() {
-        runTest("testFetchSObjectsFromServer");
-    }
-
-    @Test
-    public void testFetchSObjects() {
-        runTest("testFetchSObjects");
-    }
-
-    @Test
-    public void testSObjectCollectionFetch() {
-        runTest("testSObjectCollectionFetch");
-    }
-
-    @Test
-    public void testSyncDown() {
-        runTest("testSyncDown");
-    }
-
-    @Test
-    public void testSyncDownToGlobalStore() {
-        runTest("testSyncDownToGlobalStore");
-    }
-
-    @Test
-    public void testSyncDownWithNoOverwrite() {
-        runTest("testSyncDownWithNoOverwrite");
-    }
-
-    @Test
-    public void testReSync() {
-        runTest("testReSync");
-    }
-
-    @Test
-    public void testRefreshSyncDown() {
-        runTest("testRefreshSyncDown");
-    }
-
-    @Test
-    public void testCleanResyncGhosts() {
-        runTest("testCleanResyncGhosts");
-    }
-
-    @Test
-    public void testSyncUpLocallyUpdated() {
-        runTest("testSyncUpLocallyUpdated");
-    }
-
-    @Test
-    public void testSyncUpLocallyUpdatedWithGlobalStore() {
-        runTest("testSyncUpLocallyUpdatedWithGlobalStore");
-    }
-
-    @Test
-    public void testSyncUpLocallyUpdatedWithNoOverwrite() {
-        runTest("testSyncUpLocallyUpdatedWithNoOverwrite");
-    }
-
-    @Test
-    public void testSyncUpLocallyDeleted() {
-        runTest("testSyncUpLocallyDeleted");
-    }
-
-    @Test
-    public void testSyncUpLocallyDeletedWithNoOverwrite() {
-        runTest("testSyncUpLocallyDeletedWithNoOverwrite");
-    }
-
-    @Test
-    public void testSyncUpLocallyCreated() {
-        runTest("testSyncUpLocallyCreated");
-    }
-
-    @Test
-    public void testStoreCacheWithGlobalStoreNamed() {
-        runTest("testStoreCacheWithGlobalStoreNamed");
-    }
-
-    @Test
-    public void testSyncDownToGlobalStoreNamed() {
-        runTest("testSyncDownToGlobalStoreNamed");
-    }
-
-    @Test
-    public void testSyncUpLocallyUpdatedWithGlobalStoreNamed() {
-        runTest("testSyncUpLocallyUpdatedWithGlobalStoreNamed");
-    }
-
-    @Test
-    public void testSyncDownGetSyncDeleteSyncById() {
-        runTest("testSyncDownGetSyncDeleteSyncById");
-    }
-
-    @Test
-    public void testSyncDownGetSyncDeleteSyncByName() {
-        runTest("testSyncDownGetSyncDeleteSyncByName");
-    }
-
-    @Test
-    public void testSyncUpGetSyncDeleteSyncById() {
-        runTest("testSyncUpGetSyncDeleteSyncById");
-    }
-
-    @Test
-    public void testSyncUpGetSyncDeleteSyncByName() {
-        runTest("testSyncUpGetSyncDeleteSyncByName");
+    public void test() {
+        runTest(JS_SUITE, testName);
     }
 }


### PR DESCRIPTION
Hybrid tests run all the javascript tests at once at the beginning saving the results in a static map.

We used to have a method returning the list of of javascript tests to run and a java test method per javascript test. The java test methods were simply getting the saved result.

Now, the running of all the javascript tests happens in the static method annotated with BeforeClass.
The list of tests to run is returned by the data() method and is invoked by the the Parameterized test runner to create an instance of the test class per value. There is only one test method which simply gets the result for the test of this instance.
