### PR TITLE
Usage tracking fixes

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -60,6 +60,9 @@ public class UserAccountManager {
 
 	public static final String USER_SWITCH_INTENT_ACTION = "com.salesforce.USERSWITCHED";
 
+	// User agent feature flag for multi users
+	private static final String FEATURE_MULTI_USERS = "MU";
+
 	/**
 	 * Represents how the current user has been switched to, as found in an intent sent to a {@link android.content.BroadcastReceiver}
 	 * filtering {@link #USER_SWITCH_INTENT_ACTION}. User switching including logging in, logging out and switching between authenticated
@@ -180,7 +183,14 @@ public class UserAccountManager {
         	return null;
         }
 
-        // Reads the stored user ID and org ID.
+		// Register feature MU if more than one user
+		if (accounts.length > 1) {
+			SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_MULTI_USERS);
+		} else {
+			SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_MULTI_USERS);
+		}
+
+		// Reads the stored user ID and org ID.
         final SharedPreferences sp = context.getSharedPreferences(CURRENT_USER_PREF,
 				Context.MODE_PRIVATE);
         final String storedUserId = sp.getString(USER_ID_KEY, "");

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -455,7 +455,7 @@ public class SalesforceSDKManager {
         SalesforceSDKUpgradeManager.getInstance().upgrade();
 
         // Initializes the HTTP client.
-        HttpAccess.init(context, INSTANCE.getUserAgent());
+        HttpAccess.init(context);
 
         // Enables IDP login flow if it's set through MDM.
         final RuntimeConfig runtimeConfig = RuntimeConfig.getRuntimeConfig(context);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -702,14 +702,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             PushMessaging.register(appContext, account);
         }
 
-        // Logs analytics event for new user.
-        final JSONObject userAttr = new JSONObject();
-        try {
-            final List<UserAccount> users = UserAccountManager.getInstance().getAuthenticatedUsers();
-            userAttr.put("numUsers", (users == null) ? 0 : users.size());
-        } catch (JSONException e) {
-            SalesforceSDKLogger.e(TAG, "Exception thrown while creating JSON", e);
-        }
         callback.onAccountAuthenticatorResult(extras);
         if (SalesforceSDKManager.getInstance().getIsTestRun()) {
             logAddAccount(account);
@@ -729,8 +721,16 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
      * @param account
      */
     private void logAddAccount(UserAccount account) {
+        final JSONObject userAttr = new JSONObject();
         final JSONObject serverAttr = new JSONObject();
         try {
+            // Logs analytics event for new user.
+            final List<UserAccount> users = UserAccountManager.getInstance().getAuthenticatedUsers();
+            final int numUsers = (users == null) ? 0 : users.size();
+            userAttr.put("numUsers", numUsers);
+            EventBuilderHelper.createAndStoreEventSync("addUser", account, TAG, userAttr);
+
+            // Logging events for add user and number of servers.
             final List<LoginServerManager.LoginServer> servers = SalesforceSDKManager.getInstance().getLoginServerManager().getLoginServers();
             serverAttr.put("numLoginServers", (servers == null) ? 0 : servers.size());
             if (servers != null) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -721,18 +721,13 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
      * @param account
      */
     private void logAddAccount(UserAccount account) {
-        final JSONObject userAttr = new JSONObject();
-        final JSONObject serverAttr = new JSONObject();
+        final JSONObject attributes = new JSONObject();
         try {
-            // Logs analytics event for new user.
             final List<UserAccount> users = UserAccountManager.getInstance().getAuthenticatedUsers();
-            final int numUsers = (users == null) ? 0 : users.size();
-            userAttr.put("numUsers", numUsers);
-            EventBuilderHelper.createAndStoreEventSync("addUser", account, TAG, userAttr);
+            attributes.put("numUsers", (users == null) ? 0 : users.size());
 
-            // Logging events for add user and number of servers.
             final List<LoginServerManager.LoginServer> servers = SalesforceSDKManager.getInstance().getLoginServerManager().getLoginServers();
-            serverAttr.put("numLoginServers", (servers == null) ? 0 : servers.size());
+            attributes.put("numLoginServers", (servers == null) ? 0 : servers.size());
             if (servers != null) {
                 final JSONArray serversJson = new JSONArray();
                 for (final LoginServerManager.LoginServer server : servers) {
@@ -740,9 +735,9 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                         serversJson.put(server.url);
                     }
                 }
-                serverAttr.put("loginServers", serversJson);
+                attributes.put("loginServers", serversJson);
             }
-            EventBuilderHelper.createAndStoreEventSync("addUser", account, TAG, serverAttr);
+            EventBuilderHelper.createAndStoreEventSync("addUser", account, TAG, attributes);
         } catch (JSONException e) {
             SalesforceSDKLogger.e(TAG, "Exception thrown while creating JSON", e);
         }


### PR DESCRIPTION
There were a number of issues:
* MU feature was never set (on Android) => now it's computed in UserAccountManager.getCurrentAccount()
* addUser event with numUsers attribute was never published (the addUser event with loginServers was however published) => now we published a single addUser event with loginServers and numUsers, I will change the iOS side to also publish a single event 
* user agent attached to out going query was computed when HttpAccess was initialized => now it's computed at request time