### PR TITLE
Fixing crash when refresh token is revoked from the background

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -446,15 +446,23 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
 
                     @Override
                     public void run() {
+
                         /*
-                         * The client instance being used here needs to be
-                         * refreshed, to ensure we use the new access token.
+                         * The client instance being used here needs to be refreshed, to ensure we
+                         * use the new access token. However, if the refresh token was revoked
+                         * when the app was in the background, we need to catch that exception
+                         * and trigger a proper logout to reset the state of this class.
                          */
-                        SalesforceDroidGapActivity.this.client = SalesforceDroidGapActivity.this.clientManager.peekRestClient();
-                        setSidCookies();
-                        loadVFPingPage();
-                        final String frontDoorUrl = getFrontDoorUrl(url, BootConfig.isAbsoluteUrl(url));
-                        loadUrl(frontDoorUrl);
+                        try {
+                            SalesforceDroidGapActivity.this.client = SalesforceDroidGapActivity.this.clientManager.peekRestClient();
+                            setSidCookies();
+                            loadVFPingPage();
+                            final String frontDoorUrl = getFrontDoorUrl(url, BootConfig.isAbsoluteUrl(url));
+                            loadUrl(frontDoorUrl);
+                        } catch (AccountInfoNotFoundException e) {
+                            SalesforceHybridLogger.i(TAG, "User has been logged out.");
+                            logout(null);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
This fixes an issue where the app will crash if the refresh token was revoked in the background.