### PR TITLE
Adding support for Android Studio 3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.4'
+    classpath 'com.android.tools.build:gradle:3.2.0'
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 cdvCompileSdkVersion=android-28
 cdvMinSdkVersion=21
-cdvBuildToolsVersion=27.0.3
+cdvBuildToolsVersion=28.0.3
 android.useDeprecatedNdk=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 09 09:10:59 PDT 2018
+#Tue Sep 25 18:11:35 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
@@ -12,9 +12,6 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle
@@ -8,8 +8,12 @@ android {
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
-  sourceSets {
+  defaultConfig {
+    targetSdkVersion 28
+    minSdkVersion 21
+  }
 
+  sourceSets {
     main {
       manifest.srcFile 'AndroidManifest.xml'
       java.srcDirs = ['src']
@@ -31,7 +35,4 @@ android {
     xmlReport true
     abortOnError false
   }
-    defaultConfig {
-        minSdkVersion = 21
-    }
 }

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   sourceSets {
 
@@ -31,4 +31,7 @@ android {
     xmlReport true
     abortOnError false
   }
+    defaultConfig {
+        minSdkVersion = 21
+    }
 }

--- a/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
@@ -12,9 +12,6 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"

--- a/hybrid/HybridSampleApps/NoteSync/build.gradle
+++ b/hybrid/HybridSampleApps/NoteSync/build.gradle
@@ -8,8 +8,12 @@ android {
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
-  sourceSets {
+  defaultConfig {
+    targetSdkVersion 28
+    minSdkVersion 21
+  }
 
+  sourceSets {
     main {
       manifest.srcFile 'AndroidManifest.xml'
       java.srcDirs = ['src']
@@ -31,7 +35,4 @@ android {
     xmlReport true
     abortOnError false
   }
-    defaultConfig {
-        minSdkVersion = 21
-    }
 }

--- a/hybrid/HybridSampleApps/NoteSync/build.gradle
+++ b/hybrid/HybridSampleApps/NoteSync/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   sourceSets {
 
@@ -31,4 +31,7 @@ android {
     xmlReport true
     abortOnError false
   }
+    defaultConfig {
+        minSdkVersion = 21
+    }
 }

--- a/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/AndroidManifest.xml
@@ -12,9 +12,6 @@
         android:resizeable="true"
         android:anyDensity="true" />
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"

--- a/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/build.gradle
+++ b/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/build.gradle
@@ -8,6 +8,11 @@ android {
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
+  defaultConfig {
+    targetSdkVersion 28
+    minSdkVersion 21
+  }
+
   sourceSets {
 
     main {
@@ -31,7 +36,4 @@ android {
     xmlReport true
     abortOnError false
   }
-    defaultConfig {
-        minSdkVersion = 21
-    }
 }

--- a/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/build.gradle
+++ b/hybrid/HybridSampleApps/SmartSyncExplorerHybrid/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   sourceSets {
 
@@ -31,4 +31,7 @@ android {
     xmlReport true
     abortOnError false
   }
+    defaultConfig {
+        minSdkVersion = 21
+    }
 }

--- a/libs/SalesforceAnalytics/AndroidManifest.xml
+++ b/libs/SalesforceAnalytics/AndroidManifest.xml
@@ -8,8 +8,5 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application />
 </manifest>

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -20,8 +20,13 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
 
   buildTypes {
     debug {
@@ -49,7 +54,6 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.analytics.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   buildTypes {
     debug {
@@ -49,6 +49,7 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.analytics.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceHybrid/AndroidManifest.xml
+++ b/libs/SalesforceHybrid/AndroidManifest.xml
@@ -5,8 +5,5 @@
     android:versionCode="62"
     android:versionName="7.0.0.dev">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application />
 </manifest>

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   buildTypes {
     debug {
@@ -50,6 +50,7 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.salesforcehybrid.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -21,8 +21,13 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
 
   buildTypes {
     debug {
@@ -50,7 +55,6 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.salesforcehybrid.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceReact/AndroidManifest.xml
+++ b/libs/SalesforceReact/AndroidManifest.xml
@@ -5,8 +5,5 @@
     android:versionCode="62"
     android:versionName="7.0.0.dev">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application />
 </manifest>

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   buildTypes {
     debug {
@@ -54,6 +54,7 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.salesforcereact.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+      minSdkVersion = 21
   }
 
   packagingOptions {

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -24,8 +24,13 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
 
   buildTypes {
     debug {
@@ -54,7 +59,6 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.salesforcereact.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-      minSdkVersion = 21
   }
 
   packagingOptions {

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -5,9 +5,6 @@
 	android:versionCode="62"
 	android:versionName="7.0.0.dev">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application>
 
         <!-- Metadata for supported app restrictions -->

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   buildTypes {
       debug {
@@ -54,6 +54,7 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     api project(':libs:SalesforceAnalytics')
     api 'com.squareup.okhttp3:okhttp:3.10.0'
     api 'com.google.firebase:firebase-messaging:17.3.2'
-    api 'com.android.support:support-compat:28.0.0'
-    api 'com.android.support:customtabs:28.0.0'
+    api 'com.android.support:support-compat:27.1.1'
+    api 'com.android.support:customtabs:27.1.1'
     api 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -15,18 +15,23 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SalesforceAnalytics')
-    api 'com.squareup.okhttp3:okhttp:3.9.1'
-    api 'com.google.firebase:firebase-messaging:17.3.1'
-    api 'com.android.support:support-compat:27.1.1'
-    api 'com.android.support:customtabs:27.1.1'
+    api 'com.squareup.okhttp3:okhttp:3.10.0'
+    api 'com.google.firebase:firebase-messaging:17.3.2'
+    api 'com.android.support:support-compat:28.0.0'
+    api 'com.android.support:customtabs:28.0.0'
     api 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
 
   buildTypes {
       debug {
@@ -54,7 +59,6 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SmartStore/AndroidManifest.xml
+++ b/libs/SmartStore/AndroidManifest.xml
@@ -5,9 +5,6 @@
 	android:versionCode="62"
 	android:versionName="7.0.0.dev">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
 	<application>
 
         <!--  SmartStore Inspector screen -->

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
   
   buildTypes {
       debug {
@@ -52,6 +52,7 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.smartstore.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -15,15 +15,20 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SalesforceSDK')
-    api 'net.zetetic:android-database-sqlcipher:3.5.7'
+    api 'net.zetetic:android-database-sqlcipher:3.5.9'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
   
   buildTypes {
       debug {
@@ -52,7 +57,6 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.smartstore.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SmartSync/AndroidManifest.xml
+++ b/libs/SmartSync/AndroidManifest.xml
@@ -5,8 +5,5 @@
     android:versionCode="62"
     android:versionName="7.0.0.dev">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application />
 </manifest>

--- a/libs/SmartSync/build.gradle
+++ b/libs/SmartSync/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
   
   buildTypes {
       debug {
@@ -50,6 +50,7 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.smartsync.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SmartSync/build.gradle
+++ b/libs/SmartSync/build.gradle
@@ -20,8 +20,13 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
   
   buildTypes {
       debug {
@@ -50,7 +55,6 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.smartsync.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
+++ b/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
@@ -3,8 +3,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="com.salesforce.androidsdk.analytics.tests">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
 	<application />
 </manifest>

--- a/libs/test/SalesforceHybridTest/AndroidManifest.xml
+++ b/libs/test/SalesforceHybridTest/AndroidManifest.xml
@@ -4,9 +4,6 @@
 	package="com.salesforce.androidsdk.phonegap"
     android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.phonegap.app.SalesforceHybridTestApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">

--- a/libs/test/SalesforceReactTest/AndroidManifest.xml
+++ b/libs/test/SalesforceReactTest/AndroidManifest.xml
@@ -17,7 +17,4 @@
             </intent-filter>
         </activity>
 	</application>
-
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
 </manifest>

--- a/libs/test/SalesforceSDKTest/AndroidManifest.xml
+++ b/libs/test/SalesforceSDKTest/AndroidManifest.xml
@@ -19,8 +19,5 @@
         </activity>
 	</application>
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/libs/test/SmartStoreTest/AndroidManifest.xml
+++ b/libs/test/SmartStoreTest/AndroidManifest.xml
@@ -17,7 +17,4 @@
             </intent-filter>
         </activity>
 	</application>
-
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
 </manifest>

--- a/libs/test/SmartSyncTest/AndroidManifest.xml
+++ b/libs/test/SmartSyncTest/AndroidManifest.xml
@@ -17,7 +17,4 @@
             </intent-filter>
         </activity>
 	</application>
-
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
 </manifest>

--- a/native/NativeSampleApps/AppConfigurator/AndroidManifest.xml
+++ b/native/NativeSampleApps/AppConfigurator/AndroidManifest.xml
@@ -3,10 +3,6 @@
     package="com.salesforce.samples.appconfigurator"
     android:versionCode="1"
     android:versionName="1.0">
-
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
     
     <application
         android:allowBackup="true"

--- a/native/NativeSampleApps/AppConfigurator/build.gradle
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle
@@ -5,11 +5,15 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 28
-  buildToolsVersion '28.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
 
     sourceSets {
-
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
@@ -19,7 +23,6 @@ android {
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
         }
-
     }
     packagingOptions {
         exclude 'META-INF/LICENSE'
@@ -32,7 +35,4 @@ android {
     xmlReport true
     abortOnError false
   }
-    defaultConfig {
-        minSdkVersion = 21
-    }
 }

--- a/native/NativeSampleApps/AppConfigurator/build.gradle
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
     sourceSets {
 
@@ -32,4 +32,7 @@ android {
     xmlReport true
     abortOnError false
   }
+    defaultConfig {
+        minSdkVersion = 21
+    }
 }

--- a/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
+++ b/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
@@ -6,10 +6,6 @@
 	android:versionName="1.0"
 	android:installLocation="internalOnly">
 
-
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
 	<application android:icon="@drawable/sf__icon"
 	    android:label="@string/app_name"
 		android:name=".ConfiguredApp"

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     sourceSets {
 
@@ -32,4 +32,7 @@ android {
     xmlReport true
     abortOnError false
   }
+    defaultConfig {
+        minSdkVersion = 21
+    }
 }

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle
@@ -8,8 +8,12 @@ android {
     compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
-    sourceSets {
+    defaultConfig {
+        targetSdkVersion 28
+        minSdkVersion 21
+    }
 
+    sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
@@ -19,7 +23,6 @@ android {
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
         }
-
     }
     packagingOptions {
         exclude 'META-INF/LICENSE'
@@ -32,7 +35,4 @@ android {
     xmlReport true
     abortOnError false
   }
-    defaultConfig {
-        minSdkVersion = 21
-    }
 }

--- a/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
@@ -83,9 +83,6 @@
         -->
 	</application>
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <!--
         GCM permission to ensure that only this application can
         receive the messages and registration result. This must be of

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
   
   buildTypes {
       debug {
@@ -45,6 +45,7 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.samples.restexplorer.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 android {
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
+
+  defaultConfig {
+    targetSdkVersion 28
+    minSdkVersion 21
+  }
   
   buildTypes {
       debug {
@@ -45,7 +50,6 @@ android {
   defaultConfig {
     testApplicationId "com.salesforce.samples.restexplorer.tests"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-      minSdkVersion = 21
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/native/NativeSampleApps/SmartSyncExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/SmartSyncExplorer/AndroidManifest.xml
@@ -112,9 +112,6 @@
             android:label="Sync Contacts" />
     </application>
 
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
-
     <!--
         GCM permission to ensure that only this application can
         receive the messages and registration result. This must be of

--- a/native/NativeSampleApps/SmartSyncExplorer/build.gradle
+++ b/native/NativeSampleApps/SmartSyncExplorer/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
 android {
   compileSdkVersion 28
-  buildToolsVersion '27.0.3'
+  buildToolsVersion '28.0.3'
 
   sourceSets {
 
@@ -32,4 +32,7 @@ android {
     xmlReport true
     abortOnError false
   }
+    defaultConfig {
+        minSdkVersion = 21
+    }
 }

--- a/native/NativeSampleApps/SmartSyncExplorer/build.gradle
+++ b/native/NativeSampleApps/SmartSyncExplorer/build.gradle
@@ -8,6 +8,11 @@ android {
   compileSdkVersion 28
   buildToolsVersion '28.0.3'
 
+  defaultConfig {
+    targetSdkVersion 28
+    minSdkVersion 21
+  }
+
   sourceSets {
 
     main {
@@ -32,7 +37,4 @@ android {
     xmlReport true
     abortOnError false
   }
-    defaultConfig {
-        minSdkVersion = 21
-    }
 }

--- a/native/NativeSampleApps/test/RestExplorerTest/AndroidManifest.xml
+++ b/native/NativeSampleApps/test/RestExplorerTest/AndroidManifest.xml
@@ -4,7 +4,4 @@
     package="com.salesforce.samples.restexplorer.tests">
 
     <application />
-
-    <uses-sdk android:minSdkVersion="21"
-        android:targetSdkVersion="28" />
 </manifest>


### PR DESCRIPTION
- Upgraded `Gradle` version and build tools version to the latest recommended versions.
- `Android Studio 3.2` adds full support for API 28 and some really cool new features, such as `Dynamic App Delivery` and `Android Jetpack`.
- Fixes [this](https://issuetracker.google.com/issues/115478927) nasty bug that was preventing `Instant Run` from functioning.
- Removed duplicated declarations of `minSdkVersion` and `targetSdkVersion` from `AndroidManifest.xml` (they're already declared in `build.gradle`) per the latest recommendations from `Google`.