### PR TITLE
Prevent touch outside to dismiss the dialog

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
@@ -49,6 +49,7 @@ public class ManageSpaceActivity extends Activity {
 		super.onCreate(savedState);
 		setContentView(R.layout.sf__manage_space);
 		manageSpaceDialog = buildManageSpaceDialog();
+		manageSpaceDialog.setCanceledOnTouchOutside(false);
 		manageSpaceDialog.show();
 	}
 


### PR DESCRIPTION
Currently user may accidentally touch outside of the dialog, then the dialog is dismissed. This leaves a black screen without any instruction. 