### PR TITLE
Check run config servers when initializing

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
@@ -340,10 +340,13 @@ public class LoginServerManager {
 		if (values != null && !values.isEmpty()) {
 			return;
 		}
-		List<LoginServer> servers = getLoginServersFromXML();
-		if (servers == null || servers.isEmpty()) {
-			servers = getLegacyLoginServers();
-		}
+		List<LoginServer> servers = getLoginServers();
+                if (servers == null || servers.isEmpty()) {
+            	    servers = getLoginServersFromXML();
+                    if (servers == null || servers.isEmpty()) {
+                        servers = getLegacyLoginServers();
+                    }
+                }
 		int numServers = servers.size();
 	    final Editor edit = settings.edit();
 		for (int i = 0; i < numServers; i++) {


### PR DESCRIPTION
Prevents default selected server in shared pref from being incorrect when run config server list is present during first launch initialization.