### PR TITLE
Adding Support for Android 11 and Removing Deprecated Methods for 9.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-cdvCompileSdkVersion=29
+cdvCompileSdkVersion=30
 cdvMinSdkVersion=23
 android.useAndroidX=true
 android.enableJetifier=true

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle
@@ -5,10 +5,10 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   defaultConfig {
-    targetSdkVersion 29
+    targetSdkVersion 30
     minSdkVersion 23
   }
 

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle
@@ -5,10 +5,10 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   defaultConfig {
-    targetSdkVersion 29
+    targetSdkVersion 30
     minSdkVersion 23
   }
 

--- a/hybrid/HybridSampleApps/NoteSync/build.gradle
+++ b/hybrid/HybridSampleApps/NoteSync/build.gradle
@@ -5,10 +5,10 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   defaultConfig {
-    targetSdkVersion 29
+    targetSdkVersion 30
     minSdkVersion 23
   }
 

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -15,9 +15,9 @@ apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SmartStore')
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 }
 
 android {

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -21,10 +21,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
   

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/LayoutSyncManager.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/LayoutSyncManager.java
@@ -171,21 +171,6 @@ public class LayoutSyncManager {
     }
 
     /**
-     * Fetches layout data for the specified object type and layout type using the specified
-     * mode and triggers the supplied callback once complete.
-     *
-     * @param objectType Object type.
-     * @param layoutType Layout type. Defaults to "Full" if null is passed in.
-     * @param mode Fetch mode. See {@link com.salesforce.androidsdk.mobilesync.util.Constants.Mode} for available modes.
-     * @param syncCallback Layout sync callback.
-     * @deprecated Will be removed in Mobile SDK 9.0. Use {@link #fetchLayout(String, String, String, String, String, Constants.Mode, LayoutSyncCallback)} instead.
-     */
-    public void fetchLayout(String objectType, String layoutType, Constants.Mode mode,
-                            LayoutSyncCallback syncCallback) {
-        fetchLayout(objectType, null, layoutType, null, null, mode, syncCallback);
-    }
-
-    /**
      * Fetches layout data for the specified parameters using the specified sync mode
      * and triggers the supplied callback once complete.
      *

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/LayoutSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/LayoutSyncDownTarget.java
@@ -77,17 +77,6 @@ public class LayoutSyncDownTarget extends SyncDownTarget {
     /**
      * Parameterized constructor.
      *
-     * @param objectType Object type.
-     * @param layoutType Layout type.
-     * @deprecated Will be removed in Mobile SDK 9.0. Use {@link #LayoutSyncDownTarget(String, String, String, String, String)} instead.
-     */
-    public LayoutSyncDownTarget(String objectType, String layoutType) {
-        this(objectType, null, layoutType, null, null);
-    }
-
-    /**
-     * Parameterized constructor.
-     *
      * @param objectAPIName Object API name.
      * @param formFactor Form factor.
      * @param layoutType Layout type.
@@ -152,16 +141,6 @@ public class LayoutSyncDownTarget extends SyncDownTarget {
     @Override
     public int cleanGhosts(SyncManager syncManager, String soupName, long syncId) {
         return 0;
-    }
-
-    /**
-     * Returns the object type associated with this target.
-     *
-     * @return Object type.
-     * @deprecated Will be removed in Mobile SDK 9.0. Use {@link #getObjectAPIName()} instead.
-     */
-    public String getObjectType() {
-        return objectAPIName;
     }
 
     /**

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -22,10 +22,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
 

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -16,9 +16,9 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
     api 'com.squareup:tape:1.2.3'
     api 'io.paperdb:paperdb:2.7.1'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 }
 
 android {

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -16,9 +16,9 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
   api project(':libs:MobileSync')
   api 'org.apache.cordova:framework:8.1.0'
-  androidTestImplementation 'androidx.test:runner:1.2.0'
-  androidTestImplementation 'androidx.test:rules:1.2.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+  androidTestImplementation 'androidx.test:runner:1.3.0'
+  androidTestImplementation 'androidx.test:rules:1.3.0'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 }
 
 android {

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -22,10 +22,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
 

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -27,9 +27,9 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
   api project(':libs:MobileSync')
   api 'com.facebook.react:react-native:0.63.2'
-  androidTestImplementation 'androidx.test:runner:1.2.0'
-  androidTestImplementation 'androidx.test:rules:1.2.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+  androidTestImplementation 'androidx.test:runner:1.3.0'
+  androidTestImplementation 'androidx.test:rules:1.3.0'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 
     // JSC from node_modules
     if (useIntlJsc) {

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -41,10 +41,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
 

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -17,17 +17,17 @@ dependencies {
     api project(':libs:SalesforceAnalytics')
     api 'com.squareup.okhttp3:okhttp:3.12.1'
     api 'com.google.firebase:firebase-messaging:20.1.0'
-    api 'androidx.core:core:1.2.0'
+    api 'androidx.core:core:1.3.1'
 
     /*
      * Don't upgrade browser library version until minApiVersion >= 24.
      * This is because the latest version of this library has minVersion = 24.
      */
     api 'androidx.browser:browser:1.0.0'
-    implementation 'com.google.android.material:material:1.1.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    implementation 'com.google.android.material:material:1.2.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 }
 
 android {

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -31,10 +31,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
@@ -33,7 +33,6 @@ import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.analytics.SalesforceAnalyticsManager;
 import com.salesforce.androidsdk.rest.ClientManager;
-import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
 import java.util.List;
@@ -91,9 +90,6 @@ public class SalesforceSDKUpgradeManager {
         try {
             final String majorVersionNum = installedVersion.substring(0, 3);
             double installedVerDouble = Double.parseDouble(majorVersionNum);
-            if (installedVerDouble < 7.1) {
-                upgradeTo7Dot1();
-            }
             if (installedVerDouble < 8.2) {
                 upgradeTo8Dot2();
             }
@@ -131,10 +127,6 @@ public class SalesforceSDKUpgradeManager {
         final SharedPreferences sp = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(VERSION_SHARED_PREF,
                 Context.MODE_PRIVATE);
         return sp.getString(key, "");
-    }
-
-    private void upgradeTo7Dot1() {
-        SalesforceKeyGenerator.upgradeTo7Dot1();
     }
 
     private void upgradeTo8Dot2() {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -656,28 +656,31 @@ public class RestClient {
 			 * Standard access token expiry returns 401 as the error code.
 			 */
             if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
-				final HttpUrl currentInstanceUrl = HttpUrl.get(clientInfo.getInstanceUrl());
-				if (currentInstanceUrl != null) {
+				final URI curInstanceUrl = clientInfo.getInstanceUrl();
+				if (curInstanceUrl != null) {
+					final HttpUrl currentInstanceUrl = HttpUrl.get(curInstanceUrl);
+					if (currentInstanceUrl != null) {
 
-					// Checks if the host of the request is the same as instance URL.
-					boolean isHostInstanceUrl = currentInstanceUrl.host().equals(request.url().host());
-					refreshAccessToken();
-					if (getAuthToken() != null) {
-						request = buildAuthenticatedRequest(request);
+						// Checks if the host of the request is the same as instance URL.
+						boolean isHostInstanceUrl = currentInstanceUrl.host().equals(request.url().host());
+						refreshAccessToken();
+						if (getAuthToken() != null) {
+							request = buildAuthenticatedRequest(request);
 
-						/*
-						 * During instance migration, the instance URL could change. Hence, the host
-						 * needs to be adjusted to replace the old instance URL with the new instance
-						 * URL before replaying this request. However, this adjustment should be applied
-						 * only if the host of the request was the old instance URL. This avoids
-						 * accidental manipulation of the host for requests where the caller has
-						 * passed in their own fully formed host URL that is not instance URL.
-						 */
-						if (isHostInstanceUrl && !currentInstanceUrl.host().equals(request.url().host())) {
-							request = adjustHostInRequest(request, currentInstanceUrl.host());
+							/*
+							 * During instance migration, the instance URL could change. Hence, the host
+							 * needs to be adjusted to replace the old instance URL with the new instance
+							 * URL before replaying this request. However, this adjustment should be applied
+							 * only if the host of the request was the old instance URL. This avoids
+							 * accidental manipulation of the host for requests where the caller has
+							 * passed in their own fully formed host URL that is not instance URL.
+							 */
+							if (isHostInstanceUrl && !currentInstanceUrl.host().equals(request.url().host())) {
+								request = adjustHostInRequest(request, currentInstanceUrl.host());
+							}
+							response.close();
+							response = chain.proceed(request);
 						}
-						response.close();
-						response = chain.proceed(request);
 					}
 				}
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -575,20 +575,6 @@ public class RestRequest {
 	 * Request to get object layout data.
 	 *
 	 * @param apiVersion Salesforce API version.
-	 * @param objectType Object type.
-     * @param layoutType Layout type. Could be "Compact" or "Full".
-	 * @return RestRequest object that requests the object layout for the given object and layout types.
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm">https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm</a>
-	 * @deprecated Will be removed in Mobile SDK 9.0. Use {@link #getRequestForObjectLayout(String, String, String, String, String, String)} instead.
-	 */
-	public static RestRequest getRequestForObjectLayout(String apiVersion, String objectType, String layoutType) {
-		return getRequestForObjectLayout(apiVersion, objectType, null, layoutType, null, null);
-	}
-
-	/**
-	 * Request to get object layout data.
-	 *
-	 * @param apiVersion Salesforce API version.
 	 * @param objectAPIName Object API name.
 	 * @param formFactor Form factor. Could be "Large", "Medium" or "Small". Default value is "Large".
 	 * @param layoutType Layout type. Could be "Compact" or "Full". Default value is "Full".

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -183,7 +183,6 @@ public class RestRequest {
 	private final RequestBody requestBody;
 	private final Map<String, String> additionalHttpHeaders;
 	private final JSONObject requestBodyAsJson; // needed for composite and batch requests
-    private boolean shouldRefreshOn403 = true;
 
     /**
      * Generic constructor for arbitrary requests without a body.
@@ -338,26 +337,6 @@ public class RestRequest {
 	public Map<String, String> getAdditionalHttpHeaders() {
 		return additionalHttpHeaders;
 	}
-
-    /**
-     * Returns whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
-     *
-     * @return True - if the SDK should refresh on HTTP 403, False - otherwise.
-	 * @deprecated Will be removed in Mobile SDK 9.0.
-     */
-	public boolean getShouldRefreshOn403() {
-	    return shouldRefreshOn403;
-    }
-
-    /**
-     * Sets whether the SDK should attempt to refresh tokens if the service returns HTTP 403.
-     *
-     * @param shouldRefreshOn403 True - if the SDK should refresh on HTTP 403, False - otherwise.
-	 * @deprecated Will be removed in Mobile SDK 9.0.
-     */
-	public synchronized void setShouldRefreshOn403(boolean shouldRefreshOn403) {
-        this.shouldRefreshOn403 = shouldRefreshOn403;
-    }
 
 	/**
 	 * Request to get information about the user making the request.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -42,7 +42,6 @@ import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -165,33 +164,6 @@ public class SalesforceKeyGenerator {
             SalesforceSDKLogger.e(TAG, "Exception thrown while generating SHA-256 hash", e);
         }
         return hashedString;
-    }
-
-    /**
-     * Upgrades the keys stored in SharedPrefs to encrypted keys. This is a one-time
-     * migration step that's run while upgrading to Mobile SDK 7.1.
-     *
-     * @deprecated Will be removed in Mobile SDK 9.0.
-     */
-    public synchronized static void upgradeTo7Dot1() {
-        final SharedPreferences prefs = SalesforceSDKManager.getInstance().getAppContext().getSharedPreferences(SHARED_PREF_FILE, 0);
-        final Map<String, ?> prefContents = prefs.getAll();
-        if (prefContents != null) {
-            final Set<String> keys = prefContents.keySet();
-            for (final String key : keys) {
-                if (key != null && key.startsWith(ID_PREFIX)) {
-                    final String value = prefs.getString(key, null);
-                    if (value != null) {
-                        final PublicKey publicKey = KeyStoreWrapper.getInstance().getRSAPublicKey(KEYSTORE_ALIAS);
-                        final String keyBase = key.replaceFirst(ID_PREFIX, "");
-                        final String mutatedValue = value + String.format(Locale.US, ADDENDUM, keyBase);
-                        final String encryptedValue = Encryptor.encryptWithRSA(publicKey, mutatedValue);
-                        storeInSharedPrefs(key, encryptedValue);
-                        prefs.edit().remove(key).commit();
-                    }
-                }
-            }
-        }
     }
 
     private synchronized static String generateEncryptionKey(String name) {

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -16,10 +16,10 @@ apply plugin: 'com.jfrog.bintray'
 dependencies {
     api project(':libs:SalesforceSDK')
     api 'net.zetetic:android-database-sqlcipher:4.4.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     implementation 'com.google.android.material:material:1.2.1'
 }
 

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -24,10 +24,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
   

--- a/native/NativeSampleApps/AppConfigurator/build.gradle
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle
@@ -5,10 +5,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
 

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle
@@ -5,10 +5,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        targetSdkVersion 29
+        targetSdkVersion 30
         minSdkVersion 23
     }
 

--- a/native/NativeSampleApps/MobileSyncExplorer/build.gradle
+++ b/native/NativeSampleApps/MobileSyncExplorer/build.gradle
@@ -5,10 +5,10 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   defaultConfig {
-    targetSdkVersion 29
+    targetSdkVersion 30
     minSdkVersion 23
   }
 

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -2,16 +2,16 @@ apply plugin: 'com.android.application'
 
 dependencies {
   api project(':libs:SalesforceSDK')
-  androidTestImplementation ('androidx.test:runner:1.2.0') {
+  androidTestImplementation ('androidx.test:runner:1.3.0') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation ('androidx.test:rules:1.2.0') {
+  androidTestImplementation ('androidx.test:rules:1.3.0') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation ('androidx.test.espresso:espresso-core:3.2.0') {
+  androidTestImplementation ('androidx.test.espresso:espresso-core:3.3.0') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 }
 
 android {

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -15,10 +15,10 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 29
+  compileSdkVersion 30
 
   defaultConfig {
-    targetSdkVersion 29
+    targetSdkVersion 30
     minSdkVersion 23
   }
   


### PR DESCRIPTION
This PR:
- bumps up target API version to `API 30` for all libraries and sample apps.
- bumps up libraries to their latest versions.
- removes methods that were marked deprecated for removal in `9.0`.