### PR TITLE
Adding API to fetch OpenID token

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -115,6 +115,7 @@ public class OAuth2 {
     private static final String CUSTOM_PERMISSIONS = "custom_permissions";
     private static final String SFDC_COMMUNITY_ID = "sfdc_community_id";
     private static final String SFDC_COMMUNITY_URL = "sfdc_community_url";
+    private static final String ID_TOKEN = "id_token";
     private static final String AND = "&";
     private static final String EQUAL = "=";
     private static final String QUESTION = "?";
@@ -440,6 +441,28 @@ public class OAuth2 {
     }
 
     /**
+     * Fetches an OpenID token from the Salesforce backend. This requires an OpenID token to be
+     * configured on the Salesforce connected app in the backend. It also requires the "openid"
+     * scope to be added on the client side through bootconfig and on the connected app.
+     *
+     * @param loginServer Login server.
+     * @param clientId Client ID.
+     * @param refreshToken Refresh token.
+     * @return OpenID token.
+     */
+    public static String getOpenIDToken(String loginServer, String clientId, String refreshToken) {
+        String idToken = null;
+        try {
+            final TokenEndpointResponse tr = refreshAuthToken(HttpAccess.DEFAULT,
+                    new URI(loginServer), clientId, refreshToken, null);
+            idToken = tr.idToken;
+        } catch (Exception e) {
+            SalesforceSDKLogger.e(TAG, "Exception thrown while fetching OpenID token", e);
+        }
+        return idToken;
+    }
+
+    /**
      * Exception thrown when the refresh flow fails.
      */
     public static class OAuthFailedException extends Exception {
@@ -585,6 +608,7 @@ public class OAuth2 {
         public String communityId;
         public String communityUrl;
         public Map<String, String> additionalOauthValues;
+        public String idToken;
 
         /**
          * Parameterized constructor built during login flow.
@@ -613,6 +637,7 @@ public class OAuth2 {
                         }
                     }
                 }
+                idToken = callbackUrlParams.get(ID_TOKEN);
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);
             }
@@ -654,6 +679,7 @@ public class OAuth2 {
                         }
                     }
                 }
+                idToken = parsedResponse.optString(ID_TOKEN);
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -302,8 +302,9 @@ public class OAuth2 {
      * @param codeVerifier Code verifier used by the SP to generate 'code_challenge'.
      * @param callbackUrl Callback URL.
      * @return Full set of credentials.
-     * @throws OAuthFailedException
-     * @throws IOException
+     *
+     * @throws OAuthFailedException See {@link OAuthFailedException}.
+     * @throws IOException See {@link IOException}.
      */
     public static TokenEndpointResponse getSPCredentials(HttpAccess httpAccessor, URI loginServer,
                                                          String clientId, String code, String codeVerifier,
@@ -329,8 +330,8 @@ public class OAuth2 {
      * @param addlParams Additional parameters.
      * @return Token response.
      *
-     * @throws OAuthFailedException
-     * @throws IOException
+     * @throws OAuthFailedException See {@link OAuthFailedException}.
+     * @throws IOException See {@link IOException}.
      */
     public static TokenEndpointResponse refreshAuthToken(HttpAccess httpAccessor, URI loginServer,
                                                          String clientId, String refreshToken,
@@ -355,9 +356,6 @@ public class OAuth2 {
      * @param httpAccessor HttpAccess instance.
      * @param loginServer Login server.
      * @param refreshToken Refresh token.
-     *
-     * @throws OAuthFailedException
-     * @throws IOException
      */
     public static void revokeRefreshToken(HttpAccess httpAccessor, URI loginServer, String refreshToken) {
         final StringBuilder sb = new StringBuilder(loginServer.toString());
@@ -381,8 +379,8 @@ public class OAuth2 {
      *                       the auth code was generated from.
      * @param jwt JWT issued by the OAuth authorization flow.
      *
-     * @throws IOException
-     * @throws OAuthFailedException
+     * @throws IOException See {@link IOException}.
+     * @throws OAuthFailedException See {@link OAuthFailedException}.
      */
     public static TokenEndpointResponse swapJWTForTokens(HttpAccess httpAccessor, URI loginServerUrl,
                                                          String jwt) throws IOException, OAuthFailedException {
@@ -400,7 +398,7 @@ public class OAuth2 {
      * @param authToken Access token.
      * @return IdServiceResponse instance.
      *
-     * @throws IOException
+     * @throws IOException See {@link IOException}.
      */
     public static final IdServiceResponse callIdentityService(HttpAccess httpAccessor,
                                                               String identityServiceIdUrl,

--- a/libs/test/SalesforceSDKTest/res/values/bootconfig.xml
+++ b/libs/test/SalesforceSDKTest/res/values/bootconfig.xml
@@ -6,6 +6,7 @@
     <string-array name="oauthScopes">
         <item>api</item>
         <item>web</item>
+        <item>openid</item>
     </string-array>
     <string name="androidPushNotificationClientId"></string>
     <string name="account_type">com.salesforce.androidsdk.salesforcesdktest.login</string>

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -28,9 +28,10 @@ package com.salesforce.androidsdk.auth;
 
 import android.app.Application;
 import android.app.Instrumentation;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.filters.SmallTest;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
@@ -77,7 +78,7 @@ public class OAuth2Test {
 	/**
 	 * Testing getAuthorizationUrl.
      *
-	 * @throws URISyntaxException
+	 * @throws URISyntaxException See {@link URISyntaxException}.
 	 */
     @Test
 	public void testGetAuthorizationUrl() throws URISyntaxException {
@@ -101,7 +102,7 @@ public class OAuth2Test {
 	/**
 	 * Testing getAuthorizationUrl with params.
      *
-	 * @throws URISyntaxException
+	 * @throws URISyntaxException See {@link URISyntaxException}.
 	 */
     @Test
 	public void testGetAuthorizationUrlWithParams() throws URISyntaxException {
@@ -120,7 +121,7 @@ public class OAuth2Test {
     /**
      * Testing getAuthorizationUrl with branded login path.
      *
-     * @throws URISyntaxException
+     * @throws URISyntaxException See {@link URISyntaxException}.
      */
     @Test
     public void testGetAuthorizationUrlWithBrandedLoginPath() throws URISyntaxException {
@@ -146,7 +147,7 @@ public class OAuth2Test {
     /**
      * Testing getAuthorizationUrl with branded login path with leading slash.
      *
-     * @throws URISyntaxException
+     * @throws URISyntaxException See {@link URISyntaxException}.
      */
     @Test
     public void testGetAuthorizationUrlWithBrandedLoginPathWithLeadingSlash() throws URISyntaxException {
@@ -172,7 +173,7 @@ public class OAuth2Test {
     /**
      * Testing getAuthorizationUrl with branded login path with trailing slash.
      *
-     * @throws URISyntaxException
+     * @throws URISyntaxException See {@link URISyntaxException}.
      */
     @Test
     public void testGetAuthorizationUrlWithBrandedLoginPathWithTrailingSlash() throws URISyntaxException {
@@ -218,7 +219,7 @@ public class OAuth2Test {
     /**
 	 * Testing getAuthorizationUrl with scopes.
      *
-	 * @throws URISyntaxException
+	 * @throws URISyntaxException See {@link URISyntaxException}.
 	 */
     @Test
 	public void testGetAuthorizationUrlWithScopes() throws URISyntaxException {
@@ -238,43 +239,39 @@ public class OAuth2Test {
 	
 	
 	/**
-	 * Testing refreshAuthToken.
-	 * 
-	 * Call refresh token, then try out the auth token by calling /services/data/vXX.
-	 * 
-	 * @throws IOException
-	 * @throws URISyntaxException 
-	 * @throws OAuthFailedException 
+	 * Testing refreshAuthToken. Call refresh token, then try out the auth token by calling /services/data/vXX.
+	 *
+	 * @throws IOException See {@link IOException}.
+	 * @throws URISyntaxException See {@link URISyntaxException}.
+	 * @throws OAuthFailedException See {@link OAuthFailedException}.
 	 */
     @Test
 	public void testRefreshAuthToken() throws IOException, OAuthFailedException, URISyntaxException {
 
-		// Get an auth token using the refresh token
+		// Get an auth token using the refresh token.
 		TokenEndpointResponse refreshResponse = OAuth2.refreshAuthToken(httpAccess,
 				new URI(TestCredentials.LOGIN_URL), TestCredentials.CLIENT_ID,
                 TestCredentials.REFRESH_TOKEN, null);
         Assert.assertNotNull("Auth token should not be null", refreshResponse.authToken);
-		
-		// Let's try it out
+
+		// Let's try it out.
 		Request request = new Request.Builder()
 				.addHeader("Content-Type", "application/json")
 				.addHeader("Authorization", "Bearer " + refreshResponse.authToken)
 				.url(TestCredentials.INSTANCE_URL + "/services/data/" + ApiVersionStrings.VERSION_NUMBER)
 				.get()
 				.build();
-
 		Response resourcesResponse = httpAccess.getOkHttpClient().newCall(request).execute();
         Assert.assertEquals("HTTP response status code should have been 200 (OK)", HttpURLConnection.HTTP_OK, resourcesResponse.code());
 	}
 	
 	/**
-	 * Testing callIdentityService.
-	 * 
-	 * Call refresh token then call out to identity service and check that username returned match the one in TestCredentials.
-	 * 
-	 * @throws IOException
-	 * @throws OAuthFailedException
-	 * @throws URISyntaxException
+	 * Testing callIdentityService. Call refresh token then call out to identity service and
+     * check that username returned match the one in TestCredentials.
+	 *
+	 * @throws IOException See {@link IOException}.
+	 * @throws OAuthFailedException See {@link OAuthFailedException}.
+	 * @throws URISyntaxException See {@link URISyntaxException}.
 	 */
     @Test
 	public void testCallIdentityService() throws IOException, OAuthFailedException, URISyntaxException {
@@ -291,6 +288,6 @@ public class OAuth2Test {
         Assert.assertEquals("Wrong username returned", TestCredentials.USERNAME, id.username);
         Assert.assertEquals("Wrong pinLength returned", -1, id.pinLength);
         Assert.assertEquals("Wrong screenLockTimeout returned", -1, id.screenLockTimeout);
-        Assert.assertEquals("Wrong biometricUnlockAllowed returned", true, id.biometricUnlockAlowed);
+        Assert.assertTrue("Wrong biometricUnlockAllowed returned", id.biometricUnlockAlowed);
 	}
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -290,4 +290,14 @@ public class OAuth2Test {
         Assert.assertEquals("Wrong screenLockTimeout returned", -1, id.screenLockTimeout);
         Assert.assertTrue("Wrong biometricUnlockAllowed returned", id.biometricUnlockAlowed);
 	}
+
+    /**
+     * Testing getOpenIDToken.
+     */
+	@Test
+	public void testGetOpenIDToken() {
+        final String openIdToken = OAuth2.getOpenIDToken(TestCredentials.LOGIN_URL,
+                TestCredentials.CLIENT_ID, TestCredentials.REFRESH_TOKEN);
+        Assert.assertNotNull("OpenID token should not be null", openIdToken);
+    }
 }


### PR DESCRIPTION
This PR adds a new API to fetch OpenID token. Using this API requires an OpenID token to be configured on the connected app. It also needs the "openid" scope to be added on the client and the server.