### PR TITLE
Remove passcode requirement for app cold start

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
@@ -89,10 +89,6 @@ public class PasscodeManager  {
     // Key in preference for failed attempts
     private static final String FAILED_ATTEMPTS = "failed_attempts";
 
-    // this is a hash of the passcode to be used as part of the key to encrypt/decrypt oauth tokens
-    // It's using a different salt/key than the one used to verify the entry
-    private String passcodeHash;
-
     // Misc
     private HashConfig verificationHashConfig;
     private HashConfig encryptionHashConfig;
@@ -240,7 +236,6 @@ public class PasscodeManager  {
     	}
     	lastActivity = now();
         locked = true;
-        passcodeHash = null;
         SharedPreferences sp = ctx.getSharedPreferences(PASSCODE_PREF_NAME,
         		Context.MODE_PRIVATE);
         Editor e = sp.edit();
@@ -537,11 +532,6 @@ public class PasscodeManager  {
             }
         }
         EventsObservable.get().notifyEvent(EventType.AppLocked);
-    }
-
-    public void unlock(String passcode) {
-        passcodeHash = hashForEncryption(passcode);
-        unlock();
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
@@ -571,10 +571,6 @@ public class PasscodeManager  {
                 UUIDManager.getUuId(VSUFFIX),
                 UUIDManager.getUuId(VKEY)));
     }
-    
-    public String hashForEncryption(String passcode) {
-    	return hash(passcode, encryptionHashConfig);
-    }
 
     /**
      * Returns the legacy encryption key used before Mobile SDK 6.0.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
@@ -480,10 +480,6 @@ public class PasscodeManager  {
         return minPasscodeLength;
     }
 
-    public boolean setMinPasscodeLength(int minPasscodeLength) {
-        return setMinPasscodeLength(SalesforceSDKManager.getInstance().getAppContext(), minPasscodeLength);
-    }
-
     /**
      * @param ctx
      * @param minPasscodeLength
@@ -566,6 +562,7 @@ public class PasscodeManager  {
      * @deprecated Do not use this starting with Mobile SDK 6.0. This will be removed
      * in Mobile SDK 7.0. This is used to perform upgrade steps from a pre-6.0 SDK app.
      */
+    @Deprecated
     public String legacyHashForVerification(String passcode) {
         return hash(passcode, new HashConfig(UUIDManager.getUuId(VPREFIX),
                 UUIDManager.getUuId(VSUFFIX),
@@ -580,6 +577,7 @@ public class PasscodeManager  {
      * @deprecated Do not use this starting with Mobile SDK 6.0. This will be removed
      * in Mobile SDK 7.0. This is used to perform upgrade steps from a pre-6.0 SDK app.
      */
+    @Deprecated
     public String getLegacyEncryptionKey(String passcode) {
         return Encryptor.hash(UUIDManager.getUuId(EPREFIX) + passcode
                 + UUIDManager.getUuId(ESUFFIX), UUIDManager.getUuId(EKEY));

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
@@ -65,6 +65,7 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         // Do not create a new Fragment when the Activity is re-created such as orientation changes.
         setRetainInstance(true);
         setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Material_Light_Dialog);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
@@ -74,6 +74,10 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
     @Override
     public void onResume() {
         super.onResume();
+
+        /*
+         * TODO: Remove this check once minAPI > 23.
+         */
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
             FingerprintManager fingerprintManager = (FingerprintManager) mContext.getSystemService(Context.FINGERPRINT_SERVICE);
             if (mContext.checkSelfPermission(permission.USE_FINGERPRINT) != PackageManager.PERMISSION_GRANTED) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
@@ -60,7 +60,6 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
 
     private Button mCancelButton;
     private TextView mStatusText;
-    private Cipher mCipher;
     private PasscodeActivity mContext;
 
     @Override
@@ -81,10 +80,11 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
             FingerprintManager fingerprintManager = (FingerprintManager) mContext.getSystemService(Context.FINGERPRINT_SERVICE);
             if (mContext.checkSelfPermission(permission.USE_FINGERPRINT) != PackageManager.PERMISSION_GRANTED) {
-                //If we got so far, we already got the permission in the PasscodeActivity. This is an OS mandated check.
+
+                // If we got so far, we already got the permission in the PasscodeActivity. This is an OS mandated check.
                 return;
             }
-            fingerprintManager.authenticate(new CryptoObject(mCipher), null, 0, new AuthenticationCallback() {
+            fingerprintManager.authenticate(new CryptoObject((Cipher) null), null, 0, new AuthenticationCallback() {
 
                 @Override
                 public void onAuthenticationError(int errorCode, CharSequence errString) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
@@ -78,8 +78,6 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
     private boolean logoutEnabled;
     private AlertDialog logoutAlertDialog;
     private boolean isLogoutAlertShowing;
-    private FingerprintManager fingerprintManager;
-    private FingerprintAuthDialogFragment fingerprintAuthDialog;
 
     public enum PasscodeMode {
         Create,
@@ -481,7 +479,7 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
 
     private void showFingerprintDialog() {
         if (passcodeManager != null && isFingerprintEnabled()) {
-            fingerprintAuthDialog = new FingerprintAuthDialogFragment();
+            final FingerprintAuthDialogFragment fingerprintAuthDialog = new FingerprintAuthDialogFragment();
             fingerprintAuthDialog.setContext(this);
             fingerprintAuthDialog.show(getFragmentManager(), "fingerprintDialog");
         }
@@ -494,7 +492,7 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
          * TODO: Remove this check once minAPI > 23.
          */
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
-            fingerprintManager = (FingerprintManager) this.getSystemService(Context.FINGERPRINT_SERVICE);
+            final FingerprintManager fingerprintManager = (FingerprintManager) this.getSystemService(Context.FINGERPRINT_SERVICE);
 
             // Here, this activity is the current activity.
             if (checkSelfPermission(Manifest.permission.USE_FINGERPRINT) != PackageManager.PERMISSION_GRANTED) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
@@ -83,7 +83,7 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
         Create,
         CreateConfirm,
         Check,
-        Change;
+        Change
     }
 
     @Override
@@ -97,8 +97,8 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
         final TextView forgotPasscodeView = getForgotPasscodeView();
         if (forgotPasscodeView != null) {
             forgotPasscodeView.setText(Html.fromHtml(getForgotPasscodeString()));
+            forgotPasscodeView.setOnClickListener(this);
         }
-        forgotPasscodeView.setOnClickListener(this);
         logoutAlertDialog = buildLogoutDialog();
         title = getTitleView();
         error = getErrorView();
@@ -114,8 +114,11 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
         if (shouldChangePasscode) {
             setMode(PasscodeMode.Change);
         } else {
-            setMode(passcodeManager.hasStoredPasscode(this) ? PasscodeMode.Check : PasscodeMode.Create);
-            showFingerprintDialog();
+            final PasscodeMode mode = passcodeManager.hasStoredPasscode(this) ? PasscodeMode.Check : PasscodeMode.Create;
+            setMode(mode);
+            if (mode == PasscodeMode.Check) {
+                showFingerprintDialog();
+            }
         }
         logoutEnabled = true;
         if (savedInstanceState != null) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
@@ -226,7 +226,7 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
         case CreateConfirm:
             if (enteredPasscode.equals(firstPasscode)) {
                 passcodeManager.store(this, enteredPasscode);
-                passcodeManager.unlock(enteredPasscode);
+                passcodeManager.unlock();
                 done();
             } else {
                 error.setText(getPasscodesDontMatchError());
@@ -236,7 +236,7 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
         case Check:
             if (passcodeManager.check(this, enteredPasscode)) {
                 performUpgradeStep(enteredPasscode);
-                passcodeManager.unlock(enteredPasscode);
+                passcodeManager.unlock();
                 done();
             } else {
                 int attempts = passcodeManager.addFailedPasscodeAttempt();
@@ -489,6 +489,10 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
 
     @TargetApi(VERSION_CODES.M)
     private boolean isFingerprintEnabled() {
+
+	    /*
+         * TODO: Remove this check once minAPI > 23.
+         */
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
             fingerprintManager = (FingerprintManager) this.getSystemService(Context.FINGERPRINT_SERVICE);
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/PasscodeManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/PasscodeManagerTest.java
@@ -48,7 +48,6 @@ import org.junit.runner.RunWith;
 @SmallTest
 public class PasscodeManagerTest {
 
-    private static final String TEST_PASSCODE = "123456";
     private static final HashConfig TEST_HASH_CONFIG = new HashConfig("", "", "dummy-key");
     private static final int TEST_TIMEOUT_MS = 1000;
 
@@ -74,7 +73,7 @@ public class PasscodeManagerTest {
             setTimeoutMs(TEST_TIMEOUT_MS);
             setEnabled(true);
             // start in a known state.
-            unlock(TEST_PASSCODE);
+            unlock();
         }
 
         @Override
@@ -104,7 +103,7 @@ public class PasscodeManagerTest {
         Assert.assertTrue(pm.lockIfNeeded(null, true));
         Assert.assertTrue(pm.isLocked());
         Assert.assertTrue(startedLockActivity);
-        pm.unlock(TEST_PASSCODE);
+        pm.unlock();
         Assert.assertFalse(pm.isLocked());
     }
 
@@ -142,7 +141,7 @@ public class PasscodeManagerTest {
         Assert.assertEquals(0, pm.getFailedPasscodeAttempts());
         pm.addFailedPasscodeAttempt();
         Assert.assertEquals(1, pm.getFailedPasscodeAttempts());
-        pm.unlock(TEST_PASSCODE);
+        pm.unlock();
         Assert.assertEquals(0, pm.getFailedPasscodeAttempts());
     }
 }


### PR DESCRIPTION
**Before:**
- If passcode is enabled, go through `Create` and `Confirm` flows.
- If app is in memory, show fingerprint dialog.
- If app is not in memory, show passcode screen *WITHOUT* fingerprint.

**Now:**
- If passcode is enabled, go through `Create` and `Confirm` flows.
- If app is in memory, show fingerprint dialog.
- If app is not in memory, show fingerprint dialog.

In all cases, fingerprint dialog can fallback on created passcode if the user chooses to.