### PR TITLE
Update Server Picker UX.

### DIFF
--- a/libs/SalesforceSDK/res/layout/sf__server_picker.xml
+++ b/libs/SalesforceSDK/res/layout/sf__server_picker.xml
@@ -35,8 +35,8 @@
 		android:layout_marginLeft="20dp"
 		android:layout_marginRight="20dp"
 		android:layout_marginBottom="20dp"
-		android:background="@drawable/sf__passcode_primary_color_button"
-		android:textColor="?attr/sfColorSecondary"
+		android:background="@drawable/sf__passcode_secondary_color_button"
+		android:textColor="?attr/sfNegativeButtonTextColor"
 		android:textAllCaps="false"
 		android:textSize="14sp"
 		android:textStyle="bold" />

--- a/libs/SalesforceSDK/res/values/sf__colors.xml
+++ b/libs/SalesforceSDK/res/values/sf__colors.xml
@@ -17,4 +17,5 @@
     <color name="sf__hint_color">#42000000</color>
     <color name="sf__hint_color_dark">#42D5B0B0</color>
     <color name="sf__accessibility_nav_color">#3e3e3c</color> <!-- SLDS grey 11 -->
+    <color name="sf__subtext_color">#706E6B</color> <!-- SLDS grey 9 -->
 </resources>

--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -29,7 +29,7 @@
 	<!-- Server picker -->
 	<string name="sf__auth_login_production">Production</string>
 	<string name="sf__auth_login_sandbox">Sandbox</string>
-	<string name="sf__custom_url_button">Add Connection</string>
+	<string name="sf__custom_url_button">Add New Connection</string>
 	<string name="sf__server_url_add_title">Add Connection</string>
 	<string name="sf__server_url_default_custom_label">Name</string>
 	<string name="sf__server_url_default_custom_url">URL</string>

--- a/libs/SalesforceSDK/res/values/sf__styles.xml
+++ b/libs/SalesforceSDK/res/values/sf__styles.xml
@@ -81,13 +81,11 @@
     </style>
 
     <style name="SalesforceSDK_RadialButtonUrl" parent="@style/TextAppearance.AppCompat.Small">
-        <item name="android:textColor">@color/sf__hint_color</item>
-        <item name="android:buttonTint">@color/sf__hint_color</item>
+        <item name="android:textColor">@color/sf__subtext_color</item>
     </style>
 
     <style name="SalesforceSDK_RadialButtonUrl_Dark" parent="@style/TextAppearance.AppCompat.Small">
-        <item name="android:textColor">@color/sf__hint_color_dark</item>
-        <item name="android:buttonTint">@color/sf__hint_color_dark</item>
+        <item name="android:textColor">@color/sf__text_color_dark</item>
     </style>
 
     <style name="SalesforceSDK.Inspector" parent="Theme.MaterialComponents.Light">

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -26,6 +26,7 @@
  */
 package com.salesforce.androidsdk.ui;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.app.FragmentManager;
 import android.content.Intent;
@@ -94,6 +95,12 @@ public class ServerPickerActivity extends Activity implements
     	}
     }
 
+    @Override
+    public boolean onNavigateUp() {
+        onBackPressed();
+        return true;
+    }
+
     /**
      * Called when the 'Reset' button is clicked. Clears custom URLs.
      *
@@ -121,6 +128,10 @@ public class ServerPickerActivity extends Activity implements
         SalesforceSDKManager.getInstance().setViewNavigationVisibility(this);
         loginServerManager = SalesforceSDKManager.getInstance().getLoginServerManager();
         setContentView(R.layout.sf__server_picker);
+
+        final ActionBar actionBar = getActionBar();
+        actionBar.setTitle("Change Server");
+        actionBar.setDisplayHomeAsUpEnabled(true);
 
         /*
          * Hides the 'Add Connection' button if the MDM variable to disable


### PR DESCRIPTION
- Add back button to Server Picker action bar to indicate that the user does not need tap a save button.
- Change header text from app name to "Change Server"
- Change add connection button styling from primary to secondary to indicate adding a new connection is not a mandatory action.
- Change url text color to make it more readable.  

This work is pending UX approval.  