### PR TITLE
Enhancing session timeout rehydration in custom login URL scenarios

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
@@ -157,6 +157,10 @@ public class SalesforceWebViewClientHelper {
         if (ctx instanceof SalesforceDroidGapActivity) {
             final AuthConfigUtil.MyDomainAuthConfig authConfig = ((SalesforceDroidGapActivity) ctx).getAuthConfig();
             if (authConfig != null) {
+                final String loginPageUrl = authConfig.getLoginPageUrl();
+                if (loginPageUrl != null && url.contains(loginPageUrl)) {
+                    return true;
+                }
                 final List<String> ssoUrls = authConfig.getSsoUrls();
                 if (ssoUrls != null && ssoUrls.size() > 0) {
                    for (String ssoUrl : ssoUrls) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
@@ -90,10 +90,13 @@ public class AuthConfigUtil {
         private static final String USE_NATIVE_BROWSER_KEY = "UseAndroidNativeBrowserForAuthentication";
         private static final String SAML_PROVIDERS_KEY = "SamlProviders";
         private static final String SSO_URL_KEY = "SsoUrl";
+        private static final String LOGIN_PAGE_KEY = "LoginPage";
+        private static final String LOGIN_PAGE_URL_KEY = "LoginPageUrl";
 
         private JSONObject authConfig;
         private boolean browserLoginEnabled;
         private List<String> ssoUrls;
+        private String loginPageUrl;
 
         /**
          * Parameterized constructor.
@@ -119,6 +122,10 @@ public class AuthConfigUtil {
                             }
                         }
                     }
+                }
+                final JSONObject loginPageConfig = authConfig.optJSONObject(LOGIN_PAGE_KEY);
+                if (loginPageConfig != null) {
+                    loginPageUrl = loginPageConfig.optString(LOGIN_PAGE_URL_KEY);
                 }
             }
         }
@@ -148,6 +155,15 @@ public class AuthConfigUtil {
          */
         public List<String> getSsoUrls() {
             return ssoUrls;
+        }
+
+        /**
+         * Returns the configured login page URL.
+         *
+         * @return Configured login page URL.
+         */
+        public String getLoginPageUrl() {
+            return loginPageUrl;
         }
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -26,12 +26,12 @@
  */
 package com.salesforce.androidsdk.util;
 
-import androidx.test.filters.SmallTest;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
 
 /**
  * Tests for AuthConfigUtil.
@@ -75,7 +75,8 @@ public class AuthConfigUtilTest {
         Assert.assertNotNull("Auth config should not be null", authConfig);
         Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
         Assert.assertNotNull("SSO URLs should not be null", authConfig.getSsoUrls());
-        Assert.assertTrue("SSO URLs should have at least 1 valid entry", authConfig.getSsoUrls().size() >= 1);
+        Assert.assertTrue("SSO URLs should have at least 1 valid entry",
+                authConfig.getSsoUrls().size() >= 1);
     }
 
     @Test
@@ -84,6 +85,16 @@ public class AuthConfigUtilTest {
         Assert.assertNotNull("Auth config should not be null", authConfig);
         Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
         Assert.assertNull("SSO URLs should be null", authConfig.getSsoUrls());
+    }
+
+    @Test
+    public void testGetLoginPageUrl() {
+        final AuthConfigUtil.MyDomainAuthConfig authConfig = AuthConfigUtil.getMyDomainAuthConfig(ALTERNATE_MY_DOMAIN_ENDPOINT);
+        Assert.assertNotNull("Auth config should not be null", authConfig);
+        Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
+        Assert.assertNotNull("Login page URL should not be null", authConfig.getLoginPageUrl());
+        Assert.assertTrue("Login page URL should contain correct URL",
+                authConfig.getLoginPageUrl().contains(ALTERNATE_MY_DOMAIN_ENDPOINT));
     }
 
     @Test


### PR DESCRIPTION
In some scenarios such as communities, customers can configure custom login URLs and strip all parameters on the URL without `MyDomain` configured. This would drop `ec=302` in those cases. This PR closes that gap.