### PR TITLE
Deferred login should be given a chance to handle logout through receiver

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -818,7 +818,9 @@ public class SalesforceSDKManager {
 
         // Finishes front activity if specified, and if this is the last account.
         if (frontActivity != null && (users == null || users.size() <= 1)) {
-            frontActivity.finish();
+            // only finish if it isn't hybrid or if hybrid, requires authentication
+            if (!isHybrid() || BootConfig.getBootConfig(frontActivity).shouldAuthenticate())
+                frontActivity.finish();
         }
 
         /*


### PR DESCRIPTION
Allowing the front activity to remain when we are a hybrid app and using deferred authentication.  Otherwise user runs into the experience where the app closes immediately after login instead of resuming the unauthenticated experience that is provided by a deferred login application.