### PR TITLE
Fixing passcode tests and removing unused parameters

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/PasscodeManager.java
@@ -91,7 +91,6 @@ public class PasscodeManager  {
 
     // Misc
     private HashConfig verificationHashConfig;
-    private HashConfig encryptionHashConfig;
     private Activity frontActivity;
     private Handler handler;
     private long lastActivity;
@@ -106,21 +105,15 @@ public class PasscodeManager  {
      * @param ctx Context.
      */
    public PasscodeManager(Context ctx) {
-	   this(ctx,
-		   new HashConfig(SalesforceKeyGenerator.getUniqueId(VPREFIX),
+	   this(ctx, new HashConfig(SalesforceKeyGenerator.getUniqueId(VPREFIX),
                    SalesforceKeyGenerator.getUniqueId(VSUFFIX),
-                   SalesforceKeyGenerator.getUniqueId(VKEY)),
-		   new HashConfig(SalesforceKeyGenerator.getUniqueId(EPREFIX),
-                   SalesforceKeyGenerator.getUniqueId(ESUFFIX),
-                   SalesforceKeyGenerator.getUniqueId(EKEY)));
+                   SalesforceKeyGenerator.getUniqueId(VKEY)));
    }
 
-   public PasscodeManager(Context ctx, HashConfig verificationHashConfig,
-		   HashConfig encryptionHashConfig) {
+   public PasscodeManager(Context ctx, HashConfig verificationHashConfig) {
        this.minPasscodeLength = MIN_PASSCODE_LENGTH;
        this.lastActivity = now();
        this.verificationHashConfig = verificationHashConfig;
-       this.encryptionHashConfig = encryptionHashConfig;
        readMobilePolicy(ctx);
 
        // Locked at app startup if you're authenticated.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/PasscodeManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/PasscodeManagerTest.java
@@ -68,8 +68,7 @@ public class PasscodeManagerTest {
     private class TestPasscodeManager extends PasscodeManager {
 
         TestPasscodeManager() {
-            super(InstrumentationRegistry.getTargetContext(), TEST_HASH_CONFIG,
-            		TEST_HASH_CONFIG);
+            super(InstrumentationRegistry.getTargetContext(), TEST_HASH_CONFIG);
             setTimeoutMs(TEST_TIMEOUT_MS);
             setEnabled(true);
             // start in a known state.

--- a/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/PasscodeActivityTest.java
+++ b/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/PasscodeActivityTest.java
@@ -40,8 +40,6 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.security.PasscodeManager;
 import com.salesforce.androidsdk.ui.PasscodeActivity;
 import com.salesforce.androidsdk.ui.PasscodeActivity.PasscodeMode;
-import com.salesforce.androidsdk.util.EventsObservable.EventType;
-import com.salesforce.androidsdk.util.test.EventsListenerQueue;
 
 import junit.framework.Assert;
 
@@ -65,7 +63,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 @LargeTest
 public class PasscodeActivityTest {
 
-    private EventsListenerQueue eq;
     private Context targetContext;
     private PasscodeActivity passcodeActivity;
     private PasscodeManager passcodeManager;
@@ -83,16 +80,8 @@ public class PasscodeActivityTest {
 
         @Override
         protected void beforeActivityLaunched() {
-            eq = new EventsListenerQueue();
-
-            // Waits for app initialization to complete.
-            if (!SalesforceSDKManager.hasInstance()) {
-                eq.waitForEvent(EventType.AppCreateComplete, 5000);
-            }
             targetContext = InstrumentationRegistry.getTargetContext();
             passcodeManager = SalesforceSDKManager.getInstance().getPasscodeManager();
-            passcodeManager.reset(targetContext);
-            passcodeManager.setTimeoutMs(600000);
         }
     }
 
@@ -107,14 +96,8 @@ public class PasscodeActivityTest {
 
     @After
     public void tearDown() throws Exception {
-        if (passcodeActivity != null) {
-            passcodeActivity.finish();
-            passcodeActivity = null;
-        }
-        if (eq != null) {
-            eq.tearDown();
-            eq = null;
-        }
+        passcodeManager.reset(targetContext);
+        passcodeManager.setTimeoutMs(600000);
     }
 
     /**

--- a/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/PasscodeActivityTest.java
+++ b/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/PasscodeActivityTest.java
@@ -90,6 +90,8 @@ public class PasscodeActivityTest {
 
     @Before
     public void setUp() throws Exception {
+        passcodeManager.reset(targetContext);
+        passcodeManager.setTimeoutMs(600000);
         Assert.assertTrue("Application should be locked", passcodeManager.isLocked());
         Assert.assertFalse("Application should not have a passcode", passcodeManager.hasStoredPasscode(targetContext));
     }


### PR DESCRIPTION
Some tests were failing because they were launching `PasscodeActivity` multiple times but we were resetting passcode data in `beforeActivityLaunched()` instead of `setUp()`. I also cleaned up some code in `PasscodeManager`.