### PR TITLE
Fix hybrid remote session refresh case for SAML/SSO login flows

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -39,7 +39,6 @@ import com.salesforce.androidsdk.auth.HttpAccess.NoNetworkException;
 import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.phonegap.app.SalesforceHybridSDKManager;
 import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger;
-import com.salesforce.androidsdk.rest.ApiVersionStrings;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.ClientManager.AccountInfoNotFoundException;
 import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback;
@@ -385,6 +384,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
             public void onSuccess(RestRequest request, RestResponse response) {
                 SalesforceHybridLogger.i(TAG, "refresh callback - refresh succeeded");
                 runOnUiThread(new Runnable() {
+
                     @Override
                     public void run() {
                         /*
@@ -394,7 +394,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                         SalesforceDroidGapActivity.this.client = SalesforceDroidGapActivity.this.clientManager.peekRestClient();
                         setSidCookies();
                         loadVFPingPage();
-                        final String frontDoorUrl = getFrontDoorUrl(url, true);
+                        final String frontDoorUrl = getFrontDoorUrl(url, BootConfig.isAbsoluteUrl(url));
                         loadUrl(frontDoorUrl);
                     }
                 });
@@ -491,6 +491,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
      * @return Front-doored URL.
      */
     public String getFrontDoorUrl(String url, boolean isAbsUrl) {
+
         /*
          * We need to use the absolute URL in some cases and relative URL in some
          * other cases, because of differences between instance URL and community
@@ -498,13 +499,12 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
          * URL to use is in the 'resolveUrl' method in 'ClientInfo'.
          */
         url = (isAbsUrl ? url : client.getClientInfo().resolveUrl(url).toString());
-
-        HttpUrl frontDoorUrl = HttpUrl.parse(client.getClientInfo().getInstanceUrlAsString() + "/secur/frontdoor.jsp?").newBuilder()
+        final HttpUrl frontDoorUrl = HttpUrl.parse(client.getClientInfo().getInstanceUrlAsString()
+                + "/secur/frontdoor.jsp?").newBuilder()
                 .addQueryParameter("sid", client.getAuthToken())
                 .addQueryParameter("retURL", url)
                 .addQueryParameter("display", "touch")
                 .build();
-
         return frontDoorUrl.toString();
     }
 

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -49,6 +49,7 @@ import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.ui.SalesforceActivityDelegate;
 import com.salesforce.androidsdk.ui.SalesforceActivityInterface;
+import com.salesforce.androidsdk.util.AuthConfigUtil;
 import com.salesforce.androidsdk.util.EventsObservable;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
 
@@ -79,6 +80,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
 
     // Config
     private BootConfig bootconfig;
+    private AuthConfigUtil.MyDomainAuthConfig authConfig;
 
     // Web app loaded?
     private boolean webAppLoaded = false;
@@ -86,6 +88,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
     public SalesforceDroidGapActivity() {
         super();
         delegate = new SalesforceActivityDelegate(this);
+        authConfig = AuthConfigUtil.getMyDomainAuthConfig(SalesforceHybridSDKManager.getInstance().getLoginServerManager().getSelectedLoginServer().url);
     }
 
     /**
@@ -165,6 +168,15 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                 SalesforceHybridLogger.i(TAG, "onResume - already logged in/web app already loaded");
             }
         }
+    }
+
+    /**
+     * Returns the auth config associated with the current login server, if it exists.
+     *
+     * @return Auth config.
+     */
+    public AuthConfigUtil.MyDomainAuthConfig getAuthConfig() {
+        return authConfig;
     }
 
     /**

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
@@ -35,6 +35,7 @@ import android.webkit.WebView;
 
 import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger;
+import com.salesforce.androidsdk.util.AuthConfigUtil;
 import com.salesforce.androidsdk.util.EventsObservable;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
 import com.salesforce.androidsdk.util.UriFragmentParser;
@@ -145,8 +146,31 @@ public class SalesforceWebViewClientHelper {
             } else {
                 return BootConfig.getBootConfig(ctx).getStartPage();
             }
+        } else if (isSamlLoginRedirect(ctx, url)) {
+            return BootConfig.getBootConfig(ctx).getStartPage();
         } else {
     		return null;
     	}
+    }
+
+    private static boolean isSamlLoginRedirect(Context ctx, String url) {
+        if (ctx instanceof SalesforceDroidGapActivity) {
+            final AuthConfigUtil.MyDomainAuthConfig authConfig = ((SalesforceDroidGapActivity) ctx).getAuthConfig();
+            if (authConfig != null) {
+                final List<String> ssoUrls = authConfig.getSsoUrls();
+                if (ssoUrls != null && ssoUrls.size() > 0) {
+                   for (String ssoUrl : ssoUrls) {
+                       int paramsIndex = ssoUrl.indexOf("?");
+                       if (paramsIndex != -1) {
+                           ssoUrl = ssoUrl.substring(0, paramsIndex);
+                       }
+                       if (url.contains(ssoUrl)) {
+                           return true;
+                       }
+                   }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
@@ -31,7 +31,11 @@ import android.text.TextUtils;
 import com.salesforce.androidsdk.auth.HttpAccess;
 import com.salesforce.androidsdk.rest.RestResponse;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import okhttp3.Request;
 import okhttp3.Response;
@@ -84,9 +88,12 @@ public class AuthConfigUtil {
 
         private static final String MOBILE_SDK_KEY = "MobileSDK";
         private static final String USE_NATIVE_BROWSER_KEY = "UseAndroidNativeBrowserForAuthentication";
+        private static final String SAML_PROVIDERS_KEY = "SamlProviders";
+        private static final String SSO_URL_KEY = "SsoUrl";
 
         private JSONObject authConfig;
         private boolean browserLoginEnabled;
+        private List<String> ssoUrls;
 
         /**
          * Parameterized constructor.
@@ -99,6 +106,19 @@ public class AuthConfigUtil {
                 final JSONObject mobileSDK = authConfig.optJSONObject(MOBILE_SDK_KEY);
                 if (mobileSDK != null) {
                     browserLoginEnabled = mobileSDK.optBoolean(USE_NATIVE_BROWSER_KEY);
+                }
+                final JSONArray samlProviders = authConfig.optJSONArray(SAML_PROVIDERS_KEY);
+                if (samlProviders != null) {
+                    ssoUrls = new ArrayList<>();
+                    for (int i = 0; i < samlProviders.length(); i++) {
+                        final JSONObject provider = samlProviders.optJSONObject(i);
+                        if (provider != null) {
+                            final String ssoUrl = provider.optString(SSO_URL_KEY);
+                            if (!TextUtils.isEmpty(ssoUrl)) {
+                                ssoUrls.add(ssoUrl);
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -119,6 +139,15 @@ public class AuthConfigUtil {
          */
         public boolean isBrowserLoginEnabled() {
             return browserLoginEnabled;
+        }
+
+        /**
+         * Returns the configured SSO URLs.
+         *
+         * @return Configured SSO URLs.
+         */
+        public List<String> getSsoUrls() {
+            return ssoUrls;
         }
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
@@ -108,7 +108,7 @@ public class AuthConfigUtil {
                     browserLoginEnabled = mobileSDK.optBoolean(USE_NATIVE_BROWSER_KEY);
                 }
                 final JSONArray samlProviders = authConfig.optJSONArray(SAML_PROVIDERS_KEY);
-                if (samlProviders != null) {
+                if (samlProviders != null && samlProviders.length() > 0) {
                     ssoUrls = new ArrayList<>();
                     for (int i = 0; i < samlProviders.length(); i++) {
                         final JSONObject provider = samlProviders.optJSONObject(i);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
 public class AuthConfigUtilTest {
 
     private static final String MY_DOMAIN_ENDPOINT = "https://sdk.cs1.my.salesforce.com";
-    private static final String ALTERNATE_MY_DOMAIN_ENDPOINT = "http://powerofus.force.com";
+    private static final String ALTERNATE_MY_DOMAIN_ENDPOINT = "https://powerofus.force.com";
     private static final String SANDBOX_ENDPOINT = "https://test.salesforce.com";
     private static final String FORWARD_SLASH = "/";
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -43,6 +43,7 @@ import org.junit.runner.RunWith;
 public class AuthConfigUtilTest {
 
     private static final String MY_DOMAIN_ENDPOINT = "https://sdk.cs1.my.salesforce.com";
+    private static final String ALTERNATE_MY_DOMAIN_ENDPOINT = "http://powerofus.force.com";
     private static final String SANDBOX_ENDPOINT = "https://test.salesforce.com";
     private static final String FORWARD_SLASH = "/";
 
@@ -66,6 +67,23 @@ public class AuthConfigUtilTest {
         Assert.assertNotNull("Auth config should not be null", authConfig);
         Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
         Assert.assertTrue("Browser based login should be enabled", authConfig.isBrowserLoginEnabled());
+    }
+
+    @Test
+    public void testGetSSOUrls() {
+        final AuthConfigUtil.MyDomainAuthConfig authConfig = AuthConfigUtil.getMyDomainAuthConfig(ALTERNATE_MY_DOMAIN_ENDPOINT);
+        Assert.assertNotNull("Auth config should not be null", authConfig);
+        Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
+        Assert.assertNotNull("SSO URLs should not be null", authConfig.getSsoUrls());
+        Assert.assertTrue("SSO URLs should have at least 1 valid entry", authConfig.getSsoUrls().size() >= 1);
+    }
+
+    @Test
+    public void testGetNoSSOUrls() {
+        final AuthConfigUtil.MyDomainAuthConfig authConfig = AuthConfigUtil.getMyDomainAuthConfig(MY_DOMAIN_ENDPOINT);
+        Assert.assertNotNull("Auth config should not be null", authConfig);
+        Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
+        Assert.assertNull("SSO URLs should be null", authConfig.getSsoUrls());
     }
 
     @Test


### PR DESCRIPTION
If the org uses a SAML/SSO provider for login, it is possible to customize the SAML/SSO login URL to drop all arguments from the URL. Besides, the login redirect is beyond the control of the Salesforce IDP at this point and hence, the login redirect when a session timeout occurs will not contain `ec=301` or `startURL`. This leaves the user staring at a login page within the hybrid `WebView` that does nothing. Luckily, we can fetch the login URL in this case from `.well-known` and the container needs to do 2 things to solve this problem.
- We need to parse the SSO URLs from `.well-known` (which we already fetch) and check if these URLs are hit as part of the redirects that indicate session timeout.
- If this occurs, load the `startURL`.
This PR addresses these issues.

cc: @khawkins @chrlie 

The equivalent `iOS` PR is [here](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2616).