### PR TITLE
Moving IDP runtime config to init call

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -278,13 +278,6 @@ public class SalesforceSDKManager {
         // If your app runs in multiple processes, all the SalesforceSDKManager need to run cleanup during a logout
         cleanupReceiver = new CleanupReceiver();
         context.registerReceiver(cleanupReceiver, new IntentFilter(SalesforceSDKManager.CLEANUP_INTENT_ACTION));
-
-        // Enables IDP login flow if it's set through MDM.
-        final RuntimeConfig runtimeConfig = RuntimeConfig.getRuntimeConfig(context);
-        final String idpAppUrlScheme = runtimeConfig.getString(RuntimeConfig.ConfigKey.IDPAppURLScheme);
-        if (!TextUtils.isEmpty(idpAppUrlScheme)) {
-            this.idpAppURIScheme = idpAppUrlScheme;
-        }
     }
 
     /**
@@ -466,6 +459,13 @@ public class SalesforceSDKManager {
 
         // Initializes the HTTP client.
         HttpAccess.init(context, INSTANCE.getUserAgent());
+
+        // Enables IDP login flow if it's set through MDM.
+        final RuntimeConfig runtimeConfig = RuntimeConfig.getRuntimeConfig(context);
+        final String idpAppUrlScheme = runtimeConfig.getString(RuntimeConfig.ConfigKey.IDPAppURLScheme);
+        if (!TextUtils.isEmpty(idpAppUrlScheme)) {
+            INSTANCE.idpAppURIScheme = idpAppUrlScheme;
+        }
     }
 
     /**


### PR DESCRIPTION
Leaving in the constructor was dangerous because it calls `RuntimeConfig`, which in turn spawns a thread and calls `getInstance()` in `SalesforceSDKManager`. In some cases, that thread could get there before the call from the constructor returns and `INSTANCE` exists. Moving this to the `initInternal()` method guarantees that `INSTANCE` is available when the call to `RuntimeConfig` is made.