### PR TITLE
Prevent NPE when refresh is called by shouldOverrideUrlLoading before a REST client has been created

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -411,6 +411,13 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
      */
     public void refresh(final String url) {
         SalesforceHybridLogger.i(TAG, "refresh called");
+
+        if (client == null) {
+            // If the client is null, we should refresh through other means
+            authenticate(null);
+            return;
+        }
+
         client.sendAsync(RestRequest.getRequestForUserInfo(), new AsyncRequestCallback() {
 
             @Override


### PR DESCRIPTION
Here's the issue:

1. Create an app with `BootConfig.shouldAuthenticate` set to `false` but use a login URL for an org/community that requires authentication.
1. `SalesforceWebViewClientHelper.shouldOverrideUrlLoading` is called, which eventually calls `SalesforceDroidGapActivity.refresh`
1. The REST client has not been initialized yet, leading to a NPE on line 421

To remedy this, the authentication process is manually kicked off if the client is null. Basically, this patch allows an app to recover from a misconfigured org or community that actually requires authentication but whose `BootConfig` says otherwise.

Here's the test matrix I've run this change through:

| shouldAuthenticate | org requires auth | result                         |
|--------------------|-------------------|--------------------------------|
| false              | yes               | Login activity shown at launch. This fixes the undesired behavior of the NPE instead. |
| false              | no                | Content shown at launch        |
| true               | yes               | Login activity shown at launch |
| true               | no                | Login activity shown at launch |
