### PR TITLE
Increasing max events for AILTN

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
@@ -57,7 +57,7 @@ public class EventStoreManager {
     private String encryptionKey;
     private Book book;
     private boolean isLoggingEnabled = true;
-    private int maxEvents = 1000;
+    private int maxEvents = 10000;
 
     /**
      * Parameterized constructor.


### PR DESCRIPTION
Increasing max events to `10000`, now that we have `Paper` to store them instead of individual files.