### PR TITLE
Remove static method of forcing browser-based auth

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/HybridApp.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/HybridApp.java
@@ -44,12 +44,5 @@ public class HybridApp extends Application {
          * Replace 'idpAppURIScheme' with the URI scheme of the IDP app meant to be used.
          */
         // SalesforceHybridSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
-
-        /*
-         * Uncomment the following line to enable browser based login. This will use a
-         * Chrome custom tab to login instead of the default WebView. You will also need
-         * to uncomment a few lines of code in SalesforceSDK library project's AndroidManifest.xml.
-         */
-		// SalesforceHybridSDKManager.getInstance().setBrowserLoginEnabled(true);
 	}
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -666,7 +666,8 @@ public class SalesforceSDKManager {
     }
 
     /**
-     * Sets whether browser based login should be used instead of WebView.
+     * Sets whether browser based login should be used instead of WebView. This should NOT be used
+     * directly by apps, this is meant for internal use, based on the value configured on the server.
      *
      * @param browserLoginEnabled True - if Chrome should be used for login, False - otherwise.
      */

--- a/native/NativeSampleApps/ConfiguredApp/src/com/salesforce/samples/configuredapp/ConfiguredApp.java
+++ b/native/NativeSampleApps/ConfiguredApp/src/com/salesforce/samples/configuredapp/ConfiguredApp.java
@@ -47,12 +47,5 @@ public class ConfiguredApp extends Application {
          * Replace 'idpAppURIScheme' with the URI scheme of the IDP app meant to be used.
          */
         // SalesforceSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
-
-		/*
-         * Uncomment the following line to enable browser based login. This will use a
-         * Chrome custom tab to login instead of the default WebView. You will also need
-         * to uncomment a few lines of code in SalesforceSDK library project's AndroidManifest.xml.
-         */
-		// SalesforceSDKManager.getInstance().setBrowserLoginEnabled(true);
 	}
 }

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
@@ -48,13 +48,6 @@ public class RestExplorerApp extends Application {
         // SalesforceSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
 
 		/*
-         * Uncomment the following line to enable browser based login. This will use a
-         * Chrome custom tab to login instead of the default WebView. You will also need
-         * to uncomment a few lines of code in SalesforceSDK library project's AndroidManifest.xml.
-         */
-		// SalesforceSDKManager.getInstance().setBrowserLoginEnabled(true);
-
-		/*
 		 * Un-comment the line below to enable push notifications in this app.
 		 * Replace 'pnInterface' with your implementation of 'PushNotificationInterface'.
 		 * Add your Google package ID in 'bootonfig.xml', as the value

--- a/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
+++ b/native/NativeSampleApps/SmartSyncExplorer/src/com/salesforce/samples/smartsyncexplorer/SmartSyncExplorerApp.java
@@ -48,13 +48,6 @@ public class SmartSyncExplorerApp extends Application {
          */
         // SmartSyncSDKManager.getInstance().setIDPAppURIScheme(idpAppURIScheme);
 
-        /*
-         * Uncomment the following line to enable browser based login. This will use a
-         * Chrome custom tab to login instead of the default WebView. You will also need
-         * to uncomment a few lines of code in SalesforceSDK library project's AndroidManifest.xml.
-         */
-        // SmartSyncSDKManager.getInstance().setBrowserLoginEnabled(true);
-
 		/*
 		 * Un-comment the line below to enable push notifications in this app.
 		 * Replace 'pnInterface' with your implementation of 'PushNotificationInterface'.


### PR DESCRIPTION
This was made available as a filler before the checkbox was available on the connected app endpoint and `.well-known` config.