### PR TITLE
Fixing a potential NPE when applicationId is configurable in gradle

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -49,6 +49,7 @@ import android.provider.Settings;
 import android.text.TextUtils;
 import android.webkit.CookieManager;
 
+import com.salesforce.androidsdk.BuildConfig;
 import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -1515,6 +1515,6 @@ public class SalesforceSDKManager {
         } catch (IllegalAccessException e) {
             SalesforceSDKLogger.e(TAG, "getBuildConfigValue failed", e);
         }
-        return null;
+        return BuildConfig.DEBUG; // we don't want to return a null value; return this value at minimum
     }
 }


### PR DESCRIPTION
Fixing an issue where this may be null if applicationId or package name is build/flavor dependent.

Original code was in place for issues where release/debug was not consistent in build process for android. Libraries prior to android plugin 3.0 often would be always release.

With android gradle 'implementation' instead of 'compile' library projects would use the same build config as app, so 'BuildConfig.DEBUG' does accurately give back the correct answer in this case.