### PR TITLE
[BUGFIX] Using app context instead of activity context to avoid memory leak

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
@@ -83,8 +83,12 @@ public class SalesforceActivityDelegate {
                 final ClientManager.LoginOptions loginOptions = SalesforceSDKManager.getInstance().getLoginOptions();
 
                 // Gets a rest client.
-                new ClientManager(activity, accountType, loginOptions,
-                        SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()).getRestClient(activity, new ClientManager.RestClientCallback() {
+                new ClientManager(
+                        SalesforceSDKManager.getInstance().getAppContext(),
+                        accountType,
+                        loginOptions,
+                        SalesforceSDKManager.getInstance().shouldLogoutWhenTokenRevoked()
+                ).getRestClient(activity, new ClientManager.RestClientCallback() {
 
                     @Override
                     public void authenticatedRestClient(RestClient client) {


### PR DESCRIPTION
## Description
In `SalesforceActivityDelegate`, we replace the usage of Activity Context to build `ClientManager` since it may lead to memory leak when the activity is destroyed. We use Application Context instead.

## Motivation and Context
Using [LeakCanary](https://square.github.io/leakcanary/), we can detect memory leak when the related Activity is destroyed. The reference is kept by the `ClientManager` and its underlaying dependencies.

## How Has This Been Tested?
- Configure [LeakCanary](https://square.github.io/leakcanary/) on your project which imports the Salesforce SDK 
- Start an activity which uses `SalesforceActivityDelegate` such as `SalesforceActivity`
- Quit the activity
- Check the leak does not exist anymore