### PR TITLE
setupGlobal/UserStore/SyncsFromConfig no longer calls getSmartStore if no configs

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -441,7 +441,10 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      */
     public void setupGlobalStoreFromDefaultConfig() {
         SmartStoreLogger.d(TAG, "Setting up global store using config found in res/raw/globalstore.json");
-        setupStoreFromConfig(getGlobalSmartStore(), R.raw.globalstore);
+        StoreConfig config = new StoreConfig(context, R.raw.globalstore);
+        if (config.hasSoups()) {
+            config.registerSoups(getGlobalSmartStore());
+        }
     }
 
     /**
@@ -449,18 +452,10 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      */
     public void setupUserStoreFromDefaultConfig() {
         SmartStoreLogger.d(TAG, "Setting up user store using config found in res/raw/userstore.json");
-        setupStoreFromConfig(getSmartStore(), R.raw.userstore);
-    }
-
-    /**
-     * Setup given store using config found in given json resource file
-     *
-     * @param store
-     * @param resourceId
-     */
-    private void setupStoreFromConfig(SmartStore store, int resourceId) {
-        StoreConfig config = new StoreConfig(context, resourceId);
-        config.registerSoups(store);
+        StoreConfig config = new StoreConfig(context, R.raw.userstore);
+        if (config.hasSoups()) {
+            config.registerSoups(getSmartStore());
+        }
     }
 
     @Override

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/config/StoreConfig.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/config/StoreConfig.java
@@ -98,6 +98,14 @@ public class StoreConfig {
     }
 
     /**
+     * Return true if soups are defined in config
+     * @return
+     */
+    public boolean hasSoups() {
+        return soupConfigs != null && soupConfigs.length() > 0;
+    }
+
+    /**
      * Register the soup from the config in the given store
      * NB: only feedback is through the logs - the config is static so getting it right is something the developer should do while writing the app
      * @param store

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/app/SmartSyncSDKManager.java
@@ -32,7 +32,7 @@ import android.content.Context;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
+import com.salesforce.androidsdk.smartsync.R;
 import com.salesforce.androidsdk.smartsync.accounts.SmartSyncUserAccountManager;
 import com.salesforce.androidsdk.smartsync.config.SyncsConfig;
 import com.salesforce.androidsdk.smartsync.manager.CacheManager;
@@ -194,7 +194,10 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
 	 */
 	public void setupGlobalSyncsFromDefaultConfig() {
 		SmartSyncLogger.d(TAG, "Setting up global syncs using config found in res/raw/globalsyncs.json");
-		setupSyncsFromConfig(getGlobalSmartStore(), com.salesforce.androidsdk.smartsync.R.raw.globalsyncs);
+		SyncsConfig config = new SyncsConfig(context, R.raw.globalsyncs);
+		if (config.hasSyncs()) {
+			config.createSyncs(getGlobalSmartStore());
+		}
 	}
 
 	/**
@@ -202,17 +205,10 @@ public class SmartSyncSDKManager extends SmartStoreSDKManager {
 	 */
 	public void setupUserSyncsFromDefaultConfig() {
 		SmartSyncLogger.d(TAG, "Setting up user syncs using config found in res/raw/usersyncs.json");
-		setupSyncsFromConfig(getSmartStore(), com.salesforce.androidsdk.smartsync.R.raw.usersyncs);
+		SyncsConfig config = new SyncsConfig(context, R.raw.usersyncs);
+		if (config.hasSyncs()) {
+			config.createSyncs(getSmartStore());
+		}
 	}
 
-	/**
-	 * Setup syncs in given store using config found in given json resource file
-	 *
-	 * @param store
-	 * @param resourceId
-	 */
-	private void setupSyncsFromConfig(SmartStore store, int resourceId) {
-		SyncsConfig config = new SyncsConfig(context, resourceId);
-		config.createSyncs(store);
-	}
 }

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/config/SyncsConfig.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/config/SyncsConfig.java
@@ -103,6 +103,13 @@ public class SyncsConfig {
         }
     }
 
+    /**
+     * Return true if syncs are defined in config
+     * @return
+     */
+    public boolean hasSyncs() {
+        return syncConfigs != null && syncConfigs.length() > 0;
+    }
 
     /**
      * Create the syncs from the config in the given store


### PR DESCRIPTION
setupGlobal/UserStore/SyncsFromConfig no longer calls getSmartStore or getGlobalSmartStore if there is no config (or if it's empty).