### PR TITLE
Upsert by user-defined external id should fail if no value found

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -1221,6 +1221,10 @@ public class SmartStore  {
 	            if (externalIdObj != null) {
 	                entryId = lookupSoupEntryId(soupName, externalIdPath, externalIdObj + "");
 	            }
+	            else {
+					// Cannot have empty values for user-defined external ID upsert.
+					throw new SmartStoreException("For upsert with external ID path '" + externalIdPath + "', value cannot be empty for any entries.");
+				}
 	        }
 
 	        // If we have an entryId, let's do an update, otherwise let's do a create

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
@@ -487,6 +487,23 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	}
 
 	/**
+	 * Testing upsert by user-defined external id without value (should fail)
+	 * @throws JSONException
+	 */
+	@Test
+	public void testUpsertByUserDefinedExternalIdWithoutValue() throws JSONException {
+		JSONObject soupElt = new JSONObject("{'value':'va1'}");
+		try {
+			store.upsert(TEST_SOUP, soupElt, "key");
+			Assert.fail("Exception was expected: value cannot be empty for upsert by user-defined external id");
+		} catch (RuntimeException e) {
+			Assert.assertTrue("Wrong exception",
+					e.getMessage().contains("For upsert with external ID path")
+							&& e.getMessage().contains("value cannot be empty for any entries"));
+		}
+	}
+
+	/**
 	 * Testing upsert with an external id that is not unique in the soup
 	 * @throws JSONException
 	 */


### PR DESCRIPTION
Aligning with iOS implementation