### PR TITLE
Fixes for tests

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -333,11 +333,17 @@ public class OAuth2 {
                                                          String clientId, String refreshToken,
                                                          Map<String,String> addlParams)
             throws OAuthFailedException, IOException {
-        final FormBody.Builder formBodyBuilder = makeTokenEndpointParams(REFRESH_TOKEN,
-                clientId, addlParams);
-        formBodyBuilder.add(REFRESH_TOKEN, refreshToken);
-        formBodyBuilder.add(FORMAT, JSON);
-        return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder);
+        final FormBody.Builder builder = new FormBody.Builder();
+        builder.add(GRANT_TYPE, REFRESH_TOKEN);
+        builder.add(CLIENT_ID, clientId);
+        builder.add(REFRESH_TOKEN, refreshToken);
+        builder.add(FORMAT, JSON);
+        if (addlParams != null ) {
+            for (final Map.Entry<String,String> entry : addlParams.entrySet()) {
+                builder.add(entry.getKey(),entry.getValue());
+            }
+        }
+        return makeTokenEndpointRequest(httpAccessor, loginServer, builder);
     }
 
     /**
@@ -433,17 +439,6 @@ public class OAuth2 {
         } else {
             throw new OAuthFailedException(new TokenErrorResponse(response), response.code());
         }
-    }
-
-    private static FormBody.Builder makeTokenEndpointParams(String grantType, String clientId,
-                                                            Map<String,String> addlParams) {
-        final FormBody.Builder builder = new FormBody.Builder().add(GRANT_TYPE, grantType).add(CLIENT_ID, clientId);
-        if (addlParams != null ) {
-            for (final Map.Entry<String,String> entry : addlParams.entrySet()) {
-                builder.add(entry.getKey(),entry.getValue());
-            }
-        }
-        return builder;
     }
 
     /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
@@ -73,7 +73,7 @@ public class HttpAccessTest {
 		okHttpClient = httpAccess.getOkHttpClient();
 		resourcesUrl = HttpUrl.parse(TestCredentials.INSTANCE_URL + "/services/data/" + TestCredentials.API_VERSION + "/");
 		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
-				new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+				new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID,
                 TestCredentials.REFRESH_TOKEN, null);
 		headers = new Headers.Builder()
 				.add("Content-Type", "application/json")

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -252,7 +252,7 @@ public class OAuth2Test {
 
 		// Get an auth token using the refresh token
 		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
-				new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+				new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID,
                 TestCredentials.REFRESH_TOKEN, null);
         Assert.assertNotNull("Auth token should not be null", refreshResponse.authToken);
 		
@@ -282,7 +282,7 @@ public class OAuth2Test {
 
 		// Get an auth token using the refresh token
 		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
-                new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+                new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID,
                 TestCredentials.REFRESH_TOKEN, null);
         Assert.assertNotNull("Auth token should not be null", refreshResponse.authToken);
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -107,7 +107,7 @@ public class RestClientTest {
         TestCredentials.init(InstrumentationRegistry.getContext());
         httpAccess = new HttpAccess(null, "dummy-agent");
         TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
-                new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+                new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID,
                 TestCredentials.REFRESH_TOKEN, null);
         authToken = refreshResponse.authToken;
         instanceUrl = refreshResponse.instanceUrl;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
@@ -141,7 +141,7 @@ abstract public class ManagerTestCase {
     private RestClient initRestClient() throws Exception {
         httpAccess = new HttpAccess(null, "dummy-agent");
         final TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
-        		new URI(TestCredentials.INSTANCE_URL), TestCredentials.CLIENT_ID,
+        		new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID,
         		TestCredentials.REFRESH_TOKEN, null);
         final String authToken = refreshResponse.authToken;
         final ClientInfo clientInfo = new ClientInfo(new URI(TestCredentials.INSTANCE_URL),


### PR DESCRIPTION
Calls to the token endpoint should use `loginUrl`, not `instanceUrl`.