### PR TITLE
Clean ghosts should not remove records downloaded by the sync

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
@@ -74,9 +74,6 @@ public class SyncManager {
 
     private static final String FEATURE_SMART_SYNC = "SY";
 
-    // Field added to record to remember sync it came through
-    public static final String SYNC_ID = "__sync_id__";
-
     // Static member
     private static Map<String, SyncManager> INSTANCES = new HashMap<String, SyncManager>();
 
@@ -637,11 +634,8 @@ public class SyncManager {
             // Figure out records to save
             JSONArray recordsToSave = idsToSkip == null ? records : removeWithIds(records, idsToSkip, idField);
 
-            // Add sync id in records
-            addSyncId(recordsToSave, sync.getId());
-
             // Save to smartstore.
-            target.saveRecordsToLocalStore(this, soupName, recordsToSave);
+            target.saveRecordsToLocalStore(this, soupName, recordsToSave, sync.getId());
             countSaved += records.length();
             maxTimeStamp = Math.max(maxTimeStamp, target.getLatestModificationTimeStamp(records));
 
@@ -668,13 +662,6 @@ public class SyncManager {
             }
         }
         return arr;
-    }
-
-    private void addSyncId(JSONArray records, long syncId) throws JSONException {
-        for (int i = 0; i < records.length(); i++) {
-            JSONObject record = records.getJSONObject(i);
-            record.put(SYNC_ID, syncId);
-        }
     }
 
     /**

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
@@ -74,6 +74,9 @@ public class SyncManager {
 
     private static final String FEATURE_SMART_SYNC = "SY";
 
+    // Field added to record to remember sync it came through
+    public static final String SYNC_ID = "__sync_id__";
+
     // Static member
     private static Map<String, SyncManager> INSTANCES = new HashMap<String, SyncManager>();
 
@@ -436,7 +439,7 @@ public class SyncManager {
         final SyncDownTarget target = (SyncDownTarget) sync.getTarget();
 
         // Ask target to clean up ghosts
-        final int localIdSize = target.cleanGhosts(this, soupName);
+        final int localIdSize = target.cleanGhosts(this, soupName, syncId);
         threadPool.execute(new Runnable() {
             @Override
             public void run() {
@@ -634,6 +637,9 @@ public class SyncManager {
             // Figure out records to save
             JSONArray recordsToSave = idsToSkip == null ? records : removeWithIds(records, idsToSkip, idField);
 
+            // Add sync id in records
+            addSyncId(recordsToSave, sync.getId());
+
             // Save to smartstore.
             target.saveRecordsToLocalStore(this, soupName, recordsToSave);
             countSaved += records.length();
@@ -662,6 +668,13 @@ public class SyncManager {
             }
         }
         return arr;
+    }
+
+    private void addSyncId(JSONArray records, long syncId) throws JSONException {
+        for (int i = 0; i < records.length(); i++) {
+            JSONObject record = records.getJSONObject(i);
+            record.put(SYNC_ID, syncId);
+        }
     }
 
     /**

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncDownTarget.java
@@ -163,16 +163,15 @@ public class ParentChildrenSyncDownTarget extends SoqlSyncDownTarget {
 
 
     @Override
-    public int cleanGhosts(SyncManager syncManager, String soupName) throws JSONException, IOException {
+    public int cleanGhosts(SyncManager syncManager, String soupName, long syncId) throws JSONException, IOException {
         // Taking care of ghost parents
-        int localIdsSize = super.cleanGhosts(syncManager, soupName);
+        int localIdsSize = super.cleanGhosts(syncManager, soupName, syncId);
 
         // Taking care of ghost children
 
         // NB: ParentChildrenSyncDownTarget's getNonDirtyRecordIdsSql does a join between parent and children soups
         // We only want to look at the children soup, so using SoqlSyncDownTarget's getNonDirtyRecordIdsSql
-
-        final Set<String> localChildrenIds = getIdsWithQuery(syncManager, super.getNonDirtyRecordIdsSql(childrenInfo.soupName, childrenInfo.idFieldName));
+        final Set<String> localChildrenIds = getIdsWithQuery(syncManager, super.getNonDirtyRecordIdsSql(childrenInfo.soupName, childrenInfo.idFieldName, ""));
         final Set<String> remoteChildrenIds = getChildrenRemoteIdsWithSoql(syncManager, getSoqlForRemoteChildrenIds());
         if (remoteChildrenIds != null) {
             localChildrenIds.removeAll(remoteChildrenIds);
@@ -312,7 +311,7 @@ public class ParentChildrenSyncDownTarget extends SoqlSyncDownTarget {
     }
 
     @Override
-    protected String getNonDirtyRecordIdsSql(String soupName, String idField) {
+    protected String getNonDirtyRecordIdsSql(String soupName, String idField, String additionalPredicate) {
         return ParentChildrenSyncTargetHelper.getNonDirtyRecordIdsSql(parentInfo, childrenInfo, idField);
     }
 

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncDownTarget.java
@@ -171,7 +171,7 @@ public class ParentChildrenSyncDownTarget extends SoqlSyncDownTarget {
 
         // NB: ParentChildrenSyncDownTarget's getNonDirtyRecordIdsSql does a join between parent and children soups
         // We only want to look at the children soup, so using SoqlSyncDownTarget's getNonDirtyRecordIdsSql
-        final Set<String> localChildrenIds = getIdsWithQuery(syncManager, super.getNonDirtyRecordIdsSql(childrenInfo.soupName, childrenInfo.idFieldName, ""));
+        final Set<String> localChildrenIds = getIdsWithQuery(syncManager, super.getNonDirtyRecordIdsSql(childrenInfo.soupName, childrenInfo.idFieldName, buildSyncIdPredicateIfIndexed(syncManager, childrenInfo.soupName, syncId)));
         final Set<String> remoteChildrenIds = getChildrenRemoteIdsWithSoql(syncManager, getSoqlForRemoteChildrenIds());
         if (remoteChildrenIds != null) {
             localChildrenIds.removeAll(remoteChildrenIds);
@@ -312,13 +312,13 @@ public class ParentChildrenSyncDownTarget extends SoqlSyncDownTarget {
 
     @Override
     protected String getNonDirtyRecordIdsSql(String soupName, String idField, String additionalPredicate) {
-        return ParentChildrenSyncTargetHelper.getNonDirtyRecordIdsSql(parentInfo, childrenInfo, idField);
+        return ParentChildrenSyncTargetHelper.getNonDirtyRecordIdsSql(parentInfo, childrenInfo, idField, additionalPredicate);
     }
 
     @Override
-    public void saveRecordsToLocalStore(SyncManager syncManager, String soupName, JSONArray records) throws JSONException {
+    public void saveRecordsToLocalStore(SyncManager syncManager, String soupName, JSONArray records, long syncId) throws JSONException {
         // NB: method is called during sync down so for this target records contain parent and children
-        ParentChildrenSyncTargetHelper.saveRecordTreesToLocalStore(syncManager, this, parentInfo, childrenInfo, records);
+        ParentChildrenSyncTargetHelper.saveRecordTreesToLocalStore(syncManager, this, parentInfo, childrenInfo, records, syncId);
     }
 
 }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncDownTarget.java
@@ -149,11 +149,8 @@ public abstract class SyncDownTarget extends SyncTarget {
      */
     public int cleanGhosts(SyncManager syncManager, String soupName, long syncId) throws JSONException, IOException {
 
-        // If the soup has an index on __sync_id__, compute predicate to only target records with this syncId
-        String additionalPredicate = buildSyncIdPredicateIfIndexed(syncManager, soupName, syncId);
-
-         // Fetches list of IDs present in local soup that have not been modified locally.
-        final Set<String> localIds = getNonDirtyRecordIds(syncManager, soupName, getIdFieldName(), additionalPredicate);
+        // Fetches list of IDs present in local soup that have not been modified locally.
+        final Set<String> localIds = getNonDirtyRecordIds(syncManager, soupName, getIdFieldName(), buildSyncIdPredicateIfIndexed(syncManager, soupName, syncId));
 
          // Fetches list of IDs still present on the server from the list of local IDs
          // and removes the list of IDs that are still present on the server.
@@ -182,8 +179,8 @@ public abstract class SyncDownTarget extends SyncTarget {
         String additionalPredicate = "";
         IndexSpec[] indexSpecs = syncManager.getSmartStore().getSoupIndexSpecs(soupName);
         for(IndexSpec indexSpec : indexSpecs) {
-            if (indexSpec.path.equals(SyncManager.SYNC_ID)) {
-                additionalPredicate = String.format("AND {%s:%s} = %d", soupName, SyncManager.SYNC_ID, syncId);
+            if (indexSpec.path.equals(SYNC_ID)) {
+                additionalPredicate = String.format("AND {%s:%s} = %d", soupName, SYNC_ID, syncId);
                 break;
             }
         }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncDownTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncDownTarget.java
@@ -26,6 +26,7 @@
  */
 package com.salesforce.androidsdk.smartsync.target;
 
+import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartsync.manager.SyncManager;
 import com.salesforce.androidsdk.smartsync.util.Constants;
 import com.salesforce.androidsdk.smartsync.util.SmartSyncLogger;
@@ -74,7 +75,7 @@ public abstract class SyncDownTarget extends SyncTarget {
         case sosl:    return new SoslSyncDownTarget(target);
         case soql:    return new SoqlSyncDownTarget(target);
         case refresh: return new RefreshSyncDownTarget(target);
-            case parent_children: return new ParentChildrenSyncDownTarget(target);
+        case parent_children: return new ParentChildrenSyncDownTarget(target);
         case custom:
         default:
             try {
@@ -142,12 +143,17 @@ public abstract class SyncDownTarget extends SyncTarget {
      * Delete from local store records that a full sync down would no longer download
      * @param syncManager
      * @param soupName
+     * @param syncId
      * @return
      * @throws JSONException, IOException
      */
-    public int cleanGhosts(SyncManager syncManager, String soupName) throws JSONException, IOException {
+    public int cleanGhosts(SyncManager syncManager, String soupName, long syncId) throws JSONException, IOException {
+
+        // If the soup has an index on __sync_id__, compute predicate to only target records with this syncId
+        String additionalPredicate = buildSyncIdPredicateIfIndexed(syncManager, soupName, syncId);
+
          // Fetches list of IDs present in local soup that have not been modified locally.
-        final Set<String> localIds = getNonDirtyRecordIds(syncManager, soupName, getIdFieldName());
+        final Set<String> localIds = getNonDirtyRecordIds(syncManager, soupName, getIdFieldName(), additionalPredicate);
 
          // Fetches list of IDs still present on the server from the list of local IDs
          // and removes the list of IDs that are still present on the server.
@@ -166,15 +172,35 @@ public abstract class SyncDownTarget extends SyncTarget {
     }
 
     /**
+     * Return predicate to target records with this sync id if there is an index on __sync_id__
+     * @param syncManager
+     * @param soupName
+     * @param syncId
+     * @return
+     */
+    protected String buildSyncIdPredicateIfIndexed(SyncManager syncManager, String soupName, long syncId) {
+        String additionalPredicate = "";
+        IndexSpec[] indexSpecs = syncManager.getSmartStore().getSoupIndexSpecs(soupName);
+        for(IndexSpec indexSpec : indexSpecs) {
+            if (indexSpec.path.equals(SyncManager.SYNC_ID)) {
+                additionalPredicate = String.format("AND {%s:%s} = %d", soupName, SyncManager.SYNC_ID, syncId);
+                break;
+            }
+        }
+        return additionalPredicate;
+    }
+
+    /**
      * Return ids of non-dirty records (records NOT locally created/updated or deleted)
      * @param syncManager
      * @param soupName
      * @param idField
+     * @param additionalPredicate
      * @return
      * @throws JSONException
      */
-    protected SortedSet<String> getNonDirtyRecordIds(SyncManager syncManager, String soupName, String idField) throws JSONException {
-        String nonDirtyRecordsSql = getNonDirtyRecordIdsSql(soupName, idField);
+    protected SortedSet<String> getNonDirtyRecordIds(SyncManager syncManager, String soupName, String idField, String additionalPredicate) throws JSONException {
+        String nonDirtyRecordsSql = getNonDirtyRecordIdsSql(soupName, idField, additionalPredicate);
         return getIdsWithQuery(syncManager, nonDirtyRecordsSql);
     }
 
@@ -182,10 +208,11 @@ public abstract class SyncDownTarget extends SyncTarget {
      * Return SmartSQL to identify non-dirty records
      * @param soupName
      * @param idField
+     * @param additionalPredicate
      * @return
      */
-    protected String getNonDirtyRecordIdsSql(String soupName, String idField) {
-        return String.format("SELECT {%s:%s} FROM {%s} WHERE {%s:%s} = 'false' ORDER BY {%s:%s} ASC", soupName, idField, soupName, soupName, LOCAL, soupName, idField);
+    protected String getNonDirtyRecordIdsSql(String soupName, String idField, String additionalPredicate) {
+        return String.format("SELECT {%s:%s} FROM {%s} WHERE {%s:%s} = 'false' %s ORDER BY {%s:%s} ASC", soupName, idField, soupName, soupName, LOCAL, additionalPredicate, soupName, idField);
     }
 
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
@@ -93,7 +93,7 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
                 new IndexSpec(Constants.NAME, SmartStore.Type.string),
                 new IndexSpec(Constants.DESCRIPTION, SmartStore.Type.string),
                 new IndexSpec(SyncTarget.LOCAL, SmartStore.Type.string),
-                new IndexSpec(SyncManager.SYNC_ID, SmartStore.Type.integer)
+                new IndexSpec(SyncTarget.SYNC_ID, SmartStore.Type.integer)
         };
         smartStore.registerSoup(soupName, indexSpecs);
     }
@@ -472,7 +472,7 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
             JSONArray row = accountsFromDb.getJSONArray(i);
             JSONObject soupElt = row.getJSONObject(0);
             String id = soupElt.getString(Constants.ID);
-            Assert.assertEquals("Wrong sync id", syncId, soupElt.getInt(SyncManager.SYNC_ID));
+            Assert.assertEquals("Wrong sync id", syncId, soupElt.getInt(SyncTarget.SYNC_ID));
         }
     }
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
@@ -92,7 +92,8 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
                 new IndexSpec(Constants.ID, SmartStore.Type.string),
                 new IndexSpec(Constants.NAME, SmartStore.Type.string),
                 new IndexSpec(Constants.DESCRIPTION, SmartStore.Type.string),
-                new IndexSpec(SyncTarget.LOCAL, SmartStore.Type.string)
+                new IndexSpec(SyncTarget.LOCAL, SmartStore.Type.string),
+                new IndexSpec(SyncManager.SYNC_ID, SmartStore.Type.integer)
         };
         smartStore.registerSoup(soupName, indexSpecs);
     }
@@ -454,6 +455,24 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
             Assert.assertEquals("Id was not updated", expectLocallyCreated, id.startsWith(LOCAL_ID_PREFIX));
             Assert.assertEquals("Wrong local flag", expectLocallyUpdated, soupElt.getBoolean(SyncTarget.LOCALLY_UPDATED));
             Assert.assertEquals("Wrong local flag", expectLocallyDeleted, soupElt.getBoolean(SyncTarget.LOCALLY_DELETED));
+        }
+    }
+
+    /**
+     * Check records syncId field in db
+     * @param ids
+     * @param syncId value expected in __sync_id__ field
+     * @param soupName
+     * @throws JSONException
+     */
+    protected void checkDbSyncIdField(String[] ids, long syncId, String soupName) throws JSONException {
+        QuerySpec smartStoreQuery = QuerySpec.buildSmartQuerySpec(String.format("SELECT {%s:_soup} FROM {%s} WHERE {%s:Id} IN %s", soupName, soupName, soupName, makeInClause(ids)), ids.length);
+        JSONArray accountsFromDb = smartStore.query(smartStoreQuery, 0);
+        for (int i=0; i<accountsFromDb.length(); i++) {
+            JSONArray row = accountsFromDb.getJSONArray(i);
+            JSONObject soupElt = row.getJSONObject(0);
+            String id = soupElt.getString(Constants.ID);
+            Assert.assertEquals("Wrong sync id", syncId, soupElt.getInt(SyncManager.SYNC_ID));
         }
     }
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
@@ -646,11 +646,15 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         ParentChildrenSyncDownTarget firstTarget = getAccountContactsSyncDownTarget(
                 String.format("%s IN %s", Constants.ID, makeInClause(accountIdsFirstSubset)));
         long firstSyncId = trySyncDown(SyncState.MergeMode.OVERWRITE, firstTarget, ACCOUNTS_SOUP, accountIdsFirstSubset.length, 1);
+        checkDbExist(ACCOUNTS_SOUP, accountIdsFirstSubset, Constants.ID);
+        checkDbSyncIdField(accountIdsFirstSubset, firstSyncId, ACCOUNTS_SOUP);
 
         // Runs a first sync down (bringing down accounts id2, id3, id4, id5 and their contacts)
         ParentChildrenSyncDownTarget secondTarget = getAccountContactsSyncDownTarget(
                 String.format("%s IN %s", Constants.ID, makeInClause(accountIdsSecondSubset)));
         long secondSyncId = trySyncDown(SyncState.MergeMode.OVERWRITE, secondTarget, ACCOUNTS_SOUP, accountIdsSecondSubset.length, 1);
+        checkDbExist(ACCOUNTS_SOUP, accountIdsSecondSubset, Constants.ID);
+        checkDbSyncIdField(accountIdsSecondSubset, secondSyncId, ACCOUNTS_SOUP);
 
         // Deletes id0, id2, id5 on the server
         deleteRecordsOnServer(new HashSet<>(Arrays.asList(accountIds[0], accountIds[2], accountIds[5])), Constants.ACCOUNT);

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
@@ -169,8 +169,8 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
                 new ChildrenInfo("Child", "Children", "childrenSoup", "ChildParentId", "ChildId", "ChildLastModifiedDate"),
                 Arrays.asList("ChildName", "School"),
                 RelationshipType.LOOKUP);
-        Assert.assertEquals("SELECT DISTINCT {parentsSoup:IdForQuery} FROM {parentsSoup} WHERE {parentsSoup:__local__} = 'false' AND NOT EXISTS (SELECT {childrenSoup:ChildId} FROM {childrenSoup} WHERE {childrenSoup:ChildParentId} = {parentsSoup:ParentId} AND {childrenSoup:__local__} = 'true')",
-                target.getNonDirtyRecordIdsSql("parentsSoup", "IdForQuery", ""));
+        Assert.assertEquals("SELECT DISTINCT {parentsSoup:IdForQuery} FROM {parentsSoup} WHERE {parentsSoup:__local__} = 'false' AND {parentsSoup:__sync_id__} = 123 AND NOT EXISTS (SELECT {childrenSoup:ChildId} FROM {childrenSoup} WHERE {childrenSoup:ChildParentId} = {parentsSoup:ParentId} AND {childrenSoup:__local__} = 'true')",
+                target.getNonDirtyRecordIdsSql("parentsSoup", "IdForQuery", "AND {parentsSoup:__sync_id__} = 123"));
 
     }
 
@@ -229,6 +229,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         // - not have _soupEntryId field
         final int numberAccounts = 4;
         final int numberContactsPerAccount = 3;
+        final long syncId = 123;
         JSONObject accountAttributes = new JSONObject();
         accountAttributes.put(TYPE, Constants.ACCOUNT);
         JSONObject contactAttributes = new JSONObject();
@@ -263,7 +264,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
 
         // Now calling saveRecordsToLocalStore
         ParentChildrenSyncDownTarget target = getAccountContactsSyncDownTarget();
-        target.saveRecordsToLocalStore(syncManager, ACCOUNTS_SOUP, records);
+        target.saveRecordsToLocalStore(syncManager, ACCOUNTS_SOUP, records, syncId);
 
         // Checking accounts and contacts soup
         // Making sure local fields are populated
@@ -279,6 +280,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
             Assert.assertEquals(false, accountFromDb.getBoolean(SyncTarget.LOCALLY_CREATED));
             Assert.assertEquals(false, accountFromDb.getBoolean(SyncTarget.LOCALLY_DELETED));
             Assert.assertEquals(false, accountFromDb.getBoolean(SyncTarget.LOCALLY_UPDATED));
+            Assert.assertEquals(syncId, accountFromDb.getLong(SyncTarget.SYNC_ID));
             JSONObject[] contactsFromDb = queryWithInClause(CONTACTS_SOUP, ACCOUNT_ID, new String[]{account.getString(Constants.ID)}, SmartStore.SOUP_ENTRY_ID);
             JSONObject[] contacts = mapAccountContacts.get(account);
             Assert.assertEquals("Wrong number of contacts in db", contacts.length, contactsFromDb.length);
@@ -291,6 +293,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
                 Assert.assertEquals(false, contactFromDb.getBoolean(SyncTarget.LOCALLY_CREATED));
                 Assert.assertEquals(false, contactFromDb.getBoolean(SyncTarget.LOCALLY_DELETED));
                 Assert.assertEquals(false, contactFromDb.getBoolean(SyncTarget.LOCALLY_UPDATED));
+                Assert.assertEquals(syncId, contactFromDb.getLong(SyncTarget.SYNC_ID));
                 Assert.assertEquals(accountFromDb.getString(Constants.ID), contactFromDb.getString(ACCOUNT_ID));
             }
         }
@@ -623,6 +626,62 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
             }
         }
     }
+
+    /**
+     * Tests clean ghosts when soup is populated through more than one sync down
+     */
+    @Test
+    public void testCleanResyncGhostsForParentChildrenWithMultipleSyncs() throws Exception {
+        final int numberAccounts = 6;
+        final int numberContactsPerAccount = 3;
+
+        // Creating up test accounts and contacts on server
+        createAccountsAndContactsOnServer(numberAccounts, numberContactsPerAccount);
+
+        final String[] accountIds = accountIdToFields.keySet().toArray(new String[0]);
+        final String[] accountIdsFirstSubset = Arrays.copyOfRange(accountIds, 0, 3); // id0, id1, id2
+        final String[] accountIdsSecondSubset = Arrays.copyOfRange(accountIds, 2, 6); //          id2, id3, id4, id5
+
+        // Runs a first sync down (bringing down accounts id0, id1, id2 and their contacts)
+        ParentChildrenSyncDownTarget firstTarget = getAccountContactsSyncDownTarget(
+                String.format("%s IN %s", Constants.ID, makeInClause(accountIdsFirstSubset)));
+        long firstSyncId = trySyncDown(SyncState.MergeMode.OVERWRITE, firstTarget, ACCOUNTS_SOUP, accountIdsFirstSubset.length, 1);
+
+        // Runs a first sync down (bringing down accounts id2, id3, id4, id5 and their contacts)
+        ParentChildrenSyncDownTarget secondTarget = getAccountContactsSyncDownTarget(
+                String.format("%s IN %s", Constants.ID, makeInClause(accountIdsSecondSubset)));
+        long secondSyncId = trySyncDown(SyncState.MergeMode.OVERWRITE, secondTarget, ACCOUNTS_SOUP, accountIdsSecondSubset.length, 1);
+
+        // Deletes id0, id2, id5 on the server
+        deleteRecordsOnServer(new HashSet<>(Arrays.asList(accountIds[0], accountIds[2], accountIds[5])), Constants.ACCOUNT);
+
+        // Cleaning ghosts of first sync (should only remove id0 and its contacts)
+        syncManager.cleanResyncGhosts(firstSyncId);
+        checkDbExist(ACCOUNTS_SOUP, new String[] { accountIds[1], accountIds[2], accountIds[3], accountIds[4], accountIds[5]}, Constants.ID);
+        checkDbDeleted(ACCOUNTS_SOUP, new String[] { accountIds[0]}, Constants.ID);
+        for (String accountId : accountIdContactIdToFields.keySet()) {
+            if (accountId == accountIds[0]) {
+                checkDbDeleted(CONTACTS_SOUP, accountIdContactIdToFields.get(accountId).keySet().toArray(new String[0]), Constants.ID);
+            } else {
+                checkDb(accountIdContactIdToFields.get(accountId), CONTACTS_SOUP);
+
+            }
+        }
+
+        // Cleaning ghosts of second sync (should remove id2 and id5 and their contacts)
+        syncManager.cleanResyncGhosts(secondSyncId);
+        checkDbExist(ACCOUNTS_SOUP, new String[] { accountIds[1], accountIds[3], accountIds[4]}, Constants.ID);
+        checkDbDeleted(ACCOUNTS_SOUP, new String[] { accountIds[2], accountIds[5]}, Constants.ID);
+        for (String accountId : accountIdContactIdToFields.keySet()) {
+            if (accountId == accountIds[0] || accountId == accountIds[2] || accountId == accountIds[5]) {
+                checkDbDeleted(CONTACTS_SOUP, accountIdContactIdToFields.get(accountId).keySet().toArray(new String[0]), Constants.ID);
+            } else {
+                checkDb(accountIdContactIdToFields.get(accountId), CONTACTS_SOUP);
+
+            }
+        }
+    }
+
 
     /**
      * Create accounts and contacts locally, sync up with merge mode OVERWRITE, check smartstore and server afterwards

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
@@ -170,7 +170,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
                 Arrays.asList("ChildName", "School"),
                 RelationshipType.LOOKUP);
         Assert.assertEquals("SELECT DISTINCT {parentsSoup:IdForQuery} FROM {parentsSoup} WHERE {parentsSoup:__local__} = 'false' AND NOT EXISTS (SELECT {childrenSoup:ChildId} FROM {childrenSoup} WHERE {childrenSoup:ChildParentId} = {parentsSoup:ParentId} AND {childrenSoup:__local__} = 'true')",
-                target.getNonDirtyRecordIdsSql("parentsSoup", "IdForQuery"));
+                target.getNonDirtyRecordIdsSql("parentsSoup", "IdForQuery", ""));
 
     }
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTestCase.java
@@ -533,7 +533,7 @@ public class ParentChildrenSyncTestCase extends SyncManagerTestCase {
 
     protected void tryGetNonDirtyRecordIds(JSONObject[] expectedRecords) throws JSONException {
         ParentChildrenSyncDownTarget target = getAccountContactsSyncDownTarget();
-        SortedSet<String> nonDirtyRecordIds = target.getNonDirtyRecordIds(syncManager, ACCOUNTS_SOUP, Constants.ID);
+        SortedSet<String> nonDirtyRecordIds = target.getNonDirtyRecordIds(syncManager, ACCOUNTS_SOUP, Constants.ID, "");
         Assert.assertEquals("Wrong number of non-dirty records", expectedRecords.length, nonDirtyRecordIds.size());
         for (JSONObject expectedRecord : expectedRecords) {
             Assert.assertTrue(nonDirtyRecordIds.contains(expectedRecord.getString(Constants.ID)));

--- a/native/NativeSampleApps/SmartSyncExplorer/res/raw/userstore.json
+++ b/native/NativeSampleApps/SmartSyncExplorer/res/raw/userstore.json
@@ -9,7 +9,8 @@
         { "path": "__local__", "type": "string"},
         { "path": "__locally_created__", "type": "string"},
         { "path": "__locally_updated__", "type": "string"},
-        { "path": "__locally_deleted__", "type": "string"}
+        { "path": "__locally_deleted__", "type": "string"},
+        { "path": "__sync_id__", "type": "integer"}
       ]
     }
   ]


### PR DESCRIPTION
Addressing: https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues/1339

- During sync down, the sync id is stored in the records.
- During clean ghosts, only records with the given sync id are removed.
- Also updated parent-children clean ghosts.
- Added tests.

NB:
- If you don't have an index on the sync id field, then clean ghosts use the old behavior (delete any records in the soup that would not be returned by a full sync).
- If more than one sync are run into a soup and a record is downloaded by multiple syncs, then the sync id field on that record will have the id of the last sync run. And therefore only running clean ghost for that sync might delete the record.