### PR TITLE
Avoiding wasteful deserialization/serialization when querying smartstore

### DIFF
--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
@@ -223,13 +223,8 @@ public class SmartStoreReactBridge extends ReactContextBaseJavaModule {
 		storeCursor.moveToPageIndex(index);
 
 		// Build json result
-		try {
-			JSONObject result = storeCursor.getData(smartStore);
-			ReactBridgeHelper.invoke(successCallback, result);
-		} catch (JSONException e) {
-            SalesforceReactLogger.e(TAG, "moveCursorToPageIndex call failed", e);
-			errorCallback.invoke(e.toString());
-		}
+		JSONObject result = storeCursor.getData(smartStore);
+		ReactBridgeHelper.invoke(successCallback, result);
 	}
 
 	/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -797,85 +797,115 @@ public class SmartStore  {
      * @throws JSONException
 	 */
 	public JSONArray query(QuerySpec querySpec, int pageIndex) throws JSONException {
+		StringBuilder resultBuilder = new StringBuilder();
+		queryAsString(resultBuilder, querySpec, pageIndex);
+		return new JSONArray(resultBuilder.toString());
+	}
+	/**
+	 * Run a query given by its query Spec, only returned results from selected page
+	 * without deserializing any JSON
+	 *
+	 * @param resultBuilder string builder to which results are appended
+	 * @param querySpec
+	 * @param pageIndex
+	 */
+	public void queryAsString(StringBuilder resultBuilder, QuerySpec querySpec, int pageIndex) {
 		final SQLiteDatabase db = getDatabase();
-    	synchronized(db) {
+		synchronized(db) {
 			QueryType qt = querySpec.queryType;
-	    	String sql = convertSmartSql(querySpec.smartSql);
+			String sql = convertSmartSql(querySpec.smartSql);
 
-	        // Page
-	        int offsetRows = querySpec.pageSize * pageIndex;
-	        int numberRows = querySpec.pageSize;
-	        String limit = offsetRows + "," + numberRows;
-	    	Cursor cursor = null;
-	    	try {
-	    		cursor = DBHelper.getInstance(db).limitRawQuery(db, sql, limit, querySpec.getArgs());
-	            JSONArray results = new JSONArray();
-	            if (cursor.moveToFirst()) {
-	                do {
-	                	// Smart queries
-	                	if (qt == QueryType.smart || querySpec.selectPaths != null) {
-	                		results.put(getDataFromRow(cursor));
-	                	}
-	            		// Exact/like/range queries
-	                	else {
-	                		if (cursor.getColumnIndex(SoupSpec.FEATURE_EXTERNAL_STORAGE) >= 0) {
+			// Page
+			int offsetRows = querySpec.pageSize * pageIndex;
+			int numberRows = querySpec.pageSize;
+			String limit = offsetRows + "," + numberRows;
+			Cursor cursor = null;
+			try {
+				cursor = DBHelper.getInstance(db).limitRawQuery(db, sql, limit, querySpec.getArgs());
+				resultBuilder.append("[");
+				int currentRow = 0;
+				if (cursor.moveToFirst()) {
+					do {
+						if (currentRow > 0) {
+							resultBuilder.append(", ");
+						}
+						currentRow++;
+
+						// Smart queries
+						if (qt == QueryType.smart || querySpec.selectPaths != null) {
+							getDataFromRowAsString(resultBuilder, cursor);
+						}
+						// Exact/like/range queries
+						else {
+							if (cursor.getColumnIndex(SoupSpec.FEATURE_EXTERNAL_STORAGE) >= 0) {
 								// Presence of external storage column implies we must fetch from storage. Soup name and entry id values can be extracted
 								String soupTableName = cursor.getString(cursor.getColumnIndex(SoupSpec.FEATURE_EXTERNAL_STORAGE));
 								Long soupEntryId = cursor.getLong(cursor.getColumnIndex(SmartStore.SOUP_ENTRY_ID));
-								results.put(((DBOpenHelper) dbOpenHelper).loadSoupBlob(soupTableName, soupEntryId, encryptionKey));
-	                		} else {
-								results.put(new JSONObject(cursor.getString(0)));
-	                		}
-	                	}
-	                } while (cursor.moveToNext());
-	            }
-	            return results;
-	    	} finally {
-	    		safeClose(cursor);
-	    	}
-    	}
+								resultBuilder.append(((DBOpenHelper) dbOpenHelper).loadSoupBlobAsString(soupTableName, soupEntryId, encryptionKey));
+							} else {
+								resultBuilder.append(cursor.getString(0));
+							}
+						}
+					} while (cursor.moveToNext());
+				}
+				resultBuilder.append("]");
+
+			} finally {
+				safeClose(cursor);
+			}
+		}
 	}
 
-
-	/**
-	 * Return JSONArray for one row of data from cursor
-	 * @param cursor
-	 * @return
-	 * @throws JSONException
-	 */
-	private JSONArray getDataFromRow(Cursor cursor) throws JSONException {
-		JSONArray row = new JSONArray();
+	private void getDataFromRowAsString(StringBuilder resultBuilder, Cursor cursor)  {
 		int columnCount = cursor.getColumnCount();
+		resultBuilder.append("[");
 		for (int i=0; i<columnCount; i++) {
-            int valueType = cursor.getType(i);
+			if (i > 0) {
+				resultBuilder.append(",");
+			}
+			int valueType = cursor.getType(i);
 			String columnName = cursor.getColumnName(i);
-            if (valueType == Cursor.FIELD_TYPE_NULL) {
-                row.put(null);
-            }
-            else if (valueType == Cursor.FIELD_TYPE_STRING) {
-                String raw = cursor.getString(i);
-                if (columnName.equals(SoupSpec.FEATURE_EXTERNAL_STORAGE)) {
-                    // Presence of external storage column implies we must fetch from storage. Soup name and entry id values can be extracted
-                    String soupTableName = cursor.getString(i);
-                    Long soupEntryId = cursor.getLong(i + 1);
-                    row.put(((DBOpenHelper) dbOpenHelper).loadSoupBlob(soupTableName, soupEntryId, encryptionKey));
-                    i++; // skip next column (_soupEntryId)
-                } else if (columnName.equals(SOUP_COL) || columnName.startsWith(SOUP_COL + ":") /* :num is appended to column name when result set has more than one column with same name */) {
-                    row.put(new JSONObject(raw));
-                    // Note: we could end up returning a string if you aliased the column
-                }
-                else {
-                    row.put(raw);
-                }
-            }
-            else if (valueType == Cursor.FIELD_TYPE_INTEGER) {
-                row.put(cursor.getLong(i));
-            }
-            else if (valueType == Cursor.FIELD_TYPE_FLOAT) {
-                row.put(cursor.getDouble(i));
-            }
+			if (valueType == Cursor.FIELD_TYPE_NULL) {
+				resultBuilder.append("null");
+			}
+			else if (valueType == Cursor.FIELD_TYPE_STRING) {
+				String raw = cursor.getString(i);
+				if (columnName.equals(SoupSpec.FEATURE_EXTERNAL_STORAGE)) {
+					// Presence of external storage column implies we must fetch from storage. Soup name and entry id values can be extracted
+					String soupTableName = cursor.getString(i);
+					Long soupEntryId = cursor.getLong(i + 1);
+					resultBuilder.append(((DBOpenHelper) dbOpenHelper).loadSoupBlobAsString(soupTableName, soupEntryId, encryptionKey));
+					i++; // skip next column (_soupEntryId)
+				} else if (columnName.equals(SOUP_COL) || columnName.startsWith(SOUP_COL + ":") /* :num is appended to column name when result set has more than one column with same name */) {
+					resultBuilder.append(raw);
+					// Note: we could end up returning a string if you aliased the column
+				}
+				else {
+					raw = escapeStringValue(raw);
+					resultBuilder.append("\"").append(raw).append("\"");
+				}
+			}
+			else if (valueType == Cursor.FIELD_TYPE_INTEGER) {
+				resultBuilder.append(cursor.getLong(i));
+			}
+			else if (valueType == Cursor.FIELD_TYPE_FLOAT) {
+				resultBuilder.append(cursor.getDouble(i));
+			}
 		}
-		return row;
+		resultBuilder.append("]");
+	}
+
+	private String escapeStringValue(String raw) {
+		String escaped = raw;
+		escaped = escaped.replace("\\", "\\\\");
+		escaped = escaped.replace("/", "\\/");
+		escaped = escaped.replace("\"", "\\\"");
+		escaped = escaped.replace("\b", "\\b");
+		escaped = escaped.replace("\f", "\\f");
+		escaped = escaped.replace("\n", "\\n");
+		escaped = escaped.replace("\r", "\\r");
+		escaped = escaped.replace("\t", "\\t");
+		return escaped;
 	}
 
 	/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/StoreCursor.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/StoreCursor.java
@@ -77,21 +77,39 @@ public class StoreCursor {
 		// Always between 0 and totalPages-1
 		this.currentPageIndex = (newPageIndex < 0 ? 0 : newPageIndex >= totalPages ? totalPages - 1 : newPageIndex);
 	}
-	
+
 	/**
+	 * Returns cursor meta data (page index, size etc) and data (entries in page) as a FakeJSONObject
+	 * NB: json data is never deserialized
 	 * @param smartStore
-	 * @return json containing cursor meta data (page index, size etc) and data (entries in page)
-	 * Note: query is run to build json
-	 * @throws JSONException 
 	 */
-	public JSONObject getData(SmartStore smartStore) throws JSONException {
-		JSONObject json = new JSONObject();
-		json.put(CURSOR_ID, cursorId);
-		json.put(CURRENT_PAGE_INDEX, currentPageIndex);
-		json.put(PAGE_SIZE, querySpec.pageSize);
-		json.put(TOTAL_ENTRIES, totalEntries);
-		json.put(TOTAL_PAGES, totalPages);
-		json.put(CURRENT_PAGE_ORDERED_ENTRIES, smartStore.query(querySpec, currentPageIndex));
+	public FakeJSONObject getData(SmartStore smartStore)  {
+		StringBuilder resultBuilder = new StringBuilder();
+		resultBuilder.append("{")
+			.append("\"").append(CURSOR_ID).append("\":").append(cursorId).append(", ")
+			.append("\"").append(CURRENT_PAGE_INDEX).append("\":").append(currentPageIndex).append(", ")
+			.append("\"").append(PAGE_SIZE).append("\":").append(querySpec.pageSize).append(", ")
+			.append("\"").append(TOTAL_ENTRIES).append("\":").append(totalEntries).append(", ")
+			.append("\"").append(TOTAL_PAGES).append("\":").append(totalPages).append(", ")
+			.append("\"").append(CURRENT_PAGE_ORDERED_ENTRIES).append("\":");
+		smartStore.queryAsString(resultBuilder, querySpec, currentPageIndex);
+		resultBuilder.append("}");
+		return new FakeJSONObject(resultBuilder.toString());
+	}
+}
+
+/**
+ * A subclass of JSONObject that doesn't actually parse the stringified json passed to its constructor
+ * Use this class to avoid deserialization if you are calling a method that only wants to serialize the JSONObject
+ */
+class FakeJSONObject extends JSONObject {
+	private String json;
+
+	public FakeJSONObject(String json) {
+		this.json = json;
+	}
+
+	public String toString() {
 		return json;
 	}
 }


### PR DESCRIPTION
- smartstore query from hybrid or react native application no longer do any deserialization or serialization in native land / and there is no javascript code change required
- native app only deserialize once the full result is built (*)

(*) probably not faster but that way the code is cleaner (query is calling queryAsString)
     now it is very easy to use another JSON library to parse the result set