### PR TITLE
Pass Firebase app scoped by appName

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
@@ -84,7 +84,7 @@ public class SFDCRegistrationIntentService extends JobIntentService {
             }
 
             // Fetches an instance ID from Firebase once the initialization is complete.
-            final FirebaseInstanceId instanceID = FirebaseInstanceId.getInstance();
+            final FirebaseInstanceId instanceID = FirebaseInstanceId.getInstance(FirebaseApp.getInstance(appName));
             final String token = instanceID.getToken(BootConfig.getBootConfig(this).getPushNotificationClientId(), FCM);
             final UserAccount account = SalesforceSDKManager.getInstance().getUserAccountManager().getCurrentUser();
 


### PR DESCRIPTION
FirebaseInstanceId.getInstance() will look for default name, we should now use the scoped appName