### PR TITLE
Removing deprecated NDK usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 cdvCompileSdkVersion=android-28
 cdvMinSdkVersion=21
 cdvBuildToolsVersion=28.0.3
-android.useDeprecatedNdk=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
This is not supported anymore in the latest version of Gradle.