### PR TITLE
Caching current user

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
@@ -363,7 +363,7 @@ public class SmartStorePlugin extends ForcePlugin {
         if (isGlobal) {
             SmartStoreSDKManager.getInstance().removeGlobalSmartStore(storeName);
         } else {
-            final UserAccount account = UserAccountManager.getInstance().getCurrentUser();
+            final UserAccount account = UserAccountManager.getInstance().getCachedCurrentUser();
             if (account == null) {
                 throw new Exception("No user account found");
             }  else {
@@ -684,7 +684,7 @@ public class SmartStorePlugin extends ForcePlugin {
         if (isGlobal) {
             return SmartStoreSDKManager.getInstance().getGlobalSmartStore(storeName);
         } else {
-            final UserAccount account = UserAccountManager.getInstance().getCurrentUser();
+            final UserAccount account = UserAccountManager.getInstance().getCachedCurrentUser();
             if (account == null) {
                 throw new Exception("No user account found");
             }  else {

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
@@ -666,7 +666,7 @@ public class SmartStoreReactBridge extends ReactContextBaseJavaModule {
             SmartStoreSDKManager.getInstance().removeGlobalSmartStore(storeName);
             ReactBridgeHelper.invoke(successCallback, true);
         } else {
-            final UserAccount account = UserAccountManager.getInstance().getCurrentUser();
+            final UserAccount account = UserAccountManager.getInstance().getCachedCurrentUser();
             if (account == null) {
                 errorCallback.invoke("No user account found");
             }  else {
@@ -724,7 +724,7 @@ public class SmartStoreReactBridge extends ReactContextBaseJavaModule {
         if (isGlobal) {
             return SmartStoreSDKManager.getInstance().getGlobalSmartStore(storeName);
         } else {
-            final UserAccount account = UserAccountManager.getInstance().getCurrentUser();
+            final UserAccount account = UserAccountManager.getInstance().getCachedCurrentUser();
             if (account == null) {
                 throw new Exception("No user account found");
             }  else {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -317,6 +317,7 @@ public class UserAccountManager {
 		if (user.equals(curUser)) {
 			return;
 		}
+		clearCachedCurrentUser(curUser);
 		final ClientManager cm = new ClientManager(context, accountType,
 				SalesforceSDKManager.getInstance().getLoginOptions(), true);
 		final Account account = cm.getAccountByName(user.getAccountName());

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -132,6 +132,7 @@ public class UserAccountManager {
 	 * @param orgId Org ID.
 	 */
 	public void storeCurrentUserInfo(String userId, String orgId) {
+		clearCachedCurrentUser();
 		final SharedPreferences sp = context.getSharedPreferences(CURRENT_USER_PREF,
 				Context.MODE_PRIVATE);
         final Editor e = sp.edit();
@@ -186,13 +187,10 @@ public class UserAccountManager {
 	}
 
 	/**
-	 * Get rid of cached current user account if it matches the passed userAccount.
-	 * @param userAccount
+	 * Get rid of cached current user account
 	 */
-	public void clearCachedCurrentUser(UserAccount userAccount) {
-		if (cachedCurrentUserAccount != null && cachedCurrentUserAccount.equals(userAccount)) {
-			cachedCurrentUserAccount = null;
-		}
+	public void clearCachedCurrentUser() {
+		cachedCurrentUserAccount = null;
 	}
 
 	/**
@@ -317,7 +315,6 @@ public class UserAccountManager {
 		if (user.equals(curUser)) {
 			return;
 		}
-		clearCachedCurrentUser(curUser);
 		final ClientManager cm = new ClientManager(context, accountType,
 				SalesforceSDKManager.getInstance().getLoginOptions(), true);
 		final Account account = cm.getAccountByName(user.getAccountName());

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -102,6 +102,7 @@ public class UserAccountManager {
 	private Context context;
 	private AccountManager accountManager;
 	private String accountType;
+	private UserAccount cachedCurrentUserAccount;
 
 	/**
 	 * Returns a singleton instance of this class.
@@ -167,7 +168,31 @@ public class UserAccountManager {
 	 * @return Current user that's logged in.
 	 */
 	public UserAccount getCurrentUser() {
-		return buildUserAccount(getCurrentAccount());
+		cachedCurrentUserAccount = buildUserAccount(getCurrentAccount());
+		return cachedCurrentUserAccount;
+	}
+
+	/**
+	 * Returns a cached value of the current user.
+	 *
+	 * NB: The oauth tokens might be outdated
+	 *     Should be used by methods that only care about the current user's identity (org id, user id etc)
+	 *     Is faster than getCurrentUser()
+	 *
+	 * @return Current user that's logged in (with potentially outdated oauth tokens)
+	 */
+	public UserAccount getCachedCurrentUser() {
+		return cachedCurrentUserAccount != null ? cachedCurrentUserAccount : getCurrentUser() /* will populate cachedCurrentUserAccount */ ;
+	}
+
+	/**
+	 * Get rid of cached current user account if it matches the passed userAccount.
+	 * @param userAccount
+	 */
+	public void clearCachedCurrentUser(UserAccount userAccount) {
+		if (cachedCurrentUserAccount != null && cachedCurrentUserAccount.equals(userAccount)) {
+			cachedCurrentUserAccount = null;
+		}
 	}
 
 	/**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
@@ -69,7 +69,7 @@ public class AnalyticsPublisherService extends JobIntentService {
      * Handles the publish action in the provided background thread.
      */
     private void handleActionPublish() {
-        final UserAccount userAccount = UserAccountManager.getInstance().getCurrentUser();
+        final UserAccount userAccount = UserAccountManager.getInstance().getCachedCurrentUser();
         if (userAccount != null) {
             final SalesforceAnalyticsManager analyticsManager = SalesforceAnalyticsManager.getInstance(userAccount);
             analyticsManager.publishAllEvents();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/EventBuilderHelper.java
@@ -117,7 +117,7 @@ public class EventBuilderHelper {
 
         UserAccount account = userAccount;
         if (account == null) {
-            account = UserAccountManager.getInstance().getCurrentUser();
+            account = UserAccountManager.getInstance().getCachedCurrentUser();
         }
         if (account == null) {
             return;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -761,7 +761,7 @@ public class SalesforceSDKManager {
     protected void cleanUp(UserAccount userAccount) {
         SalesforceAnalyticsManager.reset(userAccount);
         RestClient.clearCaches(userAccount);
-        UserAccountManager.getInstance().clearCachedCurrentUser(userAccount);
+        UserAccountManager.getInstance().clearCachedCurrentUser();
     }
 
     /**
@@ -1319,7 +1319,7 @@ public class SalesforceSDKManager {
                 "Browser Login Enabled", isBrowserLoginEnabled() + "",
                 "IDP Enabled", isIDPLoginFlowEnabled() + "",
                 "Identity Provider", isIdentityProvider() + "",
-                "Current User", usersToString(getUserAccountManager().getCurrentUser()),
+                "Current User", usersToString(getUserAccountManager().getCachedCurrentUser()),
                 "Authenticated Users", usersToString(getUserAccountManager().getAuthenticatedUsers().toArray(new UserAccount[0]))
         ));
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -761,6 +761,7 @@ public class SalesforceSDKManager {
     protected void cleanUp(UserAccount userAccount) {
         SalesforceAnalyticsManager.reset(userAccount);
         RestClient.clearCaches(userAccount);
+        UserAccountManager.getInstance().clearCachedCurrentUser(userAccount);
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -643,6 +643,7 @@ public class ClientManager {
                 }
                 final UserAccount userAccount = UserAccountManager.getInstance().buildUserAccount(account);
                 userAccount.downloadProfilePhoto();
+                UserAccountManager.getInstance().clearCachedCurrentUser();
             } catch (OAuth2.OAuthFailedException ofe) {
                 if (ofe.isRefreshTokenInvalid()) {
                     SalesforceSDKLogger.i(TAG, "Invalid Refresh Token: (Error: " +

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -166,7 +166,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * @return SmartStore instance.
      */
     public SmartStore getSmartStore() {
-        return getSmartStore(getUserAccountManager().getCurrentUser());
+        return getSmartStore(getUserAccountManager().getCachedCurrentUser());
     }
 
     /**
@@ -233,7 +233,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * @return True - if the user has a smart store database, False - otherwise.
      */
     public boolean hasSmartStore() {
-        return hasSmartStore(getUserAccountManager().getCurrentUser(), null);
+        return hasSmartStore(getUserAccountManager().getCachedCurrentUser(), null);
     }
 
     /**
@@ -290,7 +290,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * Removes the default smart store for the current user.
      */
     public void removeSmartStore() {
-        removeSmartStore(getUserAccountManager().getCurrentUser());
+        removeSmartStore(getUserAccountManager().getCachedCurrentUser());
     }
 
     /**
@@ -333,9 +333,9 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * @throws JSONException
      */
     public List<String> getGlobalStoresPrefixList(){
-        UserAccount userAccount = getUserAccountManager().getCurrentUser();
+        UserAccount userAccount = getUserAccountManager().getCachedCurrentUser();
         String communityId = userAccount!=null?userAccount.getCommunityId():null;
-        List<String> globalDBNames = DBOpenHelper.getGlobalDatabasePrefixList(context,getUserAccountManager().getCurrentUser(),communityId);
+        List<String> globalDBNames = DBOpenHelper.getGlobalDatabasePrefixList(context,getUserAccountManager().getCachedCurrentUser(),communityId);
         return globalDBNames;
     }
 
@@ -345,9 +345,9 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * @throws JSONException
      */
     public List<String> getUserStoresPrefixList() {
-        UserAccount userAccount = getUserAccountManager().getCurrentUser();
+        UserAccount userAccount = getUserAccountManager().getCachedCurrentUser();
         String communityId = userAccount!=null?userAccount.getCommunityId():null;
-        List<String> userDBName = DBOpenHelper.getUserDatabasePrefixList(context,getUserAccountManager().getCurrentUser(),communityId);
+        List<String> userDBName = DBOpenHelper.getUserDatabasePrefixList(context,getUserAccountManager().getCachedCurrentUser(),communityId);
         return userDBName;
     }
 
@@ -370,8 +370,8 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
         List<String> globalDBNames = this.getUserStoresPrefixList();
         for(String storeName : globalDBNames) {
             removeSmartStore(storeName,
-                    UserAccountManager.getInstance().getCurrentUser(),
-                    UserAccountManager.getInstance().getCurrentUser().getCommunityId());
+                    UserAccountManager.getInstance().getCachedCurrentUser(),
+                    UserAccountManager.getInstance().getCachedCurrentUser().getCommunityId());
         }
     }
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/SmartStoreInspectorActivity.java
@@ -142,7 +142,7 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 
 	private void readExtras() {
 		Bundle bundle = getIntent().getExtras();
-		boolean hasUser = SmartStoreSDKManager.getInstance().getUserAccountManager().getCurrentUser() != null;
+		boolean hasUser = SmartStoreSDKManager.getInstance().getUserAccountManager().getCachedCurrentUser() != null;
 		// isGlobal is set to true
 		//   if no bundle, or no value for isGlobalStore in bundle, or true specified for isGlobalStore in bundle, or there is no current user
 		isGlobal = bundle == null || !bundle.containsKey(IS_GLOBAL_STORE) || bundle.getBoolean(IS_GLOBAL_STORE) || !hasUser;
@@ -183,7 +183,7 @@ public class SmartStoreInspectorActivity extends Activity implements AdapterView
 
 	private void setupStore(boolean isGlobal, String dbName) {
 		SmartStoreSDKManager mgr = SmartStoreSDKManager.getInstance();
-		UserAccount currentUser = mgr.getUserAccountManager().getCurrentUser();
+		UserAccount currentUser = mgr.getUserAccountManager().getCachedCurrentUser();
 		if (this.isGlobal != isGlobal || !this.dbName.equals(dbName) || smartStore == null) {
 			this.isGlobal = isGlobal;
 			this.dbName = dbName;

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/LayoutSyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/LayoutSyncManager.java
@@ -111,7 +111,7 @@ public class LayoutSyncManager {
     public static synchronized LayoutSyncManager getInstance(UserAccount account, String communityId,
                                                              SmartStore smartStore) {
         if (account == null) {
-            account = SmartSyncSDKManager.getInstance().getUserAccountManager().getCurrentUser();
+            account = SmartSyncSDKManager.getInstance().getUserAccountManager().getCachedCurrentUser();
         }
         if (smartStore == null) {
             smartStore = SmartSyncSDKManager.getInstance().getSmartStore(account, communityId);

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/MetadataSyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/MetadataSyncManager.java
@@ -111,7 +111,7 @@ public class MetadataSyncManager {
     public static synchronized MetadataSyncManager getInstance(UserAccount account, String communityId,
                                                              SmartStore smartStore) {
         if (account == null) {
-            account = SmartSyncSDKManager.getInstance().getUserAccountManager().getCurrentUser();
+            account = SmartSyncSDKManager.getInstance().getUserAccountManager().getCachedCurrentUser();
         }
         if (smartStore == null) {
             smartStore = SmartSyncSDKManager.getInstance().getSmartStore(account, communityId);

--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/manager/SyncManager.java
@@ -135,7 +135,7 @@ public class SyncManager {
      */
     public static synchronized SyncManager getInstance(UserAccount account, String communityId, SmartStore smartStore) {
         if (account == null) {
-            account = SmartSyncSDKManager.getInstance().getUserAccountManager().getCurrentUser();
+            account = SmartSyncSDKManager.getInstance().getUserAccountManager().getCachedCurrentUser();
         }
         if (smartStore == null) {
             smartStore = SmartSyncSDKManager.getInstance().getSmartStore(account, communityId);


### PR DESCRIPTION
NB: only returning the cached value from a new method (getCachedCurrentUser()). getCachedCurrentUser() should only be used by callers that only care about the user identity (org id, user id) and not the tokens (since they could be outdated).

Locally on simulator, getCurrentUser() runs on average in 34 ms while getCachedCurrent() runs in 0.14 ms.