### PR TITLE
Reduced memory usage during smartstore native queries

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/StoreCursor.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/StoreCursor.java
@@ -82,8 +82,9 @@ public class StoreCursor {
 	 * Returns cursor meta data (page index, size etc) and data (entries in page) as a FakeJSONObject
 	 * NB: json data is never deserialized
 	 * @param smartStore
+	 * @throws JSONException
 	 */
-	public FakeJSONObject getData(SmartStore smartStore)  {
+	public FakeJSONObject getData(SmartStore smartStore) throws JSONException {
 		StringBuilder resultBuilder = new StringBuilder();
 		resultBuilder.append("{")
 			.append("\"").append(CURSOR_ID).append("\":").append(cursorId).append(", ")


### PR DESCRIPTION
**Problem:**
With the [deserialization optimization](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/1798), we routed native smartstore query through queryAsString: we get the full result in a StringBuffer, turn it into a String, then turn that into a JSONArray. So at one point, we have 3 copies on the stack. For large result sets, that cause a out of memory exceptions. 

**To reproduce the OOMs:**
Add the following parameters to SmartStoreLoadTest (and SmartStoreLoadExternalStorageTest)
{"UpsertQuery1StringIndex1000fields1000characters", Type.string, NUMBER_ENTRIES, 1000, 1000, 1}

**Solution:**
Native smartstore query are back to building the result JSONArray incrementally. 
Both query(...) and queryAsString(...) now calls runQuery(...) which expects either a JSONArray or StringBuffer and getDataFromRow is back.
NB: The optimization is still there fore hybrid queries.