### PR TITLE
Follow up PR for sqlcipher 4 settings

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -418,6 +418,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
         devSupportInfos.addAll(Arrays.asList(
                 "SQLCipher version", getSmartStore().getSQLCipherVersion(),
                 "SQLCipher Compile Options", TextUtils.join(", ", getSmartStore().getCompileOptions()),
+                "SQLCipher Runtime Setting", TextUtils.join(", ", getSmartStore().getRuntimeSettings()),
                 "User Stores", TextUtils.join(", ", getUserStoresPrefixList()),
                 "Global Stores", TextUtils.join(", ", getGlobalStoresPrefixList())
         ));

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -1735,18 +1735,27 @@ public class SmartStore  {
 	}
 
 	/**
-	 * Get compile options
+	 * Get SQLCipher runtime settings
 	 *
-	 * @return list of compile options
+	 * @return list of SQLCipher runtime settings
+	 */
+	public List<String> getRuntimeSettings() {
+		return queryPragma("cipher_settings");
+	}
+
+	/**
+	 * Get SQLCipher compile options
+	 *
+	 * @return list of SQLCipher compile options
 	 */
 	public List<String> getCompileOptions() {
 		return queryPragma("compile_options");
 	}
 
 	/**
-	 * Get sqlcipher version
+	 * Get SQLCipher version
 	 *
-	 * @return sqlcipher version
+	 * @return SQLCipher version
 	 */
 	public String getSQLCipherVersion() {
 		return TextUtils.join(" ", queryPragma("cipher_version"));

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreExternalStorageTest.java
@@ -128,7 +128,7 @@ public class SmartStoreExternalStorageTest extends SmartStoreTest {
 		int dbBlobsDirSizeBefore = totalSizeBefore - dBFileSizeBefore;
 
 		// Populate db with several entries
-		for (int i = 0; i < 100; i++) {
+		for (int i = 0; i < 512; i++) {
 			JSONObject soupElt = new JSONObject("{'key':'abcd" + i + "', 'value':'va" + i + "', 'otherValue':'ova" + i + "'}");
 			store.create(TEST_SOUP, soupElt);
 		}

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/SmartStoreTest.java
@@ -28,8 +28,9 @@ package com.salesforce.androidsdk.store;
 
 import android.database.Cursor;
 import android.os.SystemClock;
-import androidx.test.filters.MediumTest;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
 
 import com.salesforce.androidsdk.smartstore.store.DBHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
@@ -99,6 +100,21 @@ public class SmartStoreTest extends SmartStoreTestCase {
         Assert.assertTrue("ENABLE_FTS3_PARENTHESIS flag not found in compile options", compileOptions.contains("ENABLE_FTS3_PARENTHESIS"));
         Assert.assertTrue("ENABLE_FTS5 flag not found in compile options", compileOptions.contains("ENABLE_FTS5"));
         Assert.assertTrue("ENABLE_JSON1 flag not found in compile options", compileOptions.contains("ENABLE_JSON1"));
+	}
+
+	/**
+	 * Checking runtime settings
+	 */
+	@Test
+	public void testRuntimeSettings() {
+		List<String> settings = store.getRuntimeSettings();
+		// Make sure run time settings are 4.x settings except for kdf_iter
+		Assert.assertTrue("Wrong kdf_iter", settings.contains("PRAGMA kdf_iter = 4000;"));
+		Assert.assertTrue("Wrong cipher_page_size", settings.contains("PRAGMA cipher_page_size = 4096;"));
+		Assert.assertTrue("Wrong cipher_user_hmac", settings.contains("PRAGMA cipher_use_hmac = 1;"));
+		Assert.assertTrue("Wrong cipher_plaintext_header_size", settings.contains("PRAGMA cipher_plaintext_header_size = 0;"));
+		Assert.assertTrue("Wrong cipher_hmac_algorithm", settings.contains("PRAGMA cipher_hmac_algorithm = HMAC_SHA512;"));
+		Assert.assertTrue("Wrong cipher_kdf_algorithm", settings.contains("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA512;"));
 	}
 
 	/**


### PR DESCRIPTION
* added getRuntimeSettings() method
* added test checking runtime settings
* showing runtime settings in dev menu
* fixed test that stopped working (because of larger page size)