### PR TITLE
Sync up can now provided a external id field name

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -67,20 +67,27 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
      * Construct SyncUpTarget
      */
     public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist) {
-        this(createFieldlist, updateFieldlist, MAX_SUB_REQUESTS_COMPOSITE_API);
+        this(createFieldlist, updateFieldlist, null, null, null, MAX_SUB_REQUESTS_COMPOSITE_API);
+    }
+
+    /**
+     * Construct SyncUpTarget with given id/modifiedDate/externalId fields
+     */
+    public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, String idFieldName, String modificationDateFieldName, String externalIdFieldName) {
+        this(createFieldlist, updateFieldlist, idFieldName, modificationDateFieldName, externalIdFieldName, MAX_SUB_REQUESTS_COMPOSITE_API);
     }
 
     /**
      * Construct SyncUpTarget with a different maxBatchSize (NB: cannot exceed MAX_SUB_REQUESTS_COMPOSITE_API)
      */
     public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, int maxBatchSize) {
-        this(createFieldlist, updateFieldlist, maxBatchSize, null, null, null);
+        this(createFieldlist, updateFieldlist, null, null, null, maxBatchSize);
     }
 
     /**
      * Construct BatchSyncUpTarget with a different maxBatchSize and id/modifiedDate/externalId fields
      */
-    public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, int maxBatchSize, String idFieldName, String modificationDateFieldName, String externalIdFieldName) {
+    public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, String idFieldName, String modificationDateFieldName, String externalIdFieldName, int maxBatchSize) {
         super(createFieldlist, updateFieldlist, idFieldName, modificationDateFieldName, externalIdFieldName);
         this.maxBatchSize = Math.min(maxBatchSize, MAX_SUB_REQUESTS_COMPOSITE_API); // composite api allows up to 25 subrequests
     }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -197,9 +197,10 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
             if (isCreate) {
                 fieldlist = this.createFieldlist != null ? this.createFieldlist : fieldlist;
                 fields = buildFieldsMap(record, fieldlist, getIdFieldName(), getModificationDateFieldName());
+                String externalId = getExternalIdFieldName() != null ? record.getString(getExternalIdFieldName()) : null;
 
-                if (getExternalIdFieldName() != null && fields.get(getExternalIdFieldName()) != null) {
-                    String externalId = (String) fields.get(getExternalIdFieldName());
+                // Do upsert if externalId specified
+                if (externalId != null) {
                     return RestRequest.getRequestForUpsert(apiVersion, objectType, getExternalIdFieldName(), externalId, fields);
                 }
                 // Do a create otherwise

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -197,7 +197,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
             if (isCreate) {
                 fieldlist = this.createFieldlist != null ? this.createFieldlist : fieldlist;
                 fields = buildFieldsMap(record, fieldlist, getIdFieldName(), getModificationDateFieldName());
-                String externalId = getExternalIdFieldName() != null ? record.getString(getExternalIdFieldName()) : null;
+                String externalId = getExternalIdFieldName() != null ? JSONObjectHelper.optString(record, getExternalIdFieldName()) : null;
 
                 // Do upsert if externalId specified
                 if (externalId != null) {

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -71,17 +71,17 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
     }
 
     /**
-     * Construct SyncUpTarget with given id/modifiedDate/externalId fields
-     */
-    public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, String idFieldName, String modificationDateFieldName, String externalIdFieldName) {
-        this(createFieldlist, updateFieldlist, idFieldName, modificationDateFieldName, externalIdFieldName, MAX_SUB_REQUESTS_COMPOSITE_API);
-    }
-
-    /**
      * Construct SyncUpTarget with a different maxBatchSize (NB: cannot exceed MAX_SUB_REQUESTS_COMPOSITE_API)
      */
     public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, int maxBatchSize) {
         this(createFieldlist, updateFieldlist, null, null, null, maxBatchSize);
+    }
+
+    /**
+     * Construct SyncUpTarget with given id/modifiedDate/externalId fields
+     */
+    public BatchSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, String idFieldName, String modificationDateFieldName, String externalIdFieldName) {
+        this(createFieldlist, updateFieldlist, idFieldName, modificationDateFieldName, externalIdFieldName, MAX_SUB_REQUESTS_COMPOSITE_API);
     }
 
     /**

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -26,11 +26,11 @@
  */
 package com.salesforce.androidsdk.mobilesync.target;
 
+import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
+import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
-import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
-import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 
 import org.json.JSONArray;
@@ -201,7 +201,7 @@ public class SyncUpTarget extends SyncTarget {
         fieldlist = this.createFieldlist != null ? this.createFieldlist : fieldlist;
         final String objectType = (String) SmartStore.project(record, Constants.SOBJECT_TYPE);
         final Map<String,Object> fields = buildFieldsMap(record, fieldlist, getIdFieldName(), getModificationDateFieldName());
-        final String externalId = externalIdFieldName != null ? record.getString(externalIdFieldName) : null;
+        final String externalId = externalIdFieldName != null ? JSONObjectHelper.optString(record, externalIdFieldName) : null;
         if (externalId != null) {
             return upsertOnServer(syncManager, objectType, fields, externalId);
         } else {

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -162,6 +162,13 @@ public class SyncUpTarget extends SyncTarget {
     }
 
     /**
+     * @return The field name of an external id field of the record.  Default to null.
+     */
+    public String getExternalIdFieldName() {
+        return externalIdFieldName;
+    }
+
+    /**
      * Save record with last error if any
      * @param syncManager
      * @param soupName

--- a/libs/test/MobileSyncTest/res/raw/usersyncs.json
+++ b/libs/test/MobileSyncTest/res/raw/usersyncs.json
@@ -128,6 +128,9 @@
       "syncType": "syncUp",
       "soupName": "accounts",
       "target": {
+        "idFieldName": "IdX",
+        "modificationDateFieldName": "LastModifiedDateX",
+        "externalIdFieldName": "ExternalIdX"
       },
       "options": {
         "fieldlist": ["Name", "Description"],

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
@@ -238,7 +238,7 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         SyncState sync = syncManager.getSyncStatus("batchSyncUp");
         Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
         checkStatus(sync, SyncState.Type.syncUp, sync.getId(),
-                new BatchSyncUpTarget(),
+                new BatchSyncUpTarget(null, null, BatchSyncUpTarget.MAX_SUB_REQUESTS_COMPOSITE_API, "IdX", "LastModifiedDateX", "ExternalIdX"),
                 SyncOptions.optionsForSyncUp(Arrays.asList(new String[]{"Name", "Description"}), MergeMode.OVERWRITE),
                 SyncState.Status.NEW, 0);
     }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
@@ -238,7 +238,7 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         SyncState sync = syncManager.getSyncStatus("batchSyncUp");
         Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
         checkStatus(sync, SyncState.Type.syncUp, sync.getId(),
-                new BatchSyncUpTarget(null, null, BatchSyncUpTarget.MAX_SUB_REQUESTS_COMPOSITE_API, "IdX", "LastModifiedDateX", "ExternalIdX"),
+                new BatchSyncUpTarget(null, null, "IdX", "LastModifiedDateX", "ExternalIdX", BatchSyncUpTarget.MAX_SUB_REQUESTS_COMPOSITE_API),
                 SyncOptions.optionsForSyncUp(Arrays.asList(new String[]{"Name", "Description"}), MergeMode.OVERWRITE),
                 SyncState.Status.NEW, 0);
     }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTargetTest.java
@@ -28,7 +28,7 @@
 package com.salesforce.androidsdk.mobilesync.target;
 
 import com.salesforce.androidsdk.mobilesync.util.Constants;
-import com.salesforce.androidsdk.mobilesync.util.SyncState;
+import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
 import com.salesforce.androidsdk.util.test.JSONTestHelper;
 
 import org.json.JSONArray;
@@ -53,8 +53,8 @@ import androidx.test.filters.SmallTest;
 public class BatchSyncUpTargetTest extends SyncUpTargetTest {
 
     @Override
-    protected void trySyncUp(int numberChanges, SyncState.MergeMode mergeMode, List<String> createFieldlist, List<String> updateFieldlist) throws JSONException {
-        trySyncUp(new BatchSyncUpTarget(createFieldlist, updateFieldlist, 2), numberChanges, mergeMode);
+    protected void trySyncUp(int numberChanges, SyncOptions options, List<String> createFieldlist, List<String> updateFieldlist, String externalIdFieldName) throws JSONException {
+        trySyncUp(new BatchSyncUpTarget(createFieldlist, updateFieldlist, null, null, externalIdFieldName), numberChanges, options, false);
     }
 
     @Test

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
@@ -301,7 +301,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         // Update Id field to match and existing id for record 1 and 2
         localRecord1.put(Constants.ID, id1);
         smartStore.upsert(ACCOUNTS_SOUP, localRecord1);
-        localRecord1.put(Constants.ID, id2);
+        localRecord2.put(Constants.ID, id2);
         smartStore.upsert(ACCOUNTS_SOUP, localRecord2);
 
         // Sync up with external id field name - NB: only syncing up name field not description

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
@@ -275,68 +275,6 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         trySyncUpWithLocallyCreatedRecords(SyncState.MergeMode.OVERWRITE);
     }
 
-    /**
-     * Create accounts locally but with external id field populated, sync up with external id field name provided, check smartstore and server afterwards
-     * @throws Exception
-     */
-    @Test
-    public void testSyncUpWithExternalId() throws Exception {
-        String externalIdFieldName = "Id";
-
-        // Creating 3 new names
-        String name1 = createRecordName(Constants.ACCOUNT);
-        String name2 = createRecordName(Constants.ACCOUNT);
-        String name3 = createRecordName(Constants.ACCOUNT);
-
-        // Get id of two records on the server
-        String[] allIds = idToFields.keySet().toArray(new String[0]);
-        Arrays.sort(allIds);
-        String id1 = allIds[0];
-        String id2 = allIds[1];
-
-        // Create accounts locally
-        JSONObject[] localAccounts = createAccountsLocally(new String[] { name1, name2, name3});
-        JSONObject localRecord1 = localAccounts[0];
-        JSONObject localRecord2 = localAccounts[1];
-        JSONObject localRecord3 = localAccounts[2];
-
-        // Update Id field to match and existing id for record 1 and 2
-        localRecord1.put(externalIdFieldName, id1);
-        smartStore.upsert(ACCOUNTS_SOUP, localRecord1);
-        localRecord2.put(externalIdFieldName, id2);
-        smartStore.upsert(ACCOUNTS_SOUP, localRecord2);
-        localRecord3.put(externalIdFieldName, null);
-        smartStore.upsert(ACCOUNTS_SOUP, localRecord3);
-
-        // Sync up with external id field name - NB: only syncing up name field not description
-        SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[]{Constants.NAME}));
-        trySyncUp(3, options, null, null, externalIdFieldName);
-
-        // Getting id for third record upserted - the one without an valid external id
-        String id3 = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{}, Constants.NAME, new String[] { name3 }).keySet().toArray(new String[0])[0];
-
-        // Expected records locally
-        Map<String, Map<String, Object>> expectedDbIdToFields = new HashMap<>();
-        expectedDbIdToFields.put(id1, createFieldsMapFromNameDescription(name1, localRecord1.getString(Constants.DESCRIPTION)));
-        expectedDbIdToFields.put(id2, createFieldsMapFromNameDescription(name2, localRecord2.getString(Constants.DESCRIPTION)));
-        expectedDbIdToFields.put(id3, createFieldsMapFromNameDescription(name3, localRecord3.getString(Constants.DESCRIPTION)));
-
-        // Check db
-        checkDbStateFlags(expectedDbIdToFields.keySet(), false, false, false, ACCOUNTS_SOUP);
-        checkDb(expectedDbIdToFields, ACCOUNTS_SOUP);
-
-        // Expected records on server
-        Map<String, Map<String, Object>> expectedServerIdToFields = new HashMap();
-        expectedServerIdToFields.put(id1, createFieldsMapFromNameDescription(name1, (String) idToFields.get(id1).get(Constants.DESCRIPTION)));
-        expectedServerIdToFields.put(id2, createFieldsMapFromNameDescription(name2, (String) idToFields.get(id2).get(Constants.DESCRIPTION)));
-        expectedServerIdToFields.put(id3, createFieldsMapFromNameDescription(name3, null));
-
-        // Check server
-        checkServer(expectedServerIdToFields, Constants.ACCOUNT);
-
-        // Adding to idToFields so that they get deleted in tearDown
-        idToFields.putAll(expectedServerIdToFields);
-    }
 
     /**
      * Create accounts locally, sync up with mege mode LEAVE_IF_CHANGED, check smartstore and server afterwards
@@ -628,6 +566,69 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
 
         // Adding to idToFields so that they get deleted in tearDown.
         idToFields.putAll(idToFieldsCreated);
+    }
+
+    /**
+     * Create accounts locally but with external id field populated, sync up with external id field name provided, check smartstore and server afterwards
+     * @throws Exception
+     */
+    @Test
+    public void testSyncUpWithExternalId() throws Exception {
+        String externalIdFieldName = "Id";
+
+        // Creating 3 new names
+        String name1 = createRecordName(Constants.ACCOUNT);
+        String name2 = createRecordName(Constants.ACCOUNT);
+        String name3 = createRecordName(Constants.ACCOUNT);
+
+        // Get id of two records on the server
+        String[] allIds = idToFields.keySet().toArray(new String[0]);
+        Arrays.sort(allIds);
+        String id1 = allIds[0];
+        String id2 = allIds[1];
+
+        // Create accounts locally
+        JSONObject[] localAccounts = createAccountsLocally(new String[] { name1, name2, name3});
+        JSONObject localRecord1 = localAccounts[0];
+        JSONObject localRecord2 = localAccounts[1];
+        JSONObject localRecord3 = localAccounts[2];
+
+        // Update Id field to match and existing id for record 1 and 2
+        localRecord1.put(externalIdFieldName, id1);
+        smartStore.upsert(ACCOUNTS_SOUP, localRecord1);
+        localRecord2.put(externalIdFieldName, id2);
+        smartStore.upsert(ACCOUNTS_SOUP, localRecord2);
+        localRecord3.put(externalIdFieldName, null);
+        smartStore.upsert(ACCOUNTS_SOUP, localRecord3);
+
+        // Sync up with external id field name - NB: only syncing up name field not description
+        SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[]{Constants.NAME}));
+        trySyncUp(3, options, null, null, externalIdFieldName);
+
+        // Getting id for third record upserted - the one without an valid external id
+        String id3 = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{}, Constants.NAME, new String[] { name3 }).keySet().toArray(new String[0])[0];
+
+        // Expected records locally
+        Map<String, Map<String, Object>> expectedDbIdToFields = new HashMap<>();
+        expectedDbIdToFields.put(id1, createFieldsMapFromNameDescription(name1, localRecord1.getString(Constants.DESCRIPTION)));
+        expectedDbIdToFields.put(id2, createFieldsMapFromNameDescription(name2, localRecord2.getString(Constants.DESCRIPTION)));
+        expectedDbIdToFields.put(id3, createFieldsMapFromNameDescription(name3, localRecord3.getString(Constants.DESCRIPTION)));
+
+        // Check db
+        checkDbStateFlags(expectedDbIdToFields.keySet(), false, false, false, ACCOUNTS_SOUP);
+        checkDb(expectedDbIdToFields, ACCOUNTS_SOUP);
+
+        // Expected records on server
+        Map<String, Map<String, Object>> expectedServerIdToFields = new HashMap();
+        expectedServerIdToFields.put(id1, createFieldsMapFromNameDescription(name1, (String) idToFields.get(id1).get(Constants.DESCRIPTION)));
+        expectedServerIdToFields.put(id2, createFieldsMapFromNameDescription(name2, (String) idToFields.get(id2).get(Constants.DESCRIPTION)));
+        expectedServerIdToFields.put(id3, createFieldsMapFromNameDescription(name3, null));
+
+        // Check server
+        checkServer(expectedServerIdToFields, Constants.ACCOUNT);
+
+        // Adding to idToFields so that they get deleted in tearDown
+        idToFields.putAll(expectedServerIdToFields);
     }
 
     /**

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
@@ -281,6 +281,8 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      */
     @Test
     public void testSyncUpWithExternalId() throws Exception {
+        String externalIdFieldName = "Id";
+
         // Creating 3 new names
         String name1 = createRecordName(Constants.ACCOUNT);
         String name2 = createRecordName(Constants.ACCOUNT);
@@ -299,14 +301,16 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         JSONObject localRecord3 = localAccounts[2];
 
         // Update Id field to match and existing id for record 1 and 2
-        localRecord1.put(Constants.ID, id1);
+        localRecord1.put(externalIdFieldName, id1);
         smartStore.upsert(ACCOUNTS_SOUP, localRecord1);
-        localRecord2.put(Constants.ID, id2);
+        localRecord2.put(externalIdFieldName, id2);
         smartStore.upsert(ACCOUNTS_SOUP, localRecord2);
+        localRecord3.put(externalIdFieldName, null);
+        smartStore.upsert(ACCOUNTS_SOUP, localRecord3);
 
         // Sync up with external id field name - NB: only syncing up name field not description
         SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[]{Constants.NAME}));
-        trySyncUp(3, options, null, null, Constants.ID);
+        trySyncUp(3, options, null, null, externalIdFieldName);
 
         // Getting id for third record upserted - the one without an valid external id
         String id3 = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{}, Constants.NAME, new String[] { name3 }).keySet().toArray(new String[0])[0];


### PR DESCRIPTION
Locally created records providing an external id are upserted during sync up.

* SyncUpTarget and BatchSyncUpTarget both support the new field
* Added test for SyncUpTarget and BatchSyncUpTarget 
* Using the new field in one of the example config and modified config test accordingly

NB:
* ParentChildrenSyncUpTarget does not support it (yet)
