### PR TITLE
Using BiometricPrompt for fingerprint auth on Android P (DO NOT MERGE)

### DIFF
--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -104,6 +104,9 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
 
-    <!-- TODO: Remove the -sdk-23 tag when the minsdk version is 23 -->
-    <uses-permission-sdk-23 android:name="android.permission.USE_FINGERPRINT" />
+    <!-- USE_FINGERPRINT is available from API 23 to API 27 and should be removed once minAPI > 27 -->
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+
+    <!-- USE_BIOMETRIC is available on API 28 and higher -->
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>

--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -72,11 +72,12 @@
     <string name="sf__idp_app_url_scheme_description">Used to specify IDP app\'s URL scheme to be used.</string>
 
 	<!-- Fingerprint auth resources-->
+	<string name="sf__fingerprint_title">Fingerprint Authentication</string>
 	<string name="sf__fingerprint_description">Confirm fingerprint to continue</string>
 	<string name="sf__fingerprint_hint">Touch sensor</string>
-	<string name="sf__fingerprint_cancel">Use Passcode</string>
+	<string name="sf__fingerprint_cancel">Use passcode</string>
 	<string name="sf__fingerprint_success">Success</string>
-	<string name="sf__fingerprint_failed">Fingerprint Authentication Failed</string>
+	<string name="sf__fingerprint_failed">Fingerprint authentication failed</string>
 
 	<!-- Dev support -->
 	<string name="sf__dev_support_title">Mobile SDK Dev Support</string>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/FingerprintAuthDialogFragment.java
@@ -58,7 +58,6 @@ import javax.crypto.Cipher;
 @TargetApi(VERSION_CODES.M)
 public class FingerprintAuthDialogFragment extends DialogFragment {
 
-    private Button mCancelButton;
     private TextView mStatusText;
     private PasscodeActivity mContext;
 
@@ -76,7 +75,7 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
         super.onResume();
 
         /*
-         * TODO: Remove this check once minAPI > 23.
+         * TODO: Remove this check once minAPI >= 23.
          */
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
             FingerprintManager fingerprintManager = (FingerprintManager) mContext.getSystemService(Context.FINGERPRINT_SERVICE);
@@ -137,14 +136,15 @@ public class FingerprintAuthDialogFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
         final View v = inflater.inflate(R.layout.sf__fingerprint_dialog, container, false);
-        mCancelButton = v.findViewById(R.id.sf__use_password_button);
-        mCancelButton.setOnClickListener(new View.OnClickListener() {
+        private Button cancelButton = v.findViewById(R.id.sf__use_password_button);
+        cancelButton.setOnClickListener(new View.OnClickListener() {
+
             @Override
             public void onClick(View view) {
                 dismiss();
             }
         });
-        mStatusText = (TextView) v.findViewById(R.id.sf__fingerprint_status);
+        mStatusText = v.findViewById(R.id.sf__fingerprint_status);
         return v;
     }
 


### PR DESCRIPTION
`FingerprintManager` is deprecated in `Android P` and has been replaced with `BiometricPrompt`, which is the OS-provided blessed UI for any biometric authentication. Right now it defaults to fingerprint, but in the future it would automatically support `Face ID`, etc. out of the box.