### PR TITLE
Encrypting output stream and decrypting input stream classes

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/DecrypterInputStream.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/DecrypterInputStream.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2020-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.androidsdk.analytics.security;
+
+import android.util.Base64;
+import com.salesforce.androidsdk.analytics.util.WatchableStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/** Input stream that decrypts content written with a EncrypterOutputStream */
+public class DecrypterInputStream extends InputStream implements WatchableStream {
+
+    private static final String PREFER_CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
+
+    private InputStream cipherInputStream;
+    private List<Watcher> watchers;
+
+    public DecrypterInputStream(FileInputStream inputStream, String encryptionKey)
+            throws GeneralSecurityException, IOException {
+
+        byte[] iv = new byte[16];
+        inputStream.read(iv);
+        Cipher cipher = getCipher(encryptionKey, Cipher.DECRYPT_MODE, iv);
+        cipherInputStream = new CipherInputStream(inputStream, cipher);
+        watchers = new ArrayList<>();
+    }
+
+    public static Cipher getCipher(String encryptionKey, int mode, byte[] iv)
+            throws GeneralSecurityException {
+        final Cipher cipher = Cipher.getInstance(PREFER_CIPHER_TRANSFORMATION);
+        final byte[] keyBytes = Base64.decode(encryptionKey, Base64.DEFAULT);
+        final SecretKeySpec keySpec = new SecretKeySpec(keyBytes, cipher.getAlgorithm());
+        final IvParameterSpec ivSpec = new IvParameterSpec(iv);
+        cipher.init(mode, keySpec, ivSpec);
+        return cipher;
+    }
+
+    public DecrypterInputStream() {
+        throw new IllegalArgumentException("Constructor not supported");
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return cipherInputStream.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return cipherInputStream.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return cipherInputStream.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return cipherInputStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!watchers.isEmpty()) {
+            for (Watcher watcher : watchers) {
+                watcher.onClose();
+            }
+        }
+        cipherInputStream.close();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        cipherInputStream.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        cipherInputStream.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return cipherInputStream.markSupported();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return cipherInputStream.read();
+    }
+
+    public void addWatcher(Watcher watcher) {
+        this.watchers.add(watcher);
+    }
+}

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/EncrypterOutputStream.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/EncrypterOutputStream.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.androidsdk.analytics.security;
+
+import com.salesforce.androidsdk.analytics.util.WatchableStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import javax.crypto.Cipher;
+import javax.crypto.CipherOutputStream;
+
+/** Output stream that encrypts content - can be read back with a DecrypterInputStream */
+public class EncrypterOutputStream extends OutputStream implements WatchableStream {
+
+    private static final String SHA1PRNG = "SHA1PRNG";
+
+    private OutputStream cipherOutputStream;
+    private List<Watcher> watchers;
+
+    public EncrypterOutputStream(FileOutputStream outputStream, String encryptionKey)
+            throws GeneralSecurityException, IOException {
+        final Cipher cipher =
+                DecrypterInputStream.getCipher(
+                        encryptionKey, Cipher.ENCRYPT_MODE, generateInitVector());
+        outputStream.write(cipher.getIV());
+        cipherOutputStream = new CipherOutputStream(outputStream, cipher);
+        watchers = new ArrayList<>();
+    }
+
+    private static byte[] generateInitVector() throws NoSuchAlgorithmException {
+        final SecureRandom random = SecureRandom.getInstance(SHA1PRNG);
+        byte[] iv = new byte[16];
+        random.nextBytes(iv);
+        return iv;
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        cipherOutputStream.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        cipherOutputStream.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        cipherOutputStream.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!watchers.isEmpty()) {
+            for (Watcher watcher : watchers) {
+                watcher.onClose();
+            }
+        }
+        cipherOutputStream.close();
+    }
+
+    @Override
+    public void write(int i) throws IOException {
+        cipherOutputStream.write(i);
+    }
+
+    public void addWatcher(Watcher watcher) {
+        this.watchers.add(watcher);
+    }
+}

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/util/WatchableStream.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/util/WatchableStream.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.androidsdk.analytics.util;
+
+/** Interface for stream that can be watched (on close etc) */
+public interface WatchableStream {
+
+    void addWatcher(Watcher watcher);
+
+    interface Watcher {
+        void onClose();
+    }
+}

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncrypterStreamTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncrypterStreamTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2020-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.androidsdk.analytics.security;
+
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import java.io.BufferedReader;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for {@link EncrypterOutputStream} and {@link DecrypterInputStream}
+ *
+ */
+@RunWith(AndroidJUnit4.class)
+public class EncrypterStreamTest {
+
+    private static final String TEST_FILE = "encrypter_stream_test_file";
+
+    private Context context;
+    private String encryptionKey;
+
+    @Before
+    public void setUp() throws Exception {
+        encryptionKey = Encryptor.hash("test-key", "hashing-key");
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        context.deleteFile(TEST_FILE);
+    }
+
+    /**
+     * Write an encrypted file using EncrypterOutputStream and read it back using
+     * DecrypterInputStream
+     */
+    @Test
+    public void testWriteAndReadThroughStream() {
+        String contentToWrite = "testWriteAndReadThroughStream";
+        writeThroughStream(contentToWrite);
+        String readContent = readThroughStream();
+        Assert.assertEquals(contentToWrite, readContent);
+    }
+
+    /**
+     * Write an encrypted file using Encryptor.encrypt and a FileOutputStream and read it back using
+     * DecrypterInputStream
+     *
+     * <p>Note: won't work because Encryptor.encrypt base-64 encodes content
+     */
+    // @Test
+    public void testWriteWithEncryptorAndReadThroughStream() {
+        String contentToWrite = "testWriteWithEncryptorAndReadThroughStream";
+        writeWithEncryptor(contentToWrite);
+        String readContent = readThroughStream();
+        Assert.assertEquals(contentToWrite, readContent);
+    }
+
+    /**
+     * Test that writes an encrypted file using EncrypterOutputStream and reads it back using
+     * FileInputStream and Encryptor.decrypt
+     *
+     * <p>Note: won't work because Encryptor.decrypt expect the encrypted content base 64 encoded
+     */
+    // @Test
+    public void testWriteThroughStreamAndReadWithEncryptor() {
+        String contentToWrite = "testWriteThroughStreamAndReadWithEncryptor";
+        writeThroughStream(contentToWrite);
+        String readContent = readWithEncryptor();
+        Assert.assertEquals(contentToWrite, readContent);
+    }
+
+    /**
+     * Test that writes an encrypted file using using Encryptor.encrypt and a FileOutputStream and
+     * reads it back using FileInputStream and Encryptor.decrypt
+     */
+    @Test
+    public void testWriteAndReadWithEncryptor() {
+        String contentToWrite = "testWriteAndReadWithEncryptor";
+        writeWithEncryptor(contentToWrite);
+        String readContent = readWithEncryptor();
+        Assert.assertEquals(contentToWrite, readContent);
+    }
+
+    /**
+     * Helper method to write an encrypted file using EncrypterOutputStream
+     *
+     * @param content
+     */
+    private void writeThroughStream(String content) {
+        try (FileOutputStream f = context.openFileOutput(TEST_FILE, Context.MODE_PRIVATE);
+                EncrypterOutputStream outputStream =
+                        new EncrypterOutputStream(f, encryptionKey); ) {
+
+            outputStream.write(content.getBytes(StandardCharsets.UTF_8));
+
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Helper method to read an encrypted file using DecrypterInputStream
+     *
+     * @return content of file as string
+     */
+    private String readThroughStream() {
+        try (FileInputStream f = context.openFileInput(TEST_FILE);
+                DecrypterInputStream i = new DecrypterInputStream(f, encryptionKey); ) {
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(i));
+            StringBuilder out = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                out.append(line);
+            }
+            return out.toString();
+
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Helper method to write an encrypted file using a FileOutputStream and Encryptor.encrypt
+     *
+     * @param content
+     */
+    private void writeWithEncryptor(String content) {
+        try (FileOutputStream outputStream =
+                context.openFileOutput(TEST_FILE, Context.MODE_PRIVATE)) {
+            String encryptedString = Encryptor.encrypt(content, encryptionKey);
+            outputStream.write(encryptedString.getBytes(StandardCharsets.UTF_8));
+
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * Helper method to read an encrypted file using a FileInputStream and Encryptor.decrypt
+     *
+     * @return content of file as string
+     */
+    private String readWithEncryptor() {
+        File file = new File(context.getFilesDir(), TEST_FILE);
+        try (FileInputStream f = new FileInputStream(file);
+                DataInputStream dataInputStream = new DataInputStream(f); ) {
+
+            byte[] bytes = new byte[(int) file.length()];
+            dataInputStream.readFully(bytes);
+            return Encryptor.decrypt(bytes, encryptionKey);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
New classes for the `SalesforceAnalytics` library
* `EncrypterOutputStream`: stream to write an encrypted file 
* `DecrypterInputStream`: stream to read an encrypted file 
* `WatchableStream`: interface for streams that can be watched (e.g. when close), useful for instance to time operations when the stream is being read by code outside the sdk

Also added test suite `EncrypterStreamTest`.
NB: Unfortunately encrypted files created the "old" way (using `Encryptor`) cannot be read using a `DecrypterInputStream` because Encryptor base 64 encodes the encrypted bytes. It would be nice to switch to the stream classes for all our encrypted files needs (e.g. external storage for `smartstore`) - for that we need migration code.