### PR TITLE
Fixing logout bug with multiple users

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -942,8 +942,8 @@ public class SalesforceSDKManager {
     	} else {
     	    clientMgr.removeAccount(account);
     	}
+        isLoggingOut = false;
         notifyLogoutComplete(showLoginPage);
-    	isLoggingOut = false;
 
     	// Revokes the existing refresh token.
         if (shouldLogoutWhenTokenRevoked() && refreshToken != null) {


### PR DESCRIPTION
We switched logout from async to sync. As a result, in the multi-user scenario, logging out from an account was causing issues. This is because we attempt to make a `peekRestClient()` call before `isLoggingOut` is reset indicating completion of logout. This fixes the sequence of resetting the flag before sending the intent that logout is complete.