### PR TITLE
Replacing deprecated removeAccount() calls with removeAccountExplicitly

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -937,17 +937,12 @@ public class SalesforceSDKManager {
     					clientMgr.removeAccounts(accounts);
     				}
     				clientMgr.removeAccount(accounts[accounts.length - 1]);
-                    notifyLogoutComplete(showLoginPage);
-    			} else {
-    				notifyLogoutComplete(showLoginPage);
     			}
-    		} else {
-    			notifyLogoutComplete(showLoginPage);
     		}
     	} else {
     	    clientMgr.removeAccount(account);
-            notifyLogoutComplete(showLoginPage);
     	}
+        notifyLogoutComplete(showLoginPage);
     	isLoggingOut = false;
 
     	// Revokes the existing refresh token.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -28,8 +28,6 @@ package com.salesforce.androidsdk.app;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
-import android.accounts.AccountManagerCallback;
-import android.accounts.AccountManagerFuture;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
@@ -938,14 +936,8 @@ public class SalesforceSDKManager {
     				for (int i = 0; i < accounts.length - 1; i++) {
     					clientMgr.removeAccounts(accounts);
     				}
-    				clientMgr.removeAccountAsync(accounts[accounts.length - 1],
-    						new AccountManagerCallback<Boolean>() {
-
-    	    			@Override
-    	    			public void run(AccountManagerFuture<Boolean> arg0) {
-    	    				notifyLogoutComplete(showLoginPage);
-    	    			}
-    	    		});
+    				clientMgr.removeAccount(accounts[accounts.length - 1]);
+                    notifyLogoutComplete(showLoginPage);
     			} else {
     				notifyLogoutComplete(showLoginPage);
     			}
@@ -953,13 +945,8 @@ public class SalesforceSDKManager {
     			notifyLogoutComplete(showLoginPage);
     		}
     	} else {
-    		clientMgr.removeAccountAsync(account, new AccountManagerCallback<Boolean>() {
-
-    			@Override
-    			public void run(AccountManagerFuture<Boolean> arg0) {
-    				notifyLogoutComplete(showLoginPage);
-    			}
-    		});
+    	    clientMgr.removeAccount(account);
+            notifyLogoutComplete(showLoginPage);
     	}
     	isLoggingOut = false;
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -50,7 +50,6 @@ import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -284,15 +283,9 @@ public class ClientManager {
      * @param accounts The array of accounts to remove.
      */
     public void removeAccounts(Account[] accounts) {
-        List<AccountManagerFuture<Boolean>> removalFutures = new ArrayList<AccountManagerFuture<Boolean>>();
-        for (Account a : accounts) {
-            removalFutures.add(accountManager.removeAccount(a, null, null));
-        }
-        for (AccountManagerFuture<Boolean> f : removalFutures) {
-            try {
-                f.getResult();
-            } catch (Exception ex) {
-                SalesforceSDKLogger.w(TAG, "Exception removing old account", ex);
+        if (accounts != null && accounts.length > 0) {
+            for (final Account account : accounts) {
+                removeAccount(account);
             }
         }
     }
@@ -412,16 +405,13 @@ public class ClientManager {
     }
 
     /**
-     * Removes the user account from the account manager. This is an
-     * asynchronous process, the callback will be called on completion, if
-     * specified.
+     * Removes the user account from the account manager. This is safe to call from main thread.
      *
      * @param acc Account to be removed.
-     * @param callback The callback to call when the account removal completes.
      */
-    public void removeAccountAsync(Account acc, AccountManagerCallback<Boolean> callback) {
+    public void removeAccount(Account acc) {
         if (acc != null) {
-            accountManager.removeAccount(acc, callback, null);
+            accountManager.removeAccountExplicitly(acc);
         }
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
@@ -28,12 +28,14 @@ package com.salesforce.androidsdk.rest;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
-import android.accounts.AccountManagerCallback;
-import android.accounts.AccountManagerFuture;
 import android.app.Application;
 import android.app.Instrumentation;
 import android.content.Context;
 import android.os.Bundle;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
@@ -62,10 +64,6 @@ import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.MediumTest;
-import androidx.test.platform.app.InstrumentationRegistry;
 
 @RunWith(AndroidJUnit4.class)
 @MediumTest
@@ -462,10 +460,10 @@ public class ClientManagerTest {
     }
 
     /**
-     * Test removeAccountAsync
+     * Test removeAccount
      */
     @Test
-    public void testRemoveAccountAsync() throws Exception {
+    public void testRemoveAccount() throws Exception {
 
         // Make sure we have no accounts initially
         assertNoAccounts();
@@ -477,28 +475,11 @@ public class ClientManagerTest {
         Account[] accounts = clientManager.getAccounts();
         Assert.assertEquals("Two accounts should have been returned", 1, accounts.length);
 
-        // Call removeAccountAsync
-        final BlockingQueue<AccountManagerFuture<Boolean>> q = new ArrayBlockingQueue<AccountManagerFuture<Boolean>>(1);
-        clientManager.removeAccountAsync(clientManager.getAccount(), new AccountManagerCallback<Boolean>() {
+        // Call removeAccount
+        clientManager.removeAccount(clientManager.getAccount());
 
-            @Override
-            public void run(AccountManagerFuture<Boolean> future) {
-                q.add(future);
-            }
-        });
-
-        // Wait for removeAccountAsync to complete
-        try {
-            AccountManagerFuture<Boolean> f = q.poll(10L, TimeUnit.SECONDS);
-            Assert.assertNotNull("AccountManagerFuture expected", f);
-            Assert.assertTrue("Removal should have returned true", f.getResult());
-
-            // Make sure there are no accounts left
-            assertNoAccounts();
-
-        } catch (InterruptedException e) {
-            Assert.fail("removeAccountAsync did not return after 5s");
-        }
+        // Make sure there are no accounts left
+        assertNoAccounts();
     }
 
     /**


### PR DESCRIPTION
We have a custom `AuthenticatorService` that we use to interact with `AccountManager`. As a result, we use `addAccountExplicitly()` to add accounts to `AccountManager`. However, for removal, we use `removeAccount()`, instead of `removeAccountExplicitly()`. This is because `removeAccountExplicitly()` was introduced in `API 22`, and until this upcoming release, our minimum was `API 21`. Now, our minimum is `API 23`, and we can switch to this new, better-suited API for our account removal. Switching to `removeAccountExplicitly()` is required, because it fixes a bug in our code when `DISALLOW_MODIFY_ACCOUNTS` is set by an MDM provider. Basically, when this flag is set, it allows only programmatic addition and removal of accounts, i.e. through `addAccountExplicitly()` and `removeAccountExplicitly()`. In our case, addition works, but removal fails, leaving the user stuck unable to log out of the app. This PR fixes that bug. See [this doc](https://developer.android.com/reference/android/os/UserManager.html#DISALLOW_MODIFY_ACCOUNTS) for more information.