### PR TITLE
Replacing Persistence Solution for Instrumentation Events with Paper

### DIFF
--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -14,8 +14,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 dependencies {
-    implementation 'com.squareup:tape:1.2.3'
-    implementation 'io.paperdb:paperdb:2.6'
+    api 'com.squareup:tape:1.2.3'
+    api 'io.paperdb:paperdb:2.6'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -14,7 +14,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 dependencies {
-    api 'com.squareup:tape:1.2.3'
+    implementation 'com.squareup:tape:1.2.3'
+    implementation 'io.paperdb:paperdb:2.6'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/FileLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/FileLogger.java
@@ -35,6 +35,7 @@ import com.squareup.tape.QueueFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,8 +47,6 @@ import java.util.List;
 public class FileLogger {
 
     private static final String LOG_SUFFIX = "_log";
-    private static final String UTF8 = "UTF-8";
-    private static final String ASCII = "US-ASCII";
     private static final String FILE_LOGGER_PREFS = "sf_file_logger_prefs";
     private static final String TAG = "FileLogger";
     private static final int MAX_SIZE = 10000;
@@ -74,10 +73,8 @@ public class FileLogger {
 
     /**
      * Flushes the log file and resets it to its original state.
-     *
-     * @throws IOException If the operation failed.
      */
-    public void flushLog() throws IOException {
+    public void flushLog() {
         try {
             file.clear();
         } catch (IOException e) {
@@ -129,7 +126,7 @@ public class FileLogger {
                 file.remove();
             }
             if (maxSize > 0) {
-                file.add(logLine.getBytes(UTF8));
+                file.add(logLine.getBytes(StandardCharsets.UTF_8));
             }
         } catch (Exception e) {
             Log.e(TAG, "Failed to write log line", e);
@@ -174,7 +171,7 @@ public class FileLogger {
         try {
             byte[] logLineBytes = file.peek();
             if (logLineBytes != null && logLineBytes.length > 0) {
-                logLine = new String(logLineBytes, ASCII);
+                logLine = new String(logLineBytes, StandardCharsets.US_ASCII);
             }
         } catch (IOException e) {
             Log.e(TAG, "Failed to read log line", e);

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/manager/AnalyticsManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/manager/AnalyticsManager.java
@@ -31,6 +31,8 @@ import android.content.Context;
 import com.salesforce.androidsdk.analytics.model.DeviceAppAttributes;
 import com.salesforce.androidsdk.analytics.store.EventStoreManager;
 
+import io.paperdb.Paper;
+
 /**
  * This class serves as an interface to the various
  * functions of the SalesforceAnalytics library.
@@ -53,6 +55,7 @@ public class AnalyticsManager {
      */
     public AnalyticsManager(String uniqueId, Context context, String encryptionKey,
                              DeviceAppAttributes deviceAppAttributes) {
+        Paper.init(context);
         storeManager = new EventStoreManager(uniqueId, context, encryptionKey);
         this.deviceAppAttributes = deviceAppAttributes;
         globalSequenceId = 0;

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
@@ -50,7 +50,7 @@ import io.paperdb.Paper;
  */
 public class EventStoreManager {
 
-    private static final String FILENAME = "Event_Store";
+    private static final String FILENAME = "event_store";
     private static final String TAG = "EventStoreManager";
 
     private Context context;

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
@@ -36,13 +36,11 @@ import com.salesforce.androidsdk.analytics.util.SalesforceAnalyticsLogger;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.List;
+
+import io.paperdb.Book;
+import io.paperdb.Paper;
 
 /**
  * Provides APIs to store events in an encrypted store on the filesystem.
@@ -52,13 +50,12 @@ import java.util.List;
  */
 public class EventStoreManager {
 
+    private static final String FILENAME = "Event_Store";
     private static final String TAG = "EventStoreManager";
 
-    private String filenameSuffix;
-    private File rootDir;
-    private EventFileFilter fileFilter;
     private Context context;
     private String encryptionKey;
+    private Book book;
     private boolean isLoggingEnabled = true;
     private int maxEvents = 1000;
 
@@ -71,11 +68,9 @@ public class EventStoreManager {
      * @param encryptionKey Encryption key (must be Base 64 encoded).
      */
     public EventStoreManager(String filenameSuffix, Context context, String encryptionKey) {
-        this.filenameSuffix = filenameSuffix;
         this.context = context;
         this.encryptionKey = encryptionKey;
-        fileFilter = new EventFileFilter(filenameSuffix);
-        rootDir = context.getFilesDir();
+        book = Paper.bookOn(context.getFilesDir().getAbsolutePath(), FILENAME + filenameSuffix);
     }
 
     /**
@@ -92,15 +87,7 @@ public class EventStoreManager {
         if (!shouldStoreEvent()) {
             return;
         }
-        final String filename = event.getEventId() + filenameSuffix;
-        FileOutputStream outputStream;
-        try {
-            outputStream = context.openFileOutput(filename, Context.MODE_PRIVATE);
-            outputStream.write(encrypt(event.toJson().toString()).getBytes());
-            outputStream.close();
-        } catch (Exception e) {
-            SalesforceAnalyticsLogger.e(context, TAG, "Exception occurred while saving event to filesystem", e);
-        }
+        book.write(event.getEventId(), encrypt(event.toJson().toString()));
     }
 
     /**
@@ -132,9 +119,20 @@ public class EventStoreManager {
             SalesforceAnalyticsLogger.e(context, TAG, "Invalid event ID supplied: " + eventId);
             return null;
         }
-        final String filename = eventId + filenameSuffix;
-        final File file = new File(rootDir, filename);
-        return fetchEvent(file);
+        InstrumentationEvent event = null;
+        final String encryptedEvent = book.read(eventId, null);
+        if (!TextUtils.isEmpty(encryptedEvent)) {
+            final String decryptedEvent = decrypt(encryptedEvent);
+            if (!TextUtils.isEmpty(decryptedEvent)) {
+                try {
+                    final JSONObject jsonObject = new JSONObject(decryptedEvent);
+                    event = new InstrumentationEvent(jsonObject);
+                } catch (JSONException e) {
+                    SalesforceAnalyticsLogger.e(context, TAG, "Exception occurred while attempting to convert to JSON", e);
+                }
+            }
+        }
+        return event;
     }
 
     /**
@@ -143,10 +141,10 @@ public class EventStoreManager {
      * @return List of events.
      */
     public List<InstrumentationEvent> fetchAllEvents() {
-        final List<File> files = getAllFiles();
+        final List<String> eventIds = book.getAllKeys();
         final List<InstrumentationEvent> events = new ArrayList<>();
-        for (final File file : files) {
-            final InstrumentationEvent event = fetchEvent(file);
+        for (final String eventId : eventIds) {
+            final InstrumentationEvent event = fetchEvent(eventId);
             if (event != null) {
                 events.add(event);
             }
@@ -158,16 +156,9 @@ public class EventStoreManager {
      * Deletes a specific event stored on the filesystem.
      *
      * @param eventId Unique identifier for the event.
-     * @return True - if successful, False - otherwise.
      */
-    public boolean deleteEvent(String eventId) {
-        if (TextUtils.isEmpty(eventId)) {
-            SalesforceAnalyticsLogger.e(context, TAG, "Invalid event ID supplied: " + eventId);
-            return false;
-        }
-        final String filename = eventId + filenameSuffix;
-        final File file = new File(rootDir, filename);
-        return file.delete();
+    public void deleteEvent(String eventId) {
+        book.delete(eventId);
     }
 
     /**
@@ -187,10 +178,7 @@ public class EventStoreManager {
      * Deletes all the events stored on the filesystem for that unique identifier.
      */
     public void deleteAllEvents() {
-        final List<File> files = getAllFiles();
-        for (final File file : files) {
-            file.delete();
-        }
+        book.destroy();
     }
 
     /**
@@ -236,64 +224,11 @@ public class EventStoreManager {
      * @return Number of stored events.
      */
     public int getNumStoredEvents() {
-        int numFiles = 0;
-        final File[] listOfFiles = rootDir.listFiles();
-        if (listOfFiles != null) {
-            numFiles = listOfFiles.length;
-        }
-        return numFiles;
+        return book.getAllKeys().size();
     }
 
     private boolean shouldStoreEvent() {
-        final List<File> files = getAllFiles();
-        int fileCount = 0;
-        if (files != null) {
-            fileCount = files.size();
-        }
-        return (isLoggingEnabled && (fileCount < maxEvents));
-    }
-
-    private InstrumentationEvent fetchEvent(File file) {
-        if (file == null || !file.exists()) {
-            SalesforceAnalyticsLogger.e(context, TAG, "File does not exist");
-            return null;
-        }
-        InstrumentationEvent event = null;
-        String eventString = null;
-        final StringBuilder json = new StringBuilder();
-        try {
-            final BufferedReader br = new BufferedReader(new FileReader(file));
-            String line;
-            while ((line = br.readLine()) != null) {
-                json.append(line).append('\n');
-            }
-            br.close();
-            eventString = decrypt(json.toString());
-        } catch (Exception ex) {
-            SalesforceAnalyticsLogger.e(context, TAG, "Exception occurred while attempting to read file contents", ex);
-        }
-        if (!TextUtils.isEmpty(eventString)) {
-            try {
-                final JSONObject jsonObject = new JSONObject(eventString);
-                event = new InstrumentationEvent(jsonObject);
-            } catch (JSONException e) {
-                SalesforceAnalyticsLogger.e(context, TAG, "Exception occurred while attempting to convert to JSON", e);
-            }
-        }
-        return event;
-    }
-
-    private List<File> getAllFiles() {
-        final List<File> files = new ArrayList<>();
-        final File[] listOfFiles = rootDir.listFiles();
-        if (listOfFiles != null) {
-            for (final File file : listOfFiles) {
-                if (file != null && fileFilter.accept(rootDir, file.getName())) {
-                    files.add(file);
-                }
-            }
-        }
-        return files;
+        return (isLoggingEnabled && (getNumStoredEvents() < maxEvents));
     }
 
     private String encrypt(String data) {
@@ -302,29 +237,5 @@ public class EventStoreManager {
 
     private String decrypt(String data) {
         return Encryptor.decrypt(data, encryptionKey);
-    }
-
-    /**
-     * This class acts as a filter to identify only the relevant event files.
-     *
-     * @author bhariharan
-     */
-    private static class EventFileFilter implements FilenameFilter {
-
-        private String fileSuffix;
-
-        /**
-         * Parameterized constructor.
-         *
-         * @param fileSuffix Filename suffix.
-         */
-        EventFileFilter(String fileSuffix) {
-            this.fileSuffix = fileSuffix;
-        }
-
-        @Override
-        public boolean accept(File dir, String filename) {
-            return (filename != null && filename.endsWith(fileSuffix));
-        }
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -95,6 +95,8 @@ import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
 
+import io.paperdb.Paper;
+
 /**
  * This class serves as an interface to the various
  * functions of the Salesforce SDK. In order to use the SDK,
@@ -356,6 +358,7 @@ public class SalesforceSDKManager {
 	 * @param context Application context.
 	 */
     public static void initInternal(Context context) {
+        Paper.init(context);
 
         // Upgrades to the latest version.
         SalesforceSDKUpgradeManager.getInstance().upgrade();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -95,8 +95,6 @@ import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
 
-import io.paperdb.Paper;
-
 /**
  * This class serves as an interface to the various
  * functions of the Salesforce SDK. In order to use the SDK,
@@ -358,7 +356,6 @@ public class SalesforceSDKManager {
 	 * @param context Application context.
 	 */
     public static void initInternal(Context context) {
-        Paper.init(context);
 
         // Upgrades to the latest version.
         SalesforceSDKUpgradeManager.getInstance().upgrade();


### PR DESCRIPTION
- Currently, a single instrumentation event is stored in a single file. As a result, each write creates a new file, and in order to check if max limit of events has been reached, we look up the number of files created.
- As the number of events increases, this approach isn't the best. What we need is a simple key-value store that is fast.
- [Paper](https://github.com/pilgr/Paper) is an open source library that offers this functionality.
- I replaced the existing implementation using `Paper` instead.
- <b>Good news:</b> no public APIs were broken as part of this exercise, so we aren't breaking `semver`.
- Only the internals of reads and writes have been updated.