### PR TITLE
Calling error callback in cordova plugin and react native bridge when…

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
@@ -120,8 +120,12 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
                 @Override
                 public void onSuccess(RestRequest request, RestResponse response) {
                     try {
+                        // Not a 2xx status
+                        if (!response.isSuccess()) {
+                            callbackContext.error(response.asString());
+                        }
                         // Binary response
-                        if (returnBinary) {
+                        else if (returnBinary) {
                             JSONObject result = new JSONObject();
                             result.put(CONTENT_TYPE, response.getContentType());
                             result.put(ENCODED_BODY, Base64.encodeToString(response.asBytes(), Base64.DEFAULT));

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
@@ -106,8 +106,12 @@ public class SalesforceNetReactBridge extends ReactContextBaseJavaModule {
                         // - one that expects map back from the server
                         // - one that expects array back from the server
 
+                        // Not a 2xx status
+                        if (!response.isSuccess()) {
+                            errorCallback.invoke(response.asString());
+                        }
                         // Binary response
-                        if (returnBinary) {
+                        else if (returnBinary) {
                             JSONObject result = new JSONObject();
                             result.put(CONTENT_TYPE, response.getContentType());
                             result.put(ENCODED_BODY, Base64.encodeToString(response.asBytes(), Base64.DEFAULT));


### PR DESCRIPTION
… getting a non 2xx response

More consistent with iOS implementation
But still a bit divergent: iOS returns the NSError, Android returns the response body