### PR TITLE
Removing legacy upgrade code

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
@@ -38,8 +38,6 @@ public class SalesforceSDKUpgradeManager {
 
     private static final String VERSION_SHARED_PREF = "version_info";
     private static final String ACC_MGR_KEY = "acc_mgr_version";
-    private static final String SHARED_PREF_6_0 = "upgrade_6_0";
-    private static final String UPGRADE_REQUIRED_KEY = "passcode_upgrade_required";
 
     private static SalesforceSDKUpgradeManager INSTANCE = null;
 
@@ -105,16 +103,5 @@ public class SalesforceSDKUpgradeManager {
         final SharedPreferences sp = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(VERSION_SHARED_PREF,
                 Context.MODE_PRIVATE);
         return sp.getString(key, "");
-    }
-
-    /**
-     * Returns if re-encryption is required in an app with passcode enabled.
-     *
-     * @return True - if re-encryption is required, False - otherwise.
-     */
-    public boolean isPasscodeUpgradeRequired() {
-        final SharedPreferences sp = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(SHARED_PREF_6_0,
-                Context.MODE_PRIVATE);
-        return sp.getBoolean(UPGRADE_REQUIRED_KEY, false);
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/PasscodeActivity.java
@@ -53,7 +53,6 @@ import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
-import com.salesforce.androidsdk.app.SalesforceSDKUpgradeManager;
 import com.salesforce.androidsdk.security.PasscodeManager;
 
 import java.util.List;
@@ -447,7 +446,7 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
      * a custom fingerprint auth layout if the app chooses to do so.
      */
     protected void showFingerprintDialog() {
-        if (passcodeManager != null && isFingerprintEnabled() && !SalesforceSDKUpgradeManager.getInstance().isPasscodeUpgradeRequired()) {
+        if (passcodeManager != null && isFingerprintEnabled()) {
             final FingerprintAuthDialogFragment fingerprintAuthDialog = new FingerprintAuthDialogFragment();
             fingerprintAuthDialog.setContext(this);
             fingerprintAuthDialog.show(getFragmentManager(), "fingerprintDialog");
@@ -467,7 +466,8 @@ public class PasscodeActivity extends Activity implements OnEditorActionListener
             if (checkSelfPermission(Manifest.permission.USE_FINGERPRINT) != PackageManager.PERMISSION_GRANTED) {
                 requestPermissions(new String[]{ permission.USE_FINGERPRINT}, REQUEST_CODE_ASK_PERMISSIONS);
             } else {
-                return fingerprintManager != null && fingerprintManager.isHardwareDetected() && fingerprintManager.hasEnrolledFingerprints();
+                return fingerprintManager != null && fingerprintManager.isHardwareDetected()
+                        && fingerprintManager.hasEnrolledFingerprints();
             }
         }
         return false;


### PR DESCRIPTION
We had already removed the other legacy upgrade code a while ago. Somehow this was overlooked. A couple of reasons to remove it:
- Without the other code, this is useless anyway.
- In my next PR, I will be switching the hashing from `BouncyCastle` to `Conscrypt` for `Android P`, which means the passcode isn't going to work anyway, so this upgrade step is irrelevant in `Mobile SDK 7.0`.