### PR TITLE
Avoid exception from multiple initializeApp calls

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
@@ -59,7 +59,11 @@ public class SFDCRegistrationIntentService extends JobIntentService {
             final String pushClientId = BootConfig.getBootConfig(context).getPushNotificationClientId();
             final FirebaseOptions firebaseOptions = new FirebaseOptions.Builder().
                     setGcmSenderId(pushClientId).setApplicationId(context.getPackageName()).build();
-            FirebaseApp.initializeApp(context, firebaseOptions);
+            if (FirebaseApp.getApps(context).isEmpty()) {
+                //Ensure initializeApp is only called once
+                FirebaseApp.initializeApp(context, firebaseOptions);
+            }
+
 
             // Fetches an instance ID from Firebase once the initialization is complete.
             final FirebaseInstanceId instanceID = FirebaseInstanceId.getInstance();


### PR DESCRIPTION
Firebase can only intitalizeApp once per App name.  Default App name is used here so there will be an exception thrown when a second MSDK login attempts to register for push. 

https://firebase.google.com/docs/reference/android/com/google/firebase/FirebaseApp#initializeApp(android.content.Context,%20com.google.firebase.FirebaseOptions)