### PR TITLE
Getting rid of minor warnings

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/transform/Transform.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/transform/Transform.java
@@ -43,5 +43,5 @@ public interface Transform {
      * @param event Event to be transformed.
      * @return JSON representation after transformation.
      */
-    public JSONObject transform(InstrumentationEvent event);
+    JSONObject transform(InstrumentationEvent event);
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisher.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisher.java
@@ -41,5 +41,5 @@ public interface AnalyticsPublisher {
      * @param events Events to be published.
      * @return True - if successful, False - otherwise.
      */
-    public boolean publish(JSONArray events);
+    boolean publish(JSONArray events);
 }


### PR DESCRIPTION
Interface methods don't need an explicit `public` access modifier.