### PR TITLE
Saving user account before passcode creation (if any)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -385,9 +385,7 @@ public class LoginActivity extends AccountAuthenticatorActivity
 
 	@Override
 	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-		if (requestCode == PasscodeManager.PASSCODE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-			webviewHelper.onNewPasscode();
-		} else if (requestCode == SPRequestHandler.IDP_REQUEST_CODE) {
+		if (requestCode == SPRequestHandler.IDP_REQUEST_CODE) {
             spRequestHandler.handleIDPResponse(resultCode, data);
         } else {
 	        super.onActivityResult(requestCode, resultCode, data);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -188,26 +188,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     	webview.loadUrl("about:blank");
     }
 
-    /**
-     * Method called by login activity when it resumes after the passcode activity
-     *
-     * When the server has a mobile policy requiring a passcode, we start the passcode activity after completing the
-     * auth flow (see onAuthFlowComplete).
-     * When the passcode activity completes, the login activity's onActivityResult gets invoked, and it calls this method
-     * to finalize the account creation.
-     */
-    public void onNewPasscode() {
-
-    	/*
-    	 * Re-encryption of existing accounts with the new passcode is taken
-    	 * care of in the 'Confirm Passcode' step in PasscodeActivity.
-    	 */
-        if (accountOptions != null) {
-            final UserAccount addedAccount = addAccount();
-            callback.finish(addedAccount);
-        }
-    }
-
     /** Factory method for the WebViewClient, you can replace this with something else if you need to */
     protected WebViewClient makeWebViewClient() {
     	return new AuthWebViewClient();
@@ -590,6 +570,9 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 mgr.getAdminPermsManager().setPrefs(id.customPermissions, account);
             }
 
+            // Save the user account
+            addAccount(account);
+
             // Screen lock required by mobile policy.
             if (id.screenLockTimeout > 0) {
 
@@ -597,33 +580,16 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 final PasscodeManager passcodeManager = mgr.getPasscodeManager();
                 passcodeManager.storeMobilePolicyForOrg(account, id.screenLockTimeout * 1000 * 60, id.pinLength);
                 passcodeManager.setTimeoutMs(id.screenLockTimeout * 1000 * 60);
-                boolean changeRequired = passcodeManager.setMinPasscodeLength((Activity) getContext(), id.pinLength);
-
-                /*
-                 * Checks if a passcode already exists. If a passcode has NOT
-                 * been created yet, the user is taken through the passcode
-                 * creation flow, at the end of which account data is encrypted.
-                 */
-                if (!passcodeManager.hasStoredPasscode(mgr.getAppContext())) {
-
-                    // This will bring up the create passcode screen - we will create the account in onResume.
-                    passcodeManager.setEnabled(true);
-                    passcodeManager.lockIfNeeded((Activity) getContext(), true);
-                } else if (!changeRequired) {
-
-                    // If a passcode change is required, the lock screen will have already been set in setMinPasscodeLength.
-                    final UserAccount addedAccount = addAccount();
-                    callback.finish(addedAccount);
-                }
             }
 
             // No screen lock required or no mobile policy specified.
             else {
                 final PasscodeManager passcodeManager = mgr.getPasscodeManager();
                 passcodeManager.storeMobilePolicyForOrg(account, 0, PasscodeManager.MIN_PASSCODE_LENGTH);
-                final UserAccount addedAccount = addAccount();
-                callback.finish(addedAccount);
             }
+
+            // All done
+            callback.finish(account);
         }
 
         protected void handleException(Exception ex) {
@@ -652,7 +618,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
         }
     }
 
-    protected UserAccount addAccount() {
+    protected void addAccount(final UserAccount account) {
         ClientManager clientManager = new ClientManager(getContext(),
                 SalesforceSDKManager.getInstance().getAccountType(),
                 loginOptions, SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked());
@@ -689,16 +655,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     	 */
         final Context appContext = SalesforceSDKManager.getInstance().getAppContext();
         final String pushNotificationId = BootConfig.getBootConfig(appContext).getPushNotificationClientId();
-        final UserAccount account = UserAccountBuilder.getInstance().authToken(accountOptions.authToken).
-                refreshToken(accountOptions.refreshToken).loginServer(loginOptions.getLoginUrl()).
-                idUrl(accountOptions.identityUrl).instanceServer(accountOptions.instanceUrl).
-                orgId(accountOptions.orgId).userId(accountOptions.userId).username(accountOptions.username).
-                accountName(accountName).communityId(accountOptions.communityId).
-                communityUrl(accountOptions.communityUrl).firstName(accountOptions.firstName).
-                lastName(accountOptions.lastName).displayName(accountOptions.displayName).
-                email(accountOptions.email).photoUrl(accountOptions.photoUrl).
-                thumbnailUrl(accountOptions.thumbnailUrl).
-                additionalOauthValues(accountOptions.additionalOauthValues).build();
         if (!TextUtils.isEmpty(pushNotificationId)) {
             PushMessaging.register(appContext, account);
         }
@@ -714,7 +670,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 }
             });
         }
-        return account;
     }
 
     /**


### PR DESCRIPTION
Passcode is no longer used to encrypt user account data and therefore user account can be saved without waiting for passcode to be created
=> it simplifies the code
=> flow was broken in case of app being killed during passcode creation flow, on restart, the passcode creation flow would resume, but once completed, since no account had been saved, user would get a login screen