### PR TITLE
Capturing error during sync up on record

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
@@ -607,21 +607,32 @@ public class SyncManager {
         switch (action) {
             case create:
                 recordServerId = target.createOnServer(this, record, options.getFieldlist());
+                // Success
                 if (recordServerId != null) {
                     record.put(target.getIdFieldName(), recordServerId);
                     target.cleanAndSaveInLocalStore(this, soupName, record);
+                }
+                // Failure
+                else {
+                    target.saveRecordToLocalStoreWithLastError(this, soupName, record);
                 }
                 break;
             case delete:
                 statusCode = (locallyCreated
                         ? HttpURLConnection.HTTP_NOT_FOUND // if locally created it can't exist on the server - we don't need to actually do the deleteOnServer call
                         : target.deleteOnServer(this, record));
+                // Success
                 if (RestResponse.isSuccess(statusCode) || statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
                     target.deleteFromLocalStore(this, soupName, record);
+                }
+                // Failure
+                else {
+                    target.saveRecordToLocalStoreWithLastError(this, soupName, record);
                 }
                 break;
             case update:
                 statusCode = target.updateOnServer(this, record, options.getFieldlist());
+                // Success
                 if (RestResponse.isSuccess(statusCode)) {
                     target.cleanAndSaveInLocalStore(this, soupName, record);
                 }
@@ -637,6 +648,10 @@ public class SyncManager {
                     else {
                         // Leave local record alone
                     }
+                }
+                // Failure
+                else {
+                    target.saveRecordToLocalStoreWithLastError(this, soupName, record);
                 }
                 break;
         }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncUpTarget.java
@@ -232,6 +232,10 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
 
                 deleteFromLocalStore(syncManager, soupName, record);
             }
+            // Failure
+            else {
+                saveRecordToLocalStoreWithError(syncManager, soupName, record, response != null ? response.toString() : null);
+            }
         }
 
         // Create / update case
@@ -261,6 +265,10 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                     needReRun = true;
                 }
             }
+            // Failure
+            else {
+                saveRecordToLocalStoreWithError(syncManager, soupName, record, response != null ? response.toString() : null);
+            }
         }
         return needReRun;
     }
@@ -277,6 +285,10 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                     || statusCode == HttpURLConnection.HTTP_NOT_FOUND) // or the record was already deleted on the server
             {
                 deleteFromLocalStore(syncManager, soupName, record);
+            }
+            // Failure
+            else {
+                saveRecordToLocalStoreWithError(syncManager, soupName, record, response != null ? response.toString() : null);
             }
         }
 
@@ -316,6 +328,10 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                     // We need a re-run
                     needReRun = true;
                 }
+            }
+            // Failure
+            else {
+                saveRecordToLocalStoreWithError(syncManager, soupName, record, response != null ? response.toString() : null);
             }
         }
         return needReRun;

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncTarget.java
@@ -175,7 +175,7 @@ public abstract class SyncTarget {
      * @param soupName
      * @param record
      */
-    public void saveInLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
+    protected void saveInLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
         saveInSmartStore(syncManager.getSmartStore(), soupName, record, getIdFieldName(), true);
         SmartSyncLogger.d(TAG, "saveInLocalStore", record);
     }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/SyncTarget.java
@@ -62,6 +62,9 @@ public abstract class SyncTarget {
     public static final String LOCALLY_DELETED = "__locally_deleted__";
     public static final String LOCAL = "__local__";
 
+    // Field added to record to capture last sync error if any
+    public static final String LAST_ERROR = "__last_error__";
+
     // Field added to record to remember sync it came through
     public static final String SYNC_ID = "__sync_id__";
 
@@ -119,7 +122,6 @@ public abstract class SyncTarget {
         return modificationDateFieldName;
     }
 
-
     /**
      * Return ids of "dirty" records (records locally created/upated or deleted)
      * @param syncManager
@@ -152,11 +154,12 @@ public abstract class SyncTarget {
             hasMore = (results.length() == PAGE_SIZE);
             ids.addAll(toSortedSet(results));
         }
+
         return ids;
     }
 
     /**
-     * Save record in local store
+     * Save cleaned record in local store
      * @param syncManager
      * @param soupName
      * @param record
@@ -166,8 +169,23 @@ public abstract class SyncTarget {
         SmartSyncLogger.d(TAG, "cleanAndSaveInLocalStore", record);
     }
 
+    /**
+     * Save record in local store
+     * @param syncManager
+     * @param soupName
+     * @param record
+     */
+    public void saveInLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
+        saveInSmartStore(syncManager.getSmartStore(), soupName, record, getIdFieldName(), true);
+        SmartSyncLogger.d(TAG, "saveInLocalStore", record);
+    }
+
     protected void cleanAndSaveInSmartStore(SmartStore smartStore, String soupName, JSONObject record, String idFieldName, boolean handleTx) throws JSONException {
         cleanRecord(record);
+        saveInSmartStore(smartStore, soupName, record, idFieldName, handleTx);
+    }
+
+    protected void saveInSmartStore(SmartStore smartStore, String soupName, JSONObject record, String idFieldName, boolean handleTx) throws JSONException {
         if (record.has(SmartStore.SOUP_ENTRY_ID)) {
             // Record came from smartstore
             smartStore.update(soupName, record, record.getLong(SmartStore.SOUP_ENTRY_ID), handleTx);
@@ -183,6 +201,7 @@ public abstract class SyncTarget {
         record.put(LOCALLY_CREATED, false);
         record.put(LOCALLY_UPDATED, false);
         record.put(LOCALLY_DELETED, false);
+        record.put(LAST_ERROR, null);
     }
 
     /**

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -313,14 +313,16 @@ public class SyncManagerTest extends SyncManagerTestCase {
         checkDbStateFlags(idToFieldsBadNames.keySet(), true, false, false, ACCOUNTS_SOUP);
 
         for (Map<String, Object> fields : idToFieldsBadNames.values()) {
-            if (fields.get(Constants.NAME).equals(nameTooLong)) {
-                Assert.assertTrue("Name too large error expected", ((String) fields.get(SyncTarget.LAST_ERROR)).contains("Account Name: data value too large"));
+            String name = (String) fields.get(Constants.NAME);
+            String lastError = (String) fields.get(SyncTarget.LAST_ERROR);
+            if (name.equals(nameTooLong)) {
+                Assert.assertTrue("Name too large error expected", lastError.contains("Account Name: data value too large"));
             }
-            else if (fields.get(Constants.NAME).equals("")) {
-                Assert.assertTrue("Missing name error expected", ((String) fields.get(SyncTarget.LAST_ERROR)).contains("Required fields are missing: [Name]"));
+            else if (name.equals("")) {
+                Assert.assertTrue("Missing name error expected", lastError.contains("Required fields are missing: [Name]"));
             }
             else {
-                Assert.fail("Unexpected record found: " + fields.get(Constants.NAME));
+                Assert.fail("Unexpected record found: " + name);
             }
         }
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -282,7 +282,7 @@ public class SyncManagerTest extends SyncManagerTestCase {
      */
     @Test
     public void testSyncUpWithErrors() throws Exception {
-        //
+        // Build name too long
         StringBuffer buffer = new StringBuffer(256);
         for (int i = 0; i < 256; i++) buffer.append("x");
         String nameTooLong = buffer.toString();

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
@@ -469,11 +469,16 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
             JSONArray row = accountsFromDb.getJSONArray(i);
             JSONObject soupElt = row.getJSONObject(0);
             String id = soupElt.getString(Constants.ID);
-            Assert.assertEquals("Wrong local flag", expectLocallyCreated || expectLocallyUpdated || expectLocallyDeleted, soupElt.getBoolean(SyncTarget.LOCAL));
+            boolean expectDirty = expectLocallyCreated || expectLocallyUpdated || expectLocallyDeleted;
+            Assert.assertEquals("Wrong local flag", expectDirty, soupElt.getBoolean(SyncTarget.LOCAL));
             Assert.assertEquals("Wrong local flag", expectLocallyCreated, soupElt.getBoolean(SyncTarget.LOCALLY_CREATED));
             Assert.assertEquals("Id was not updated", expectLocallyCreated, id.startsWith(LOCAL_ID_PREFIX));
             Assert.assertEquals("Wrong local flag", expectLocallyUpdated, soupElt.getBoolean(SyncTarget.LOCALLY_UPDATED));
             Assert.assertEquals("Wrong local flag", expectLocallyDeleted, soupElt.getBoolean(SyncTarget.LOCALLY_DELETED));
+            // Last error field should be empty for a clean record
+            if (!expectDirty) {
+                Assert.assertTrue("Last error should be empty", TextUtils.isEmpty(JSONObjectHelper.optString(soupElt, SyncTarget.LAST_ERROR)));
+            }
         }
     }
 

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTestCase.java
@@ -463,13 +463,13 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
      * @throws JSONException
      */
     protected void checkDbStateFlags(Collection<String> ids, boolean expectLocallyCreated, boolean expectLocallyUpdated, boolean expectLocallyDeleted, String soupName) throws JSONException {
+        boolean expectDirty = expectLocallyCreated || expectLocallyUpdated || expectLocallyDeleted;
         QuerySpec smartStoreQuery = QuerySpec.buildSmartQuerySpec(String.format("SELECT {%s:_soup} FROM {%s} WHERE {%s:Id} IN %s", soupName, soupName, soupName, makeInClause(ids)), ids.size());
         JSONArray accountsFromDb = smartStore.query(smartStoreQuery, 0);
         for (int i=0; i<accountsFromDb.length(); i++) {
             JSONArray row = accountsFromDb.getJSONArray(i);
             JSONObject soupElt = row.getJSONObject(0);
             String id = soupElt.getString(Constants.ID);
-            boolean expectDirty = expectLocallyCreated || expectLocallyUpdated || expectLocallyDeleted;
             Assert.assertEquals("Wrong local flag", expectDirty, soupElt.getBoolean(SyncTarget.LOCAL));
             Assert.assertEquals("Wrong local flag", expectLocallyCreated, soupElt.getBoolean(SyncTarget.LOCALLY_CREATED));
             Assert.assertEquals("Id was not updated", expectLocallyCreated, id.startsWith(LOCAL_ID_PREFIX));

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
@@ -929,14 +929,12 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
 
         // Check valid records in db: should no longer be marked as dirty
         checkDbStateFlags(Arrays.asList(account1Id), false, false, false, ACCOUNTS_SOUP);
-        checkDbStateFlags(Arrays.asList(contact11Id), false, false, false, CONTACTS_SOUP);
-        checkDbStateFlags(Arrays.asList(contact21Id), false, false, false, CONTACTS_SOUP);
+        checkDbStateFlags(Arrays.asList(contact11Id, contact21Id), false, false, false, CONTACTS_SOUP);
 
         // Check invalid records in db
         // Should still be marked as dirty
         checkDbStateFlags(Arrays.asList(account2Id), false, true, false, ACCOUNTS_SOUP);
-        checkDbStateFlags(Arrays.asList(contact12Id), false, true, false, CONTACTS_SOUP);
-        checkDbStateFlags(Arrays.asList(contact22Id), false, true, false, CONTACTS_SOUP);
+        checkDbStateFlags(Arrays.asList(contact12Id, contact22Id), false, true, false, CONTACTS_SOUP);
         // Should have populated last error fields
         checkDbLastErrorField(new String[] { account2Id }, "Account Name: data value too large", ACCOUNTS_SOUP);
         checkDbLastErrorField(new String[] { contact12Id, contact22Id }, "Last Name: data value too large", CONTACTS_SOUP);

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
@@ -880,4 +880,95 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         deleteRecordsOnServer(new HashSet<String>(Arrays.asList(newAccountId)), Constants.ACCOUNT);
         deleteRecordsOnServer(contactIdToFieldsCreated.keySet(), Constants.CONTACT);
     }
+
+    /**
+     * Create accounts and contacts on server, sync down
+     * Update some of the accounts and contacts - using bad names (too long) for some
+     * Sync up
+     * Check smartstore and server afterwards
+     */
+    @Test
+    public void testSyncUpWithErrors() throws Exception {
+        // Creating test accounts and contacts on server
+        createAccountsAndContactsOnServer(3, 3);
+
+        // Sync down
+        ParentChildrenSyncDownTarget syncDownTarget = getAccountContactsSyncDownTarget(
+                String.format("%s IN %s", Constants.ID, makeInClause(accountIdToFields.keySet())));
+        trySyncDown(SyncState.MergeMode.OVERWRITE, syncDownTarget, ACCOUNTS_SOUP, 3, 1);
+
+        // Picking accounts / contacts
+        String[] accountIds = accountIdToFields.keySet().toArray(new String[0]);
+        String account1Id = accountIds[0];
+        String[] contactIdsOfAccount1 = accountIdContactIdToFields.get(account1Id).keySet().toArray(new String[0]);
+        String contact11Id = contactIdsOfAccount1[0];
+        String contact12Id = contactIdsOfAccount1[1];
+
+        String account2Id = accountIds[1];
+        String[] contactIdsOfAccount2 = accountIdContactIdToFields.get(account2Id).keySet().toArray(new String[0]);
+        String contact21Id = contactIdsOfAccount2[0];
+        String contact22Id = contactIdsOfAccount2[1];
+
+        // Build long suffix
+        StringBuffer buffer = new StringBuffer(255);
+        for (int i = 0; i < 255; i++) buffer.append("x");
+        String suffixTooLong = buffer.toString();
+
+        // Updating with valid values
+        Map<String, Object> updatedAccount1Fields = updateRecordLocally(ACCOUNTS_SOUP, account1Id, accountIdToFields.get(account1Id)).get(account1Id);
+        Map<String, Object> updatedContact11Fields = updateRecordLocally(CONTACTS_SOUP, contact11Id, accountIdContactIdToFields.get(account1Id).get(contact11Id)).get(contact11Id);
+        Map<String, Object> updatedContact21Fields = updateRecordLocally(CONTACTS_SOUP, contact21Id, accountIdContactIdToFields.get(account2Id).get(contact21Id)).get(contact21Id);
+
+        // Updating with invalid values
+        updateRecordLocally(ACCOUNTS_SOUP, account2Id, accountIdToFields.get(account2Id), suffixTooLong);
+        updateRecordLocally(CONTACTS_SOUP, contact12Id, accountIdContactIdToFields.get(account1Id).get(contact12Id), suffixTooLong);
+        updateRecordLocally(CONTACTS_SOUP, contact22Id, accountIdContactIdToFields.get(account2Id).get(contact22Id), suffixTooLong);
+
+        // Sync up
+        trySyncUp(getAccountContactsSyncUpTarget(), 2, SyncState.MergeMode.OVERWRITE);
+
+        // Check valid records in db: should no longer be marked as dirty
+        checkDbStateFlags(Arrays.asList(account1Id), false, false, false, ACCOUNTS_SOUP);
+        checkDbStateFlags(Arrays.asList(contact11Id), false, false, false, CONTACTS_SOUP);
+        checkDbStateFlags(Arrays.asList(contact21Id), false, false, false, CONTACTS_SOUP);
+
+        // Check invalid records in db
+        // Should still be marked as dirty
+        checkDbStateFlags(Arrays.asList(account2Id), false, true, false, ACCOUNTS_SOUP);
+        checkDbStateFlags(Arrays.asList(contact12Id), false, true, false, CONTACTS_SOUP);
+        checkDbStateFlags(Arrays.asList(contact22Id), false, true, false, CONTACTS_SOUP);
+        // Should have populated last error fields
+        checkDbLastErrorField(new String[] { account2Id }, "Account Name: data value too large", ACCOUNTS_SOUP);
+        checkDbLastErrorField(new String[] { contact12Id, contact22Id }, "Last Name: data value too large", CONTACTS_SOUP);
+
+        // Check server
+        Map<String, Map<String, Object>> accountIdToFieldsExpectedOnServer = new HashMap<>();
+        for (String id : accountIds) {
+            // Only update to account1 should have gone through
+            if (id.equals(account1Id)) {
+                accountIdToFieldsExpectedOnServer.put(id, updatedAccount1Fields);
+            }
+            else {
+                accountIdToFieldsExpectedOnServer.put(id, accountIdToFields.get(id));
+            }
+        }
+        checkServer(accountIdToFieldsExpectedOnServer, Constants.ACCOUNT);
+
+        Map<String, Map<String, Object>> contactIdToFieldsExpectedOnServer = new HashMap<>();
+        for (String id : accountIds) {
+            Map<String, Map<String, Object>> contactIdToFields = accountIdContactIdToFields.get(id);
+            for (String cid : contactIdToFields.keySet()) {
+                // Only update to contact11 and contact21 should have gone through
+                if (cid.equals(contact11Id)) {
+                    contactIdToFieldsExpectedOnServer.put(cid, updatedContact11Fields);
+                } else if (cid.equals(contact21Id)) {
+                    contactIdToFieldsExpectedOnServer.put(cid, updatedContact21Fields);
+                } else {
+                    contactIdToFieldsExpectedOnServer.put(cid, contactIdToFields.get(cid));
+                }
+            }
+        }
+        checkServer(contactIdToFieldsExpectedOnServer, Constants.CONTACT);
+    }
+
 }

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTestCase.java
@@ -212,7 +212,7 @@ public class ParentChildrenSyncTestCase extends SyncManagerTestCase {
             // Check db and server - local changes should have made it over
             checkDbAndServerAfterCompletedSyncUp(accountId, contactId, otherContactId, remoteChangeForAccount, localChangeForContact, remoteChangeForContact, localUpdatesAccount, localUpdatesContact, localChangeForAccount);
 
-            // Sync up with overwrite - there should be dirty records found
+            // Sync up with overwrite - there should be no dirty records found
             trySyncUp(syncUpTarget, 0, SyncState.MergeMode.OVERWRITE);
         }
         // In all other cases, leave-if-changed will fail


### PR DESCRIPTION
If a record fails to sync up, the server response is saved in a `__last_error__` field on the record.
NB: That field will be cleared in subsequent successful sync up