### PR TITLE
Add semi-colon only if sub-type exists

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/model/InstrumentationEventBuilder.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/model/InstrumentationEventBuilder.java
@@ -298,9 +298,9 @@ public class InstrumentationEventBuilder {
                 final String subtype = networkInfo.getSubtypeName();
                 if (!TextUtils.isEmpty(type)) {
                     connectionType.append(type);
-                    connectionType.append(";");
                 }
                 if (!TextUtils.isEmpty(subtype)) {
+                    connectionType.append(";");
                     connectionType.append(subtype);
                 }
             }


### PR DESCRIPTION
This prevents us from sending type as `WiFi;`, since `WiFi` has no sub-type.