### PR TITLE
Get communityId from UserAccount instance

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -176,7 +176,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
      * @return SmartStore instance.
      */
     public SmartStore getSmartStore(UserAccount account) {
-        return getSmartStore(account, null);
+        return getSmartStore(account, account.getCommunityId());
     }
 
     /**


### PR DESCRIPTION
Even if the logged in user is a community user, default userstore created by the following
call
```java
SalesforceReactSDKManager.getInstance().setupUserStoreFromDefaultConfig();
```
has a filename format of 
```
smartstore_{orgID}_{userID}_internal.db
```
This diff fixes the above so the filenames have the following format 
```
smartstore_{orgID}_{userID}_{communityID}.db
```
