### PR TITLE
Migrating to AndroidX

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ cdvCompileSdkVersion=android-28
 cdvMinSdkVersion=21
 cdvBuildToolsVersion=28.0.3
 android.useDeprecatedNdk=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -15,8 +15,8 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api 'com.squareup:tape:1.2.3'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
 }
 
 android {
@@ -53,7 +53,7 @@ android {
   }
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.analytics.tests"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
   api project(':libs:SmartSync')
   api 'org.apache.cordova:framework:7.0.0'
-  androidTestImplementation 'com.android.support.test:runner:1.0.2'
-  androidTestImplementation 'com.android.support.test:rules:1.0.2'
+  androidTestImplementation 'androidx.test:runner:1.1.0'
+  androidTestImplementation 'androidx.test:rules:1.1.0'
 }
 
 android {
@@ -54,7 +54,7 @@ android {
   }
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.salesforcehybrid.tests"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -19,8 +19,8 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
   api project(':libs:SmartSync')
   api 'com.facebook.react:react-native:0.56.1'
-  androidTestImplementation 'com.android.support.test:runner:1.0.2'
-  androidTestImplementation 'com.android.support.test:rules:1.0.2'
+  androidTestImplementation 'androidx.test:runner:1.1.0'
+  androidTestImplementation 'androidx.test:rules:1.1.0'
 }
 
 android {
@@ -58,7 +58,7 @@ android {
 
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.salesforcereact.tests"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   packagingOptions {

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.reactnative.bridge;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Base64;
 
 import com.facebook.react.bridge.Callback;

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -17,11 +17,11 @@ dependencies {
     api project(':libs:SalesforceAnalytics')
     api 'com.squareup.okhttp3:okhttp:3.10.0'
     api 'com.google.firebase:firebase-messaging:17.3.2'
-    api 'com.android.support:support-compat:27.1.1'
-    api 'com.android.support:customtabs:27.1.1'
+    api 'androidx.core:core:1.0.0'
+    api 'androidx.browser:browser:1.0.0'
     api 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
 }
 
 android {
@@ -58,7 +58,7 @@ android {
   }
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.tests"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
@@ -28,7 +28,7 @@ package com.salesforce.androidsdk.analytics;
 
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.app.JobIntentService;
+import androidx.core.app.JobIntentService;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.java
@@ -34,7 +34,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Bundle;
-import android.support.v4.app.JobIntentService;
+import androidx.core.app.JobIntentService;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
@@ -32,7 +32,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.app.JobIntentService;
+import androidx.core.app.JobIntentService;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
@@ -28,7 +28,7 @@ package com.salesforce.androidsdk.push;
 
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.app.JobIntentService;
+import androidx.core.app.JobIntentService;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.iid.FirebaseInstanceId;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -41,7 +41,7 @@ import android.os.Bundle;
 import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
-import android.support.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsIntent;
 import android.text.TextUtils;
 import android.webkit.ClientCertRequest;
 import android.webkit.SslErrorHandler;

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -16,9 +16,9 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
     api project(':libs:SalesforceSDK')
     api 'net.zetetic:android-database-sqlcipher:3.5.9'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }
 
 android {
@@ -56,7 +56,7 @@ android {
   }
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.smartstore.tests"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -28,7 +28,7 @@ package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;

--- a/libs/SmartSync/build.gradle
+++ b/libs/SmartSync/build.gradle
@@ -15,8 +15,8 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SmartStore')
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
 }
 
 android {
@@ -54,7 +54,7 @@ android {
   }
   defaultConfig {
     testApplicationId "com.salesforce.androidsdk.smartsync.tests"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/FileLoggerTest.java
@@ -27,9 +27,9 @@
 package com.salesforce.androidsdk.analytics.logger;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
@@ -27,9 +27,9 @@
 package com.salesforce.androidsdk.analytics.logger;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/model/InstrumentationEventBuilderTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/model/InstrumentationEventBuilderTest.java
@@ -27,9 +27,9 @@
 package com.salesforce.androidsdk.analytics.model;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 import android.text.TextUtils;
 import android.util.Log;
 

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.analytics.security;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/store/EventStoreManagerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/store/EventStoreManagerTest.java
@@ -27,9 +27,9 @@
 package com.salesforce.androidsdk.analytics.store;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.analytics.manager.AnalyticsManager;
 import com.salesforce.androidsdk.analytics.model.DeviceAppAttributes;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ForceJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/ForceJSTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.phonegap;
 
-import android.support.test.filters.SmallTest;
+import androidx.test.filters.SmallTest;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JSTestCase.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JSTestCase.java
@@ -28,7 +28,7 @@ package com.salesforce.androidsdk.phonegap;
 
 import android.app.Instrumentation;
 import android.content.Intent;
-import android.support.test.InstrumentationRegistry;
+import androidx.test.InstrumentationRegistry;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.phonegap.plugin.TestRunnerPlugin;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JavaScriptPluginVersionTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JavaScriptPluginVersionTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.phonegap;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.phonegap.plugin.JavaScriptPluginVersion;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoJSTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.phonegap;
 
-import android.support.test.filters.SmallTest;
+import androidx.test.filters.SmallTest;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoPluginTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SDKInfoPluginTest.java
@@ -28,9 +28,9 @@ package com.salesforce.androidsdk.phonegap;
 
 import android.content.Context;
 import android.content.pm.PackageManager.NameNotFoundException;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.config.BootConfig;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.phonegap;
 
-import android.support.test.filters.MediumTest;
+import androidx.test.filters.MediumTest;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreLoadJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreLoadJSTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.phonegap;
 
-import android.support.test.filters.LargeTest;
+import androidx.test.filters.LargeTest;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartSyncJSTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.phonegap;
 
-import android.support.test.filters.LargeTest;
+import androidx.test.filters.LargeTest;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactHarnessTest.java
+++ b/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactHarnessTest.java
@@ -28,7 +28,7 @@
 package com.salesforce.androidsdk.reactnative;
 
 
-import android.support.test.filters.SmallTest;
+import androidx.test.filters.SmallTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactNetTest.java
+++ b/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactNetTest.java
@@ -28,7 +28,7 @@
 package com.salesforce.androidsdk.reactnative;
 
 
-import android.support.test.filters.SmallTest;
+import androidx.test.filters.SmallTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactOAuthTest.java
+++ b/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactOAuthTest.java
@@ -28,7 +28,7 @@
 package com.salesforce.androidsdk.reactnative;
 
 
-import android.support.test.filters.SmallTest;
+import androidx.test.filters.SmallTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactSmartStoreTest.java
+++ b/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactSmartStoreTest.java
@@ -28,7 +28,7 @@
 package com.salesforce.androidsdk.reactnative;
 
 
-import android.support.test.filters.SmallTest;
+import androidx.test.filters.SmallTest;
 
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 

--- a/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactSmartSyncTest.java
+++ b/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactSmartSyncTest.java
@@ -28,7 +28,7 @@
 package com.salesforce.androidsdk.reactnative;
 
 
-import android.support.test.filters.SmallTest;
+import androidx.test.filters.SmallTest;
 
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 import com.salesforce.androidsdk.smartsync.manager.SyncManager;

--- a/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactTestCase.java
+++ b/libs/test/SalesforceReactTest/src/com/salesforce/androidsdk/reactnative/ReactTestCase.java
@@ -28,8 +28,8 @@
 package com.salesforce.androidsdk.reactnative;
 
 import android.content.Intent;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.reactnative.util.ReactTestActivity;
 import com.salesforce.androidsdk.reactnative.util.TestResult;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
@@ -31,9 +31,9 @@ import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -30,9 +30,9 @@ import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
@@ -31,9 +31,9 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 import android.util.Log;
 
 import com.salesforce.androidsdk.MainActivity;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/HttpAccessTest.java
@@ -26,9 +26,9 @@
  */
 package com.salesforce.androidsdk.auth;
 
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestCredentials;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/IDPRequestHandlerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/IDPRequestHandlerTest.java
@@ -28,9 +28,9 @@ package com.salesforce.androidsdk.auth;
 
 import android.app.Application;
 import android.app.Instrumentation;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 import android.util.Log;
 
 import com.salesforce.androidsdk.TestCredentials;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginServerManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginServerManagerTest.java
@@ -29,9 +29,9 @@ package com.salesforce.androidsdk.auth;
 import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -28,9 +28,9 @@ package com.salesforce.androidsdk.auth;
 
 import android.app.Application;
 import android.app.Instrumentation;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestCredentials;
 import com.salesforce.androidsdk.TestForceApp;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/config/BootConfigTest.java
@@ -27,9 +27,9 @@
 package com.salesforce.androidsdk.config;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
@@ -34,9 +34,9 @@ import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestCredentials;
 import com.salesforce.androidsdk.TestForceApp;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -26,9 +26,9 @@
  */
 package com.salesforce.androidsdk.rest;
 
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.LargeTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestCredentials;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.rest;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.rest.RestRequest.RestMethod;
 import com.salesforce.androidsdk.util.test.JSONTestHelper;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/files/ConnectUriBuilderTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/files/ConnectUriBuilderTest.java
@@ -27,8 +27,8 @@
 package com.salesforce.androidsdk.rest.files;
 
 import android.net.Uri;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/files/FileRequestsTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/files/FileRequestsTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.rest.files;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/files/RenditionTypeTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/files/RenditionTypeTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.rest.files;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/PasscodeManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/PasscodeManagerTest.java
@@ -28,9 +28,9 @@ package com.salesforce.androidsdk.security;
 
 import android.content.Context;
 import android.os.Looper;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.security.PasscodeManager.HashConfig;
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/SalesforceKeyGeneratorTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/SalesforceKeyGeneratorTest.java
@@ -28,9 +28,9 @@ package com.salesforce.androidsdk.security;
 
 import android.app.Application;
 import android.app.Instrumentation;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.analytics.security.Encryptor;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.util;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/JSONObjectHelperTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/JSONObjectHelperTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.util;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.util.test.JSONTestHelper;
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/LogUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/LogUtilTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.util;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 import android.util.Pair;
 
 import org.junit.Assert;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/DBOpenHelperTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/DBOpenHelperTest.java
@@ -28,9 +28,9 @@ package com.salesforce.androidsdk.store;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/IndexSpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/IndexSpecTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/QuerySpecTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlExternalStorageTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartSqlTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreAlterTest.java
@@ -27,8 +27,8 @@
 package com.salesforce.androidsdk.store;
 
 import android.database.Cursor;
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.AlterSoupLongOperation;
 import com.salesforce.androidsdk.smartstore.store.DBHelper;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
@@ -27,8 +27,8 @@
 package com.salesforce.androidsdk.store;
 
 import android.database.Cursor;
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFTSExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFTSExternalStorageTest.java
@@ -27,8 +27,8 @@
 package com.salesforce.androidsdk.store;
 
 
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchSpeedTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchSpeedTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.LargeTest;
+import androidx.test.filters.LargeTest;
 import android.util.Log;
 
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreFullTextSearchTest.java
@@ -27,8 +27,8 @@
 package com.salesforce.androidsdk.store;
 
 import android.database.Cursor;
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreInspectorActivityTest.java
@@ -27,10 +27,10 @@
 package com.salesforce.androidsdk.store;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.MediumTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.MediumTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 import android.widget.ListAdapter;
 import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
@@ -57,11 +57,11 @@ import org.junit.runner.RunWith;
 import java.util.HashSet;
 import java.util.Set;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static android.support.test.espresso.action.ViewActions.replaceText;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Tests for SmartStoreInspectorActivity

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadExternalStorageTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.LargeTest;
+import androidx.test.filters.LargeTest;
 
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTest.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.LargeTest;
+import androidx.test.filters.LargeTest;
 import android.util.Log;
 
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreLoadTestCase.java
@@ -26,7 +26,7 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.InstrumentationRegistry;
+import androidx.test.InstrumentationRegistry;
 import android.util.Log;
 
 import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreOtherLoadExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreOtherLoadExternalStorageTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.runner.AndroidJUnit4;
 import android.util.Log;
 
 import com.salesforce.androidsdk.analytics.security.Encryptor;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreOtherLoadTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreOtherLoadTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.runner.AndroidJUnit4;
 import android.util.Log;
 
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
@@ -28,8 +28,8 @@ package com.salesforce.androidsdk.store;
 
 import android.database.Cursor;
 import android.os.SystemClock;
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTestCase.java
@@ -28,7 +28,7 @@ package com.salesforce.androidsdk.store;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.support.test.InstrumentationRegistry;
+import androidx.test.InstrumentationRegistry;
 
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
 import com.salesforce.androidsdk.smartstore.store.DBHelper;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SoupSpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SoupSpecTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.store;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.SoupSpec;
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/StoreConfigTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/StoreConfigTest.java
@@ -28,9 +28,9 @@
 package com.salesforce.androidsdk.store;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.MainActivity;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/config/SyncsConfigTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/config/SyncsConfigTest.java
@@ -27,8 +27,8 @@
 
 package com.salesforce.androidsdk.smartsync.config;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartsync.app.SmartSyncSDKManager;
 import com.salesforce.androidsdk.smartsync.manager.SyncManagerTestCase;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/LayoutSyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/LayoutSyncManagerTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.smartsync.manager;
 
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartsync.model.Layout;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/ManagerTestCase.java
@@ -29,7 +29,7 @@ package com.salesforce.androidsdk.smartsync.manager;
 import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
+import androidx.test.InstrumentationRegistry;
 
 import com.salesforce.androidsdk.analytics.logger.SalesforceLogger;
 import com.salesforce.androidsdk.auth.HttpAccess;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/MetadataSyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/MetadataSyncManagerTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.smartsync.manager;
 
-import android.support.test.filters.MediumTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartsync.model.Metadata;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/manager/SyncManagerTest.java
@@ -26,8 +26,8 @@
  */
 package com.salesforce.androidsdk.smartsync.manager;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartsync.target.LayoutSyncDownTarget;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenOtherSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenOtherSyncTest.java
@@ -27,7 +27,7 @@
 
 package com.salesforce.androidsdk.smartsync.target;
 
-import android.support.test.filters.LargeTest;
+import androidx.test.filters.LargeTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/ParentChildrenSyncTest.java
@@ -27,8 +27,8 @@
 
 package com.salesforce.androidsdk.smartsync.target;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartsync.target.ParentChildrenSyncTargetHelper.RelationshipType;

--- a/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/SoqlSyncDownTargetTest.java
+++ b/libs/test/SmartSyncTest/src/com/salesforce/androidsdk/smartsync/target/SoqlSyncDownTargetTest.java
@@ -27,8 +27,8 @@
 
 package com.salesforce.androidsdk.smartsync.target;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.runner.AndroidJUnit4;
 
 import com.salesforce.androidsdk.smartsync.manager.SyncManagerTestCase;
 import com.salesforce.androidsdk.smartsync.util.Constants;

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 dependencies {
   api project(':libs:SalesforceSDK')
-  androidTestImplementation ('com.android.support.test:runner:1.0.2') {
+  androidTestImplementation ('androidx.test:runner:1.1.0') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation ('com.android.support.test:rules:1.0.2') {
+  androidTestImplementation ('androidx.test:rules:1.1.0') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation ('com.android.support.test.espresso:espresso-core:3.0.2') {
+  androidTestImplementation ('androidx.test.espresso:espresso-core:3.1.0') {
     exclude module: 'support-annotations'
   }
 }
@@ -49,7 +49,7 @@ android {
   }
   defaultConfig {
     testApplicationId "com.salesforce.samples.restexplorer.tests"
-    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   packagingOptions {
     exclude 'META-INF/LICENSE'

--- a/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/PasscodeActivityTest.java
+++ b/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/PasscodeActivityTest.java
@@ -29,10 +29,10 @@ package com.salesforce.samples.restexplorer;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.Intent;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 import android.text.TextUtils;
 import android.widget.TextView;
 
@@ -48,12 +48,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static android.support.test.espresso.action.ViewActions.pressImeActionButton;
-import static android.support.test.espresso.action.ViewActions.replaceText;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Tests for PasscodeActivity.

--- a/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/ServerPickerActivityTest.java
+++ b/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/ServerPickerActivityTest.java
@@ -29,9 +29,9 @@ package com.salesforce.samples.restexplorer;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
-import android.support.test.filters.SmallTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 import android.view.View;
 import android.widget.EditText;
 
@@ -48,11 +48,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static android.support.test.espresso.action.ViewActions.replaceText;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Tests for ServerPickerActivity.


### PR DESCRIPTION
`AndroidX` is the replacement for `Google Support Libraries`. `Android P` is the transition phase for this. The next version of Android is likely to support only `AndroidX`. We should make the transition right now to support some new features.

The only changes in this PR are namespaces, package names in import statements, and Gradle dependencies.

The changes in this PR were auto-generated by `Android Studio` using instructions from [here](https://developer.android.com/jetpack/androidx/migrate).

```
With Android Studio 3.2 and higher, you can quickly migrate an existing project to use AndroidX by selecting Refactor > Migrate to AndroidX from the menu bar.
```

Most of the changes are in the tests, only a couple of library changes for `Chrome Tabs`.

Thanks for bringing this to my attention, @smcnulty-sfdc!