### PR TITLE
Handle exception thrown in some rare cases

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -519,13 +519,13 @@ public class ClientManager {
                 }
                 gettingAuthToken = true;
             }
-
-            // Invalidate current auth token.
-            final String cachedAuthToken = clientManager.peekRestClient(acc).getAuthToken();
-            clientManager.invalidateToken(cachedAuthToken);
             String newAuthToken = null;
             String newInstanceUrl = null;
             try {
+
+                // Invalidate current auth token.
+                final String cachedAuthToken = clientManager.peekRestClient(acc).getAuthToken();
+                clientManager.invalidateToken(cachedAuthToken);
                 final Bundle bundle = refreshStaleToken(acc);
                 if (bundle == null) {
                     SalesforceSDKLogger.w(TAG, "Bundle was null while getting auth token");


### PR DESCRIPTION
In some rare cases, it's possible that `peekRestClient()` will throw `AccountInfoNotFoundException`. This could occur if a refresh is kicked off but a logout occurs while that request is in flight from a different thread. The exception thrown by `peekRestClient()` should be handled without the app crashing. This will notify the higher layers that the refresh was unsuccessful (correctly).