### PR TITLE
Migrating from IntentService to JobIntentService for better job scheduling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.2'
+    classpath 'com.android.tools.build:gradle:3.1.3'
   }
 }
 

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -103,14 +103,19 @@
         </service>
 
         <service android:name="com.salesforce.androidsdk.push.SFDCRegistrationIntentService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false">
         </service>
 
         <receiver android:name="com.salesforce.androidsdk.push.PushService$SFDCRegistrationRetryAlarmReceiver"
             android:exported="false" />
+
         <service android:name="com.salesforce.androidsdk.push.PushService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
+
         <service android:name="com.salesforce.androidsdk.analytics.AnalyticsPublisherService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
     </application>
 

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -121,6 +121,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 
-    <!--TODO: Remove the -sdk-23 tag when the minsdk version is 23-->
+    <!-- TODO: Remove the -sdk-23 tag when the minsdk version is 23 -->
     <uses-permission-sdk-23 android:name="android.permission.USE_FINGERPRINT" />
 </manifest>

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     api project(':libs:SalesforceAnalytics')
     api 'com.squareup.okhttp3:okhttp:3.9.0'
     api 'com.google.android.gms:play-services-gcm:12.0.1'
+    api 'com.android.support:support-compat:26.1.0'
     api 'com.android.support:customtabs:26.1.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test:rules:1.0.1'

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
@@ -41,7 +41,7 @@ import com.salesforce.androidsdk.accounts.UserAccountManager;
 public class AnalyticsPublisherService extends JobIntentService {
 
     private static final String ACTION_PUBLISH = "com.salesforce.androidsdk.analytics.action.ANALYTICS_PUBLISH";
-    private static final int JOB_ID = 1000;
+    private static final int JOB_ID = 81;
 
     /**
      * Starts this service to publish stored events. If the service is already

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
@@ -26,9 +26,9 @@
  */
 package com.salesforce.androidsdk.analytics;
 
-import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
+import android.support.v4.app.JobIntentService;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
@@ -38,17 +38,10 @@ import com.salesforce.androidsdk.accounts.UserAccountManager;
  *
  * @author bhariharan
  */
-public class AnalyticsPublisherService extends IntentService {
+public class AnalyticsPublisherService extends JobIntentService {
 
     private static final String ACTION_PUBLISH = "com.salesforce.androidsdk.analytics.action.ANALYTICS_PUBLISH";
-    private static final String TAG = "AnalyticsPublisherService";
-
-    /**
-     * Default constructor.
-     */
-    public AnalyticsPublisherService() {
-        super(TAG);
-    }
+    private static final int JOB_ID = 1000;
 
     /**
      * Starts this service to publish stored events. If the service is already
@@ -59,11 +52,11 @@ public class AnalyticsPublisherService extends IntentService {
     public static void startActionPublish(Context context) {
         final Intent intent = new Intent(context, AnalyticsPublisherService.class);
         intent.setAction(ACTION_PUBLISH);
-        context.startService(intent);
+        enqueueWork(context, AnalyticsPublisherService.class, JOB_ID, intent);
     }
 
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(Intent intent) {
         if (intent != null) {
             final String action = intent.getAction();
             if (ACTION_PUBLISH.equals(action)) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.java
@@ -31,6 +31,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.os.Bundle;
+import android.support.v4.app.JobIntentService;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -54,6 +55,7 @@ import java.util.concurrent.Executors;
 public class PushMessaging {
 
     private static final String TAG = "PushMessaging";
+    private static final int JOB_ID = 8;
 
 	// Public constants.
     public static final String UNREGISTERED_ATTEMPT_COMPLETE_EVENT = "com.salesfore.mobilesdk.c2dm.UNREGISTERED";
@@ -93,7 +95,8 @@ public class PushMessaging {
             setInProgress(context, true, account);
             if (checkPlayServices(context)) {
                 final Intent intent = new Intent(context, SFDCRegistrationIntentService.class);
-                context.startService(intent);
+                JobIntentService.enqueueWork(context, SFDCRegistrationIntentService.class,
+                        JOB_ID, intent);
             }
         } else {
             registerSFDCPush(context, account);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCInstanceIDListenerService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCInstanceIDListenerService.java
@@ -27,10 +27,14 @@
 package com.salesforce.androidsdk.push;
 
 import android.content.Intent;
+import android.support.v4.app.JobIntentService;
 
 import com.google.android.gms.iid.InstanceIDListenerService;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
 public class SFDCInstanceIDListenerService extends InstanceIDListenerService {
+
+    private static final int JOB_ID = 21;
 
     /**
      * Called if InstanceID token is updated. This may occur if the security of
@@ -41,7 +45,9 @@ public class SFDCInstanceIDListenerService extends InstanceIDListenerService {
     public void onTokenRefresh() {
 
         // Fetch updated Instance ID token and notify our app's server of any changes (if applicable).
-        Intent intent = new Intent(this, SFDCRegistrationIntentService.class);
+        final Intent intent = new Intent(this, SFDCRegistrationIntentService.class);
         startService(intent);
+        JobIntentService.enqueueWork(SalesforceSDKManager.getInstance().getAppContext(),
+                SFDCRegistrationIntentService.class, JOB_ID, intent);
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCInstanceIDListenerService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCInstanceIDListenerService.java
@@ -46,7 +46,6 @@ public class SFDCInstanceIDListenerService extends InstanceIDListenerService {
 
         // Fetch updated Instance ID token and notify our app's server of any changes (if applicable).
         final Intent intent = new Intent(this, SFDCRegistrationIntentService.class);
-        startService(intent);
         JobIntentService.enqueueWork(SalesforceSDKManager.getInstance().getAppContext(),
                 SFDCRegistrationIntentService.class, JOB_ID, intent);
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.push;
 
-import android.app.IntentService;
 import android.content.Intent;
+import android.support.v4.app.JobIntentService;
 
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 import com.google.android.gms.iid.InstanceID;
@@ -36,16 +36,12 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
-public class SFDCRegistrationIntentService extends IntentService {
+public class SFDCRegistrationIntentService extends JobIntentService {
 
     private static final String TAG = "RegIntentService";
 
-    public SFDCRegistrationIntentService() {
-        super(TAG);
-    }
-
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(Intent intent) {
         try {
             final InstanceID instanceID = InstanceID.getInstance(this);
             final String token = instanceID.getToken(BootConfig.getBootConfig(this).getPushNotificationClientId(),


### PR DESCRIPTION
Starting with `Android Oreo`, implicit receivers triggering an `IntentService` are no longer allowed in the background. This restriction comes in place only if `targetApiVersion > 26`. Within the SDK there are a few classes that use `IntentService`. However, it is rare that these services are triggered from the background. They are usually deterministically triggered by code when the app is in the foreground.

`Android` has added a new type of service called `JobIntentService` that makes handling any job scheduling requests super easy. This is available in the support library and is backward compatible with old `Android` versions too. Based on the `targetApiVersion` of the app, it automatically determines whether to use `startService()` or `JobScheduler` (introduced in `API 26`) to run the request. `JobScheduler` is more optimal, conserves battery life and is the way forward.

References:
- [JobIntentService](https://developer.android.com/reference/android/support/v4/app/JobIntentService).
- [Background Execution in Oreo](https://developer.android.com/about/versions/oreo/background).

I attended a couple of sessions on `JobScheduler` at `Google I/O` this year. It does some pretty cool stuff and abstracts the gory details away from the caller.