### PR TITLE
Fixing compilation error with Play Services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
-    jcenter()
     google()
+    jcenter()
   }
 
   dependencies {
@@ -17,7 +17,7 @@ allprojects {
       // All of React Native (JS, Android binaries) is installed from npm
       url "$rootProject.projectDir/libs/SalesforceReact/node_modules/react-native/android"
     }
-    jcenter()
     google()
+    jcenter()
   }
 }


### PR DESCRIPTION
`Google` moved `Play Services` from `jCenter()` to `google()` (its own internal `Maven` repository). The order matters - `Cordova` made a similar fix earlier this morning.