### PR TITLE
Allow the authenticator service's icon to be rebranded.

### DIFF
--- a/libs/SalesforceSDK/res/values/strings.xml
+++ b/libs/SalesforceSDK/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="app_name">SalesforceSDK</string>
     <string name="account_type">com.salesforce.androidsdk</string>
     <string name="app_package">com.salesforce.androidsdk</string>
+    <!-- The icon visible for accounts in the Settings app. This is safely parsed as a reference and not a string. -->
+    <string name="authenticator_icon">@drawable/sf__icon</string>
 
     <!-- If you're only supporting recent versions of Android (e.g. 3.x and up), you can override this to be touch and get a better looking login UI  -->
     <string name="oauth_display_type">touch</string>

--- a/libs/SalesforceSDK/res/xml/authenticator.xml
+++ b/libs/SalesforceSDK/res/xml/authenticator.xml
@@ -1,3 +1,3 @@
 <account-authenticator xmlns:android="http://schemas.android.com/apk/res/android"
-	android:accountType="@string/account_type" android:icon="@drawable/sf__icon"
-	android:smallIcon="@drawable/sf__icon" android:label="@string/app_name" />
+	android:accountType="@string/account_type" android:icon="@string/authenticator_icon"
+	android:smallIcon="@string/authenticator_icon" android:label="@string/app_name" />


### PR DESCRIPTION
This PR allows the account icon provided by the authenticator service (visible in the Settings app) to be overridden at the app level. `<account-authenticator>` seems to be outside the responsibility of variant/manifest merging, so I've chosen to use an overridable string.