### PR TITLE
Fixed the issue that the response can be consumed multiple times.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestResponse.java
@@ -123,9 +123,8 @@ public class RestResponse {
 					responseAsBytes = new byte[0];
 					responseCharSet = StandardCharsets.UTF_8;
 				}
-
-				consumed = true;
 			} finally {
+				consumed = true;
 				response.close();
 			}
 		}
@@ -138,7 +137,7 @@ public class RestResponse {
 	public void consumeQuietly() {
 		try {
 			consume();
-		} catch (IOException e) {
+		} catch (Exception e) {
 			SalesforceSDKLogger.e(TAG, "Content could not be written to a byte array", e);
 		}
 	}


### PR DESCRIPTION
- put 'consumed = true' into the finally block, so that it will be updated even when there is any exception in the try block. As a result, the same response won't be consumed again when consume() is called later on.
- updated consumeQuietly() to make sure it will swallow any exception. 