### PR TITLE
@W-8247135 Call parent onDismiss, fixes issue when dismissing dialog

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/CustomServerUrlEditor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/CustomServerUrlEditor.java
@@ -123,6 +123,7 @@ public class CustomServerUrlEditor extends DialogFragment {
 		if (activity != null) {
 			activity.rebuildDisplay();
 		}
+		super.onDismiss(dialog);
 	}
 
 	/**


### PR DESCRIPTION
Addresses issue outlined in https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008h6aiIAA/view
By insuring the parent onDismiss is called, this ensures the dialog is left in the correct state when dismissed by
the back button or clicking outside the dialog.

