### PR TITLE
Upgrading to SQLCipher 4.0.1

### DIFF
--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SalesforceSDK')
-    api 'net.zetetic:android-database-sqlcipher:3.5.9'
+    api 'net.zetetic:android-database-sqlcipher:4.0.1'
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -397,9 +397,16 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 
 	static class DBHook implements SQLiteDatabaseHook {
 		public void preKey(SQLiteDatabase database) {
-			database.execSQL("PRAGMA cipher_default_kdf_iter = '4000'");
-			// the new default for sqlcipher 3.x (64000) is too slow
-			// also that way we can open 2.x databases without any migration
+			// using sqlcipher 2.x kdf iter
+			// because 3.x default (64000) and 4.x default (256000) are too slow
+			// to be able to open 2.x databases without any migration
+			database.execSQL("PRAGMA cipher_default_kdf_iter = 4000");
+
+			// using sqlcipher 3.x page size, hmac algorithm and kdf algorithm
+			// to be able to open 3.x databases without any migration
+			database.execSQL("PRAGMA cipher_default_page_size = 1024");
+			database.execSQL("PRAGMA cipher_default_hmac_algorithm = HMAC_SHA1");
+			database.execSQL("PRAGMA cipher_default_kdf_algorithm = PBKDF2_HMAC_SHA1");
 		}
 
 		public void postKey(SQLiteDatabase database) {

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -397,16 +397,12 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 
 	static class DBHook implements SQLiteDatabaseHook {
 		public void preKey(SQLiteDatabase database) {
-			// using sqlcipher 2.x kdf iter
-			// because 3.x default (64000) and 4.x default (256000) are too slow
-			// to be able to open 2.x databases without any migration
+			// Using sqlcipher 3.x default settings
+			// => should open 3.x databases without any migration
+			database.execSQL("PRAGMA cipher_default_compatibility = 3");
+			// Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
+			// => should open 2.x databases without any migration
 			database.execSQL("PRAGMA cipher_default_kdf_iter = 4000");
-
-			// using sqlcipher 3.x page size, hmac algorithm and kdf algorithm
-			// to be able to open 3.x databases without any migration
-			database.execSQL("PRAGMA cipher_default_page_size = 1024");
-			database.execSQL("PRAGMA cipher_default_hmac_algorithm = HMAC_SHA1");
-			database.execSQL("PRAGMA cipher_default_kdf_algorithm = PBKDF2_HMAC_SHA1");
 		}
 
 		public void postKey(SQLiteDatabase database) {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
@@ -102,6 +102,14 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	}
 
 	/**
+	 * Checking sqlcipher version
+	 */
+	@Test
+	public void testSQLCipherVersion() {
+		Assert.assertEquals("Wrong sqlcipher version", "4.0.1 community", store.getSQLCipherVersion());
+	}
+
+	/**
 	 * Method to check soup blob with one stored by db. Can be overridden to check external storage if necessary.
 	 */
 	protected void assertSameSoupAsDB(JSONObject soup, Cursor c, String soupName, Long id) throws JSONException {


### PR DESCRIPTION
Taking the path of least resistance, opening every database with 3.x settings (except of kdf iter, where we are still using 2.x value for performance reason).

We should evaluate if 4.x settings have performance benefits (e.g. the larger page size). 
If they do, we will have to either:
- have code to try 4.x settings first then fall back on 3.x settings if that fails (to open older databases),
- or we should have code (or an API) for migrating older databases to 4.x.