### PR TITLE
Fixing a corner case bug/regression with logout from the background

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -716,8 +716,9 @@ public class SalesforceSDKManager {
      *
      * @param frontActivity Front activity.
      * @param account Account.
+     * @param shouldDismissActivity Dismisses current activity if true, does nothing otherwise.
      */
-    private void cleanUp(Activity frontActivity, Account account) {
+    private void cleanUp(Activity frontActivity, Account account, boolean shouldDismissActivity) {
         final UserAccount userAccount = UserAccountManager.getInstance().buildUserAccount(account);
 
         // Clean up in this process
@@ -728,8 +729,8 @@ public class SalesforceSDKManager {
 
         final List<UserAccount> users = getUserAccountManager().getAuthenticatedUsers();
 
-        // Finishes front activity if specified, and if this is the last account.
-        if (frontActivity != null && (users == null || users.size() <= 1)) {
+        // Finishes front activity if specified, if this is the last account.
+        if (shouldDismissActivity && frontActivity != null && (users == null || users.size() <= 1)) {
             frontActivity.finish();
         }
 
@@ -922,7 +923,7 @@ public class SalesforceSDKManager {
     private void removeAccount(ClientManager clientMgr, final boolean showLoginPage,
     		String refreshToken, String loginServer,
     		Account account, Activity frontActivity) {
-    	cleanUp(frontActivity, account);
+    	cleanUp(frontActivity, account, showLoginPage);
 
     	/*
     	 * Removes the existing account, if any. 'account == null' does not

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -116,9 +116,6 @@ public class SalesforceSDKManager {
      */
     private static final String CLEANUP_INTENT_ACTION = "com.salesforce.CLEANUP";
 
-    // Receiver for CLEANUP_INTENT_ACTION broadcast
-    private CleanupReceiver cleanupReceiver;
-
     // Key in broadcast for process id
     private static final String PROCESS_ID_KEY = "processId";
 
@@ -139,20 +136,19 @@ public class SalesforceSDKManager {
     private static final String DEFAULT_APP_DISPLAY_NAME = "Salesforce";
     private static final String INTERNAL_ENTROPY = "6cgs4f";
     private static final String TAG = "SalesforceSDKManager";
-    protected static String AILTN_APP_NAME;
+    private static String AILTN_APP_NAME;
 
     /**
      * Instance of the SalesforceSDKManager to use for this process.
      */
     protected static SalesforceSDKManager INSTANCE;
-    private static final int PUSH_UNREGISTER_TIMEOUT_MILLIS = 30000;
 
     protected Context context;
-    protected LoginOptions loginOptions;
-    protected Class<? extends Activity> mainActivityClass;
-    protected Class<? extends Activity> loginActivityClass = LoginActivity.class;
-    protected Class<? extends PasscodeActivity> passcodeActivityClass = PasscodeActivity.class;
-    protected Class<? extends AccountSwitcherActivity> switcherActivityClass = AccountSwitcherActivity.class;
+    private LoginOptions loginOptions;
+    private Class<? extends Activity> mainActivityClass;
+    private Class<? extends Activity> loginActivityClass = LoginActivity.class;
+    private Class<? extends PasscodeActivity> passcodeActivityClass = PasscodeActivity.class;
+    private Class<? extends AccountSwitcherActivity> switcherActivityClass = AccountSwitcherActivity.class;
     private PasscodeManager passcodeManager;
     private LoginServerManager loginServerManager;
     private boolean isTestRun = false;
@@ -257,7 +253,7 @@ public class SalesforceSDKManager {
         }
 
         // If your app runs in multiple processes, all the SalesforceSDKManager need to run cleanup during a logout
-        cleanupReceiver = new CleanupReceiver();
+        final CleanupReceiver cleanupReceiver = new CleanupReceiver();
         context.registerReceiver(cleanupReceiver, new IntentFilter(SalesforceSDKManager.CLEANUP_INTENT_ACTION));
     }
 
@@ -349,7 +345,7 @@ public class SalesforceSDKManager {
 	 *
 	 * @param context Application context.
 	 */
-    public static void initInternal(Context context) {
+    protected static void initInternal(Context context) {
 
         // Upgrades to the latest version.
         SalesforceSDKUpgradeManager.getInstance().upgrade();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -345,7 +345,7 @@ public class SalesforceSDKManager {
 	 *
 	 * @param context Application context.
 	 */
-    protected static void initInternal(Context context) {
+    public static void initInternal(Context context) {
 
         // Upgrades to the latest version.
         SalesforceSDKUpgradeManager.getInstance().upgrade();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -136,7 +136,7 @@ public class SalesforceSDKManager {
     private static final String DEFAULT_APP_DISPLAY_NAME = "Salesforce";
     private static final String INTERNAL_ENTROPY = "6cgs4f";
     private static final String TAG = "SalesforceSDKManager";
-    private static String AILTN_APP_NAME;
+    protected static String AILTN_APP_NAME;
 
     /**
      * Instance of the SalesforceSDKManager to use for this process.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
@@ -202,7 +202,7 @@ public class SalesforceSDKManagerTest {
          * This is meant to be used ONLY by tests.
          */
         public static void resetAiltnAppName() {
-            AILTN_APP_NAME = null;
+            setAiltnAppName(null);
         }
 
         /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTest.java
@@ -202,7 +202,7 @@ public class SalesforceSDKManagerTest {
          * This is meant to be used ONLY by tests.
          */
         public static void resetAiltnAppName() {
-            setAiltnAppName(null);
+            AILTN_APP_NAME = null;
         }
 
         /**


### PR DESCRIPTION
In some corner cases, an app might want to log out from the background, i.e. with no `Activity` involved. Some examples are:
- from `Settings` screen.
- from a background `Service`.
- from a `Security` screen (where we don't want the screen to be dismissed).

We have always had a flag to support this, but it appears to have regressed at some point, rendering the flag useless. When this flag is set to `false`, we should not dismiss the `Activity` passed in, if any. This PR fixes this issue (and a few warnings).