### PR TITLE
Deprecating 'shouldRefreshOn403' for Removal in 9.0

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -684,6 +684,7 @@ public class RestClient {
          * Returns whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
          *
          * @return True - if the SDK should refresh on HTTP 403, False - otherwise.
+		 * @deprecated Will be removed in Mobile SDK 9.0.
          */
         public boolean getShouldRefreshOn403() {
             return shouldRefreshOn403;
@@ -693,6 +694,7 @@ public class RestClient {
          * Sets whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
          *
          * @param shouldRefreshOn403 True - if the SDK should refresh on HTTP 403, False - otherwise.
+		 * @deprecated Will be removed in Mobile SDK 9.0.
          */
         public synchronized void setShouldRefreshOn403(boolean shouldRefreshOn403) {
             this.shouldRefreshOn403 = shouldRefreshOn403;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -343,6 +343,7 @@ public class RestRequest {
      * Returns whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
      *
      * @return True - if the SDK should refresh on HTTP 403, False - otherwise.
+	 * @deprecated Will be removed in Mobile SDK 9.0.
      */
 	public boolean getShouldRefreshOn403() {
 	    return shouldRefreshOn403;
@@ -352,6 +353,7 @@ public class RestRequest {
      * Sets whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
      *
      * @param shouldRefreshOn403 True - if the SDK should refresh on HTTP 403, False - otherwise.
+	 * @deprecated Will be removed in Mobile SDK 9.0.
      */
 	public synchronized void setShouldRefreshOn403(boolean shouldRefreshOn403) {
         this.shouldRefreshOn403 = shouldRefreshOn403;


### PR DESCRIPTION
This parameter was added to support legacy org migration/split use cases on certain specific APIs. This doesn't apply anymore, and there are more legitimate use cases where this needs to be turned off. The SDK should only refresh on `401` going forward - that's the only legitimate refresh flow now.