### PR TITLE
Adding userinfo endpoint, changing cheap refresh API calls

### DIFF
--- a/hybrid/HybridSampleApps/NoteSync/src/com/salesforce/samples/notesync/ContentSoqlSyncDownTarget.java
+++ b/hybrid/HybridSampleApps/NoteSync/src/com/salesforce/samples/notesync/ContentSoqlSyncDownTarget.java
@@ -97,7 +97,7 @@ public class ContentSoqlSyncDownTarget extends SoqlSyncDownTarget {
     @Override
     public JSONArray startFetch(SyncManager syncManager, long maxTimeStamp) throws IOException, JSONException {
         String queryToRun = maxTimeStamp > 0 ? SoqlSyncDownTarget.addFilterForReSync(getQuery(maxTimeStamp), getModificationDateFieldName(), maxTimeStamp) : getQuery(maxTimeStamp);
-        syncManager.getRestClient().sendSync(RestRequest.getRequestForResources(syncManager.apiVersion)); // cheap call to refresh session
+        syncManager.getRestClient().sendSync(RestRequest.getRequestForUserInfo()); // cheap call to refresh session
         RestRequest request = buildQueryRequest(syncManager.getRestClient().getAuthToken(), queryToRun);
         RestResponse response = syncManager.sendSyncWithSmartSyncUserAgent(request);
         JSONArray records = parseSoapResponse(response);

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -321,7 +321,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                      * but a stale session ID will cause the WebView to redirect
                      * to the web login.
                      */
-                    SalesforceDroidGapActivity.this.client.sendAsync(RestRequest.getRequestForResources(ApiVersionStrings.getVersionNumber(SalesforceDroidGapActivity.this)), new AsyncRequestCallback() {
+                    SalesforceDroidGapActivity.this.client.sendAsync(RestRequest.getRequestForUserInfo(), new AsyncRequestCallback() {
 
                         @Override
                         public void onSuccess(RestRequest request, RestResponse response) {
@@ -379,7 +379,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
      */
     public void refresh(final String url) {
         SalesforceHybridLogger.i(TAG, "refresh called");
-        client.sendAsync(RestRequest.getRequestForResources(ApiVersionStrings.getVersionNumber(this)), new AsyncRequestCallback() {
+        client.sendAsync(RestRequest.getRequestForUserInfo(), new AsyncRequestCallback() {
 
             @Override
             public void onSuccess(RestRequest request, RestResponse response) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPRequestHandler.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPRequestHandler.java
@@ -112,8 +112,7 @@ public class IDPRequestHandler {
         Exception exception = null;
         String accessToken = null;
         try {
-            restResponse = restClient.sendSync(RestRequest.getRequestForResources(
-                    ApiVersionStrings.getVersionNumber(context)));
+            restResponse = restClient.sendSync(RestRequest.getRequestForUserInfo());
         } catch (IOException e) {
             exception = e;
         } finally {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -520,12 +520,13 @@ public class RestClient {
 			return instanceUrl;
 		}
 
+		/**
+		 * Resolves the given {@link RestRequest} to its URL.
+		 * @param request The Rest request to resolve.
+		 * @return The URI associated with the Rest request.
+		 */
 		public URI resolveUrl(RestRequest request) {
 			return resolveUrl(request.getPath(), request.getEndpoint());
-		}
-
-		public URI resolveUrl(String path) {
-			return resolveUrl(path, RestRequest.RestEndpoint.INSTANCE);
 		}
 
 		/**
@@ -535,7 +536,20 @@ public class RestClient {
 		 * @param path Path.
 		 * @return Resolved URL.
 		 */
-		private URI resolveUrl(String path, RestRequest.RestEndpoint endpoint) {
+		public URI resolveUrl(String path) {
+			return resolveUrl(path, RestRequest.RestEndpoint.INSTANCE);
+		}
+
+		/**
+		 * Resolves the given path against the community URL, login URL, or instance
+		 * URL.  If the user is a community user, the community URL will be used.  Otherwise,
+		 * the URL will be built from the
+		 * {@link com.salesforce.androidsdk.rest.RestRequest.RestEndpoint} parameter.
+		 * @param path Path
+		 * @param endpoint The Rest endpoint of the URL.
+		 * @return Resolved URL.
+		 */
+		public URI resolveUrl(String path, RestRequest.RestEndpoint endpoint) {
 			String resolvedPathStr = path;
 
 			// Resolve URL only for a relative URL.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -242,6 +242,16 @@ public class RestRequest {
         this(method, RestEndpoint.INSTANCE, path, requestBodyAsJson, additionalHttpHeaders);
     }
 
+    /**
+     * Generic constructor for arbitrary requests.
+     *
+     * @param method				HTTP method used for the request (GET/POST/DELETE etc).
+     * @param endpoint				The endpoint associated with the request.
+     * @param path					URI path. This will be resolved against the user's current
+     * 								Rest endpoint, as specified by the endpoint parameter.
+     * @param requestBody			Request body, if one exists. Can be null.
+     * @param additionalHttpHeaders	Additional headers.
+     */
     public RestRequest(RestMethod method, RestEndpoint endpoint, String path, RequestBody requestBody, Map<String, String> additionalHttpHeaders) {
         this.method = method;
         this.endpoint = endpoint;
@@ -251,6 +261,16 @@ public class RestRequest {
         this.requestBodyAsJson = null;
     }
 
+    /**
+     * Generic constructor for arbitrary requests.
+     *
+     * @param method				HTTP method used for the request (GET/POST/DELETE etc).
+     * @param endpoint				The endpoint associated with the request.
+     * @param path					URI path. This will be resolved against the user's current
+     * 								Rest endpoint, as specified by the endpoint parameter.
+     * @param requestBodyAsJson		Request body as JSON, if one exists. Can be null.
+     * @param additionalHttpHeaders	Additional headers.
+     */
     public RestRequest(RestMethod method, RestEndpoint endpoint, String path, JSONObject requestBodyAsJson,  Map<String, String> additionalHttpHeaders) {
         this.method = method;
         this.endpoint = endpoint;
@@ -267,6 +287,9 @@ public class RestRequest {
 		return method;
 	}
 
+	/**
+	 * @return The endpoint of the request.
+	 */
 	public RestEndpoint getEndpoint() { return endpoint; }
 
 	/**
@@ -297,6 +320,11 @@ public class RestRequest {
 		return additionalHttpHeaders;
 	}
 
+	/**
+	 * Request to get information about the user making the request.
+	 * @return RestRequest object that requests user info.
+	 * @see <a href="https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm">https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm</a></a>
+	 */
 	public static RestRequest getRequestForUserInfo() {
 		return new RestRequest(RestMethod.GET, RestEndpoint.LOGIN, RestAction.USERINFO.getPath(), (RequestBody) null, null);
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -117,11 +117,16 @@ public class RestRequest {
 	public enum RestMethod {
 		GET, POST, PUT, DELETE, HEAD, PATCH
 	}
+
+	public enum RestEndpoint {
+		LOGIN, INSTANCE
+	}
 	
 	/**
 	 * Enumeration for all REST API actions.
 	 */
 	private enum RestAction {
+		USERINFO("/services/oauth2/userinfo"),
 		VERSIONS(SERVICES_DATA),
 		RESOURCES(SERVICES_DATA + "%s/"),
 		DESCRIBE_GLOBAL(SERVICES_DATA + "%s/sobjects/"),
@@ -152,6 +157,7 @@ public class RestRequest {
 	}
 
 	private final RestMethod method;
+	private final RestEndpoint endpoint;
 	private final String path;
 	private final RequestBody requestBody;
 	private final Map<String, String> additionalHttpHeaders;
@@ -218,11 +224,7 @@ public class RestRequest {
      * Note: Do not use this constructor if requestBody is not null and you want to build a batch or composite request.
      */
     public RestRequest(RestMethod method, String path, RequestBody requestBody, Map<String, String> additionalHttpHeaders) {
-        this.method = method;
-        this.path = path;
-        this.requestBody = requestBody;
-        this.additionalHttpHeaders = additionalHttpHeaders;
-        this.requestBodyAsJson = null;
+    	this(method, RestEndpoint.INSTANCE, path, requestBody, additionalHttpHeaders);
     }
 
 
@@ -236,8 +238,22 @@ public class RestRequest {
      *
      * Note: Use this constructor if requestBody is not null and you want to build a batch or composite request.
      */
-	public RestRequest(RestMethod method, String path, JSONObject requestBodyAsJson,  Map<String, String> additionalHttpHeaders) {
+    public RestRequest(RestMethod method, String path, JSONObject requestBodyAsJson,  Map<String, String> additionalHttpHeaders) {
+        this(method, RestEndpoint.INSTANCE, path, requestBodyAsJson, additionalHttpHeaders);
+    }
+
+    public RestRequest(RestMethod method, RestEndpoint endpoint, String path, RequestBody requestBody, Map<String, String> additionalHttpHeaders) {
         this.method = method;
+        this.endpoint = endpoint;
+        this.path = path;
+        this.requestBody = requestBody;
+        this.additionalHttpHeaders = additionalHttpHeaders;
+        this.requestBodyAsJson = null;
+    }
+
+    public RestRequest(RestMethod method, RestEndpoint endpoint, String path, JSONObject requestBodyAsJson,  Map<String, String> additionalHttpHeaders) {
+        this.method = method;
+        this.endpoint = endpoint;
         this.path = path;
         this.requestBody = requestBodyAsJson == null ? null : RequestBody.create(MEDIA_TYPE_JSON, requestBodyAsJson.toString());
         this.additionalHttpHeaders = additionalHttpHeaders;
@@ -250,6 +266,8 @@ public class RestRequest {
 	public RestMethod getMethod() {
 		return method;
 	}
+
+	public RestEndpoint getEndpoint() { return endpoint; }
 
 	/**
 	 * @return  Path of the request.
@@ -277,6 +295,10 @@ public class RestRequest {
 	 */
 	public Map<String, String> getAdditionalHttpHeaders() {
 		return additionalHttpHeaders;
+	}
+
+	public static RestRequest getRequestForUserInfo() {
+		return new RestRequest(RestMethod.GET, RestEndpoint.LOGIN, RestAction.USERINFO.getPath(), (RequestBody) null, null);
 	}
 
 	/**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -182,6 +182,31 @@ public class RestClientTest {
     }
 
     @Test
+    public void testClientInfoResolveRequestWithLoginEndpoint() {
+        RestRequest r = new RestRequest(RestMethod.GET, RestRequest.RestEndpoint.LOGIN, "/a", (JSONObject) null, null);
+        Assert.assertEquals("URL should have login host endpoint", TestCredentials.LOGIN_URL + "/a", clientInfo.resolveUrl(r).toString());
+    }
+
+    @Test
+    public void testClientInfoResolveRequestWithInstanceEndpoint() {
+        RestRequest r = new RestRequest(RestMethod.GET, RestRequest.RestEndpoint.INSTANCE, "/a", (JSONObject) null, null);
+        Assert.assertEquals("URL should have instance host endpoint", TestCredentials.INSTANCE_URL + "/a", clientInfo.resolveUrl(r).toString());
+    }
+
+    @Test
+    public void testClientInfoResolveRequestWithCommunity() throws Exception {
+        final ClientInfo info = new ClientInfo(new URI(TestCredentials.INSTANCE_URL),
+                new URI(TestCredentials.LOGIN_URL),
+                new URI(TestCredentials.IDENTITY_URL),
+                TestCredentials.ACCOUNT_NAME, TestCredentials.USERNAME,
+                TestCredentials.USER_ID, TestCredentials.ORG_ID, null,
+                TestCredentials.COMMUNITY_URL, null, null, null, null, null, null, testOauthValues);
+        RestRequest r = new RestRequest(RestMethod.GET, RestRequest.RestEndpoint.LOGIN, "/a", (JSONObject) null, null);
+        Assert.assertEquals("Community URL should take precedence over login or instance endpoint",
+                TestCredentials.COMMUNITY_URL + "/a", info.resolveUrl(r).toString());
+    }
+
+    @Test
     public void testGetInstanceUrlForCommunity() throws Exception {
         final ClientInfo info = new ClientInfo(new URI(TestCredentials.INSTANCE_URL),
         		new URI(TestCredentials.LOGIN_URL),

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
@@ -90,6 +90,19 @@ public class RestRequestTest {
     }
 
 	/**
+	 * Test for getRequestForUserInfo
+	 */
+	@Test
+	public void testGetRequestForUserInfo() {
+		RestRequest request = RestRequest.getRequestForUserInfo();
+		Assert.assertEquals("Wrong method", RestMethod.GET, request.getMethod());
+		Assert.assertEquals("Wrong path", "/services/oauth2/userinfo", request.getPath());
+		Assert.assertEquals("Wrong endpoint", RestRequest.RestEndpoint.LOGIN, request.getEndpoint());
+		Assert.assertNull("Wrong request entity", request.getRequestBody());
+		Assert.assertNull("Wrong additional headers", request.getAdditionalHttpHeaders());
+	}
+
+	/**
 	 * Test for getRequestForVersions
 	 */
     @Test


### PR DESCRIPTION
Analogous to https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2479, changing the "check session" API endpoint to the [user info endpoint](https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm), which averts errors due to a user not having API access configured (a common Communities use case).

Android's a little tricker than the iOS work, because `RestRequest` has no context to user-based endpoint configuration.  This approach would add an abstraction to allow the conceptual endpoint to be optionally specified.

**Note:** This is a work in progress.  I didn't want to go any further until the approach was validated.