### PR TITLE
Allow overriding of auto-refresh on HTTP 403

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -94,6 +94,7 @@ public class RestClient {
 	 * Interface through which the result of an asynchronous request is handled.
 	 */
 	public interface AsyncRequestCallback {
+
 		/**
 		 * NB: onSuccess runs on a network thread
 		 *     If you are making your call from an activity and need to make UI changes
@@ -198,6 +199,7 @@ public class RestClient {
 	private synchronized void setOkHttpClientBuilder() {
 		final String cacheKey = getCacheKey();
 		OkHttpClient.Builder okHttpClientBuilder = OK_CLIENT_BUILDERS.get(cacheKey);
+
 		// If none cached, create new one
 		if (okHttpClientBuilder == null) {
 			okHttpClientBuilder = httpAccessor.getOkHttpClientBuilder()
@@ -219,8 +221,8 @@ public class RestClient {
 		if (okHttpClient != null) {
 			OK_CLIENTS.put(cacheKey, okHttpClient);
 		}
-
 		okHttpClient = OK_CLIENTS.get(cacheKey);
+
 		// If none cached, create new one
 		if (okHttpClient == null) {
 			okHttpClient = getOkHttpClientBuilder().build();
@@ -261,9 +263,6 @@ public class RestClient {
 		StringBuilder sb = new StringBuilder();
 		sb.append("RestClient: {\n")
 		  .append(this.oAuthRefreshInterceptor.clientInfo.toString())
-		  // Un-comment if you must: tokens should not be printed to the log
-		  // .append("   authToken: ").append(getAuthToken()).append("\n")
-		  // .append("   refreshToken: ").append(getRefreshToken()).append("\n")
 		  .append("   timeSinceLastRefresh: ").append(oAuthRefreshInterceptor.getElapsedTimeSinceLastRefresh()).append("\n")
 		  .append("}\n");
 		return sb.toString();
@@ -321,14 +320,13 @@ public class RestClient {
                 .url(HttpUrl.get(this.oAuthRefreshInterceptor.clientInfo.resolveUrl(restRequest)))
                 .method(restRequest.getMethod().toString(), restRequest.getRequestBody());
 
-        // Adding addition headers
+        // Adding additional headers
         final Map<String, String> additionalHttpHeaders = restRequest.getAdditionalHttpHeaders();
         if (additionalHttpHeaders != null) {
             for (Map.Entry<String, String> entry : additionalHttpHeaders.entrySet()) {
                 builder.addHeader(entry.getKey(), entry.getValue());
             }
         }
-
         return builder.build();
     }
 
@@ -338,23 +336,23 @@ public class RestClient {
 	 * @param restRequest
 	 * @param callback
 	 * @return okHttp Call object (through which you can cancel the request or get the request back)
-		 */
-		public Call sendAsync(final RestRequest restRequest, final AsyncRequestCallback callback) {
-			Request request = buildRequest(restRequest);
-			Call call = okHttpClient.newCall(request);
-			call.enqueue(new Callback() {
-								 @Override
-								 public void onFailure(Call call, IOException e) {
+	 */
+    public Call sendAsync(final RestRequest restRequest, final AsyncRequestCallback callback) {
+	    Request request = buildRequest(restRequest);
+		Call call = okHttpClient.newCall(request);
+		call.enqueue(new Callback() {
+
+            @Override
+			public void onFailure(Call call, IOException e) {
 									 callback.onError(e);
 								 }
 
-								 @Override
-								 public void onResponse(Call call, Response response) throws IOException {
-									 callback.onSuccess(restRequest, new RestResponse(response));
-								 }
-							 }
-					);
-			return call;
+			@Override
+			public void onResponse(Call call, Response response) throws IOException {
+			    callback.onSuccess(restRequest, new RestResponse(response));
+            }
+		});
+		return call;
 	}
 
 	/**
@@ -370,7 +368,6 @@ public class RestClient {
         return new RestResponse(response);
 	}
 
-
     /**
      * Send the given restRequest synchronously and return a RestResponse
      * Note: Cannot be used by code on the UI thread (use sendAsync instead).
@@ -381,6 +378,7 @@ public class RestClient {
      */
     public RestResponse sendSync(RestRequest restRequest, Interceptor... interceptors) throws IOException {
         Request request = buildRequest(restRequest);
+
         // builder that shares the same connection pool, dispatcher, and configuration with the original client
         OkHttpClient.Builder clientBuilder = getOkHttpClient().newBuilder();
         for (Interceptor interceptor : interceptors) {
@@ -591,7 +589,9 @@ public class RestClient {
         public static final String NOUSER = "nouser";
 
         public UnauthenticatedClientInfo() {
-            super(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            super(null, null, null, null, null,
+                    null, null, null, null, null,
+                    null, null, null, null, null, null);
         }
 
         @Override
@@ -753,6 +753,7 @@ public class RestClient {
          * Swaps the existing access token for a new one.
          */
         private void refreshAccessToken() throws IOException {
+
             // If we haven't retried already and we have an accessTokenProvider
             // Then let's try to get a new authToken
             if (authTokenProvider != null) {
@@ -769,6 +770,7 @@ public class RestClient {
                 String instanceUrl = authTokenProvider.getInstanceUrl();
                 if (!clientInfo.instanceUrl.toString().equalsIgnoreCase(instanceUrl)) {
                     try {
+
                         // Create a new ClientInfo
                         clientInfo = new ClientInfo(new URI(instanceUrl),
                                 clientInfo.loginUrl, clientInfo.identityUrl,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -168,7 +168,6 @@ public class RestRequest {
 	private final Map<String, String> additionalHttpHeaders;
 	private final JSONObject requestBodyAsJson; // needed for composite and batch requests
 
-
     /**
      * Generic constructor for arbitrary requests without a body.
      *
@@ -231,7 +230,6 @@ public class RestRequest {
     public RestRequest(RestMethod method, String path, RequestBody requestBody, Map<String, String> additionalHttpHeaders) {
     	this(method, RestEndpoint.INSTANCE, path, requestBody, additionalHttpHeaders);
     }
-
 
     /**
      * Generic constructor for arbitrary requests.
@@ -423,7 +421,6 @@ public class RestRequest {
 			path.append("?fields=");
 			path.append(URLEncoder.encode(toCsv(fieldList).toString(), UTF_8));
 		}
-
 		return new RestRequest(RestMethod.GET, path.toString());
 	}
 
@@ -587,7 +584,6 @@ public class RestRequest {
 		JSONObject compositeRequestJson =  new JSONObject();
 		compositeRequestJson.put(COMPOSITE_REQUEST, requestsArrayJson);
         compositeRequestJson.put(ALL_OR_NONE, allOrNone);
-
 		return new RestRequest(RestMethod.POST, RestAction.COMPOSITE.getPath(apiVersion), compositeRequestJson);
 	}
 
@@ -633,7 +629,6 @@ public class RestRequest {
         JSONObject batchRequestJson =  new JSONObject();
         batchRequestJson.put(BATCH_REQUESTS, requestsArrayJson);
         batchRequestJson.put(HALT_ON_ERROR, haltOnError);
-
         return new RestRequest(RestMethod.POST, RestAction.BATCH.getPath(apiVersion), batchRequestJson);
     }
 
@@ -652,7 +647,6 @@ public class RestRequest {
         for (SObjectTree objectTree : objectTrees) {
             jsonTrees.put(objectTree.asJSON());
         }
-
         RequestBody body = RequestBody.create(MEDIA_TYPE_JSON, JSONObjectHelper.makeJSONObject(RECORDS, jsonTrees).toString());
         return new RestRequest(RestMethod.POST, RestAction.SOBJECT_TREE.getPath(apiVersion, objectType), body);
     }
@@ -678,6 +672,7 @@ public class RestRequest {
      * Helper class for getRequestForSObjectTree.
      */
     public static class SObjectTree {
+
         final String objectType;
         final String objectTypePlural;
         final String referenceId;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -126,9 +126,6 @@ public class RestRequest {
 		LOGIN, INSTANCE
 	}
 
-	/**
-	 * Enumeration for all REST API actions.
-	 */
 	private enum RestAction {
 
 		USERINFO("/services/oauth2/userinfo"),
@@ -167,6 +164,7 @@ public class RestRequest {
 	private final RequestBody requestBody;
 	private final Map<String, String> additionalHttpHeaders;
 	private final JSONObject requestBodyAsJson; // needed for composite and batch requests
+    private boolean shouldRefreshOn403 = true;
 
     /**
      * Generic constructor for arbitrary requests without a body.
@@ -322,6 +320,24 @@ public class RestRequest {
 	public Map<String, String> getAdditionalHttpHeaders() {
 		return additionalHttpHeaders;
 	}
+
+    /**
+     * Returns whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
+     *
+     * @return True - if the SDK should refresh on HTTP 403, False - otherwise.
+     */
+	public boolean getShouldRefreshOn403() {
+	    return shouldRefreshOn403;
+    }
+
+    /**
+     * Sets whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
+     *
+     * @param shouldRefreshOn403 True - if the SDK should refresh on HTTP 403, False - otherwise.
+     */
+	public synchronized void setShouldRefreshOn403(boolean shouldRefreshOn403) {
+        this.shouldRefreshOn403 = shouldRefreshOn403;
+    }
 
 	/**
 	 * Request to get information about the user making the request.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -119,10 +119,13 @@ public class RestRequest {
 		GET, POST, PUT, DELETE, HEAD, PATCH
 	}
 
+    /**
+     * Enumeration for all REST API endpoints.
+     */
 	public enum RestEndpoint {
 		LOGIN, INSTANCE
 	}
-	
+
 	/**
 	 * Enumeration for all REST API actions.
 	 */

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -43,6 +43,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -106,7 +107,7 @@ public class RestRequest {
     /**
      * HTTP date format
      */
-    public static final DateFormat HTTP_DATE_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+    public static final DateFormat HTTP_DATE_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
     static {
         HTTP_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
     }
@@ -126,6 +127,7 @@ public class RestRequest {
 	 * Enumeration for all REST API actions.
 	 */
 	private enum RestAction {
+
 		USERINFO("/services/oauth2/userinfo"),
 		VERSIONS(SERVICES_DATA),
 		RESOURCES(SERVICES_DATA + "%s/"),
@@ -669,7 +671,6 @@ public class RestRequest {
         }
     }
 
-
     /**
      * Helper class for getRequestForSObjectTree.
      */
@@ -690,22 +691,19 @@ public class RestRequest {
 
         public JSONObject asJSON() throws JSONException {
             JSONObject parentJson = buildJsonForRecord(objectType, referenceId, fields);
-
             if (childrenTrees != null) {
+
                 // Grouping children trees by type and figuring out object type to object type plural mapping
                 Map<String, String> objectTypeToObjectTypePlural = new HashMap<>();
                 Map<String, List<SObjectTree>> objectTypeToChildrenTrees = new HashMap<>();
                 for (SObjectTree childTree : childrenTrees) {
                     String childObjectType = childTree.objectType;
-
                     if (!objectTypeToObjectTypePlural.containsKey(childObjectType)) {
                         objectTypeToObjectTypePlural.put(childObjectType, childTree.objectTypePlural);
                     }
-
                     if (!objectTypeToChildrenTrees.containsKey(childObjectType)) {
                         objectTypeToChildrenTrees.put(childObjectType, new ArrayList<SObjectTree>());
                     }
-
                     objectTypeToChildrenTrees.get(childObjectType).add(childTree);
                 }
 
@@ -718,7 +716,6 @@ public class RestRequest {
                         JSONObject childJson = buildJsonForRecord(childrenObjectType, childTree.referenceId, childTree.fields);
                         childrenJsonArray.put(childJson);
                     }
-
                     parentJson.put(objectTypeToObjectTypePlural.get(childrenObjectType), JSONObjectHelper.makeJSONObject(RECORDS, childrenJsonArray));
                 }
             }
@@ -731,12 +728,9 @@ public class RestRequest {
             JSONObject jsonForAttributes = new JSONObject();
             jsonForAttributes.put(REFERENCE_ID, referenceId);
             jsonForAttributes.put(TYPE, objectType);
-
             JSONObject jsonForRecord = new JSONObject(fields);
             jsonForRecord.put(ATTRIBUTES, jsonForAttributes);
-
             return jsonForRecord;
         }
     }
-
 }


### PR DESCRIPTION
This PR allows the caller to override the default behavior of attempting to refresh on `HTTP 403` for a given request.