### PR TITLE
Moving to RN 0.56.1

### DIFF
--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
   api project(':libs:SmartSync')
-  api 'com.facebook.react:react-native:0.55.4'
+  api 'com.facebook.react:react-native:0.56.1'
   androidTestImplementation 'com.android.support.test:runner:1.0.2'
   androidTestImplementation 'com.android.support.test:rules:1.0.2'
 }

--- a/libs/SalesforceReact/package.json
+++ b/libs/SalesforceReact/package.json
@@ -8,13 +8,13 @@
     "dependencies": {
         "chai": "4.1.2",
         "eslint": "^4.0.0",
-        "react": "16.3.1",
-        "react-native": "0.55.4",
+        "react": "16.4.1",
+        "react-native": "0.56.1",
         "react-native-cli": "^2.0.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev",
         "whatwg-fetch": "1.1.1"
     },
     "devDependencies": {
-        "babel-preset-react-native": "1.9.1"
+        "babel-preset-react-native": "5.0.2"
     }
 }


### PR DESCRIPTION
Moving to RN 0.56.1, first tried 0.57.1, but ran into an issue (see https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/commit/1add4778589616feafb9500b91fd5ed005510a0e)

All react tests are passing