### PR TITLE
Flag to choose between query as string (default) and query as object …

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
@@ -91,6 +91,12 @@ public class SmartStorePlugin extends ForcePlugin {
 		return STORE_CURSORS.get(db);
 	}
 
+	private static boolean useQueryAsString = true;
+
+	protected static void setUseQueryAsString(boolean b) {
+		useQueryAsString = b;
+	}
+
 	/**
 	 * Supported plugin actions that the client can take.
 	 */
@@ -282,7 +288,7 @@ public class SmartStorePlugin extends ForcePlugin {
 		storeCursor.moveToPageIndex(index);
 
 		// Build json result
-		JSONObject result = storeCursor.getData(smartStore);
+		JSONObject result = useQueryAsString ? storeCursor.getDataSerialized(smartStore) : storeCursor.getDataDeserialized(smartStore);
 
 		// Done
 		callbackContext.success(result);
@@ -519,7 +525,7 @@ public class SmartStorePlugin extends ForcePlugin {
 		getSmartStoreCursors(smartStore).put(storeCursor.cursorId, storeCursor);
 
 		// Build json result
-		JSONObject result = storeCursor.getData(smartStore);
+		JSONObject result = useQueryAsString ? storeCursor.getDataSerialized(smartStore) : storeCursor.getDataDeserialized(smartStore);
 
 		// Done
 		callbackContext.success(result);

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
@@ -223,7 +223,7 @@ public class SmartStoreReactBridge extends ReactContextBaseJavaModule {
 		storeCursor.moveToPageIndex(index);
 
 		// Build json result
-		JSONObject result = storeCursor.getData(smartStore);
+		JSONObject result = storeCursor.getDataSerialized(smartStore);
 		ReactBridgeHelper.invoke(successCallback, result);
 	}
 
@@ -395,7 +395,7 @@ public class SmartStoreReactBridge extends ReactContextBaseJavaModule {
 		getSmartStoreCursors(smartStore).put(storeCursor.cursorId, storeCursor);
 
 		// Build json result
-		JSONObject result = storeCursor.getData(smartStore);
+		JSONObject result = storeCursor.getDataSerialized(smartStore);
 
 		// Done
         ReactBridgeHelper.invoke(successCallback, result);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/StoreCursor.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/StoreCursor.java
@@ -83,7 +83,7 @@ public class StoreCursor {
 	 * NB: json data is never deserialized
 	 * @param smartStore
 	 */
-	public FakeJSONObject getData(SmartStore smartStore) {
+	public FakeJSONObject getDataSerialized(SmartStore smartStore) {
 		StringBuilder resultBuilder = new StringBuilder();
 		resultBuilder.append("{")
 			.append("\"").append(CURSOR_ID).append("\":").append(cursorId).append(", ")
@@ -95,6 +95,21 @@ public class StoreCursor {
 		smartStore.queryAsString(resultBuilder, querySpec, currentPageIndex);
 		resultBuilder.append("}");
 		return new FakeJSONObject(resultBuilder.toString());
+	}
+
+	/**
+	 * Returns cursor meta data (page index, size etc) and data (entries in page) as a JSONObject
+	 * @param smartStore
+	 */
+	public JSONObject getDataDeserialized(SmartStore smartStore) throws JSONException {
+		JSONObject result = new JSONObject();
+		result.put(CURSOR_ID, cursorId);
+		result.put(CURRENT_PAGE_INDEX, currentPageIndex);
+		result.put(PAGE_SIZE, querySpec.pageSize);
+		result.put(TOTAL_ENTRIES, totalEntries);
+		result.put(TOTAL_PAGES, totalPages);
+		result.put(CURRENT_PAGE_ORDERED_ENTRIES, smartStore.query(querySpec, currentPageIndex));
+		return result;
 	}
 }
 


### PR DESCRIPTION
…in SmartStorePlugin

To mirror https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid/pull/108
Also added method on StoreCursor to use query as object (done on iOS in https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3049)