### PR TITLE
Adding new API for an easy way to refresh and persist auth tokens

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -544,7 +544,7 @@ public class ClientManager {
 
     /**
      * AuthTokenProvider implementation that calls out to the AccountManager to get a new access token.
-     * The AccountManager calls ForceAuthenticatorService to do the actual refresh.
+     * The AccountManager calls AuthenticatorService to do the actual refresh.
      * @see AuthenticatorService
      */
     public static class AccMgrAuthTokenProvider implements RestClient.AuthTokenProvider {


### PR DESCRIPTION
Currently, there's an easy way to refresh tokens from the server, but no single API that does the refresh and handles persisting the new token as well. This adds a convenient way of refreshing and persisting the response. This is useful for apps like `Trailhead GO` that make their own requests using `OkHttpClient`, but need an easy way to refresh tokens in the SDK.