### PR TITLE
BatchSyncUpTarget was not handling local records without id properly

### DIFF
--- a/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/BatchSyncUpTarget.java
+++ b/libs/SmartSync/src/com/salesforce/androidsdk/smartsync/target/BatchSyncUpTarget.java
@@ -32,6 +32,7 @@ import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartsync.manager.SyncManager;
 import com.salesforce.androidsdk.smartsync.util.Constants;
 import com.salesforce.androidsdk.smartsync.util.SyncState;
+import com.salesforce.androidsdk.util.JSONObjectHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -115,7 +116,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
         LinkedHashMap<String, RestRequest> refIdToRequests = new LinkedHashMap<>();
         for (int i = 0; i < records.size(); i++) {
             JSONObject record = records.get(i);
-            String id = record.getString(getIdFieldName());
+            String id = JSONObjectHelper.optString(record, getIdFieldName());
 
             if (id == null) {
                 // create local id - needed for refId


### PR DESCRIPTION
That [change](https://github.com/forcedotcom/SalesforceMobileSDK-Android/commit/6b34b708b0b4bc8b05ffb5538c9fc32307bd2c9e#diff-2c642ba74807ad55b26b40af627a4d12R120) was not correct because JSONObject throws an exception if the key doesn't exist.