### PR TITLE
PushService is now subclassable

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -33,6 +33,7 @@ import android.accounts.AccountManagerFuture;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -67,6 +68,7 @@ import com.salesforce.androidsdk.config.LoginServerManager;
 import com.salesforce.androidsdk.config.RuntimeConfig;
 import com.salesforce.androidsdk.push.PushMessaging;
 import com.salesforce.androidsdk.push.PushNotificationInterface;
+import com.salesforce.androidsdk.push.PushService;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
 import com.salesforce.androidsdk.rest.RestClient;
@@ -161,6 +163,7 @@ public class SalesforceSDKManager {
     private AdminSettingsManager adminSettingsManager;
     private AdminPermsManager adminPermsManager;
     private PushNotificationInterface pushNotificationInterface;
+    private Class<? extends PushService> pushServiceType;
     private String uid; // device id
     private volatile boolean loggedOut = false;
     private SortedSet<String> features;
@@ -587,6 +590,50 @@ public class SalesforceSDKManager {
      */
     public synchronized PushNotificationInterface getPushNotificationReceiver() {
     	return pushNotificationInterface;
+    }
+
+    /**
+     * Sets the class that will be used as a push service.
+     *
+     * <p>
+     * If a class other than {@link PushService} is used, it must also be declared in the manifest and the
+     * {@link PushService} element must be disabled.
+     * </p>
+     *
+     * <pre>
+     * <code>
+     * &lt;service
+     *    android:enabled="false"
+     *    android:name="com.salesforce.androidsdk.push.PushService"
+     *    tools:node="merge"/&gt;
+     *
+     * &lt;service
+     *    android:enabled="true"
+     *    android:exported="false"
+     *    android:name="your.push.service"/&gt;
+     * </code>
+     * </pre>
+     *
+     * @param type the service class
+     */
+    public synchronized void setPushServiceType(Class<? extends PushService> type) {
+        pushServiceType = type;
+        if (!PushService.class.equals(type)) {
+            try {
+                context.getPackageManager().getServiceInfo(new ComponentName(context, type), 0);
+            } catch (NameNotFoundException e) {
+                throw new IllegalStateException(String.format("%s must be declared and enabled in the manifest", type));
+            }
+        }
+    }
+
+    /**
+     *  Returns the class that will be used as a push service.
+     *
+     *  @return the service class
+     */
+    public synchronized Class<? extends PushService> getPushServiceType() {
+        return pushServiceType;
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -163,7 +163,7 @@ public class SalesforceSDKManager {
     private AdminSettingsManager adminSettingsManager;
     private AdminPermsManager adminPermsManager;
     private PushNotificationInterface pushNotificationInterface;
-    private Class<? extends PushService> pushServiceType;
+    private Class<? extends PushService> pushServiceType = PushService.class;
     private String uid; // device id
     private volatile boolean loggedOut = false;
     private SortedSet<String> features;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
@@ -35,7 +35,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.PowerManager;
-import android.support.annotation.NonNull;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
@@ -267,10 +266,9 @@ public class PushService extends IntentService {
 	 * @return the response from registration
 	 * @throws IOException if the request could not be made
 	 */
-	@NonNull
 	protected RestResponse onSendRegisterPushNotificationRequest(
-			@NonNull Map<String, Object> requestBodyJsonFields,
-			@NonNull RestClient restClient) throws IOException {
+			Map<String, Object> requestBodyJsonFields,
+			RestClient restClient) throws IOException {
 		return restClient.sendSync(RestRequest.getRequestForCreate(
 				ApiVersionStrings.getVersionNumber(context), MOBILE_PUSH_SERVICE_DEVICE, requestBodyJsonFields));
 	}
@@ -285,7 +283,7 @@ public class PushService extends IntentService {
      * @param status the registration status. One of the {@code REGISTRATION_STATUS_XXX} constants
      * @param userAccount the user account that's performing registration
      */
-	protected void onPushNotificationRegistrationStatus(int status, @NonNull UserAccount userAccount) {
+	protected void onPushNotificationRegistrationStatus(int status, UserAccount userAccount) {
 		// Do nothing
 	}
 
@@ -343,10 +341,9 @@ public class PushService extends IntentService {
 	 * @return the response from unregistration
 	 * @throws IOException if the request could not be made
 	 */
-    @NonNull
 	protected RestResponse onSendUnregisterPushNotificationRequest(
-			@NonNull String registeredId,
-			@NonNull RestClient restClient) throws IOException {
+			String registeredId,
+			RestClient restClient) throws IOException {
 		return restClient.sendSync(RestRequest.getRequestForDelete(
 				ApiVersionStrings.getVersionNumber(context), MOBILE_PUSH_SERVICE_DEVICE, registeredId));
 	}


### PR DESCRIPTION
This allows for easier subclassing of `PushService` by overriding the methods that create requests for registration and unregistration. In order to specify that the subclass service be used, it has to be specified in the manifest (I've added an example in the Javadoc) and it has to be set with `SalesforceSDKManager.setPushServiceType`. This is because the service is started programmtically in a static method in PushMessaging and we need to know the correct class.

 I've also added a callback method for receiving the current registration status. This has been kept protected for subclassing purposes.