### PR TITLE
Fixing corner case bug around logout of multiple users

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -163,7 +163,6 @@ public class SalesforceSDKManager {
     private PushNotificationInterface pushNotificationInterface;
     private Class<? extends PushService> pushServiceType = PushService.class;
     private String uid; // device id
-    private volatile boolean loggedOut = false;
     private SortedSet<String> features;
     private List<String> additionalOauthKeys;
     private String loginBrand;
@@ -807,7 +806,7 @@ public class SalesforceSDKManager {
         }
 	}
 
-    private void unregisterPush(final ClientManager clientMgr, final boolean showLoginPage,
+    private synchronized void unregisterPush(final ClientManager clientMgr, final boolean showLoginPage,
     		final String refreshToken, final String loginServer,
             final Account account, final Activity frontActivity, boolean isLastAccount) {
         final IntentFilter intentFilter = new IntentFilter(PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT);
@@ -834,30 +833,27 @@ public class SalesforceSDKManager {
         (new Thread() {
             public void run() {
                 long startTime = System.currentTimeMillis();
-                while ((System.currentTimeMillis() - startTime) < PUSH_UNREGISTER_TIMEOUT_MILLIS
-                        && !loggedOut) {
+                while ((System.currentTimeMillis() - startTime) < PUSH_UNREGISTER_TIMEOUT_MILLIS) {
 
                     // Waits for half a second at a time.
                     SystemClock.sleep(500);
                 }
                 postPushUnregister(pushUnregisterReceiver, clientMgr, showLoginPage,
                 		refreshToken, loginServer, account, frontActivity);
-            };
+            }
         }).start();
     }
 
-    private synchronized void postPushUnregister(BroadcastReceiver pushReceiver,
+    private void postPushUnregister(BroadcastReceiver pushReceiver,
     		final ClientManager clientMgr, final boolean showLoginPage,
     		final String refreshToken, final String loginServer,
             final Account account, Activity frontActivity) {
-        if (!loggedOut) {
-            try {
-                context.unregisterReceiver(pushReceiver);
-            } catch (Exception e) {
-                SalesforceSDKLogger.e(TAG, "Exception occurred while un-registering", e);
-            }
-    		removeAccount(clientMgr, showLoginPage, refreshToken, loginServer, account, frontActivity);
+        try {
+            context.unregisterReceiver(pushReceiver);
+        } catch (Exception e) {
+            SalesforceSDKLogger.e(TAG, "Exception occurred while un-registering", e);
         }
+        removeAccount(clientMgr, showLoginPage, refreshToken, loginServer, account, frontActivity);
     }
 
     /**
@@ -923,7 +919,6 @@ public class SalesforceSDKManager {
 		final UserAccount userAcc = getUserAccountManager().buildUserAccount(account);
 		int numAccounts = mgr.getAccountsByType(getAccountType()).length;
     	if (PushMessaging.isRegistered(context, userAcc) && refreshToken != null) {
-    		loggedOut = false;
     		unregisterPush(clientMgr, showLoginPage, refreshToken,
     				loginServer, account, frontActivity, (numAccounts == 1));
     	} else {
@@ -945,7 +940,6 @@ public class SalesforceSDKManager {
     private void removeAccount(ClientManager clientMgr, final boolean showLoginPage,
     		String refreshToken, String loginServer,
     		Account account, Activity frontActivity) {
-    	loggedOut = true;
     	cleanUp(frontActivity, account);
 
     	/*
@@ -991,7 +985,7 @@ public class SalesforceSDKManager {
     	isLoggingOut = false;
 
     	// Revokes the existing refresh token.
-        if (shouldLogoutWhenTokenRevoked() && account != null && refreshToken != null) {
+        if (shouldLogoutWhenTokenRevoked() && refreshToken != null) {
         	new RevokeTokenTask(refreshToken, loginServer).execute();
         }
     }


### PR DESCRIPTION
The `loggedOut` flag was causing issues around some corner cases. We don't need it anymore since there are guardrails around access to that method even if we call `logout` from multiple threads.