### PR TITLE
Adding checks around generated encryption key

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -97,10 +97,15 @@ public class SalesforceKeyGenerator {
      * @return Encryption key.
      */
     public static String getEncryptionKey(String name) {
+        if (TextUtils.isEmpty(name)) {
+            return null;
+        }
         String encryptionKey = CACHED_ENCRYPTION_KEYS.get(name);
         if (encryptionKey == null) {
             encryptionKey = generateEncryptionKey(name);
-            CACHED_ENCRYPTION_KEYS.put(name, encryptionKey);
+            if (encryptionKey != null) {
+                CACHED_ENCRYPTION_KEYS.put(name, encryptionKey);
+            }
         }
         return encryptionKey;
     }


### PR DESCRIPTION
In some rare cases, the generated key can be `null` (if the hardware module, i.e. `Keystore` is unresponsive or unavailable, for instance). It is also device-dependent. If we attempt to insert a `null` value in a `ConcurrentHashMap`, it'll throw an NPE, which is being reported in #1958. This fixes that issue.