### PR TITLE
Allowed customization of the unauthenticated start page used by SalesforceDroidGapActivity

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -225,7 +225,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                 // Remote
                 else {
                     SalesforceHybridLogger.w(TAG, "onResumeNotLoggedIn - should not authenticate/remote start page - loading web app");
-                    loadRemoteStartPage(bootconfig.getUnauthenticatedStartPage(), false);
+                    loadRemoteStartPage(getUnauthenticatedStartPage(), false);
                 }
             }
         } catch (BootConfig.BootConfigException e) {
@@ -306,6 +306,15 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
      */
     public BootConfig getBootConfig() {
         return bootconfig;
+    }
+
+    /**
+     * Returns the unauthenticated start page from BootConfig.
+     *
+     * @return The unauthenticated start page
+     */
+    protected String getUnauthenticatedStartPage() {
+        return bootconfig.getUnauthenticatedStartPage();
     }
 
     /**


### PR DESCRIPTION
This PR allows subclasses of `SalesforceDroidGapActivity` to override the unauthenticated URL passed to Cordova at runtime. If this method is not overridden, the default value from `BootConfig` is still used for backwards compatibility.

This is the only usage of `unauthenticatedStartPage` in the SDK, so synchronization of the value with `BootConfig` itself shouldn't be needed.