### PR TITLE
Un-registering from GCM push notifications only when the last account logs out

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -890,30 +890,15 @@ public class SalesforceSDKManager {
         }
 	}
 
-    /**
-     * Unregisters from push notifications for both GCM (Android) and SFDC, and waits either for
-     * unregistration to complete or for the operation to time out. The timeout period is defined
-     * in PUSH_UNREGISTER_TIMEOUT_MILLIS. 
-     *
-     * If timeout occurs while the user is logged in, this method attempts to unregister the push
-     * unregistration receiver, and then removes the user's account.
-     *
-     * @param clientMgr ClientManager instance.
-     * @param showLoginPage True - if the login page should be shown, False - otherwise.
-     * @param refreshToken Refresh token.
-     * @param loginServer Login server.
-     * @param account Account instance.
-     * @param frontActivity Front activity.
-     */
     private void unregisterPush(final ClientManager clientMgr, final boolean showLoginPage,
     		final String refreshToken, final String loginServer,
-            final Account account, final Activity frontActivity) {
+            final Account account, final Activity frontActivity, boolean isLastAccount) {
         final IntentFilter intentFilter = new IntentFilter(PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT);
         final BroadcastReceiver pushUnregisterReceiver = new BroadcastReceiver() {
 
             @Override
             public void onReceive(Context context, Intent intent) {
-                if (intent.getAction().equals(PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT)) {
+                if (PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT.equals(intent.getAction())) {
                     postPushUnregister(this, clientMgr, showLoginPage,
                     		refreshToken, loginServer, account, frontActivity);
                 }
@@ -923,7 +908,7 @@ public class SalesforceSDKManager {
 
         // Unregisters from notifications on logout.
 		final UserAccount userAcc = getUserAccountManager().buildUserAccount(account);
-        PushMessaging.unregister(context, userAcc);
+        PushMessaging.unregister(context, userAcc, isLastAccount);
 
         /*
          * Starts a background thread to wait up to the timeout period. If
@@ -932,7 +917,8 @@ public class SalesforceSDKManager {
         (new Thread() {
             public void run() {
                 long startTime = System.currentTimeMillis();
-                while ((System.currentTimeMillis() - startTime) < PUSH_UNREGISTER_TIMEOUT_MILLIS && !loggedOut) {
+                while ((System.currentTimeMillis() - startTime) < PUSH_UNREGISTER_TIMEOUT_MILLIS
+                        && !loggedOut) {
 
                     // Waits for half a second at a time.
                     SystemClock.sleep(500);
@@ -943,20 +929,6 @@ public class SalesforceSDKManager {
         }).start();
     }
 
-    /**
-     * This method is called either when unregistration for push notifications 
-     * is complete and the user has logged out, or when a timeout occurs while waiting. 
-     * If the user has not logged out, this method attempts to unregister the push 
-     * notification unregistration receiver, and then removes the user's account.
-     *
-     * @param pushReceiver Broadcast receiver.
-     * @param clientMgr ClientManager instance.
-     * @param showLoginPage True - if the login page should be shown, False - otherwise.
-     * @param refreshToken Refresh token.
-     * @param loginServer Login server.
-     * @param account Account instance.
-     * @param frontActivity Front activity.
-     */
     private synchronized void postPushUnregister(BroadcastReceiver pushReceiver,
     		final ClientManager clientMgr, final boolean showLoginPage,
     		final String refreshToken, final String loginServer,
@@ -965,7 +937,7 @@ public class SalesforceSDKManager {
             try {
                 context.unregisterReceiver(pushReceiver);
             } catch (Exception e) {
-                SalesforceSDKLogger.e(TAG, "Exception occurred while unregistering", e);
+                SalesforceSDKLogger.e(TAG, "Exception occurred while un-registering", e);
             }
     		removeAccount(clientMgr, showLoginPage, refreshToken, loginServer, account, frontActivity);
         }
@@ -1031,10 +1003,11 @@ public class SalesforceSDKManager {
 		 * if the refresh token is available.
 		 */
 		final UserAccount userAcc = getUserAccountManager().buildUserAccount(account);
+		int numAccounts = mgr.getAccountsByType(getAccountType()).length;
     	if (PushMessaging.isRegistered(context, userAcc) && refreshToken != null) {
     		loggedOut = false;
     		unregisterPush(clientMgr, showLoginPage, refreshToken,
-    				loginServer, account, frontActivity);
+    				loginServer, account, frontActivity, (numAccounts == 1));
     	} else {
     		removeAccount(clientMgr, showLoginPage, refreshToken,
                     loginServer, account, frontActivity);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.java
@@ -30,9 +30,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
-import android.content.pm.ServiceInfo;
 import android.os.Bundle;
 
 import com.google.android.gms.common.ConnectionResult;
@@ -73,7 +70,7 @@ public class PushMessaging {
     private static final String IN_PROGRESS = "inprogress";
     private static final long DEFAULT_BACKOFF = 30000;
 
-    // background executor
+    // Background executor.
     private static final ExecutorService threadPool = Executors.newFixedThreadPool(2);
 
     /**
@@ -95,8 +92,7 @@ public class PushMessaging {
         if (account != null && !isRegistered(context, account)) {
             setInProgress(context, true, account);
             if (checkPlayServices(context)) {
-                // Start IntentService to register this application with GCM.
-                Intent intent = new Intent(context, SFDCRegistrationIntentService.class);
+                final Intent intent = new Intent(context, SFDCRegistrationIntentService.class);
                 context.startService(intent);
             }
         } else {
@@ -105,31 +101,32 @@ public class PushMessaging {
     }
 
     /**
-     * Performs GCM and SFDC un-registration from push notifications for the
-     * specified user account.
+     * Performs SFDC un-registration from push notifications for the specified user account.
+     * Performs GCM un-registration only if this is the last account being logged out.
      *
-     * @param context
-     *         Context.
-     * @param account
-     *         User account.
+     * @param context Context.
+     * @param account User account.
+     * @param isLastAccount True - if this is the last logged in account, False - otherwise.
      */
-    public static void unregister(Context context, UserAccount account) {
+    public static void unregister(Context context, UserAccount account, boolean isLastAccount) {
         if (isRegistered(context, account)) {
             setInProgress(context, true, account);
-            final InstanceID instanceID = InstanceID.getInstance(context);
 
-            threadPool.execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        // avoid running on main thread
-                        instanceID.deleteInstanceID();
-                    } catch (IOException e) {
-                        SalesforceSDKLogger.e(TAG, "Error deleting InstanceID", e);
+            // Deletes InstanceID only if there are no other logged in accounts.
+            if (isLastAccount) {
+                final InstanceID instanceID = InstanceID.getInstance(context);
+                threadPool.execute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        try {
+                            instanceID.deleteInstanceID();
+                        } catch (IOException e) {
+                            SalesforceSDKLogger.e(TAG, "Error deleting InstanceID", e);
+                        }
                     }
-                }
-            });
-
+                });
+            }
             unregisterSFDCPush(context, account);
         }
     }
@@ -146,7 +143,7 @@ public class PushMessaging {
     }
 
     /**
-     * Initiates push unregistration against the SFDC endpoint.
+     * Initiates push un-registration against the SFDC endpoint.
      *
      * @param context Context.
      * @param account User account.
@@ -362,37 +359,12 @@ public class PushMessaging {
         editor.commit();
     }
 
-    /**
-     * Returns the name of the shared pref file for the specified account.
-     *
-     * @param account User account.
-     * @return Name of the shared pref file.
-     */
     private static String getSharedPrefFile(UserAccount account) {
     	String sharedPrefFile = GCM_PREFS;
     	if (account != null) {
     		sharedPrefFile = sharedPrefFile + account.getUserLevelFilenameSuffix();
     	}
     	return sharedPrefFile;
-    }
-
-    /**
-     * Returns the service info associated with an intent.
-     *
-     * @param context Context.
-     * @param intent Intent.
-     * @return Service info.
-     */
-    private static ServiceInfo getServiceInfo(Context context, Intent intent) {
-    	ServiceInfo si = null;
-    	final PackageManager pm = context.getPackageManager();
-        if (pm != null) {
-        	final ResolveInfo ri = pm.resolveService(intent, 0);
-        	if (ri != null) {
-        		si = ri.serviceInfo;
-        	}
-        }
-        return si;
     }
 
     private static boolean checkPlayServices(Context context) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushNotificationInterface.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushNotificationInterface.java
@@ -37,5 +37,5 @@ import android.os.Bundle;
  */
 public interface PushNotificationInterface {
 
-	public void onPushMessageReceived(Bundle message);
+	void onPushMessageReceived(Bundle message);
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
@@ -240,7 +240,7 @@ public class PushService extends IntentService {
         	final String id = PushMessaging.getDeviceId(context, account);
         	unregisterSFDCPushNotification(id, account);
     	} catch (Exception e) {
-            SalesforceSDKLogger.e(TAG, "Error occurred during SFDC unregistration", e);
+            SalesforceSDKLogger.e(TAG, "Error occurred during SFDC un-registration", e);
     	} finally {
         	PushMessaging.clearRegistrationInfo(context, account);
             context.sendBroadcast((new Intent(PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT)).setPackage(context.getPackageName()));
@@ -250,7 +250,7 @@ public class PushService extends IntentService {
 
     private String registerSFDCPushNotification(String registrationId,
     		UserAccount account) {
-    	final Map<String, Object> fields = new HashMap<String, Object>();
+    	final Map<String, Object> fields = new HashMap<>();
     	fields.put(CONNECTION_TOKEN, registrationId);
     	fields.put(SERVICE_TYPE, ANDROID_GCM);
     	try {
@@ -286,23 +286,18 @@ public class PushService extends IntentService {
     	return null;
     }
 
-    private boolean unregisterSFDCPushNotification(String registeredId,
+    private void unregisterSFDCPushNotification(String registeredId,
     		UserAccount account) {
     	final RestRequest req = RestRequest.getRequestForDelete(ApiVersionStrings.getVersionNumber(context),
     			MOBILE_PUSH_SERVICE_DEVICE, registeredId);
     	try {
     		final RestClient client = getRestClient(account);
     		if (client != null) {
-            	final RestResponse res = client.sendSync(req);
-            	if (res.getStatusCode() == HttpURLConnection.HTTP_NO_CONTENT) {
-            		return true;
-            	}
-            	res.consume();
+            	client.sendSync(req).consume();
     		}
     	} catch (IOException e) {
-			SalesforceSDKLogger.e(TAG, "Push notification unregistration failed", e);
+			SalesforceSDKLogger.e(TAG, "Push notification un-registration failed", e);
     	}
-    	return false;
     }
 
     private RestClient getRestClient(UserAccount account) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCGcmListenerService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCGcmListenerService.java
@@ -26,29 +26,28 @@
  */
 package com.salesforce.androidsdk.push;
 
+import android.os.Bundle;
+
 import com.google.android.gms.gcm.GcmListenerService;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
-import android.os.Bundle;
-
 public class SFDCGcmListenerService extends GcmListenerService {
+
     public static final String KEY_FROM = "from";
 
     /**
      * Called when message is received.
      *
-     * @param from
-     *         SenderID of the sender.
-     * @param data
-     *         Data bundle containing message data as key/value pairs.
-     *         For Set of keys use data.keySet().
+     * @param from SenderID of the sender.
+     * @param data Data bundle containing message data as key/value pairs.
      */
     @Override
     public void onMessageReceived(String from, Bundle data) {
         if (data != null && SalesforceSDKManager.hasInstance()) {
             final PushNotificationInterface pnInterface = SalesforceSDKManager.getInstance().getPushNotificationReceiver();
             if (pnInterface != null) {
-                // Add 'from' to the Bundle directly before passing it back
+
+                // Add 'from' to the Bundle directly before passing it back.
                 data.putString(KEY_FROM, from);
                 pnInterface.onPushMessageReceived(data);
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCInstanceIDListenerService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCInstanceIDListenerService.java
@@ -26,11 +26,12 @@
  */
 package com.salesforce.androidsdk.push;
 
-import com.google.android.gms.iid.InstanceIDListenerService;
-
 import android.content.Intent;
 
+import com.google.android.gms.iid.InstanceIDListenerService;
+
 public class SFDCInstanceIDListenerService extends InstanceIDListenerService {
+
     /**
      * Called if InstanceID token is updated. This may occur if the security of
      * the previous token had been compromised. This call is initiated by the
@@ -38,6 +39,7 @@ public class SFDCInstanceIDListenerService extends InstanceIDListenerService {
      */
     @Override
     public void onTokenRefresh() {
+
         // Fetch updated Instance ID token and notify our app's server of any changes (if applicable).
         Intent intent = new Intent(this, SFDCRegistrationIntentService.class);
         startService(intent);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
@@ -47,14 +47,15 @@ public class SFDCRegistrationIntentService extends IntentService {
     @Override
     protected void onHandleIntent(Intent intent) {
         try {
-            InstanceID instanceID = InstanceID.getInstance(this);
-            String token = instanceID.getToken(BootConfig.getBootConfig(this).getPushNotificationClientId(),
-                                               GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
+            final InstanceID instanceID = InstanceID.getInstance(this);
+            final String token = instanceID.getToken(BootConfig.getBootConfig(this).getPushNotificationClientId(),
+                    GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
+            final UserAccount account = SalesforceSDKManager.getInstance().getUserAccountManager().getCurrentUser();
 
-            UserAccount account = SalesforceSDKManager.getInstance().getUserAccountManager().getCurrentUser();
-            // Store the new token
+            // Store the new token.
             PushMessaging.setRegistrationId(this, token, account);
-            // Send it to SFDC
+
+            // Send it to SFDC.
             PushMessaging.registerSFDCPush(this, account);
         } catch (Exception e) {
             SalesforceSDKLogger.e(TAG, "Error during GCM registration", e);


### PR DESCRIPTION
`InstanceID` should be deleted only when the last user account logs out.