### PR TITLE
Fix NPE in debug menu

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -1356,8 +1356,10 @@ public class SalesforceSDKManager {
     private String usersToString(UserAccount... userAccounts) {
         List<String> accountNames = new ArrayList<>();
         if (userAccounts != null) {
-            for (UserAccount userAccount : userAccounts) {
-                accountNames.add(userAccount.getAccountName());
+            for (final UserAccount userAccount : userAccounts) {
+                if (userAccount != null) {
+                    accountNames.add(userAccount.getAccountName());
+                }
             }
         }
         return TextUtils.join(", ", accountNames);


### PR DESCRIPTION
We're using `getCachedCurrentUser()` to get the current user and passing that in via `varargs`. This will be `null` in the unauthenticated use case. We need a `null` check here.