### PR TITLE
Fixing crash with rogue custom URL

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
@@ -41,6 +41,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -120,8 +121,7 @@ public class LoginServerManager {
 
         // Selection has been saved before.
         if (name != null && url != null) {
-            final LoginServer server = new LoginServer(name, url, isCustom);
-            selectedServer = server;
+            selectedServer = new LoginServer(name, url, isCustom);
         } else {
 
             // First time selection defaults to the first server on the list.
@@ -229,7 +229,7 @@ public class LoginServerManager {
 	 * @return List of login servers or null.
 	 */
 	public List<LoginServer> getLoginServersFromRuntimeConfig() {
-		RuntimeConfig runtimeConfig = RuntimeConfig.getRuntimeConfig(ctx);
+		final RuntimeConfig runtimeConfig = RuntimeConfig.getRuntimeConfig(ctx);
 		String[] mdmLoginServers = null;
 		try {
 			mdmLoginServers = runtimeConfig.getStringArray(ConfigKey.AppServiceHosts);
@@ -242,7 +242,7 @@ public class LoginServerManager {
 				mdmLoginServers = new String[] {loginServer};
 			}
 		}
-		final List<LoginServer> allServers = new ArrayList<LoginServer>();
+		final List<LoginServer> allServers = new ArrayList<>();
 		if (mdmLoginServers != null) {
 			String[] mdmLoginServersLabels = null;
 			try {
@@ -257,13 +257,13 @@ public class LoginServerManager {
 				}
 			}
 			if (mdmLoginServersLabels == null || mdmLoginServersLabels.length != mdmLoginServers.length) {
-                SalesforceSDKLogger.w(TAG, "No login servers labels provided or wrong number of login servers labels provided - Using URLs for the labels");
+                SalesforceSDKLogger.w(TAG, "No login servers labels provided or wrong number of login servers labels provided - using URLs for the labels");
 				mdmLoginServersLabels = mdmLoginServers;
 			}
             final List<LoginServer> storedServers = getLoginServersFromPreferences(runtimePrefs);
 			for (int i = 0; i < mdmLoginServers.length; i++) {
-				String name = mdmLoginServersLabels[i];
-				String url = mdmLoginServers[i];
+				final String name = mdmLoginServersLabels[i];
+				final String url = mdmLoginServers[i];
 				final LoginServer server = new LoginServer(name, url, false);
                 if (storedServers == null || !storedServers.contains(server)) {
                     persistLoginServer(name, url, false, runtimePrefs);
@@ -288,7 +288,7 @@ public class LoginServerManager {
 	 * (only called when servers.xml is missing).
 	 */
 	private List<LoginServer> getLegacyLoginServers() {
-		final List<LoginServer> loginServers = new ArrayList<LoginServer>();
+		final List<LoginServer> loginServers = new ArrayList<>();
 		final LoginServer productionServer = new LoginServer(ctx.getString(R.string.sf__auth_login_production),
 				PRODUCTION_LOGIN_URL, false);
 		loginServers.add(productionServer);
@@ -307,14 +307,14 @@ public class LoginServerManager {
 		List<LoginServer> loginServers = null;
 		int id = ctx.getResources().getIdentifier("servers", "xml", ctx.getPackageName());
 		if (id != 0) {
-			loginServers = new ArrayList<LoginServer>();
+			loginServers = new ArrayList<>();
 			final XmlResourceParser xml = ctx.getResources().getXml(id);
 			int eventType = -1;		
 			while (eventType != XmlResourceParser.END_DOCUMENT) {
 				if (eventType == XmlResourceParser.START_TAG) {
 					if (xml.getName().equals("server")) {
-						String name = xml.getAttributeValue(null, "name");
-						String url = xml.getAttributeValue(null, "url");
+						final String name = xml.getAttributeValue(null, "name");
+						final String url = xml.getAttributeValue(null, "url");
 						final LoginServer loginServer = new LoginServer(name,
 								url, false);
 						loginServers.add(loginServer);
@@ -322,9 +322,7 @@ public class LoginServerManager {
 				}
 				try {
 					eventType = xml.next();
-				} catch (XmlPullParserException e) {
-                    SalesforceSDKLogger.w(TAG, "Exception thrown while parsing XML", e);
-				} catch (IOException e) {
+				} catch (XmlPullParserException | IOException e) {
                     SalesforceSDKLogger.w(TAG, "Exception thrown while parsing XML", e);
 				}
 			}
@@ -350,9 +348,9 @@ public class LoginServerManager {
 	    final Editor edit = settings.edit();
 		for (int i = 0; i < numServers; i++) {
 			final LoginServer curServer = servers.get(i);
-			edit.putString(String.format(SERVER_NAME, i), curServer.name);
-		    edit.putString(String.format(SERVER_URL, i), curServer.url);
-		    edit.putBoolean(String.format(IS_CUSTOM, i), curServer.isCustom);
+			edit.putString(String.format(Locale.US, SERVER_NAME, i), curServer.name.trim());
+		    edit.putString(String.format(Locale.US, SERVER_URL, i), curServer.url.trim());
+		    edit.putBoolean(String.format(Locale.US, IS_CUSTOM, i), curServer.isCustom);
 		    if (i == 0) {
 		    	setSelectedLoginServer(curServer);
 		    }
@@ -375,9 +373,9 @@ public class LoginServerManager {
 		}
 		int numServers = sharedPrefs.getInt(NUMBER_OF_ENTRIES, 0);
 		final Editor edit = sharedPrefs.edit();
-		edit.putString(String.format(SERVER_NAME, numServers), name);
-		edit.putString(String.format(SERVER_URL, numServers), url);
-		edit.putBoolean(String.format(IS_CUSTOM, numServers), isCustom);
+		edit.putString(String.format(Locale.US, SERVER_NAME, numServers), name.trim());
+		edit.putString(String.format(Locale.US, SERVER_URL, numServers), url.trim());
+		edit.putBoolean(String.format(Locale.US, IS_CUSTOM, numServers), isCustom);
 		edit.putInt(NUMBER_OF_ENTRIES, ++numServers);
 		edit.commit();
 	}
@@ -393,11 +391,11 @@ public class LoginServerManager {
 		if (numServers == 0) {
 			return null;
 		}
-		final List<LoginServer> allServers = new ArrayList<LoginServer>();
+		final List<LoginServer> allServers = new ArrayList<>();
 		for (int i = 0; i < numServers; i++) {
-			final String name = prefs.getString(String.format(SERVER_NAME, i), null);
-			final String url = prefs.getString(String.format(SERVER_URL, i), null);
-			boolean isCustom = prefs.getBoolean(String.format(IS_CUSTOM, i), false);
+			final String name = prefs.getString(String.format(Locale.US, SERVER_NAME, i), null);
+			final String url = prefs.getString(String.format(Locale.US, SERVER_URL, i), null);
+			boolean isCustom = prefs.getBoolean(String.format(Locale.US, IS_CUSTOM, i), false);
 			if (name != null && url != null) {
 				final LoginServer server = new LoginServer(name, url, isCustom);
 				allServers.add(server);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/RuntimeConfig.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/RuntimeConfig.java
@@ -51,9 +51,6 @@ public class RuntimeConfig {
 
 	private static final String TAG = "RuntimeConfig";
 
-	// background executor
-	private final ExecutorService threadPool = Executors.newFixedThreadPool(1);
-
 	public enum ConfigKey {
 
         // The keys here should match the key entries in 'app_restrictions.xml'.
@@ -67,8 +64,8 @@ public class RuntimeConfig {
 		IDPAppURLScheme
 	}
 
-    private boolean isManaged = false;
-	private Bundle configurations = null;
+    private boolean isManaged;
+	private Bundle configurations;
 
 	private static RuntimeConfig INSTANCE = null;
 
@@ -76,7 +73,7 @@ public class RuntimeConfig {
 		configurations = getRestrictions(ctx);
 		isManaged = hasRestrictionsProvider(ctx);
 
-		// Register MDM App Feature for User-Agent reporting
+		// Register MDM App Feature for user agent reporting.
 		if (isManaged && configurations != null && !configurations.isEmpty()) {
 			SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_MDM);
 			if (getBoolean(RuntimeConfig.ConfigKey.RequireCertAuth)) {
@@ -85,7 +82,9 @@ public class RuntimeConfig {
 		}
 
 		// Logs analytics event for MDM.
+        final ExecutorService threadPool = Executors.newFixedThreadPool(1);
 		threadPool.execute(new Runnable() {
+
 			@Override
 			public void run() {
 				final JSONObject attributes = new JSONObject();
@@ -102,7 +101,8 @@ public class RuntimeConfig {
 				} catch (JSONException e) {
 					SalesforceSDKLogger.e(TAG, "Exception thrown while creating JSON", e);
 				}
-				EventBuilderHelper.createAndStoreEventSync("mdmConfiguration", null, TAG, attributes);
+				EventBuilderHelper.createAndStoreEventSync("mdmConfiguration",
+                        null, TAG, attributes);
 			}
 		});
 	}
@@ -152,14 +152,13 @@ public class RuntimeConfig {
      * @return boolean value
      */
 	public Boolean getBoolean(ConfigKey configKey) {
-		return (configurations == null ? false : configurations.getBoolean(configKey.name()));
+        return (configurations != null && configurations.getBoolean(configKey.name());
 	}
 
 	private JSONArray getJSONArray(ConfigKey configKey) throws JSONException {
 		String[] array = getStringArray(configKey);
 		return array == null ? null : new JSONArray(array);
 	}
-
 
 	/**
 	 * Get run time config as a JSONObject
@@ -176,7 +175,6 @@ public class RuntimeConfig {
 			jsonObject.put(ConfigKey.ManagedAppCertAlias.name(), getString(ConfigKey.ManagedAppCertAlias));
 			jsonObject.put(ConfigKey.OnlyShowAuthorizedHosts.name(), getJSONArray(ConfigKey.OnlyShowAuthorizedHosts));
 			jsonObject.put(ConfigKey.IDPAppURLScheme.name(), getString(ConfigKey.IDPAppURLScheme));
-
 			return jsonObject;
 		}
 		catch (JSONException e) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigTask.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigTask.java
@@ -27,9 +27,12 @@
 package com.salesforce.androidsdk.util;
 
 import android.os.AsyncTask;
+import android.webkit.URLUtil;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.config.LoginServerManager;
+
+import okhttp3.HttpUrl;
 
 /**
  * A simple AsyncTask that fetches auth config if it exists and calls the supplied
@@ -64,8 +67,10 @@ public class AuthConfigTask extends AsyncTask<Void, Void, Void> {
 
     @Override
     protected Void doInBackground(Void... nothings) {
-        final String loginServer = SalesforceSDKManager.getInstance().getLoginServerManager().getSelectedLoginServer().url;
-        if (loginServer.equals(LoginServerManager.PRODUCTION_LOGIN_URL) || loginServer.equals(LoginServerManager.SANDBOX_LOGIN_URL)) {
+        final String loginServer = SalesforceSDKManager.getInstance().getLoginServerManager().getSelectedLoginServer().url.trim();
+        if (loginServer.equals(LoginServerManager.PRODUCTION_LOGIN_URL) ||
+                loginServer.equals(LoginServerManager.SANDBOX_LOGIN_URL) ||
+                !URLUtil.isHttpsUrl(loginServer) || HttpUrl.parse(loginServer) == null) {
             SalesforceSDKManager.getInstance().setBrowserLoginEnabled(false);
             return null;
         }


### PR DESCRIPTION
A rogue custom URL could have whitespace at the end which would cause it to be considered a valid URL, but this would throw the .`well-known` fetcher in a crash loop.