### PR TITLE
Preventing Rare Crash in PaperDB

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
@@ -120,7 +120,12 @@ public class EventStoreManager {
             return null;
         }
         InstrumentationEvent event = null;
-        final String encryptedEvent = book.read(eventId, null);
+        String encryptedEvent = null;
+        try {
+            encryptedEvent = book.read(eventId, null);
+        } catch (Exception e) {
+            SalesforceAnalyticsLogger.e(context, TAG, "Exception occurred while attempting to read event from PaperDB", e);
+        }
         if (!TextUtils.isEmpty(encryptedEvent)) {
             final String decryptedEvent = decrypt(encryptedEvent);
             if (!TextUtils.isEmpty(decryptedEvent)) {

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/store/EventStoreManager.java
@@ -53,9 +53,9 @@ public class EventStoreManager {
     private static final String FILENAME = "event_store";
     private static final String TAG = "EventStoreManager";
 
-    private Context context;
-    private String encryptionKey;
-    private Book book;
+    private final Context context;
+    private final String encryptionKey;
+    private final Book book;
     private boolean isLoggingEnabled = true;
     private int maxEvents = 10000;
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -59,14 +59,13 @@ public class SalesforceKeyGenerator {
     private static final String SHARED_PREF_FILE = "identifier.xml";
     private static final String ENCRYPTED_ID_SHARED_PREF_KEY = "encrypted_%s";
     private static final String ID_PREFIX = "id_";
-    private static final String ADDENDUM = "addendum_%s";
     private static final String KEYSTORE_ALIAS = "com.salesforce.androidsdk.security.KEYPAIR";
     private static final String SHA1 = "SHA-1";
     private static final String SHA256 = "SHA-256";
     private static final String SHA1PRNG = "SHA1PRNG";
     private static final String AES = "AES";
 
-    private static Map<String, String> CACHED_ENCRYPTION_KEYS = new ConcurrentHashMap<>();
+    private static final Map<String, String> CACHED_ENCRYPTION_KEYS = new ConcurrentHashMap<>();
 
     /**
      * Returns the unique ID being used. The default key length is 256 bits.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -191,10 +191,10 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     protected final LoginOptions loginOptions;
     private final WebView webview;
     private AccountOptions accountOptions;
-    private Activity activity;
+    private final Activity activity;
     private PrivateKey key;
     private X509Certificate[] certChain;
-    private boolean shouldReloadPage;
+    private final boolean shouldReloadPage;
 
     public void saveState(Bundle outState) {
         webview.saveState(outState);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
@@ -94,7 +94,7 @@ public class AuthConfigUtil {
         private static final String LOGIN_PAGE_KEY = "LoginPage";
         private static final String LOGIN_PAGE_URL_KEY = "LoginPageUrl";
 
-        private JSONObject authConfig;
+        private final JSONObject authConfig;
         private boolean browserLoginEnabled;
         private List<String> ssoUrls;
         private String loginPageUrl;


### PR DESCRIPTION
There's a rare situation in `PaperDB` that  causes a crash while attempting to read  a stored event. We have filed an issue with `PaperDB` [here](https://github.com/pilgr/Paper/issues/4). However, in the meanwhile, we need to prevent our applications from crashing in the background while attempting to upload events (there are many crash reports for our internal apps).