### PR TITLE
Disabling StrongBox Keymaster for now

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/files/ConnectUriBuilder.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/files/ConnectUriBuilder.java
@@ -27,6 +27,7 @@
 package com.salesforce.androidsdk.rest.files;
 
 import android.net.Uri;
+
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
 
 /**
@@ -38,7 +39,6 @@ import com.salesforce.androidsdk.rest.ApiVersionStrings;
 public class ConnectUriBuilder {
 
     public static final String EMPTY = "";
-
     private static final String ME = "me";
     private static final String PAGE = "page";
     private static final String PAGESIZE = "pageSize";
@@ -60,14 +60,14 @@ public class ConnectUriBuilder {
     }
 
     public ConnectUriBuilder appendUserId(String userId) {
-        if (userId != null && EMPTY.equals(userId)) {
+        if (EMPTY.equals(userId)) {
             throw new IllegalArgumentException("invalid user id");
         }
         return appendPath(userId == null ? ME : userId);
     }
 
     public ConnectUriBuilder appendFolderId(String folderId) {
-        if (folderId != null && EMPTY.equals(folderId)) {
+        if (EMPTY.equals(folderId)) {
             throw new IllegalArgumentException("invalid folder id");
         }
         return appendPath(folderId);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
@@ -235,7 +235,15 @@ public class KeyStoreWrapper {
                      */
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                         try {
-                            keyGenParameterSpecBuilder.setIsStrongBoxBacked(true);
+
+                            /*
+                             * Disabling StrongBox for now, since it's too slow on Pixel 3
+                             * and Pixel 3 XL.
+                             *
+                             * TODO: Re-enable in Mobile SDK 7.2.
+                             */
+                            //keyGenParameterSpecBuilder.setIsStrongBoxBacked(true);
+                            keyGenParameterSpecBuilder.setIsStrongBoxBacked(false);
                             kpg.initialize(keyGenParameterSpecBuilder.build());
                             kpg.generateKeyPair();
                         } catch (StrongBoxUnavailableException sb) {


### PR DESCRIPTION
Disabling `StrongBox Keymaster` for now, since it's too slow on `Pixel 3` and `Pixel 3 XL` devices.