### PR TITLE
Replacing stream encryption/decryption with in-memory solution

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/DecrypterInputStream.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/DecrypterInputStream.java
@@ -28,12 +28,14 @@
 package com.salesforce.androidsdk.analytics.security;
 
 import com.salesforce.androidsdk.analytics.util.WatchableStream;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 
@@ -47,7 +49,9 @@ public class DecrypterInputStream extends InputStream implements WatchableStream
             throws GeneralSecurityException, IOException {
         // First byte should be iv length
         int ivLength = inputStream.read();
-        if (ivLength != 12 && ivLength != 32) {
+
+        // IV length is always 12 for AES-GCM-256.
+        if (ivLength != 12) {
             throw new IOException("Can't decrypt file: incorrect iv length found in file: " + ivLength);
         }
         // Next bytes should be iv

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -211,6 +211,30 @@ public class Encryptor {
     }
 
     /**
+     * Decrypts data with key using using AES/GCM/NoPadding. The data is not Base64 encoded.
+     *
+     * @param data Data.
+     * @param key Key.
+     * @return Decrypted data.
+     */
+    public static byte[] decryptWithoutBase64Encoding(byte[] data, String key) {
+        if (TextUtils.isEmpty(key)) {
+            return data;
+        }
+        try {
+
+            // Decodes with Base64.
+            byte[] keyBytes = Base64.decode(key, Base64.DEFAULT);
+
+            // Decrypts with AES.
+            return decrypt(data, data.length, keyBytes, new byte[12]);
+        } catch (Exception ex) {
+            SalesforceAnalyticsLogger.w(null, TAG, "Error during decryption", ex);
+        }
+        return null;
+    }
+
+    /**
      * Encrypts data with key using AES/GCM/NoPadding.
      *
      * @param data Data.
@@ -290,6 +314,28 @@ public class Encryptor {
             byte[] keyBytes = Base64.decode(key, Base64.DEFAULT);
             byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
             return Base64.encode(encrypt(dataBytes, keyBytes, iv), Base64.DEFAULT);
+        } catch (Exception ex) {
+            SalesforceAnalyticsLogger.w(null, TAG, "Error during encryption", ex);
+        }
+        return null;
+    }
+
+    /**
+     * Encrypts data with key using AES/GCM/NoPadding. The data is not Base64 encoded.
+     *
+     * @param data Data.
+     * @param key Key.
+     * @return Encrypted data.
+     */
+    public static byte[] encryptWithoutBase64Encoding(byte[] data, String key) {
+        if (TextUtils.isEmpty(key)) {
+            return data;
+        }
+        try {
+
+            // Encrypts with our preferred cipher.
+            byte[] keyBytes = Base64.decode(key, Base64.DEFAULT);
+            return encrypt(data, keyBytes, generateInitVector());
         } catch (Exception ex) {
             SalesforceAnalyticsLogger.w(null, TAG, "Error during encryption", ex);
         }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -29,16 +29,16 @@ package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.Context;
 import android.text.TextUtils;
-import androidx.annotation.VisibleForTesting;
+
 import com.salesforce.androidsdk.analytics.security.DecrypterInputStream;
 import com.salesforce.androidsdk.analytics.security.EncrypterOutputStream;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 import com.salesforce.androidsdk.util.ManagedFilesHelper;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -138,11 +138,9 @@ public class KeyValueEncryptedFileStore  {
             return false;
         }
         if (value == null) {
-            SmartStoreLogger.w(TAG, "saveValue: Invalid value supplied: " + value);
+            SmartStoreLogger.w(TAG, "saveValue: Invalid value supplied: null");
             return false;
         }
-
-        long startNanoTime = System.nanoTime();
         try (FileOutputStream f = new FileOutputStream(getFileForKey(key));
                 EncrypterOutputStream outputStream = new EncrypterOutputStream(f, encryptionKey)) {
             outputStream.write(value.getBytes(StandardCharsets.UTF_8));
@@ -166,10 +164,9 @@ public class KeyValueEncryptedFileStore  {
             return false;
         }
         if (stream == null) {
-            SmartStoreLogger.w(TAG, "saveStream: Invalid value supplied: " + stream);
+            SmartStoreLogger.w(TAG, "saveStream: Invalid value supplied: null");
             return false;
         }
-
         try {
             saveStream(getFileForKey(key), stream, encryptionKey);
             return true;
@@ -190,16 +187,13 @@ public class KeyValueEncryptedFileStore  {
             if (inputStream == null) {
                 return null;
             }
-
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
             StringBuilder out = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
                 out.append(line);
             }
-            String result = out.toString();
-
-            return result;
+            return out.toString();
         } catch (Exception e) {
             SmartStoreLogger.e(TAG, "getValue(): Threw exception for key: " + key, e);
             return null;
@@ -213,19 +207,14 @@ public class KeyValueEncryptedFileStore  {
      * @return stream to value for given key or null if key not found.
      */
     public InputStream getStream(String key) {
-        long startNanoTime = System.nanoTime();
-
         if (!isKeyValid(key, "getStream")) {
             return null;
         }
-
         final File file = getFileForKey(key);
-
-        if (file == null || !file.exists()) {
+        if (!file.exists()) {
             SmartStoreLogger.w(TAG, "getStream: File does not exist for key: " + key);
             return null;
         }
-
         try {
             return getStream(file, encryptionKey);
         } catch (Exception e) {
@@ -319,7 +308,6 @@ public class KeyValueEncryptedFileStore  {
         return true;
     }
 
-
     private String encodeKey(String key) {
         return SalesforceKeyGenerator.getSHA256Hash(key);
     }
@@ -346,8 +334,7 @@ public class KeyValueEncryptedFileStore  {
 
     InputStream getStream(File file, String encryptionKey) throws IOException, GeneralSecurityException {
         FileInputStream f = new FileInputStream(file);
-        DecrypterInputStream inputStream = new DecrypterInputStream(f, encryptionKey);
-        return inputStream;
+        return new DecrypterInputStream(f, encryptionKey);
     }
 
     void saveStream(File file, InputStream stream, String encryptionKey)
@@ -356,7 +343,7 @@ public class KeyValueEncryptedFileStore  {
             EncrypterOutputStream outputStream = new EncrypterOutputStream(f, encryptionKey)) {
             byte[] buffer = new byte[1024];
             int len;
-            while((len=stream.read(buffer))>0){
+            while ((len = stream.read(buffer)) > 0) {
                 outputStream.write(buffer,0,len);
             }
         }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -45,7 +45,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 
 /** Key-value store backed by file system */
 public class KeyValueEncryptedFileStore  {
@@ -143,7 +142,7 @@ public class KeyValueEncryptedFileStore  {
         }
         try {
             final FileOutputStream f = new FileOutputStream(getFileForKey(key));
-            byte[] encryptedContent = Encryptor.encryptBytes(value, encryptionKey);
+            byte[] encryptedContent = Encryptor.encryptWithoutBase64Encoding(value.getBytes(), encryptionKey);
             if (encryptedContent != null) {
                 f.write(encryptedContent);
                 f.close();
@@ -343,9 +342,8 @@ public class KeyValueEncryptedFileStore  {
         final DataInputStream data = new DataInputStream(f);
         byte[] bytes = new byte[(int) file.length()];
         data.readFully(bytes);
-        final String decryptedString = Encryptor.decrypt(bytes, encryptionKey);
-        if (!TextUtils.isEmpty(decryptedString)) {
-            byte[] decryptedBytes = decryptedString.getBytes();
+        final byte[] decryptedBytes = Encryptor.decryptWithoutBase64Encoding(bytes, encryptionKey);
+        if (decryptedBytes != null) {
             return new ByteArrayInputStream(decryptedBytes);
         }
         return null;
@@ -360,8 +358,7 @@ public class KeyValueEncryptedFileStore  {
             nextByte = stream.read();
         }
         byte[] content = b.toByteArray();
-        byte[] encryptedContent = Encryptor.encryptBytes(new String(content,
-                StandardCharsets.US_ASCII), encryptionKey);
+        byte[] encryptedContent = Encryptor.encryptWithoutBase64Encoding(content, encryptionKey);
         final FileOutputStream f = new FileOutputStream(file);
         if (encryptedContent != null) {
             f.write(encryptedContent);

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncrypterStreamTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncrypterStreamTest.java
@@ -76,37 +76,33 @@ public class EncrypterStreamTest {
     @Test
     public void testWriteAndReadThroughStream() {
         String contentToWrite = "testWriteAndReadThroughStream";
-        writeThroughStream(contentToWrite);
-        String readContent = readThroughStream();
-        Assert.assertEquals(contentToWrite, readContent);
+        writeThroughStream(contentToWrite.getBytes());
+        byte[] readContent = readThroughStream();
+        Assert.assertArrayEquals(contentToWrite.getBytes(), readContent);
     }
 
     /**
      * Write an encrypted file using Encryptor.encrypt and a FileOutputStream and read it back using
      * DecrypterInputStream
-     *
-     * <p>Note: won't work because Encryptor.encrypt base-64 encodes content
      */
-    // @Test
+    @Test
     public void testWriteWithEncryptorAndReadThroughStream() {
         String contentToWrite = "testWriteWithEncryptorAndReadThroughStream";
-        writeWithEncryptor(contentToWrite);
-        String readContent = readThroughStream();
-        Assert.assertEquals(contentToWrite, readContent);
+        writeWithEncryptor(contentToWrite.getBytes());
+        byte[] readContent = readThroughStream();
+        Assert.assertArrayEquals(contentToWrite.getBytes(), readContent);
     }
 
     /**
      * Test that writes an encrypted file using EncrypterOutputStream and reads it back using
      * FileInputStream and Encryptor.decrypt
-     *
-     * <p>Note: won't work because Encryptor.decrypt expect the encrypted content base 64 encoded
      */
-    // @Test
+    @Test
     public void testWriteThroughStreamAndReadWithEncryptor() {
         String contentToWrite = "testWriteThroughStreamAndReadWithEncryptor";
-        writeThroughStream(contentToWrite);
-        String readContent = readWithEncryptor();
-        Assert.assertEquals(contentToWrite, readContent);
+        writeThroughStream(contentToWrite.getBytes());
+        byte[] readContent = readWithEncryptor();
+        Assert.assertArrayEquals(contentToWrite.getBytes(), readContent);
     }
 
     /**
@@ -116,9 +112,9 @@ public class EncrypterStreamTest {
     @Test
     public void testWriteAndReadWithEncryptor() {
         String contentToWrite = "testWriteAndReadWithEncryptor";
-        writeWithEncryptor(contentToWrite);
-        String readContent = readWithEncryptor();
-        Assert.assertEquals(contentToWrite, readContent);
+        writeWithEncryptor(contentToWrite.getBytes());
+        byte[] readContent = readWithEncryptor();
+        Assert.assertArrayEquals(contentToWrite.getBytes(), readContent);
     }
 
     /**
@@ -146,11 +142,11 @@ public class EncrypterStreamTest {
      *
      * @param content
      */
-    private void writeThroughStream(String content) {
+    private void writeThroughStream(byte[] content) {
         try (FileOutputStream f = context.openFileOutput(TEST_FILE, Context.MODE_PRIVATE);
                 EncrypterOutputStream outputStream =
                         new EncrypterOutputStream(f, encryptionKey)) {
-            outputStream.write(content.getBytes(StandardCharsets.UTF_8));
+            outputStream.write(content);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -159,18 +155,18 @@ public class EncrypterStreamTest {
     /**
      * Helper method to read an encrypted file using DecrypterInputStream
      *
-     * @return content of file as string
+     * @return content of file as bytes
      */
-    private String readThroughStream() {
+    private byte[] readThroughStream() {
         try (FileInputStream f = context.openFileInput(TEST_FILE);
-                DecrypterInputStream i = new DecrypterInputStream(f, encryptionKey); ) {
+                DecrypterInputStream i = new DecrypterInputStream(f, encryptionKey)) {
             BufferedReader reader = new BufferedReader(new InputStreamReader(i));
             StringBuilder out = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
                 out.append(line);
             }
-            return out.toString();
+            return out.toString().getBytes();
         } catch (Exception e) {
             Assert.fail(e.getMessage());
             return null;
@@ -182,11 +178,11 @@ public class EncrypterStreamTest {
      *
      * @param content
      */
-    private void writeWithEncryptor(String content) {
+    private void writeWithEncryptor(byte[] content) {
         try (FileOutputStream outputStream =
                 context.openFileOutput(TEST_FILE, Context.MODE_PRIVATE)) {
-            String encryptedString = Encryptor.encrypt(content, encryptionKey);
-            outputStream.write(encryptedString.getBytes(StandardCharsets.UTF_8));
+            byte[] encryptedBytes = Encryptor.encryptWithoutBase64Encoding(content, encryptionKey);
+            outputStream.write(encryptedBytes);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -197,13 +193,13 @@ public class EncrypterStreamTest {
      *
      * @return content of file as string
      */
-    private String readWithEncryptor() {
+    private byte[] readWithEncryptor() {
         File file = new File(context.getFilesDir(), TEST_FILE);
         try (FileInputStream f = new FileInputStream(file);
                 DataInputStream dataInputStream = new DataInputStream(f); ) {
             byte[] bytes = new byte[(int) file.length()];
             dataInputStream.readFully(bytes);
-            return Encryptor.decrypt(bytes, encryptionKey);
+            return Encryptor.decryptWithoutBase64Encoding(bytes, encryptionKey);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
             return null;

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncrypterStreamTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncrypterStreamTest.java
@@ -85,24 +85,26 @@ public class EncrypterStreamTest {
      * Write an encrypted file using Encryptor.encrypt and a FileOutputStream and read it back using
      * DecrypterInputStream
      */
-    @Test
+    // @Test
     public void testWriteWithEncryptorAndReadThroughStream() {
-        String contentToWrite = "testWriteWithEncryptorAndReadThroughStream";
-        writeWithEncryptor(contentToWrite.getBytes());
+        final String contentToWrite = "testWriteWithEncryptorAndReadThroughStream";
+        byte[] content = contentToWrite.getBytes();
+        writeWithEncryptor(content);
         byte[] readContent = readThroughStream();
-        Assert.assertArrayEquals(contentToWrite.getBytes(), readContent);
+        Assert.assertArrayEquals(content, readContent);
     }
 
     /**
      * Test that writes an encrypted file using EncrypterOutputStream and reads it back using
      * FileInputStream and Encryptor.decrypt
      */
-    @Test
+    // @Test
     public void testWriteThroughStreamAndReadWithEncryptor() {
-        String contentToWrite = "testWriteThroughStreamAndReadWithEncryptor";
-        writeThroughStream(contentToWrite.getBytes());
+        final String contentToWrite = "testWriteThroughStreamAndReadWithEncryptor";
+        byte[] content = contentToWrite.getBytes();
+        writeThroughStream(content);
         byte[] readContent = readWithEncryptor();
-        Assert.assertArrayEquals(contentToWrite.getBytes(), readContent);
+        Assert.assertArrayEquals(content, readContent);
     }
 
     /**

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
@@ -198,6 +198,22 @@ public class EncryptorTest {
 		Assert.assertEquals("Recovered text should match original", originalText, recoveredText);
 	}
 
+	/**
+	 * Encrypting/decrypting data with ciphers returned by Encryptor.encryptWithoutBase64Encoding and
+	 * Encryptor.decryptWithoutBase64Encoding.
+	 */
+	@Test
+	public void testEncryptDecryptWithoutBase64Encoding() {
+		for (final String key : TEST_KEYS) {
+			for (final String data : TEST_DATA) {
+				final byte[] dataBytes = data.getBytes();
+				byte[] encryptedData = Encryptor.encryptWithoutBase64Encoding(dataBytes, key);
+				byte[] decryptedData = Encryptor.decryptWithoutBase64Encoding(encryptedData, key);
+				Assert.assertArrayEquals("Decrypt should restore original",
+						dataBytes, decryptedData);
+			}
+		}
+	}
 
 	private static String makeKey(String passcode) {
         return Encryptor.hash(passcode, "hashing-key");

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/KeyValueEncryptedFileStoreTest.java
@@ -27,13 +27,21 @@
 package com.salesforce.androidsdk.store;
 
 import android.content.Context;
-import androidx.core.widget.TextViewCompat.AutoSizeTextType;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 import com.salesforce.androidsdk.smartstore.store.KeyValueEncryptedFileStore;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -43,11 +51,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class KeyValueEncryptedFileStoreTest {
@@ -59,7 +62,7 @@ public class KeyValueEncryptedFileStoreTest {
     private KeyValueEncryptedFileStore keyValueStore;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         context =
                 InstrumentationRegistry.getInstrumentation()
                         .getTargetContext()
@@ -73,7 +76,7 @@ public class KeyValueEncryptedFileStoreTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         keyValueStore.deleteAll();
         getStoreDir(TEST_STORE).delete();
     }
@@ -91,7 +94,7 @@ public class KeyValueEncryptedFileStoreTest {
         Assert.assertTrue("Store name is valid", KeyValueEncryptedFileStore.isValidStoreName("abc_def_ABC_DEF_012"));
         String generateStoreName = "";
         // Trying various lengths
-        for (int i=0; i<KeyValueEncryptedFileStore.MAX_STORE_NAME_LENGTH*2; i++) {
+        for (int i=0; i<KeyValueEncryptedFileStore.MAX_STORE_NAME_LENGTH * 2; i++) {
             generateStoreName += "x";
             Assert.assertEquals("Wrong value returned by isValidStoreName(\"" + generateStoreName + "\")",
                 generateStoreName.length() <= KeyValueEncryptedFileStore.MAX_STORE_NAME_LENGTH,
@@ -152,7 +155,6 @@ public class KeyValueEncryptedFileStoreTest {
         file.delete();
     }
 
-
     /**
      * Test hasKeyValueStore()
      * Call hasKeyValueStore for existing store and non-existent store
@@ -210,7 +212,6 @@ public class KeyValueEncryptedFileStoreTest {
             String value = "value" + i;
             keyValueStore.saveValue(key, value);
         }
-
         for (int i = 0; i < NUM_ENTRIES; i++) {
             String key = "key" + i;
             String expectedValue = "value" + i;
@@ -227,7 +228,6 @@ public class KeyValueEncryptedFileStoreTest {
             InputStream stream = stringToStream("value" + i);
             keyValueStore.saveStream(key, stream);
         }
-
         for (int i = 0; i < NUM_ENTRIES; i++) {
             String key = "key" + i;
             String expectedValue = "value" + i;
@@ -244,7 +244,6 @@ public class KeyValueEncryptedFileStoreTest {
             String value = "value" + i;
             keyValueStore.saveValue(key, value);
         }
-
         for (int i = 0; i < NUM_ENTRIES; i++) {
             String key = "key" + i;
             String expectedValue = "value" + i;
@@ -263,7 +262,6 @@ public class KeyValueEncryptedFileStoreTest {
             InputStream stream = stringToStream("value" + i);
             keyValueStore.saveStream(key, stream);
         }
-
         for (int i = 0; i < NUM_ENTRIES; i++) {
             String key = "key" + i;
             String expectedValue = "value" + i;
@@ -282,7 +280,6 @@ public class KeyValueEncryptedFileStoreTest {
             String value = "value" + i;
             keyValueStore.saveValue(key, value);
         }
-
         for (int i = 0; i < NUM_ENTRIES; i++) {
             String key = "key" + i;
             Assert.assertNotNull(
@@ -305,11 +302,9 @@ public class KeyValueEncryptedFileStoreTest {
             String value = "value" + i;
             keyValueStore.saveValue(key, value);
         }
-
         Assert.assertEquals("Wrong count before deleteAll", NUM_ENTRIES, keyValueStore.count());
         keyValueStore.deleteAll();
         Assert.assertEquals("Wrong count after deleteAll", 0, keyValueStore.count());
-
         for (int i = 0; i < NUM_ENTRIES; i++) {
             String key = "key" + i;
             Assert.assertNull(
@@ -428,7 +423,6 @@ public class KeyValueEncryptedFileStoreTest {
         if (inputStream == null) {
             return null;
         }
-
         try {
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
             StringBuilder out = new StringBuilder();
@@ -436,9 +430,7 @@ public class KeyValueEncryptedFileStoreTest {
             while ((line = reader.readLine()) != null) {
                 out.append(line);
             }
-
             return out.toString();
-
         } catch (IOException e) {
             Assert.fail("Failed to read from stream");
 
@@ -452,5 +444,4 @@ public class KeyValueEncryptedFileStoreTest {
             }
         }
     }
-
 }


### PR DESCRIPTION
Turns out `CipherInputStream` is a lot slower with `AES-GCM`. While this solution is not particularly good from a memory standpoint, we will need to employ this as a workaround for now, until we figure out how we can achieve acceptable performance with a streaming solution.