### PR TITLE
Misc fixes for SmartStore inspector

### DIFF
--- a/libs/SmartStore/res/values/sf__strings.xml
+++ b/libs/SmartStore/res/values/sf__strings.xml
@@ -15,7 +15,7 @@
     <string name="sf__inspector_soups_button">Soups</string>
     <string name="sf__inspector_indices_button">Indices</string>
     <string name="sf__inspector_querytext_hint">Type your query here</string>
-    <string name="sf__inspector_pagesize_hint">Page size (default: 10)</string>
+    <string name="sf__inspector_pagesize_hint">Page size (default: 100)</string>
     <string name="sf__inspector_pageindex_hint">Page index (default: 0)</string>    
     <string name="sf__inspector_no_query_specified">No query specified</string>
     <string name="sf__inspector_no_rows_returned">No rows returned</string>

--- a/libs/SmartStore/res/values/sf__strings.xml
+++ b/libs/SmartStore/res/values/sf__strings.xml
@@ -21,7 +21,4 @@
     <string name="sf__inspector_no_rows_returned">No rows returned</string>
     <string name="sf__inspector_no_soups_found">No soups found</string>
 
-    <string name="sf__inspector_soups_query">select soupName from soup_names</string>
-    <string name="sf__inspector_indices_query">select soupName, path, columnType from soup_index_map</string>
-
 </resources>

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -74,22 +74,22 @@ public class SmartStore  {
     protected static final String SOUP_NAMES_TABLE = "soup_names";
 
 	// Table to keep track of soup names and attributes.
-	protected static final String SOUP_ATTRS_TABLE = "soup_attrs";
+	public static final String SOUP_ATTRS_TABLE = "soup_attrs";
 
 	// Fts table suffix
 	public static final String FTS_SUFFIX = "_fts";
 
 	// Table to keep track of soup's index specs
-    protected static final String SOUP_INDEX_MAP_TABLE = "soup_index_map";
+    public static final String SOUP_INDEX_MAP_TABLE = "soup_index_map";
 
     // Table to keep track of status of long operations in flight
     protected static final String LONG_OPERATIONS_STATUS_TABLE = "long_operations_status";
 
     // Columns of the soup index map table
-    protected static final String SOUP_NAME_COL = "soupName";
-    protected static final String PATH_COL = "path";
+    public static final String SOUP_NAME_COL = "soupName";
+    public static final String PATH_COL = "path";
     protected static final String COLUMN_NAME_COL = "columnName";
-    protected static final String COLUMN_TYPE_COL = "columnType";
+    public static final String COLUMN_TYPE_COL = "columnType";
 
     // Columns of a soup table
     protected static final String ID_COL = "id";

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
@@ -63,6 +63,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 public class SmartStoreInspectorActivity extends Activity implements AdapterView.OnItemSelectedListener {
 
@@ -97,8 +98,8 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 	private JSONArray lastResults;
 
 	// Default queries
-	private String SOUPS_QUERY = String.format("select %s from %s", SmartStore.SOUP_NAME_COL, SmartStore.SOUP_ATTRS_TABLE);
-	private String INDICES_QUERY = String.format("select %s, %s, %s from %s", SmartStore.SOUP_NAME_COL, SmartStore.PATH_COL, SmartStore.COLUMN_TYPE_COL, SmartStore.SOUP_INDEX_MAP_TABLE);
+	private String SOUPS_QUERY = String.format(Locale.US, "select %s from %s", SmartStore.SOUP_NAME_COL, SmartStore.SOUP_ATTRS_TABLE);
+	private String INDICES_QUERY = String.format(Locale.US, "select %s, %s, %s from %s", SmartStore.SOUP_NAME_COL, SmartStore.PATH_COL, SmartStore.COLUMN_TYPE_COL, SmartStore.SOUP_INDEX_MAP_TABLE);
 
 	/**
 	 * Create intent to bring up inspector

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
@@ -279,7 +279,7 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 			return;
 		}
 
-		if (names.size() > 10) {
+		if (names.size() > 100) {
 			queryText.setText(SOUPS_QUERY);
 		} else {
 			StringBuilder sb = new StringBuilder();

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
@@ -96,6 +96,10 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 	private String lastAlertMessage;
 	private JSONArray lastResults;
 
+	// Default queries
+	private String SOUPS_QUERY = String.format("select %s from %s", SmartStore.SOUP_NAME_COL, SmartStore.SOUP_ATTRS_TABLE);
+	private String INDICES_QUERY = String.format("select %s, %s, %s from %s", SmartStore.SOUP_NAME_COL, SmartStore.PATH_COL, SmartStore.COLUMN_TYPE_COL, SmartStore.SOUP_INDEX_MAP_TABLE);
+
 	/**
 	 * Create intent to bring up inspector
 	 * @param parentActivity
@@ -276,7 +280,7 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 		}
 
 		if (names.size() > 10) {
-			queryText.setText(getString(R.string.sf__inspector_soups_query));
+			queryText.setText(SOUPS_QUERY);
 		} else {
 			StringBuilder sb = new StringBuilder();
 			boolean first = true;
@@ -301,8 +305,7 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 	 * @param v
 	 */
 	public void onIndicesClick(View v) {
-		queryText
-				.setText(getString(R.string.sf__inspector_indices_query));
+		queryText.setText(INDICES_QUERY);
 		runQuery();
 	}
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
@@ -72,7 +72,7 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
     private static final String TAG = "SmartStoreInspectorActivity";
 
 	// Default page size / index
-	private static final int DEFAULT_PAGE_SIZE = 10;
+	private static final int DEFAULT_PAGE_SIZE = 100;
 	private static final int DEFAULT_PAGE_INDEX = 0;
 	public static final String USER_STORE = " (user store)";
 	public static final String GLOBAL_STORE = " (global store)";


### PR DESCRIPTION
SmartStore inspector was still referring soup_names
It has been renamed to soup_attrs a long time ago
No longer getting query from resource file (bad idea)
Instead building the query using the constants from SmartStore.java

Also showing more rows by default (100 instead of 10)
Showing details soup info if there are 100 soups or less (instead of 10)