### PR TITLE
Update to API 28

### DIFF
--- a/.circleci/ci-helper.sh
+++ b/.circleci/ci-helper.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
 function envSetup {
-    sudo apt-get update
-    sudo apt-get install libqt5widgets5
     sudo npm install -g shelljs@0.7.0
     sudo npm install -g cordova@8.0.0
     cordova telemetry off
 
     ./install.sh
-    ./gradlew androidDependencies
 
     gem install bundler
     gem install danger
@@ -28,8 +25,8 @@ function printTestsToRun {
         if [[ ! -z ${LIBS_TO_TEST} ]]; then
             echo -e "\n\nLibraries to Test-> ${LIBS_TO_TEST//","/", "}."
 
-            # Check if this is a test job that should continue
-            if [[ -z ${CURRENT_LIB} ]] && [[ ${LIBS_TO_TEST} == *"${CURRENT_LIB}"* ]]; then
+            # Check if tests should run
+            if [[ ${LIBS_TO_TEST} == *"${CURRENT_LIB}"* ]]; then
                 circleci step halt
             fi
         else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/SalesforceMobileSDK-Android
   docker:
-    - image: circleci/android:api-27-node8-alpha
+    - image: circleci/android:api-28-node8-alpha
   environment:
     - TERM: "dumb"
     - ADB_INSTALL_TIMEOUT: 15
@@ -130,6 +130,7 @@ jobs:
             ./gradlew native:NativeSampleApps:RestExplorer:assembleAndroidTest
             ./gradlew :native:NativeSampleApps:RestExplorer:assembleDebug
       - run: *run-danger
+      - save_cache: *save-gradle-cache
       - save_cache: *save-node-cache
       - save_cache: *save-ruby-cache
       - persist_to_workspace:
@@ -145,6 +146,9 @@ jobs:
     steps:
       - *attach_workspace
       - run: *determine-tests-to-run
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-node-cache
+      - restore_cache: *restore-ruby-cache
       - run: *gcloud-auth
       - run: *run-firebase-tests
       - run: *get-firebase-results
@@ -163,6 +167,9 @@ jobs:
     steps:
       - *attach_workspace
       - run: *determine-tests-to-run
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-node-cache
+      - restore_cache: *restore-ruby-cache
       - run: *gcloud-auth
       - run: *run-firebase-tests
       - run: *get-firebase-results
@@ -181,6 +188,9 @@ jobs:
     steps:
       - *attach_workspace
       - run: *determine-tests-to-run
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-node-cache
+      - restore_cache: *restore-ruby-cache
       - run: *build-for-testing
       - run: *gcloud-auth
       - run: *run-firebase-tests
@@ -200,6 +210,9 @@ jobs:
     steps:
       - *attach_workspace
       - run: *determine-tests-to-run
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-node-cache
+      - restore_cache: *restore-ruby-cache
       - run: *build-for-testing
       - run: *gcloud-auth
       - run: *run-firebase-tests
@@ -219,6 +232,9 @@ jobs:
     steps:
       - *attach_workspace
       - run: *determine-tests-to-run
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-node-cache
+      - restore_cache: *restore-ruby-cache
       - run: *build-for-testing
       - run: *gcloud-auth
       - run: *run-firebase-tests
@@ -238,6 +254,9 @@ jobs:
     steps:
       - *attach_workspace
       - run: *determine-tests-to-run
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-node-cache
+      - restore_cache: *restore-ruby-cache
       - run: *build-for-testing
       - run: *gcloud-auth
       - run: *run-firebase-tests
@@ -257,6 +276,9 @@ jobs:
     steps:
       - *attach_workspace
       - run: *determine-tests-to-run
+      - restore_cache: *restore-gradle-cache
+      - restore_cache: *restore-node-cache
+      - restore_cache: *restore-ruby-cache
       - run: *gcloud-auth
       - run: *run-firebase-tests
       - run: *get-firebase-results
@@ -361,7 +383,11 @@ workflows:
   # PRs run on Android API 27
   pr-test:
     jobs:
-      - setup
+      - setup:
+          filters:
+            branches:
+              only:
+                - /pull*/
       - test-SalesforceAnalytics:
           requires:
             - setup


### PR DESCRIPTION
Update docker image to use the latest Android dev tools.  Actually restore cache for performance.  Skip build entirely on merge by limiting non-nightly builds to CircleCI pr branches.  