### PR TITLE
Add Content-Type to non-binary parts when building request with fileParams

### DIFF
--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
@@ -197,14 +197,13 @@ public class SalesforceNetReactBridge extends ReactContextBaseJavaModule {
     }
 
     private static RequestBody buildRequestBody(Map<String, Object> params, Map<String, Map<String, String>> fileParams) throws URISyntaxException {
+        final RequestBody paramsRequestBody = RequestBody.create(RestRequest.MEDIA_TYPE_JSON, new JSONObject(params).toString());
         if (fileParams.isEmpty()) {
-            return RequestBody.create(RestRequest.MEDIA_TYPE_JSON, new JSONObject(params).toString());
+            return paramsRequestBody;
         } else {
             MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
-            for (Map.Entry<String, Object> entry : params.entrySet()) {
-                builder.addFormDataPart(entry.getKey(), entry.getValue().toString());
-            }
-
+            builder.addFormDataPart("", null, paramsRequestBody);
+            
             // File params expected to be of the form:
             // {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}
             for(Map.Entry<String, Map<String, String>> fileParamEntry : fileParams.entrySet()) {


### PR DESCRIPTION
I have playing around with the react-native sdk and just came accross the following.
When uploading a binary file using react native salesforce sdk with the following javascript code

```js
const fileParams = {
    VersionData: {
        fileMimeType: "image/jpeg",
        fileUrl: "file:///storage/emulated/0/DCIM/Camera/IMG_20191010_094041.jpg",
        fileName: "IMG_20191010_094041.jpg"
    }
};
const payload = {
    Title: "Testing file upload title",
    Description: "Testing file upload descripton ",
    PathOnClient: "IMG_20191010_094041.jpg",
}
const endPoint = "/services/data";
const path = '/v46.0/sobjects/ContentVersion/';
net.sendRequest(endPoint, path, (...args) => {
    console.log("Successfully inserted into ContentVersion!!");
    console.log(...args);
}, (...args) => {
    console.log("Failed to insert into ContentVersion!!");
    console.log(...args);
}, "POST", payload, null, fileParams);

```
, this is the request body sent over the wire

```
--1a5ec5d4-6d62-4e63-ab42-63b86c5e81c1
Content-Disposition: form-data; name="Description"
Content-Length: 31

Testing file upload descripton 
--1a5ec5d4-6d62-4e63-ab42-63b86c5e81c1
Content-Disposition: form-data; name="Title"
Content-Length: 25

Testing file upload title
--1a5ec5d4-6d62-4e63-ab42-63b86c5e81c1
Content-Disposition: form-data; name="PathOnClient"
Content-Length: 23

IMG_20191010_094041.jpg
--1a5ec5d4-6d62-4e63-ab42-63b86c5e81c1
Content-Disposition: form-data; name="VersionData"; filename="IMG_20191010_094041.jpg"
Content-Type: image/jpeg
Content-Length: 200714

<Binary Content>
```
**The non-binary parts don't include `Content-Type` and also the multipart message isn't quite formatted as mentioned here.**
https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_insert_update_blob.htm

You get the following response body with the above request
```
[ { message: 'Multipart message must include a non-binary part',
errorCode: 'INVALID_MULTIPART_REQUEST' } ]
```

This diff will add `Content-Type` to the non-binary part of the request as follows
```
 --7e26545d-7c63-44b5-905a-71d40b956d83
Content-Disposition: form-data; name=""
Content-Type: application/json; charset=utf-8
Content-Length: 126

{"Description":"Testing file upload descripton ","Title":"Testing file upload title","PathOnClient":"IMG_20191010_094041.jpg"}
--7e26545d-7c63-44b5-905a-71d40b956d83
Content-Disposition: form-data; name="VersionData"; filename="IMG_20191010_094041.jpg"
Content-Type: image/jpeg
Content-Length: 200714

<Binary Content>
```
And here is a sample response body with new changes
```
{ id: '0686g000000XP2QAAW', success: true, errors: [] }
```