### PR TITLE
ParentChildrenSyncUpTarget can now provide an external id field name

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -208,8 +208,8 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
                 if (externalId != null
                         // the following check is there for the case
                         // where the the external id field is the id field
-                        // and the empty id field was populated by BatchSyncUpTarget using createLocalId()
-                        && !externalId.equals(createLocalId(record))) {
+                        // and the field is populated by a local id
+                        && !isLocalId(externalId)) {
                     return RestRequest.getRequestForUpsert(apiVersion, objectType, getExternalIdFieldName(), externalId, fields);
                 }
                 // Do a create otherwise
@@ -273,6 +273,6 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
 
     // Create a local id (based on the internal soup entry id)
     private String createLocalId(JSONObject record) throws JSONException {
-        return "local_" + record.getLong(SmartStore.SOUP_ENTRY_ID);
+        return LOCAL_ID_PREFIX + record.getLong(SmartStore.SOUP_ENTRY_ID);
     }
 }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -34,15 +34,13 @@ import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Subclass of SyncUpTarget that batches create/update/delete operations by using composite api
@@ -140,7 +138,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
 
             if (id == null) {
                 // create local id - needed for refId
-                id = createLocalId(record);
+                id = createLocalId();
                 record.put(getIdFieldName(), id);
             }
 
@@ -271,8 +269,4 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
         return needReRun;
     }
 
-    // Create a local id (based on the internal soup entry id)
-    private String createLocalId(JSONObject record) throws JSONException {
-        return LOCAL_ID_PREFIX + record.getLong(SmartStore.SOUP_ENTRY_ID);
-    }
 }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTargetHelper.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTargetHelper.java
@@ -28,15 +28,12 @@
 package com.salesforce.androidsdk.mobilesync.target;
 
 import android.text.TextUtils;
-
-import android.util.Log;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
-import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
 import com.salesforce.androidsdk.mobilesync.util.ChildrenInfo;
 import com.salesforce.androidsdk.mobilesync.util.ParentInfo;
-
+import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper;
+import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -118,7 +115,6 @@ public class ParentChildrenSyncTargetHelper {
 
     public static JSONArray getChildrenFromLocalStore(SmartStore smartStore, ParentInfo parentInfo, ChildrenInfo childrenInfo, JSONObject parent) throws JSONException {
         QuerySpec  querySpec = getQueryForChildren(parentInfo, childrenInfo, SmartSqlHelper.SOUP, parent.getString(parentInfo.idFieldName));
-        Log.i("------", querySpec.smartSql);
         JSONArray rows = smartStore.query(querySpec, 0);
         JSONArray children = new JSONArray();
         for (int i=0; i<rows.length(); i++) {

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTargetHelper.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTargetHelper.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.mobilesync.target;
 
 import android.text.TextUtils;
 
+import android.util.Log;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
@@ -117,6 +118,7 @@ public class ParentChildrenSyncTargetHelper {
 
     public static JSONArray getChildrenFromLocalStore(SmartStore smartStore, ParentInfo parentInfo, ChildrenInfo childrenInfo, JSONObject parent) throws JSONException {
         QuerySpec  querySpec = getQueryForChildren(parentInfo, childrenInfo, SmartSqlHelper.SOUP, parent.getString(parentInfo.idFieldName));
+        Log.i("------", querySpec.smartSql);
         JSONArray rows = smartStore.query(querySpec, 0);
         JSONArray children = new JSONArray();
         for (int i=0; i<rows.length(); i++) {

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -62,7 +62,6 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
     public static final String CHILDREN_CREATE_FIELDLIST = "childrenCreateFieldlist";
     public static final String CHILDREN_UPDATE_FIELDLIST = "childrenUpdateFieldlist";
     public static final String BODY = "body";
-    public static final String HTTP_STATUS_CODE = "httpStatusCode";
 
     private ParentInfo parentInfo;
     private ChildrenInfo childrenInfo;
@@ -410,9 +409,18 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 );
             }
             if (isCreate) {
-                return RestRequest.getRequestForCreate(apiVersion,
+                String externalId = info.externalIdFieldName != null ? JSONObjectHelper.optString(record, info.externalIdFieldName) : null;
+                if (externalId != null) {
+                    return RestRequest.getRequestForUpsert(apiVersion,
+                        info.sobjectType,
+                        info.externalIdFieldName,
+                        externalId,
+                        fields);
+                } else {
+                    return RestRequest.getRequestForCreate(apiVersion,
                         info.sobjectType,
                         fields);
+                }
             }
             else {
                 return RestRequest.getRequestForUpdate(apiVersion,

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -413,9 +413,8 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 if (externalId != null
                     // the following check is there for the case
                     // where the the external id field is the id field
-                    // and id field contains a local id
-                    // XXX how to we recognize a local id in a generic manner
-                    && !externalId.startsWith("local_")) {
+                    // and the field is populated by a local id
+                    && !isLocalId(externalId)) {
                     return RestRequest.getRequestForUpsert(apiVersion,
                         info.sobjectType,
                         info.externalIdFieldName,

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -410,7 +410,12 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
             }
             if (isCreate) {
                 String externalId = info.externalIdFieldName != null ? JSONObjectHelper.optString(record, info.externalIdFieldName) : null;
-                if (externalId != null) {
+                if (externalId != null
+                    // the following check is there for the case
+                    // where the the external id field is the id field
+                    // and id field contains a local id
+                    // XXX how to we recognize a local id in a generic manner
+                    && !externalId.startsWith("local_")) {
                     return RestRequest.getRequestForUpsert(apiVersion,
                         info.sobjectType,
                         info.externalIdFieldName,

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncTarget.java
@@ -27,21 +27,18 @@
 package com.salesforce.androidsdk.mobilesync.target;
 
 import android.text.TextUtils;
-
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.mobilesync.util.MobileSyncLogger;
+import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Abstract super class for SyncUpTarget and SyncDownTarget
@@ -61,6 +58,7 @@ public abstract class SyncTarget {
     public static final String LOCALLY_UPDATED = "__locally_updated__";
     public static final String LOCALLY_DELETED = "__locally_deleted__";
     public static final String LOCAL = "__local__";
+    public static final String LOCAL_ID_PREFIX = "local_";
 
     // Field added to record to capture last sync error if any
     public static final String LAST_ERROR = "__last_error__";
@@ -317,5 +315,22 @@ public abstract class SyncTarget {
     public void deleteFromLocalStore(SyncManager syncManager, String soupName, JSONObject record) throws JSONException {
         MobileSyncLogger.d(TAG, "deleteFromLocalStore", record);
         syncManager.getSmartStore().delete(soupName, record.getLong(SmartStore.SOUP_ENTRY_ID));
+    }
+
+    /**
+     * Generate local id for record
+     * @return generated id
+     */
+    public static String createLocalId() {
+        return LOCAL_ID_PREFIX + System.nanoTime();
+    }
+
+    /**
+     * Return true if id was generated locally
+     * @param id
+     * @return true if generated locally
+     */
+    public static boolean isLocalId(String id) {
+        return id.startsWith(LOCAL_ID_PREFIX);
     }
 }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -202,7 +202,11 @@ public class SyncUpTarget extends SyncTarget {
         final String objectType = (String) SmartStore.project(record, Constants.SOBJECT_TYPE);
         final Map<String,Object> fields = buildFieldsMap(record, fieldlist, getIdFieldName(), getModificationDateFieldName());
         final String externalId = externalIdFieldName != null ? JSONObjectHelper.optString(record, externalIdFieldName) : null;
-        if (externalId != null) {
+        if (externalId != null
+            // the following check is there for the case
+            // where the the external id field is the id field
+            // and the field is populated by a local id
+            && !isLocalId(externalId)) {
             return upsertOnServer(syncManager, objectType, fields, externalId);
         } else {
             return createOnServer(syncManager, objectType, fields);

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/util/ChildrenInfo.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/util/ChildrenInfo.java
@@ -48,18 +48,24 @@ public class ChildrenInfo extends ParentInfo {
         this(
                 json.getString(SOBJECT_TYPE),
                 json.getString(SOBJECT_TYPE_PLURAL),
-                json.getString(SOUP_NAME), json.getString(PARENT_ID_FIELD_NAME),
+                json.getString(SOUP_NAME),
+                json.getString(PARENT_ID_FIELD_NAME),
                 JSONObjectHelper.optString(json, ID_FIELD_NAME),
-                JSONObjectHelper.optString(json, MODIFICATION_DATE_FIELD_NAME)
+                JSONObjectHelper.optString(json, MODIFICATION_DATE_FIELD_NAME),
+                JSONObjectHelper.optString(json, EXTERNAL_ID_FIELD_NAME)
         );
     }
 
     public ChildrenInfo(String sobjectType, String sobjectTypePlural, String soupName, String parentIdFieldName) {
-        this(sobjectType, sobjectTypePlural, soupName, parentIdFieldName, null, null);
+        this(sobjectType, sobjectTypePlural, soupName, parentIdFieldName, null, null, null);
     }
 
     public ChildrenInfo(String sobjectType, String sobjectTypePlural, String soupName, String parentIdFieldName, String idFieldName, String modificationDateFieldName) {
-        super(sobjectType, soupName, idFieldName, modificationDateFieldName);
+        this(sobjectType, sobjectTypePlural, soupName, parentIdFieldName, idFieldName, modificationDateFieldName, null);
+    }
+
+    public ChildrenInfo(String sobjectType, String sobjectTypePlural, String soupName, String parentIdFieldName, String idFieldName, String modificationDateFieldName, String externalIdFieldName) {
+        super(sobjectType, soupName, idFieldName, modificationDateFieldName, externalIdFieldName);
         this.sobjectTypePlural = sobjectTypePlural;
         this.parentIdFieldName = parentIdFieldName;
     }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/util/ParentInfo.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/util/ParentInfo.java
@@ -41,29 +41,39 @@ public class ParentInfo {
     public static final String SOUP_NAME = "soupName";
     public static final String ID_FIELD_NAME = "idFieldName";
     public static final String MODIFICATION_DATE_FIELD_NAME = "modificationDateFieldName";
+    public static final String EXTERNAL_ID_FIELD_NAME = "externalIdFieldName";
 
     // Fields
     public final String sobjectType;
     public final String idFieldName;
     public final String modificationDateFieldName;
     public final String soupName;
+    public final String externalIdFieldName;
 
     public ParentInfo(JSONObject json) throws JSONException {
         this(
                 json.getString(SOBJECT_TYPE),
-                json.getString(SOUP_NAME), JSONObjectHelper.optString(json, ID_FIELD_NAME), JSONObjectHelper.optString(json, MODIFICATION_DATE_FIELD_NAME)
-        );
+                json.getString(SOUP_NAME),
+                JSONObjectHelper.optString(json, ID_FIELD_NAME),
+                JSONObjectHelper.optString(json, MODIFICATION_DATE_FIELD_NAME),
+                JSONObjectHelper.optString(json, EXTERNAL_ID_FIELD_NAME)
+            );
     }
 
     public ParentInfo(String sobjectType, String soupName) {
-        this(sobjectType, soupName, null, null);
+        this(sobjectType, soupName, null, null, null);
     }
 
     public ParentInfo(String sobjectType, String soupName, String idFieldName, String modificationDateFieldName) {
+        this(sobjectType, soupName, idFieldName, modificationDateFieldName, null);
+    }
+
+    public ParentInfo(String sobjectType, String soupName, String idFieldName, String modificationDateFieldName, String externalIdFieldName) {
         this.sobjectType = sobjectType;
         this.soupName = soupName;
         this.idFieldName = idFieldName != null ? idFieldName : Constants.ID;
         this.modificationDateFieldName = modificationDateFieldName != null ? modificationDateFieldName : Constants.LAST_MODIFIED_DATE;
+        this.externalIdFieldName = externalIdFieldName;
     }
 
     public JSONObject asJSON() throws JSONException {
@@ -72,6 +82,7 @@ public class ParentInfo {
         json.put(SOBJECT_TYPE, sobjectType);
         json.put(ID_FIELD_NAME, idFieldName);
         json.put(MODIFICATION_DATE_FIELD_NAME, modificationDateFieldName);
+        json.put(EXTERNAL_ID_FIELD_NAME, externalIdFieldName);
         return json;
     }
 }

--- a/libs/test/MobileSyncTest/res/raw/usersyncs.json
+++ b/libs/test/MobileSyncTest/res/raw/usersyncs.json
@@ -148,6 +148,7 @@
         "androidImpl": "com.salesforce.androidsdk.mobilesync.target.ParentChildrenSyncUpTarget",
         "parent" : {
           "idFieldName" : "IdX",
+          "externalIdFieldName": "ExternalIdX",
           "sobjectType" : "Account",
           "modificationDateFieldName" : "LastModifiedDateX",
           "soupName" : "accounts"
@@ -157,6 +158,7 @@
         "children" : {
           "parentIdFieldName" : "AccountId",
           "idFieldName" : "IdY",
+          "externalIdFieldName": "ExternalIdY",
           "sobjectType" : "Contact",
           "modificationDateFieldName" : "LastModifiedDateY",
           "soupName" : "contacts",

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
@@ -250,10 +250,10 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
         checkStatus(sync, SyncState.Type.syncUp, sync.getId(),
                 new ParentChildrenSyncUpTarget(
-                        new ParentInfo("Account", "accounts", "IdX", "LastModifiedDateX"),
+                        new ParentInfo("Account", "accounts", "IdX", "LastModifiedDateX", "ExternalIdX"),
                         Arrays.asList("IdX", "Name", "Description"),
                         Arrays.asList("Name", "Description"),
-                        new ChildrenInfo("Contact", "Contacts", "contacts", "AccountId", "IdY", "LastModifiedDateY"),
+                        new ChildrenInfo("Contact", "Contacts", "contacts", "AccountId", "IdY", "LastModifiedDateY", "ExternalIdY"),
                         Arrays.asList("LastName", "AccountId"),
                         Arrays.asList("FirstName", "AccountId"),
                         ParentChildrenSyncTargetHelper.RelationshipType.MASTER_DETAIL),

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
@@ -52,10 +52,8 @@ import org.junit.Assert;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Formatter;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -67,7 +65,6 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
 
     protected static final String TYPE = "type";
     protected static final String RECORDS = "records";
-    protected static final String LOCAL_ID_PREFIX = "local_";
     protected static final String ACCOUNTS_SOUP = "accounts";
     protected static final int TOTAL_SIZE_UNKNOWN = -2;
     protected static final String REMOTELY_UPDATED = "_r_upd";
@@ -124,17 +121,6 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
     }
 
     /**
-     * @return local id of the form local_number where number is different every time and increasing
-     */
-    protected String createLocalId() {
-        StringBuilder sb = new StringBuilder();
-        Formatter formatter = new Formatter(sb, Locale.US);
-        formatter.format(LOCAL_ID_PREFIX + System.nanoTime());
-        String name = sb.toString();
-        return name;
-    }
-
-    /**
      * Create accounts locally
      *
      * @param names
@@ -159,7 +145,7 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
         for (int i = 0; i < names.length; i++) {
             String name = names[i];
             JSONObject account = new JSONObject();
-            account.put(Constants.ID, createLocalId());
+            account.put(Constants.ID, SyncTarget.createLocalId());
             account.put(Constants.NAME, name);
             account.put(Constants.DESCRIPTION, "Description_" + name);
             account.put(Constants.ATTRIBUTES, attributes);
@@ -485,7 +471,8 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
             String id = soupElt.getString(Constants.ID);
             Assert.assertEquals("Wrong local flag", expectDirty, soupElt.getBoolean(SyncTarget.LOCAL));
             Assert.assertEquals("Wrong local flag", expectLocallyCreated, soupElt.getBoolean(SyncTarget.LOCALLY_CREATED));
-            Assert.assertEquals("Id was not updated", expectLocallyCreated, id.startsWith(LOCAL_ID_PREFIX));
+            Assert.assertEquals("Id was not updated", expectLocallyCreated, id.startsWith(
+                SyncTarget.LOCAL_ID_PREFIX));
             Assert.assertEquals("Wrong local flag", expectLocallyUpdated, soupElt.getBoolean(SyncTarget.LOCALLY_UPDATED));
             Assert.assertEquals("Wrong local flag", expectLocallyDeleted, soupElt.getBoolean(SyncTarget.LOCALLY_DELETED));
             // Last error field should be empty for a clean record

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
@@ -726,6 +726,32 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
         return idToFieldsLocallyUpdated;
     }
 
+
+    /**
+     * Helper for building fields map
+     * @param fieldName
+     * @param fieldValue
+     * @return
+     */
+    protected Map<String, Object> createFieldsMap(String fieldName, String fieldValue) {
+        final Map<String, Object> fields = new HashMap<>();
+        fields.put(fieldName, fieldValue);
+        return fields;
+    }
+
+    /**
+     * Helper for building fields map
+     * @param name
+     * @param description
+     * @return
+     */
+    protected Map<String, Object> createFieldsMapFromNameDescription(String name, String description) {
+        final Map<String, Object> fields = new HashMap<>();
+        if (name != null) fields.put(Constants.NAME, name);
+        if (description != null) fields.put(Constants.DESCRIPTION, description);
+        return fields;
+    }
+
     /**
      * Class use to customize json object
      */

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTest.java
@@ -27,7 +27,6 @@
 
 package com.salesforce.androidsdk.mobilesync.target;
 
-import android.util.Log;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import com.salesforce.androidsdk.mobilesync.target.ParentChildrenSyncTargetHelper.RelationshipType;
@@ -1018,18 +1017,6 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         String contactName1 = localContacts[1].getString(Constants.LAST_NAME);
         String contactName2 = localContacts[2].getString(Constants.LAST_NAME);
 
-
-        Log.i("---test--", "accountName0=" + accountName0);
-        Log.i("---test--", "accountName1=" + accountName1);
-        Log.i("---test--", "accountName2=" + accountName2);
-        Log.i("---test--", "originalAccountName2=" + originalAccountName2);
-
-
-        Log.i("---test--", "contactName0=" + contactName0);
-        Log.i("---test--", "contactName0original=" + originalContactName0);
-        Log.i("---test--", "contactName1=" + contactName1);
-        Log.i("---test--", "contactName2=" + contactName2);
-
         // Update Id field to match existing id for account 0 and 1
         localAccounts[0].put(externalIdFieldName, accountId0);
         smartStore.upsert(ACCOUNTS_SOUP, localAccounts[0]);
@@ -1045,13 +1032,6 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         smartStore.upsert(CONTACTS_SOUP, localContacts[1]);
         localContacts[2].put(externalIdFieldName, contactId2);
         smartStore.upsert(CONTACTS_SOUP, localContacts[2]);
-
-        Log.i("---test--", "account0=" + localAccounts[0]);
-        Log.i("---test--", "account1=" + localAccounts[1]);
-        Log.i("---test--", "account2=" + localAccounts[2]);
-        Log.i("---test--", "contact0=" + localContacts[0]);
-        Log.i("---test--", "contact1=" + localContacts[1]);
-        Log.i("---test--", "contact2=" + localContacts[2]);
 
         // Sync up
         trySyncUp(getAccountContactsSyncUpTarget(Constants.LAST_MODIFIED_DATE, Constants.LAST_MODIFIED_DATE, externalIdFieldName, externalIdFieldName), 3, SyncState.MergeMode.OVERWRITE);

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTest.java
@@ -235,12 +235,12 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         Map<JSONObject, JSONObject[]> mapAccountContacts = new HashMap<>();
         for (int i = 0; i < numberAccounts; i++) {
             JSONObject account = new JSONObject();
-            account.put(Constants.ID, createLocalId());
+            account.put(Constants.ID, SyncTarget.createLocalId());
             account.put(Constants.ATTRIBUTES, accountAttributes);
             JSONObject[] contacts = new JSONObject[numberContactsPerAccount];
             for (int j = 0; j < numberContactsPerAccount; j++) {
                 JSONObject contact = new JSONObject();
-                contact.put(Constants.ID, createLocalId());
+                contact.put(Constants.ID, SyncTarget.createLocalId());
                 contact.put(Constants.ATTRIBUTES, contactAttributes);
                 contact.put(ACCOUNT_ID, account.get(Constants.ID));
                 contacts[j] = contact;
@@ -326,13 +326,13 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         Map<JSONObject, JSONObject[]> mapAccountContacts = new HashMap<>();
         for (int i = 0; i < numberAccounts; i++) {
             JSONObject account = new JSONObject();
-            account.put(Constants.ID, createLocalId());
+            account.put(Constants.ID, SyncTarget.createLocalId());
             account.put("AccountTimeStamp1", timeStampStrs[i % timeStampStrs.length]);
             account.put("AccountTimeStamp2", timeStampStrs[0]);
             JSONObject[] contacts = new JSONObject[numberContactsPerAccount];
             for (int j = 0; j < numberContactsPerAccount; j++) {
                 JSONObject contact = new JSONObject();
-                contact.put(Constants.ID, createLocalId());
+                contact.put(Constants.ID, SyncTarget.createLocalId());
                 contact.put(ACCOUNT_ID, account.get(Constants.ID));
                 contact.put("ContactTimeStamp1", timeStampStrs[1]);
                 contact.put("ContactTimeStamp2", timeStampStrs[j % timeStampStrs.length]);

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTest.java
@@ -40,6 +40,7 @@ import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1000,17 +1001,17 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         // Get name of first contact on server
         String originalContactName0 = (String) accountIdContactIdToFields.get(accountId0).get(contactId0).get(Constants.LAST_NAME);
 
-        // Creating 3 new account names
-        String accountName0 = createRecordName(Constants.ACCOUNT);
-        String accountName1 = createRecordName(Constants.ACCOUNT);
-        String accountName2 = createRecordName(Constants.ACCOUNT);
-
         // Create accounts and contacts locally
         Map<JSONObject, JSONObject[]> accountToContactMap = createAccountsAndContactsLocally(
-            new String[]{accountName0, accountName1, accountName2}, 1);
+            new String[]{createRecordName(Constants.ACCOUNT), createRecordName(Constants.ACCOUNT), createRecordName(Constants.ACCOUNT)}, 1);
         JSONObject[] localAccounts = accountToContactMap.keySet().toArray(new JSONObject[0]);
         JSONObject[] localContacts = new JSONObject[]{accountToContactMap.get(localAccounts[0])[0],
             accountToContactMap.get(localAccounts[1])[0], accountToContactMap.get(localAccounts[2])[0] };
+
+        // Local account names
+        String accountName0 = localAccounts[0].getString(Constants.NAME);
+        String accountName1 = localAccounts[1].getString(Constants.NAME);
+        String accountName2 = localAccounts[2].getString(Constants.NAME);
 
         // Local contact names
         String contactName0 = localContacts[0].getString(Constants.LAST_NAME);
@@ -1082,7 +1083,8 @@ public class ParentChildrenSyncTest extends ParentChildrenSyncTestCase {
         // Check server
         checkServer(expectedContactsServerIdToFields, Constants.CONTACT);
 
-        // Adding to idToFields so that they get deleted in tearDown
-        accountIdToFields.putAll(expectedAccountsServerIdToFields);
+        // Clean up
+        deleteRecordsOnServer(Collections.singletonList(newAccountId), Constants.ACCOUNT);
+        deleteRecordsOnServer(Collections.singletonList(newContactId), Constants.CONTACT);
     }
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTestCase.java
@@ -587,19 +587,19 @@ public class ParentChildrenSyncTestCase extends SyncManagerTestCase {
     }
 
     protected ParentChildrenSyncUpTarget getAccountContactsSyncUpTarget() {
-        return getAccountContactsSyncUpTarget("");
-    }
-
-    private ParentChildrenSyncUpTarget getAccountContactsSyncUpTarget(String parentSoqlFilter) {
         return getAccountContactsSyncUpTarget(Constants.LAST_MODIFIED_DATE, Constants.LAST_MODIFIED_DATE);
     }
 
-    private ParentChildrenSyncUpTarget getAccountContactsSyncUpTarget(String accountModificationDateFieldName, String contactModificationDateFieldName) {
+    protected ParentChildrenSyncUpTarget getAccountContactsSyncUpTarget(String accountModificationDateFieldName, String contactModificationDateFieldName) {
+        return getAccountContactsSyncUpTarget(accountModificationDateFieldName, contactModificationDateFieldName, null, null);
+    }
+
+    protected ParentChildrenSyncUpTarget getAccountContactsSyncUpTarget(String accountModificationDateFieldName, String contactModificationDateFieldName, String accountExternalIdFieldName, String contactExternalIdFieldName) {
         return new ParentChildrenSyncUpTarget(
-                new ParentInfo(Constants.ACCOUNT, ACCOUNTS_SOUP, Constants.ID, accountModificationDateFieldName),
+                new ParentInfo(Constants.ACCOUNT, ACCOUNTS_SOUP, Constants.ID, accountModificationDateFieldName, accountExternalIdFieldName),
                 Arrays.asList(Constants.ID, Constants.NAME, Constants.DESCRIPTION),
                 Arrays.asList(Constants.NAME, Constants.DESCRIPTION),
-                new ChildrenInfo(Constants.CONTACT, Constants.CONTACT + "s", CONTACTS_SOUP, ACCOUNT_ID, Constants.ID, contactModificationDateFieldName),
+                new ChildrenInfo(Constants.CONTACT, Constants.CONTACT + "s", CONTACTS_SOUP, ACCOUNT_ID, Constants.ID, contactModificationDateFieldName, contactExternalIdFieldName),
                 Arrays.asList(Constants.LAST_NAME, ACCOUNT_ID),
                 Arrays.asList(Constants.LAST_NAME, ACCOUNT_ID),
                 RelationshipType.MASTER_DETAIL); // account-contacts are master-detail

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncTestCase.java
@@ -624,7 +624,7 @@ public class ParentChildrenSyncTestCase extends SyncManagerTestCase {
             JSONObject[] contacts = new JSONObject[numberOfContactsPerAccount];
             for (int i = 0; i < numberOfContactsPerAccount; i++) {
                 JSONObject contact = new JSONObject();
-                contact.put(Constants.ID, createLocalId());
+                contact.put(Constants.ID, SyncTarget.createLocalId());
                 contact.put(Constants.LAST_NAME, createRecordName(Constants.CONTACT));
                 contact.put(Constants.ATTRIBUTES, attributes);
                 contact.put(SyncTarget.LOCAL, true);

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
@@ -764,17 +764,4 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         return trySyncDown(mergeMode, target, ACCOUNTS_SOUP, idToFields.size(), 1, syncName);
 
     }
-
-    /**
-     * Helper for building fields map
-     * @param name
-     * @param description
-     * @return
-     */
-    protected Map<String, Object> createFieldsMapFromNameDescription(String name, String description) {
-        final Map<String, Object> fields = new HashMap<>();
-        if (name != null) fields.put(Constants.NAME, name);
-        if (description != null) fields.put(Constants.DESCRIPTION, description);
-        return fields;
-    }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/KeyValueEncryptedFileStoreTest.java
@@ -63,6 +63,14 @@ public class KeyValueEncryptedFileStoreTest {
 
     @Before
     public void setUp() {
+        try {
+            Class.forName("dalvik.system.CloseGuard")
+                .getMethod("setEnabled", boolean.class)
+                .invoke(null, true);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+
         context =
                 InstrumentationRegistry.getInstrumentation()
                         .getTargetContext()

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/store/KeyValueEncryptedFileStoreTest.java
@@ -63,6 +63,7 @@ public class KeyValueEncryptedFileStoreTest {
 
     @Before
     public void setUp() {
+        // Throw an exception if stream is not closed
         try {
             Class.forName("dalvik.system.CloseGuard")
                 .getMethod("setEnabled", boolean.class)

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DetailActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DetailActivity.java
@@ -252,8 +252,7 @@ public class DetailActivity extends SalesforceActivity implements LoaderManager.
 						Constants.ID, objectId)).getJSONObject(0);
 			} else {
 				contact = new JSONObject();
-				contact.put(Constants.ID, "local_" + System.currentTimeMillis()
-						+ Constants.EMPTY_STRING);
+				contact.put(Constants.ID, SyncTarget.createLocalId());
 				final JSONObject attributes = new JSONObject();
 				attributes.put(Constants.TYPE.toLowerCase(), Constants.CONTACT);
 				contact.put(Constants.ATTRIBUTES, attributes);


### PR DESCRIPTION
Locally created parents and/or children providing an external id are upserted during sync up.

* ParentInfo and ChildrenInfo both have the new field,
* Added test for ParentChildrenSyncUpTarget,
* Using the new field in one of the example config and modified config test accordingly,
* Added new methods: SyncTarget.createLocalId() and SyncTarget.isLocalId() - they should be used to get the correct behavior if using id field as the external id field.

The work for other sync up target was done in https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2010.