### PR TITLE
Added an option to generate an AES-128 key and related unit tests

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -73,8 +73,20 @@ public class SalesforceKeyGenerator {
      * @return Unique ID.
      */
     public static synchronized String getUniqueId(String name) {
+        return getUniqueId(name, 256);
+    }
+
+
+    /**
+     * Returns the unique ID being used based on the key length.
+     *
+     * @param name Unique name associated with this unique ID.
+     * @param length Key length
+     * @return Unique ID.
+     */
+    public static String getUniqueId(String name, int length) {
         if (UNIQUE_IDS.get(name) == null) {
-            generateUniqueId(name);
+            generateUniqueId(name, length);
         }
         return UNIQUE_IDS.get(name);
     }
@@ -137,7 +149,7 @@ public class SalesforceKeyGenerator {
         }
     }
 
-    private static void generateUniqueId(String name) {
+    private static void generateUniqueId(String name, int length) {
         final SharedPreferences prefs = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(SHARED_PREF_FILE, 0);
         final String id = prefs.getString(getSharedPrefKey(name), null);
 
@@ -149,7 +161,7 @@ public class SalesforceKeyGenerator {
             try {
 
                 // Uses SecureRandom to generate an AES-256 key.
-                final int outputKeyLength = 256;
+                final int outputKeyLength = length;
                 final SecureRandom secureRandom = SecureRandom.getInstance(SHA1PRNG);
 
                 // SecureRandom does not require seeding. It's automatically seeded from system entropy.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -46,8 +46,8 @@ import android.text.TextUtils;
 import android.util.Base64;
 
 /**
- * This class provides methods to generate a unique ID that can be used as an encryption
- * key. The key is derived from an AES-256 base using SecureRandom or AES-128 base using UUID.
+ * This class provides methods to generate a unique ID that can be used as an encryption key. The
+ * key is derived from an AES-256 base using SecureRandom or AES-128 base using UUID.
  *
  * @author bhariharan
  */
@@ -69,9 +69,7 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the unique ID being used. The default key length is 256 bits.
      *
-     * @param name
-     *         Unique name associated with this unique ID.
-     *
+     * @param name Unique name associated with this unique ID.
      * @return Unique ID.
      */
     public static synchronized String getUniqueId(String name) {
@@ -81,11 +79,8 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the unique ID being used based on the key length.
      *
-     * @param name
-     *         Unique name associated with this unique ID.
-     * @param length
-     *         Key length
-     *
+     * @param name Unique name associated with this unique ID.
+     * @param length Key length
      * @return Unique ID.
      */
     public static String getUniqueId(String name, int length) {
@@ -98,9 +93,7 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the encryption key being used.
      *
-     * @param name
-     *         Unique name associated with this encryption key.
-     *
+     * @param name Unique name associated with this encryption key.
      * @return Encryption key.
      */
     public static synchronized String getEncryptionKey(String name) {
@@ -125,9 +118,7 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the SHA-256 hashed value of the supplied private key.
      *
-     * @param privateKey
-     *         Private key.
-     *
+     * @param privateKey Private key.
      * @return SHA-256 hash.
      */
     public static String getSHA256Hash(String privateKey) {
@@ -136,7 +127,9 @@ public class SalesforceKeyGenerator {
         try {
             final MessageDigest digest = MessageDigest.getInstance(SHA256);
             byte[] hash = digest.digest(privateKeyBytes);
-            hashedString = Base64.encodeToString(hash, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+            hashedString =
+                    Base64.encodeToString(
+                            hash, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
         } catch (Exception e) {
             SalesforceSDKLogger.e(TAG, "Exception thrown while generating SHA-256 hash", e);
         }
@@ -158,7 +151,10 @@ public class SalesforceKeyGenerator {
     }
 
     private static void generateUniqueId(String name, int length) {
-        final SharedPreferences prefs = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(SHARED_PREF_FILE, 0);
+        final SharedPreferences prefs =
+                SalesforceSDKManager.getInstance()
+                        .getAppContext()
+                        .getSharedPreferences(SHARED_PREF_FILE, 0);
         final String id = prefs.getString(getSharedPrefKey(name), null);
 
         // Checks if we have a unique identifier stored.
@@ -172,12 +168,15 @@ public class SalesforceKeyGenerator {
                 final int outputKeyLength = length;
                 final SecureRandom secureRandom = SecureRandom.getInstance(SHA1PRNG);
 
-                // SecureRandom does not require seeding. It's automatically seeded from system entropy.
+                // SecureRandom does not require seeding. It's automatically seeded from system
+                // entropy.
                 final KeyGenerator keyGenerator = KeyGenerator.getInstance(AES);
                 keyGenerator.init(outputKeyLength, secureRandom);
 
                 // Generates a key based on the input length.
-                uniqueId = Base64.encodeToString(keyGenerator.generateKey().getEncoded(), Base64.NO_WRAP);
+                uniqueId =
+                        Base64.encodeToString(
+                                keyGenerator.generateKey().getEncoded(), Base64.NO_WRAP);
             } catch (NoSuchAlgorithmException e) {
                 SalesforceSDKLogger.e(TAG, "Security exception thrown", e);
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -26,6 +26,13 @@
  */
 package com.salesforce.androidsdk.security;
 
+import android.content.SharedPreferences;
+import android.text.TextUtils;
+import android.util.Base64;
+
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.util.SalesforceSDKLogger;
+
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -37,13 +44,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import javax.crypto.KeyGenerator;
-
-import com.salesforce.androidsdk.app.SalesforceSDKManager;
-import com.salesforce.androidsdk.util.SalesforceSDKLogger;
-
-import android.content.SharedPreferences;
-import android.text.TextUtils;
-import android.util.Base64;
 
 /**
  * This class provides methods to generate a unique ID that can be used as an encryption
@@ -67,30 +67,14 @@ public class SalesforceKeyGenerator {
     private static Map<String, String> CACHED_ENCRYPTION_KEYS = new HashMap<>();
 
     /**
-     * Returns the unique ID being used. The default key length is 256 bits.
+     * Returns the unique ID being used.
      *
-     * @param name
-     *         Unique name associated with this unique ID.
-     *
+     * @param name Unique name associated with this unique ID.
      * @return Unique ID.
      */
     public static synchronized String getUniqueId(String name) {
-        return getUniqueId(name, 256);
-    }
-
-    /**
-     * Returns the unique ID being used based on the key length.
-     *
-     * @param name
-     *         Unique name associated with this unique ID.
-     * @param length
-     *         Key length
-     *
-     * @return Unique ID.
-     */
-    public static String getUniqueId(String name, int length) {
         if (UNIQUE_IDS.get(name) == null) {
-            generateUniqueId(name, length);
+            generateUniqueId(name);
         }
         return UNIQUE_IDS.get(name);
     }
@@ -98,9 +82,7 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the encryption key being used.
      *
-     * @param name
-     *         Unique name associated with this encryption key.
-     *
+     * @param name Unique name associated with this encryption key.
      * @return Encryption key.
      */
     public static synchronized String getEncryptionKey(String name) {
@@ -119,15 +101,13 @@ public class SalesforceKeyGenerator {
         final SecureRandom secureRandom = new SecureRandom();
         byte[] random = new byte[128];
         secureRandom.nextBytes(random);
-        return Base64.encodeToString(random, Base64.NO_WRAP | Base64.NO_PADDING | Base64.URL_SAFE);
+        return Base64.encodeToString(random,Base64.NO_WRAP | Base64.NO_PADDING | Base64.URL_SAFE);
     }
 
     /**
      * Returns the SHA-256 hashed value of the supplied private key.
      *
-     * @param privateKey
-     *         Private key.
-     *
+     * @param privateKey Private key.
      * @return SHA-256 hash.
      */
     public static String getSHA256Hash(String privateKey) {
@@ -137,7 +117,7 @@ public class SalesforceKeyGenerator {
             final MessageDigest digest = MessageDigest.getInstance(SHA256);
             byte[] hash = digest.digest(privateKeyBytes);
             hashedString = Base64.encodeToString(hash, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
-        } catch (Exception e) {
+        } catch(Exception e) {
             SalesforceSDKLogger.e(TAG, "Exception thrown while generating SHA-256 hash", e);
         }
         return hashedString;
@@ -157,7 +137,7 @@ public class SalesforceKeyGenerator {
         }
     }
 
-    private static void generateUniqueId(String name, int length) {
+    private static void generateUniqueId(String name) {
         final SharedPreferences prefs = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(SHARED_PREF_FILE, 0);
         final String id = prefs.getString(getSharedPrefKey(name), null);
 
@@ -168,15 +148,15 @@ public class SalesforceKeyGenerator {
             String uniqueId;
             try {
 
-                // Uses SecureRandom to generate an AES key based on input length.
-                final int outputKeyLength = length;
+                // Uses SecureRandom to generate an AES-256 key.
+                final int outputKeyLength = 256;
                 final SecureRandom secureRandom = SecureRandom.getInstance(SHA1PRNG);
 
                 // SecureRandom does not require seeding. It's automatically seeded from system entropy.
                 final KeyGenerator keyGenerator = KeyGenerator.getInstance(AES);
                 keyGenerator.init(outputKeyLength, secureRandom);
 
-                // Generates a key based on the input length.
+                // Generates a 256-bit key.
                 uniqueId = Base64.encodeToString(keyGenerator.generateKey().getEncoded(), Base64.NO_WRAP);
             } catch (NoSuchAlgorithmException e) {
                 SalesforceSDKLogger.e(TAG, "Security exception thrown", e);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -46,8 +46,8 @@ import android.text.TextUtils;
 import android.util.Base64;
 
 /**
- * This class provides methods to generate a unique ID that can be used as an encryption key. The
- * key is derived from an AES-256 base using SecureRandom or AES-128 base using UUID.
+ * This class provides methods to generate a unique ID that can be used as an encryption
+ * key. The key is derived from an AES-256 base using SecureRandom or AES-128 base using UUID.
  *
  * @author bhariharan
  */
@@ -69,7 +69,9 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the unique ID being used. The default key length is 256 bits.
      *
-     * @param name Unique name associated with this unique ID.
+     * @param name
+     *         Unique name associated with this unique ID.
+     *
      * @return Unique ID.
      */
     public static synchronized String getUniqueId(String name) {
@@ -79,8 +81,11 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the unique ID being used based on the key length.
      *
-     * @param name Unique name associated with this unique ID.
-     * @param length Key length
+     * @param name
+     *         Unique name associated with this unique ID.
+     * @param length
+     *         Key length
+     *
      * @return Unique ID.
      */
     public static String getUniqueId(String name, int length) {
@@ -93,7 +98,9 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the encryption key being used.
      *
-     * @param name Unique name associated with this encryption key.
+     * @param name
+     *         Unique name associated with this encryption key.
+     *
      * @return Encryption key.
      */
     public static synchronized String getEncryptionKey(String name) {
@@ -118,7 +125,9 @@ public class SalesforceKeyGenerator {
     /**
      * Returns the SHA-256 hashed value of the supplied private key.
      *
-     * @param privateKey Private key.
+     * @param privateKey
+     *         Private key.
+     *
      * @return SHA-256 hash.
      */
     public static String getSHA256Hash(String privateKey) {
@@ -127,9 +136,7 @@ public class SalesforceKeyGenerator {
         try {
             final MessageDigest digest = MessageDigest.getInstance(SHA256);
             byte[] hash = digest.digest(privateKeyBytes);
-            hashedString =
-                    Base64.encodeToString(
-                            hash, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
+            hashedString = Base64.encodeToString(hash, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
         } catch (Exception e) {
             SalesforceSDKLogger.e(TAG, "Exception thrown while generating SHA-256 hash", e);
         }
@@ -151,10 +158,7 @@ public class SalesforceKeyGenerator {
     }
 
     private static void generateUniqueId(String name, int length) {
-        final SharedPreferences prefs =
-                SalesforceSDKManager.getInstance()
-                        .getAppContext()
-                        .getSharedPreferences(SHARED_PREF_FILE, 0);
+        final SharedPreferences prefs = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(SHARED_PREF_FILE, 0);
         final String id = prefs.getString(getSharedPrefKey(name), null);
 
         // Checks if we have a unique identifier stored.
@@ -168,15 +172,12 @@ public class SalesforceKeyGenerator {
                 final int outputKeyLength = length;
                 final SecureRandom secureRandom = SecureRandom.getInstance(SHA1PRNG);
 
-                // SecureRandom does not require seeding. It's automatically seeded from system
-                // entropy.
+                // SecureRandom does not require seeding. It's automatically seeded from system entropy.
                 final KeyGenerator keyGenerator = KeyGenerator.getInstance(AES);
                 keyGenerator.init(outputKeyLength, secureRandom);
 
                 // Generates a key based on the input length.
-                uniqueId =
-                        Base64.encodeToString(
-                                keyGenerator.generateKey().getEncoded(), Base64.NO_WRAP);
+                uniqueId = Base64.encodeToString(keyGenerator.generateKey().getEncoded(), Base64.NO_WRAP);
             } catch (NoSuchAlgorithmException e) {
                 SalesforceSDKLogger.e(TAG, "Security exception thrown", e);
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -67,12 +67,12 @@ public class SalesforceKeyGenerator {
     private static Map<String, String> CACHED_ENCRYPTION_KEYS = new HashMap<>();
 
     /**
-     * Returns the unique ID being used.
+     * Returns the unique ID being used. The default key length is 256 bits.
      *
      * @param name Unique name associated with this unique ID.
      * @return Unique ID.
      */
-    public static synchronized String getUniqueId(String name) {
+    public static String getUniqueId(String name) {
         return getUniqueId(name, 256);
     }
 
@@ -84,7 +84,7 @@ public class SalesforceKeyGenerator {
      * @param length Key length
      * @return Unique ID.
      */
-    public static String getUniqueId(String name, int length) {
+    public static synchronized String getUniqueId(String name, int length) {
         if (UNIQUE_IDS.get(name) == null) {
             generateUniqueId(name, length);
         }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
@@ -52,6 +52,7 @@ public class SalesforceKeyGeneratorTest {
 
     private static final String KEY_1 = "key_1";
     private static final String KEY_2 = "key_2";
+    private static final String KEY_3 = "key_3";
 
     @Before
 	public void setUp() throws Exception {
@@ -65,9 +66,18 @@ public class SalesforceKeyGeneratorTest {
 		final String id1 = SalesforceKeyGenerator.getUniqueId(KEY_1);
         final String id1Again = SalesforceKeyGenerator.getUniqueId(KEY_1);
 		final String id2 = SalesforceKeyGenerator.getUniqueId(KEY_2);
+        // Output: 4*Math.Ceiling(((double)bytes.Length/3))) + length of getAddendum(KEY)
+        // 4*Math.Ceiling(32/3)+14 = 58
+        Assert.assertEquals(id1.length(), 58);
 		Assert.assertEquals("Unique IDs with the same name should be the same", id1, id1Again);
         Assert.assertNotSame("Unique IDs with different names should be different", id1, id2);
-	}
+
+        final String id3 = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
+        final String id3Again = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
+        // 4*Math.Ceiling(16/3)+14 = 38
+        Assert.assertEquals(id3.length(), 38);
+        Assert.assertEquals("Unique IDs with the same name should be the same", id3, id3Again);
+    }
 
 	@Test
     public void testGetEncryptionKey() {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
@@ -26,20 +26,20 @@
  */
 package com.salesforce.androidsdk.app;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import android.app.Application;
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 
 import junit.framework.Assert;
 
-import android.app.Application;
-import android.app.Instrumentation;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * Tests for {@link SalesforceKeyGenerator}.
@@ -52,34 +52,24 @@ public class SalesforceKeyGeneratorTest {
 
     private static final String KEY_1 = "key_1";
     private static final String KEY_2 = "key_2";
-    private static final String KEY_3 = "key_3";
 
     @Before
-    public void setUp() throws Exception {
-        final Application app = Instrumentation.newApplication(TestForceApp.class,
-                                                               InstrumentationRegistry.getTargetContext());
-        InstrumentationRegistry.getInstrumentation().callApplicationOnCreate(app);
-    }
+	public void setUp() throws Exception {
+		final Application app = Instrumentation.newApplication(TestForceApp.class,
+				InstrumentationRegistry.getTargetContext());
+		InstrumentationRegistry.getInstrumentation().callApplicationOnCreate(app);
+	}
 
-    @Test
-    public void testGetUniqueId() {
-        final String id1 = SalesforceKeyGenerator.getUniqueId(KEY_1);
+	@Test
+	public void testGetUniqueId() {
+		final String id1 = SalesforceKeyGenerator.getUniqueId(KEY_1);
         final String id1Again = SalesforceKeyGenerator.getUniqueId(KEY_1);
-        final String id2 = SalesforceKeyGenerator.getUniqueId(KEY_2);
-        // 4*Math.Ceiling(((double)bytes.Length/3))) + length of getAddendum(KEY)
-        // 4*Math.Ceiling(32/3)+14 = 58
-        Assert.assertEquals(id1.length(), 58);
-        Assert.assertEquals("Unique IDs with the same name should be the same", id1, id1Again);
+		final String id2 = SalesforceKeyGenerator.getUniqueId(KEY_2);
+		Assert.assertEquals("Unique IDs with the same name should be the same", id1, id1Again);
         Assert.assertNotSame("Unique IDs with different names should be different", id1, id2);
+	}
 
-        final String id3 = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
-        final String id3Again = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
-        // 4*Math.Ceiling(16/3)+14 = 38
-        Assert.assertEquals(id3.length(), 38);
-        Assert.assertEquals("Unique IDs with the same name should be the same", id3, id3Again);
-    }
-
-    @Test
+	@Test
     public void testGetEncryptionKey() {
         final String id1 = SalesforceKeyGenerator.getEncryptionKey(KEY_1);
         final String id1Again = SalesforceKeyGenerator.getEncryptionKey(KEY_1);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
@@ -68,14 +68,14 @@ public class SalesforceKeyGeneratorTest {
 		final String id2 = SalesforceKeyGenerator.getUniqueId(KEY_2);
         // Output: 4*Math.Ceiling(((double)bytes.Length/3))) + length of getAddendum(KEY)
         // 4*Math.Ceiling(32/3)+14 = 58
-        Assert.assertEquals(id1.length(), 58);
+        Assert.assertEquals("The encoded string based on an AES-256 key should have 58 characters", id1.length(), 58);
 		Assert.assertEquals("Unique IDs with the same name should be the same", id1, id1Again);
         Assert.assertNotSame("Unique IDs with different names should be different", id1, id2);
 
         final String id3 = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
         final String id3Again = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
         // 4*Math.Ceiling(16/3)+14 = 38
-        Assert.assertEquals(id3.length(), 38);
+        Assert.assertEquals("The encoded string based on an AES-128 key should have 38 characters", id3.length(), 38);
         Assert.assertEquals("Unique IDs with the same name should be the same", id3, id3Again);
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
@@ -56,9 +56,8 @@ public class SalesforceKeyGeneratorTest {
 
     @Before
     public void setUp() throws Exception {
-        final Application app =
-                Instrumentation.newApplication(
-                        TestForceApp.class, InstrumentationRegistry.getTargetContext());
+        final Application app = Instrumentation.newApplication(TestForceApp.class,
+                                                               InstrumentationRegistry.getTargetContext());
         InstrumentationRegistry.getInstrumentation().callApplicationOnCreate(app);
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
@@ -56,8 +56,9 @@ public class SalesforceKeyGeneratorTest {
 
     @Before
     public void setUp() throws Exception {
-        final Application app = Instrumentation.newApplication(TestForceApp.class,
-                                                               InstrumentationRegistry.getTargetContext());
+        final Application app =
+                Instrumentation.newApplication(
+                        TestForceApp.class, InstrumentationRegistry.getTargetContext());
         InstrumentationRegistry.getInstrumentation().callApplicationOnCreate(app);
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceKeyGeneratorTest.java
@@ -26,20 +26,20 @@
  */
 package com.salesforce.androidsdk.app;
 
-import android.app.Application;
-import android.app.Instrumentation;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 
 import junit.framework.Assert;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import android.app.Application;
+import android.app.Instrumentation;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
 
 /**
  * Tests for {@link SalesforceKeyGenerator}.
@@ -52,24 +52,34 @@ public class SalesforceKeyGeneratorTest {
 
     private static final String KEY_1 = "key_1";
     private static final String KEY_2 = "key_2";
+    private static final String KEY_3 = "key_3";
 
     @Before
-	public void setUp() throws Exception {
-		final Application app = Instrumentation.newApplication(TestForceApp.class,
-				InstrumentationRegistry.getTargetContext());
-		InstrumentationRegistry.getInstrumentation().callApplicationOnCreate(app);
-	}
+    public void setUp() throws Exception {
+        final Application app = Instrumentation.newApplication(TestForceApp.class,
+                                                               InstrumentationRegistry.getTargetContext());
+        InstrumentationRegistry.getInstrumentation().callApplicationOnCreate(app);
+    }
 
-	@Test
-	public void testGetUniqueId() {
-		final String id1 = SalesforceKeyGenerator.getUniqueId(KEY_1);
+    @Test
+    public void testGetUniqueId() {
+        final String id1 = SalesforceKeyGenerator.getUniqueId(KEY_1);
         final String id1Again = SalesforceKeyGenerator.getUniqueId(KEY_1);
-		final String id2 = SalesforceKeyGenerator.getUniqueId(KEY_2);
-		Assert.assertEquals("Unique IDs with the same name should be the same", id1, id1Again);
+        final String id2 = SalesforceKeyGenerator.getUniqueId(KEY_2);
+        // 4*Math.Ceiling(((double)bytes.Length/3))) + length of getAddendum(KEY)
+        // 4*Math.Ceiling(32/3)+14 = 58
+        Assert.assertEquals(id1.length(), 58);
+        Assert.assertEquals("Unique IDs with the same name should be the same", id1, id1Again);
         Assert.assertNotSame("Unique IDs with different names should be different", id1, id2);
-	}
 
-	@Test
+        final String id3 = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
+        final String id3Again = SalesforceKeyGenerator.getUniqueId(KEY_3, 128);
+        // 4*Math.Ceiling(16/3)+14 = 38
+        Assert.assertEquals(id3.length(), 38);
+        Assert.assertEquals("Unique IDs with the same name should be the same", id3, id3Again);
+    }
+
+    @Test
     public void testGetEncryptionKey() {
         final String id1 = SalesforceKeyGenerator.getEncryptionKey(KEY_1);
         final String id1Again = SalesforceKeyGenerator.getEncryptionKey(KEY_1);


### PR DESCRIPTION
We are using `Google-java-format` plugin (AOSP style) in Android Studio. That's why there's so many format changes... Any suggestion to improve this?