### PR TITLE
Do not reload the Cordova WebView when foregrounding

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -161,7 +161,11 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
 
         // Not logged in
         if (client == null) {
-            onResumeNotLoggedIn();
+            if (!webAppLoaded) {
+                onResumeNotLoggedIn();
+            } else {
+                SalesforceHybridLogger.i(TAG, "onResume - unauthenticated web app already loaded");
+            }
         }
 
         // Logged in


### PR DESCRIPTION
This behavior occurs when the `RestClient` is not null but not in the unauthenticated case.