### PR TITLE
Removing unused methods

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/manager/AnalyticsManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/manager/AnalyticsManager.java
@@ -100,14 +100,4 @@ public class AnalyticsManager {
     public EventStoreManager getEventStoreManager() {
         return storeManager;
     }
-
-    /**
-     * Changes the encryption key to a new value.
-     *
-     * @param oldKey Old encryption key.
-     * @param newKey New encryption key.
-     */
-    public void changeEncryptionKey(String oldKey, String newKey) {
-        storeManager.changeEncryptionKey(oldKey, newKey);
-    }
 }

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
@@ -194,29 +194,6 @@ public class EventStoreManager {
     }
 
     /**
-     * Changes the encryption key to a new value. Fetches all stored events
-     * and re-encrypts them with the new encryption key.
-     *
-     * @param oldKey Old encryption key.
-     * @param newKey New encryption key.
-     */
-    public void changeEncryptionKey(String oldKey, String newKey) {
-
-        /*
-         * We need to disable logging while the upgrade is in progress to
-         * prevent rogue threads from attempting to write data with the old key.
-         */
-        boolean logEnabledStatus = isLoggingEnabled;
-        isLoggingEnabled = false;
-        encryptionKey = oldKey;
-        final List<InstrumentationEvent> storedEvents = fetchAllEvents();
-        deleteAllEvents();
-        encryptionKey = newKey;
-        storeEvents(storedEvents);
-        isLoggingEnabled = logEnabledStatus;
-    }
-
-    /**
      * Disables or enables logging of events. If logging is disabled, no events
      * will be stored. However, publishing of events is still possible.
      *
@@ -339,16 +316,13 @@ public class EventStoreManager {
          *
          * @param fileSuffix Filename suffix.
          */
-        public EventFileFilter(String fileSuffix) {
+        EventFileFilter(String fileSuffix) {
             this.fileSuffix = fileSuffix;
         }
 
         @Override
         public boolean accept(File dir, String filename) {
-            if (filename != null && filename.endsWith(fileSuffix)) {
-                return true;
-            }
-            return false;
+            return (filename != null && filename.endsWith(fileSuffix));
         }
     }
 }


### PR DESCRIPTION
This is part of the legacy upgrade code that was removed in `7.0`. I seem to have missed these 2 methods somehow.