### PR TITLE
cleanResyncGhosts should call its callbacks after finishing

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartSyncPlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartSyncPlugin.java
@@ -283,14 +283,23 @@ public class SmartSyncPlugin extends ForcePlugin {
      * @param callbackContext
      * @throws JSONException
      */
-    private void cleanResyncGhosts(JSONArray args, CallbackContext callbackContext) throws Exception {
+    private void cleanResyncGhosts(JSONArray args, final CallbackContext callbackContext) throws Exception {
 
         // Parse args.
         final JSONObject arg0 = args.getJSONObject(0);
         long syncId = arg0.getLong(SYNC_ID);
         final SyncManager syncManager = getSyncManager(arg0);
-        syncManager.cleanResyncGhosts(syncId);
-        callbackContext.success();
+        syncManager.cleanResyncGhosts(syncId, new SyncManager.CleanResyncGhostsCallback() {
+            @Override
+            public void onSuccess(int numRecords) {
+                callbackContext.success();
+            }
+
+            @Override
+            public void onError(Exception e) {
+                callbackContext.error(e.getMessage());
+            }
+        });
     }
 
     /**

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -869,7 +869,7 @@ public class SyncManagerTest extends SyncManagerTestCase {
 
         // Deletes 1 account on the server and verifies the ghost record is cleared from the soup.
         deleteRecordsOnServer(new HashSet<>(Arrays.asList(accountIds[0])), Constants.ACCOUNT);
-        syncManager.cleanResyncGhosts(syncId);
+        tryCleanResyncGhosts(syncId);
         checkDbExist(ACCOUNTS_SOUP, new String[] { accountIds[1], accountIds[2]}, Constants.ID);
         checkDbDeleted(ACCOUNTS_SOUP, new String[] { accountIds[0]}, Constants.ID);
 
@@ -905,12 +905,12 @@ public class SyncManagerTest extends SyncManagerTestCase {
         deleteRecordsOnServer(new HashSet<>(Arrays.asList(accountIds[0], accountIds[2], accountIds[5])), Constants.ACCOUNT);
 
         // Cleaning ghosts of first sync (should only remove id0)
-        syncManager.cleanResyncGhosts(firstSyncId);
+        tryCleanResyncGhosts(firstSyncId);
         checkDbExist(ACCOUNTS_SOUP, new String[] { accountIds[1], accountIds[2], accountIds[3], accountIds[4], accountIds[5]}, Constants.ID);
         checkDbDeleted(ACCOUNTS_SOUP, new String[] { accountIds[0]}, Constants.ID);
 
         // Cleaning ghosts of second sync (should remove id2 and id5)
-        syncManager.cleanResyncGhosts(secondSyncId);
+        tryCleanResyncGhosts(secondSyncId);
         checkDbExist(ACCOUNTS_SOUP, new String[] { accountIds[1], accountIds[3], accountIds[4]}, Constants.ID);
         checkDbDeleted(ACCOUNTS_SOUP, new String[] { accountIds[2], accountIds[5]}, Constants.ID);
 
@@ -939,7 +939,7 @@ public class SyncManagerTest extends SyncManagerTestCase {
 
         // Deletes 1 account on the server and verifies the ghost record is cleared from the soup.
         deleteRecordsOnServer(new HashSet<>(singletonList(accountIds[0])), Constants.ACCOUNT);
-        syncManager.cleanResyncGhosts(syncId);
+        tryCleanResyncGhosts(syncId);
         checkDbDeleted(ACCOUNTS_SOUP, new String[] {accountIds[0]}, Constants.ID);
 
         // Deletes the remaining accounts on the server.
@@ -967,7 +967,7 @@ public class SyncManagerTest extends SyncManagerTestCase {
 
         // Deletes 1 account on the server and verifies the ghost record is cleared from the soup.
         deleteRecordsOnServer(new HashSet<String>(Arrays.asList(accountIds[0])), Constants.ACCOUNT);
-        syncManager.cleanResyncGhosts(syncId);
+        tryCleanResyncGhosts(syncId);
         checkDbDeleted(ACCOUNTS_SOUP, new String[] {accountIds[0]}, Constants.ID);
 
         // Deletes the remaining accounts on the server.
@@ -1097,7 +1097,7 @@ public class SyncManagerTest extends SyncManagerTestCase {
         String[] ids = idToFields.keySet().toArray(new String[0]);
         String idDeleted = ids[0];
         deleteRecordsOnServer(new HashSet<String>(Arrays.asList(idDeleted)), Constants.ACCOUNT);
-        syncManager.cleanResyncGhosts(syncId);
+        tryCleanResyncGhosts(syncId);
 
         // Map of id to names expected to be found in db
         Map<String, Map<String, Object>> idToFieldsLeft = new HashMap<>(idToFields);

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
@@ -59,6 +59,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
 
 /**
  * Abstract super class for all SyncManager test classes.
@@ -159,6 +160,24 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
             createdAccounts[i] = smartStore.create(ACCOUNTS_SOUP, account);
         }
         return createdAccounts;
+    }
+
+    protected boolean tryCleanResyncGhosts(long syncId) throws JSONException, InterruptedException {
+        final ArrayBlockingQueue<Boolean> queue = new ArrayBlockingQueue<Boolean>(1);
+
+        syncManager.cleanResyncGhosts(syncId, new SyncManager.CleanResyncGhostsCallback() {
+            @Override
+            public void onSuccess(int numRecords) {
+                queue.offer(true);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                queue.offer(false);
+            }
+        });
+
+        return queue.take();
     }
 
     /**

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
@@ -608,7 +608,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         // Deletes 1 account on the server and verifies the ghost record is cleared from the soup.
         String accountIdDeleted = accountIdToFields.keySet().toArray(new String[0])[0];
         deleteRecordsOnServer(new HashSet<String>(Arrays.asList(accountIdDeleted)), Constants.ACCOUNT);
-        syncManager.cleanResyncGhosts(syncId);
+        tryCleanResyncGhosts(syncId);
 
         // Accounts and contacts expected to still be in db
         Map<String, Map<String, Object>> accountIdToFieldsLeft = new HashMap<>(accountIdToFields);
@@ -660,7 +660,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         deleteRecordsOnServer(new HashSet<>(Arrays.asList(accountIds[0], accountIds[2], accountIds[5])), Constants.ACCOUNT);
 
         // Cleaning ghosts of first sync (should only remove id0 and its contacts)
-        syncManager.cleanResyncGhosts(firstSyncId);
+        tryCleanResyncGhosts(firstSyncId);
         checkDbExist(ACCOUNTS_SOUP, new String[] { accountIds[1], accountIds[2], accountIds[3], accountIds[4], accountIds[5]}, Constants.ID);
         checkDbDeleted(ACCOUNTS_SOUP, new String[] { accountIds[0]}, Constants.ID);
         for (String accountId : accountIdContactIdToFields.keySet()) {
@@ -673,7 +673,7 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         }
 
         // Cleaning ghosts of second sync (should remove id2 and id5 and their contacts)
-        syncManager.cleanResyncGhosts(secondSyncId);
+        tryCleanResyncGhosts(secondSyncId);
         checkDbExist(ACCOUNTS_SOUP, new String[] { accountIds[1], accountIds[3], accountIds[4]}, Constants.ID);
         checkDbDeleted(ACCOUNTS_SOUP, new String[] { accountIds[2], accountIds[5]}, Constants.ID);
         for (String accountId : accountIdContactIdToFields.keySet()) {


### PR DESCRIPTION
Before
The smartsync plugin methods for cleanResyncGhosts was returning right away and there was no way to know if/when it completed.

New behavior
cleanResyncGhosts calls its callbacks after finishing (success callback if successful and error callback otherwise).

Done for ios here: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2402