### PR TITLE
Fixing Toast not showing for error messages

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -307,11 +307,12 @@ public class OAuth2 {
                                                          String clientId, String code, String codeVerifier,
                                                          String callbackUrl)
             throws OAuthFailedException, IOException {
-        final FormBody.Builder builder = new FormBody.Builder().
-                add(GRANT_TYPE, AUTHORIZATION_CODE).add(CLIENT_ID, clientId);
+        final FormBody.Builder builder = new FormBody.Builder();
+        builder.add(GRANT_TYPE, AUTHORIZATION_CODE);
+        builder.add(CLIENT_ID, clientId);
+        builder.add(FORMAT, JSON);
         builder.add(CODE, code);
         builder.add(CODE_VERIFIER, codeVerifier);
-        builder.add(FORMAT, JSON);
         builder.add(REDIRECT_URI, callbackUrl);
         return makeTokenEndpointRequest(httpAccessor, loginServer, builder);
     }
@@ -379,12 +380,10 @@ public class OAuth2 {
      * @param jwt JWT issued by the OAuth authorization flow.
      *
      * @throws IOException
-     * @throws URISyntaxException
      * @throws OAuthFailedException
      */
     public static TokenEndpointResponse swapJWTForTokens(HttpAccess httpAccessor, URI loginServerUrl,
-                                                              String jwt) throws IOException,
-            URISyntaxException, OAuthFailedException {
+                                                         String jwt) throws IOException, OAuthFailedException {
         final FormBody.Builder formBodyBuilder = new FormBody.Builder().add(GRANT_TYPE, JWT_BEARER)
                 .add(ASSERTION, jwt);
         return makeTokenEndpointRequest(httpAccessor, loginServerUrl, formBodyBuilder);
@@ -400,12 +399,11 @@ public class OAuth2 {
      * @return IdServiceResponse instance.
      *
      * @throws IOException
-     * @throws URISyntaxException
      */
     public static final IdServiceResponse callIdentityService(HttpAccess httpAccessor,
                                                               String identityServiceIdUrl,
                                                               String authToken)
-            throws IOException, URISyntaxException {
+            throws IOException {
         final Request.Builder builder = new Request.Builder().url(identityServiceIdUrl).get();
         addAuthorizationHeader(builder, authToken);
         final Request request = builder.build();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -35,6 +35,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.security.KeyChain;
 import android.text.TextUtils;
 import android.view.KeyEvent;
@@ -495,8 +497,15 @@ public class LoginActivity extends AccountAuthenticatorActivity
          *
          * @param errorMessage Error message.
          */
-        public void receivedErrorResponse(String errorMessage) {
-            Toast.makeText(LoginActivity.this, errorMessage, Toast.LENGTH_LONG).show();
+        public void receivedErrorResponse(final String errorMessage) {
+            final Handler toastHandler = new Handler(Looper.getMainLooper());
+            toastHandler.post(new Runnable() {
+
+                @Override
+                public void run() {
+                    Toast.makeText(getApplicationContext(), errorMessage, Toast.LENGTH_LONG).show();
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
The `Toast` message wasn't showing because we were attempting to display it from a background thread. We now explicitly call it on the main UI thread.