### PR TITLE
Fixing a bug where base URL should not be replaced if it's not instance URL

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -203,7 +203,7 @@ public class RestRequest {
      * @param additionalHttpHeaders Additional headers.
      *
      */
-    public RestRequest(RestMethod method, String path,  Map<String, String> additionalHttpHeaders) {
+    public RestRequest(RestMethod method, String path, Map<String, String> additionalHttpHeaders) {
         this(method, path, (RequestBody) null, additionalHttpHeaders);
     }
 
@@ -257,7 +257,7 @@ public class RestRequest {
      *
      * Note: Use this constructor if requestBody is not null and you want to build a batch or composite request.
      */
-    public RestRequest(RestMethod method, String path, JSONObject requestBodyAsJson,  Map<String, String> additionalHttpHeaders) {
+    public RestRequest(RestMethod method, String path, JSONObject requestBodyAsJson, Map<String, String> additionalHttpHeaders) {
         this(method, RestEndpoint.INSTANCE, path, requestBodyAsJson, additionalHttpHeaders);
     }
 


### PR DESCRIPTION
Currently, a `RestRequest` can be built with either `LOGIN` or `INSTANCE` as the base URL. However, it's possible to construct your own `Request` and add `OAuthRefreshInterceptor` while making that request using `OkHttpClient`. Now, in this case, the request could have any base URL, but in the case of instance split, we will automatically change the base URL to the new instance URL, and this will cause the request to fail. `Trailhead GO` was running into this issue with one of their `Heroku` APIs. So, to summarize, we need a check before we swap out the underlying base URL - we should do this only if the existing base URL is `instanceUrl` and if it has changed.

Testing:
- Tested with base URL as `instanceUrl` - `isHostInstanceUrl` was `true` as expected.
- Tested with base URL as a different URL (like `loginUrl`) - `isHostInstanceUrl` was `false` as expected.
- Not adding automation around this because:
    - Anything refresh-related is messy.
    - I have plans for more refactoring in this area in the future.