### PR TITLE
Fix issue with decryption using RSA keypair

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -264,6 +264,7 @@ public class SalesforceKeyGenerator {
                             name,
                             KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
                             .setKeySize(length)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                             .build());
                     kpg.generateKeyPair();
                 } else {


### PR DESCRIPTION
The encryption padding needs to be set in order for the private key to be used to decrypt data.