### PR TITLE
Invoking callback for logout

### DIFF
--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceOauthReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceOauthReactBridge.java
@@ -50,7 +50,9 @@ public class SalesforceOauthReactBridge extends ReactContextBaseJavaModule {
     public void authenticate(ReadableMap args,
                              Callback successCallback, Callback errorCallback) {
         final SalesforceReactActivity currentActivity = (SalesforceReactActivity) getCurrentActivity();
-        if (currentActivity != null) currentActivity.authenticate(successCallback, errorCallback);
+        if (currentActivity != null) {
+            currentActivity.authenticate(successCallback, errorCallback);
+        }
     }
 
 
@@ -58,13 +60,17 @@ public class SalesforceOauthReactBridge extends ReactContextBaseJavaModule {
     public void getAuthCredentials(ReadableMap args,
                                    Callback successCallback, Callback errorCallback) {
         final SalesforceReactActivity currentActivity = (SalesforceReactActivity) getCurrentActivity();
-        if (currentActivity != null) currentActivity.getAuthCredentials(successCallback, errorCallback);
+        if (currentActivity != null) {
+            currentActivity.getAuthCredentials(successCallback, errorCallback);
+        }
     }
 
     @ReactMethod
     public void logoutCurrentUser(ReadableMap args,
                                   Callback successCallback, Callback errorCallback) {
         final SalesforceReactActivity currentActivity = (SalesforceReactActivity) getCurrentActivity();
-        if (currentActivity != null) currentActivity.logout();
+        if (currentActivity != null) {
+            currentActivity.logout(successCallback);
+        }
     }
 }

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/ui/SalesforceReactActivity.java
@@ -175,7 +175,7 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
             public void authenticatedRestClient(RestClient client) {
                 if (client == null) {
                     SalesforceReactLogger.i(TAG, "login callback triggered with null client");
-                    logout();
+                    logout(null);
                 } else {
                     SalesforceReactLogger.i(TAG, "login callback triggered with actual client");
                     SalesforceReactActivity.this.restartReactNativeApp();
@@ -186,10 +186,15 @@ public abstract class SalesforceReactActivity extends ReactActivity implements S
 
     /**
      * Method called from bridge to logout.
+     *
+     * @param successCallback Success callback.
      */
-    public void logout() {
+    public void logout(final Callback successCallback) {
         SalesforceReactLogger.i(TAG, "logout called");
         SalesforceReactSDKManager.getInstance().logout(this);
+        if (successCallback != null) {
+            ReactBridgeHelper.invokeSuccess(successCallback, "Logout complete");
+        }
     }
 
     /**


### PR DESCRIPTION
The underlying issue is that a flag that indicates logout is in progress is never reset in JS land for deferred authentication. We can't tear down the entire bridge in this use case either. Triggering the callback allows the bridge to reset this flag when logout completes. For more details and discussion, see [this issue](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/issues/72).