### PR TITLE
Adding auth providers in addition to SAML providers to list of SSO domains

### DIFF
--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -26,12 +26,12 @@
  */
 package com.salesforce.androidsdk.util;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.SmallTest;
 
 /**
  * Tests for AuthConfigUtil.
@@ -75,16 +75,7 @@ public class AuthConfigUtilTest {
         Assert.assertNotNull("Auth config should not be null", authConfig);
         Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
         Assert.assertNotNull("SSO URLs should not be null", authConfig.getSsoUrls());
-        Assert.assertTrue("SSO URLs should have at least 1 valid entry",
-                authConfig.getSsoUrls().size() >= 1);
-    }
-
-    @Test
-    public void testGetNoSSOUrls() {
-        final AuthConfigUtil.MyDomainAuthConfig authConfig = AuthConfigUtil.getMyDomainAuthConfig(MY_DOMAIN_ENDPOINT);
-        Assert.assertNotNull("Auth config should not be null", authConfig);
-        Assert.assertNotNull("Auth config JSON should not be null", authConfig.getAuthConfig());
-        Assert.assertNull("SSO URLs should be null", authConfig.getSsoUrls());
+        Assert.assertEquals("SSO URLs should have 3 valid entries", 3, authConfig.getSsoUrls().size());
     }
 
     @Test


### PR DESCRIPTION
SSO URLs can be configured as SAML providers or auth providers on the Salesforce backend. Currently, we're only fetching the list of SAML providers, but social login is configured through auth providers, such as Facebook, Google, Apple, etc. These should be a part of the SSO URLs list as well to handle all cases.