### PR TITLE
Encryption code cleanup to isolate provider

### DIFF
--- a/.circleci/Dangerfile_PR.rb
+++ b/.circleci/Dangerfile_PR.rb
@@ -3,9 +3,6 @@
 # Warn when there is a big PR
 warn("Big PR, try to keep changes smaller if you can.", sticky: true) if git.lines_of_code > 500
 
-# Stop skipping some manual testing
-warn("📱 Needs testing on a real device if change is non-trivial.") if git.lines_of_code > 50
-
 # Mainly to encourage writing up some reasoning about the PR, rather than
 # just leaving a title
 if github.pr_body.length < 3

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -55,6 +55,8 @@ public class Encryptor {
     private static final String US_ASCII = "US-ASCII";
     private static final String PREFER_CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
     private static final String MAC_TRANSFORMATION = "HmacSHA256";
+    private static final String SHA1PRNG = "SHA1PRNG";
+    private static final String RSA_PKCS1 = "RSA/ECB/PKCS1Padding";
 
     /**
      * Decrypts data with key using AES-128.
@@ -279,7 +281,7 @@ public class Encryptor {
             return null;
         }
         try {
-            final Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+            final Cipher cipher = Cipher.getInstance(RSA_PKCS1);
             cipher.init(Cipher.ENCRYPT_MODE, publicKey);
             return cipher.doFinal(data.getBytes());
         } catch (Exception e) {
@@ -320,7 +322,7 @@ public class Encryptor {
             return null;
         }
         try {
-            final Cipher cipher = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+            final Cipher cipher = Cipher.getInstance(RSA_PKCS1);
             cipher.init(Cipher.DECRYPT_MODE, privateKey);
             byte[] decodedBytes = Base64.decode(data.getBytes(),Base64.NO_WRAP | Base64.NO_PADDING);
             return cipher.doFinal(decodedBytes);
@@ -353,7 +355,7 @@ public class Encryptor {
     }
 
     private static byte[] generateInitVector() throws NoSuchAlgorithmException, NoSuchProviderException {
-        final SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+        final SecureRandom random = SecureRandom.getInstance(SHA1PRNG);
         byte[] iv = new byte[16];
         random.nextBytes(iv);
         return iv;
@@ -387,8 +389,7 @@ public class Encryptor {
         final SecretKeySpec skeySpec = new SecretKeySpec(key, cipher.getAlgorithm());
         final IvParameterSpec ivSpec = new IvParameterSpec(iv);
         cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivSpec);
-        byte[] result = cipher.doFinal(meat, 0, meatLen);
-        return result;
+        return cipher.doFinal(meat, 0, meatLen);
     }
 
     private static Cipher getBestCipher() throws GeneralSecurityException {

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -26,8 +26,6 @@
  */
 package com.salesforce.androidsdk.analytics.security;
 
-import android.app.Service;
-import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.Base64;
@@ -59,7 +57,6 @@ public class Encryptor {
     private static final String PREFER_CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
     private static final String MAC_TRANSFORMATION = "HmacSHA256";
     private static String bestCipherAvailable;
-    private static boolean isFileSystemEncrypted;
 
     /**
      * Initializes this module.
@@ -68,10 +65,6 @@ public class Encryptor {
      * @return True - if the cryptographic module was successfully initialized, False - otherwise.
      */
     public static boolean init(Context ctx) {
-
-    	// Checks if file system encryption is available and active.
-        DevicePolicyManager devicePolicyManager = (DevicePolicyManager) ctx.getSystemService(Service.DEVICE_POLICY_SERVICE);
-        isFileSystemEncrypted = devicePolicyManager.getStorageEncryptionStatus() == DevicePolicyManager.ENCRYPTION_STATUS_ACTIVE;
 
         // Make sure the cryptographic transformations we want to use are available.
         bestCipherAvailable = null;
@@ -109,15 +102,6 @@ public class Encryptor {
             SalesforceAnalyticsLogger.e(null, TAG, "No cipher transformation available");
         }
         return cipher;
-    }
-
-    /**
-     * Checks if the file system is encrypted.
-     *
-     * @return True - if file system encryption is available and active, False - otherwise.
-     */
-    public static boolean isFileSystemEncrypted() {
-        return isFileSystemEncrypted;
     }
 
     /**

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -57,6 +57,7 @@ public class Encryptor {
     private static final String MAC_TRANSFORMATION = "HmacSHA256";
     private static final String SHA1PRNG = "SHA1PRNG";
     private static final String RSA_PKCS1 = "RSA/ECB/PKCS1Padding";
+    private static final String BOUNCY_CASTLE = "BC";
 
     /**
      * Decrypts data with key using AES-128.
@@ -240,7 +241,7 @@ public class Encryptor {
             // Signs with SHA-256.
             byte [] keyBytes = key.getBytes(UTF8);
             byte [] dataBytes = data.getBytes(UTF8);
-            final Mac sha = Mac.getInstance(MAC_TRANSFORMATION);
+            final Mac sha = Mac.getInstance(MAC_TRANSFORMATION, getEncryptionProvider());
             final SecretKeySpec keySpec = new SecretKeySpec(keyBytes, sha.getAlgorithm());
             sha.init(keySpec);
             byte [] sig = sha.doFinal(dataBytes);
@@ -395,11 +396,15 @@ public class Encryptor {
     private static Cipher getBestCipher() throws GeneralSecurityException {
         Cipher cipher = null;
         try {
-            cipher = Cipher.getInstance(PREFER_CIPHER_TRANSFORMATION);
+            cipher = Cipher.getInstance(PREFER_CIPHER_TRANSFORMATION, getEncryptionProvider());
         } catch (Exception e) {
             SalesforceAnalyticsLogger.e(null, TAG,
                     "No cipher transformation available", e);
         }
         return cipher;
+    }
+
+    private static String getEncryptionProvider() {
+        return BOUNCY_CASTLE;
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -1192,7 +1192,7 @@ public class SalesforceSDKManager {
           .append("   accountType: ").append(getAccountType()).append("\n")
           .append("   userAgent: ").append(getUserAgent()).append("\n")
           .append("   mainActivityClass: ").append(getMainActivityClass()).append("\n")
-          .append("   isFileSystemEncrypted: ").append(Encryptor.isFileSystemEncrypted()).append("\n");
+          .append("\n");
         if (passcodeManager != null) {
 
             // passcodeManager may be null at startup if the app is running in debug mode.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -454,9 +454,6 @@ public class SalesforceSDKManager {
         // Upgrades to the latest version.
         SalesforceSDKUpgradeManager.getInstance().upgrade();
 
-        // Initializes the encryption module.
-        Encryptor.init(context);
-
         // Initializes the HTTP client.
         HttpAccess.init(context, INSTANCE.getUserAgent());
 

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
@@ -26,14 +26,11 @@
  */
 package com.salesforce.androidsdk.analytics.security;
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
 import junit.framework.Assert;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,12 +52,6 @@ public class EncryptorTest {
             "hello world",
             "fake-token"
     };
-
-	@Before
-	public void setUp() throws Exception {
-		final Context targetContext = InstrumentationRegistry.getTargetContext();
-		Encryptor.init(targetContext);
-	}
 
 	/**
 	 * Test to make sure that encrypt does nothing when given a null key.


### PR DESCRIPTION
Some `BouncyCastle` functionality is being removed in `Android P`. Refactored the code to help us pivot from `BouncyCastle` and use `Conscrypt` instead if we want in the future.