### PR TITLE
Adding null check on file list

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
@@ -286,9 +286,11 @@ public class EventStoreManager {
     private List<File> getAllFiles() {
         final List<File> files = new ArrayList<>();
         final File[] listOfFiles = rootDir.listFiles();
-        for (final File file : listOfFiles) {
-            if (file != null && fileFilter.accept(rootDir, file.getName())) {
-                files.add(file);
+        if (listOfFiles != null) {
+            for (final File file : listOfFiles) {
+                if (file != null && fileFilter.accept(rootDir, file.getName())) {
+                    files.add(file);
+                }
             }
         }
         return files;


### PR DESCRIPTION
This should never happen. If the list of files is `null`, most of the SDK wouldn't work anyway.