### PR TITLE
Updating Gradle version and removing deprecated APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
+    classpath 'com.android.tools.build:gradle:3.1.0'
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 31 13:27:18 PDT 2017
+#Mon Apr 09 09:10:59 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -15,8 +15,8 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api 'com.squareup:tape:1.2.3'
-    androidTestApi 'com.android.support.test:runner:1.0.1'
-    androidTestApi 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 android {

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
   api project(':libs:SmartSync')
   api 'org.apache.cordova:framework:7.0.0'
-  androidTestApi 'com.android.support.test:runner:1.0.1'
-  androidTestApi 'com.android.support.test:rules:1.0.1'
+  androidTestImplementation 'com.android.support.test:runner:1.0.1'
+  androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 android {

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -19,9 +19,8 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
   api project(':libs:SmartSync')
   api 'com.facebook.react:react-native:0.53.3'
-
-  androidTestApi 'com.android.support.test:runner:1.0.1'
-  androidTestApi 'com.android.support.test:rules:1.0.1'
+  androidTestImplementation 'com.android.support.test:runner:1.0.1'
+  androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 android {

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -18,8 +18,8 @@ dependencies {
     api 'com.squareup.okhttp3:okhttp:3.9.0'
     api 'com.google.android.gms:play-services-gcm:11.8.0'
     api 'com.android.support:customtabs:25.2.0'
-    androidTestApi 'com.android.support.test:runner:1.0.1'
-    androidTestApi 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 android {

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
     api project(':libs:SalesforceAnalytics')
     api 'com.squareup.okhttp3:okhttp:3.9.0'
-    api 'com.google.android.gms:play-services-gcm:11.8.0'
-    api 'com.android.support:customtabs:25.2.0'
+    api 'com.google.android.gms:play-services-gcm:12.0.1'
+    api 'com.android.support:customtabs:26.1.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -16,9 +16,9 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
     api project(':libs:SalesforceSDK')
     api 'net.zetetic:android-database-sqlcipher:3.5.7'
-    androidTestApi 'com.android.support.test:runner:1.0.1'
-    androidTestApi 'com.android.support.test:rules:1.0.1'
-    androidTestApi 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }
 
 android {

--- a/libs/SmartSync/build.gradle
+++ b/libs/SmartSync/build.gradle
@@ -15,8 +15,8 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SmartStore')
-    androidTestApi 'com.android.support.test:runner:1.0.1'
-    androidTestApi 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 android {

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 dependencies {
   api project(':libs:SalesforceSDK')
-  androidTestApi ('com.android.support.test:runner:1.0.1') {
+  androidTestImplementation ('com.android.support.test:runner:1.0.1') {
     exclude module: 'support-annotations'
   }
-  androidTestApi ('com.android.support.test:rules:1.0.1') {
+  androidTestImplementation ('com.android.support.test:rules:1.0.1') {
     exclude module: 'support-annotations'
   }
-  androidTestApi ('com.android.support.test.espresso:espresso-core:3.0.1') {
+  androidTestImplementation ('com.android.support.test.espresso:espresso-core:3.0.1') {
     exclude module: 'support-annotations'
   }
 }


### PR DESCRIPTION
- Upgraded to the latest recommended `Gradle` version.
- Replace `androidTestApi` with `androidTestImplementation`, since `androidTestApi` will be removed by the end of `2018`.