### PR TITLE
Key value store that keeps recently accessed values in a in-memory lru cache for faster access

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -50,7 +50,7 @@ import java.io.InputStream;
  * to employ this as a workaround for now, until we figure out how we can achieve acceptable
  * performance with a streaming solution, since CipherInputStream is a lot slower with AES-GCM.
  */
-public class KeyValueEncryptedFileStore  {
+public class KeyValueEncryptedFileStore implements KeyValueStore {
 
     private static final String TAG = KeyValueEncryptedFileStore.class.getSimpleName();
     public static final int MAX_STORE_NAME_LENGTH = 96;
@@ -135,6 +135,7 @@ public class KeyValueEncryptedFileStore  {
      * @param value Value to be persisted.
      * @return True - if successful, False - otherwise.
      */
+    @Override
     public boolean saveValue(String key, String value) {
         if (!isKeyValid(key, "saveValue")) {
             return false;
@@ -176,6 +177,7 @@ public class KeyValueEncryptedFileStore  {
      * @param stream Stream to be persisted.
      * @return True - if successful, False - otherwise.
      */
+    @Override
     public boolean saveStream(String key, InputStream stream) {
         if (!isKeyValid(key, "saveStream")) {
             return false;
@@ -199,6 +201,7 @@ public class KeyValueEncryptedFileStore  {
      * @param key Unique identifier.
      * @return value for given key or null if key not found.
      */
+    @Override
     public String getValue(String key) {
         try (InputStream inputStream = getStream(key)) {
             if (inputStream == null) {
@@ -217,6 +220,7 @@ public class KeyValueEncryptedFileStore  {
      * @param key Unique identifier.
      * @return stream to value for given key or null if key not found.
      */
+    @Override
     public InputStream getStream(String key) {
         if (!isKeyValid(key, "getStream")) {
             return null;
@@ -240,6 +244,7 @@ public class KeyValueEncryptedFileStore  {
      * @param key Unique identifier.
      * @return True - if successful, False - otherwise.
      */
+    @Override
     public synchronized boolean deleteValue(String key) {
         if (!isKeyValid(key, "deleteValue")) {
             return false;
@@ -248,6 +253,7 @@ public class KeyValueEncryptedFileStore  {
     }
 
     /** Deletes all stored values. */
+    @Override
     public void deleteAll() {
         for (File file : safeListFiles()) {
             SmartStoreLogger.i(TAG, "deleting file :" + file.getName());
@@ -256,11 +262,13 @@ public class KeyValueEncryptedFileStore  {
     }
 
     /** @return number of entries in the store. */
+    @Override
     public int count() {
         return safeListFiles().length;
     }
 
     /** @return True if store is empty. */
+    @Override
     public boolean isEmpty() {
         return safeListFiles().length == 0;
     }
@@ -275,6 +283,7 @@ public class KeyValueEncryptedFileStore  {
     /**
      * @return store name
      */
+    @Override
     public String getStoreName() {
         return storeDir.getName();
     }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueStore.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.androidsdk.smartstore.store;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface KeyValueStore {
+
+    String getValue(String key);
+
+    InputStream getStream(String key);
+
+    boolean saveValue(String key, String value);
+
+    boolean saveStream(String key, InputStream stream) throws IOException;
+
+    boolean deleteValue(String key);
+
+    void deleteAll();
+
+    int count();
+
+    boolean isEmpty();
+
+    String getStoreName();
+}

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStore.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN]
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.androidsdk.smartstore.store;
+
+import android.util.LruCache;
+import com.salesforce.androidsdk.analytics.security.Encryptor;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Key value store that keeps recently accessed values in a in-memory lru cache for faster access
+ */
+public class MemCachedKeyValueStore implements KeyValueStore {
+
+    private KeyValueStore keyValueStore;
+    private LruCache<String, String> memCache;
+
+    public MemCachedKeyValueStore(KeyValueStore keyValueStore, int cacheSize){
+        this.keyValueStore = keyValueStore;
+        memCache = new LruCache<>(cacheSize);
+    }
+
+    @Override
+    public String getValue(String key) {
+        String value = memCache.get(key);
+        if (value == null) {
+            value = keyValueStore.getValue(key);
+            if (value != null) {
+                keyValueStore.saveValue(key, value);
+                memCache.put(key, value);
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public InputStream getStream(String key) {
+        String value = getValue(key);
+        return value == null ?  null : new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public boolean saveValue(String key, String value) {
+        if (keyValueStore.saveValue(key, value)) {
+            memCache.put(key, value);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean saveStream(String key, InputStream stream) throws IOException {
+        String value = Encryptor.getStringFromStream(stream);
+        return saveValue(key, value);
+    }
+
+    @Override
+    public boolean deleteValue(String key) {
+        if (keyValueStore.deleteValue(key)) {
+            memCache.remove(key);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void deleteAll() {
+        memCache.evictAll();
+        keyValueStore.deleteAll();
+    }
+
+    @Override
+    public int count() {
+        return keyValueStore.count();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return keyValueStore.isEmpty();
+    }
+
+    @Override
+    public String getStoreName() {
+        return keyValueStore.getStoreName();
+    }
+}

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStore.java
@@ -39,8 +39,8 @@ import java.nio.charset.StandardCharsets;
  */
 public class MemCachedKeyValueStore implements KeyValueStore {
 
-    private KeyValueStore keyValueStore;
-    private LruCache<String, String> memCache;
+    KeyValueStore keyValueStore;
+    LruCache<String, String> memCache;
 
     public MemCachedKeyValueStore(KeyValueStore keyValueStore, int cacheSize){
         this.keyValueStore = keyValueStore;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/TestForceApp.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/TestForceApp.java
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk;
 
 import android.app.Application;
-
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 
 /**

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManagerTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManagerTest.java
@@ -24,13 +24,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.app;
+package com.salesforce.androidsdk.smartstore.app;
 
 import android.content.Context;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 import com.salesforce.androidsdk.accounts.UserAccount;
-import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.KeyValueEncryptedFileStore;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelperTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelperTest.java
@@ -24,22 +24,20 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.Context;
 import android.os.Bundle;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
 import androidx.test.platform.app.InstrumentationRegistry;
-
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
 import com.salesforce.androidsdk.analytics.security.Encryptor;
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
-
+import java.io.File;
+import java.util.Map;
+import java.util.Set;
 import net.sqlcipher.database.SQLiteDatabase;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -47,10 +45,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.io.File;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Tests for obtaining and deleting databases via the DBOpenHelper.

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/IndexSpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/IndexSpecTest.java
@@ -24,14 +24,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.SmallTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
+import androidx.test.filters.SmallTest;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -24,33 +24,27 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.Context;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
-
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
-import com.salesforce.androidsdk.smartstore.store.KeyValueEncryptedFileStore;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class KeyValueEncryptedFileStoreTest {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueStoreInspectorActivityTest.java
@@ -24,28 +24,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
-
-import android.content.Intent;
-import android.widget.AutoCompleteTextView;
-import android.widget.Button;
-
-import androidx.test.espresso.matcher.RootMatchers;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.MediumTest;
-import androidx.test.rule.ActivityTestRule;
-
-import com.salesforce.androidsdk.analytics.EventBuilderHelper;
-import com.salesforce.androidsdk.smartstore.R;
-import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
-import com.salesforce.androidsdk.smartstore.store.KeyValueEncryptedFileStore;
-import com.salesforce.androidsdk.smartstore.ui.KeyValueStoreInspectorActivity;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+package com.salesforce.androidsdk.smartstore.store;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -55,6 +34,23 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.CoreMatchers.allOf;
+
+import android.content.Intent;
+import android.widget.AutoCompleteTextView;
+import android.widget.Button;
+import androidx.test.espresso.matcher.RootMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.rule.ActivityTestRule;
+import com.salesforce.androidsdk.analytics.EventBuilderHelper;
+import com.salesforce.androidsdk.smartstore.R;
+import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
+import com.salesforce.androidsdk.smartstore.ui.KeyValueStoreInspectorActivity;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * Tests for KeyValueStoreInspectorActivity

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2021-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.smartstore.store;
+
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.salesforce.androidsdk.analytics.security.Encryptor;
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for MemCachedKeyValueStore */
+@RunWith(AndroidJUnit4.class)
+public class MemCachedKeyValueStoreTest {
+    static final String TEST_STORE = "TEST_STORE";
+    static final int NUM_ENTRIES = 100;
+
+    private KeyValueEncryptedFileStore store;
+    private MemCachedKeyValueStore memCachedStore;
+
+    @Before
+    public void setUp() {
+        // Throw an exception if stream is not closed
+        try {
+            Class.forName("dalvik.system.CloseGuard")
+                .getMethod("setEnabled", boolean.class)
+                .invoke(null, true);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+
+        Context context =
+            InstrumentationRegistry.getInstrumentation()
+                .getTargetContext()
+                .getApplicationContext();
+        
+        SmartStoreSDKManager.initNative(context, null);
+        store = new KeyValueEncryptedFileStore(context, TEST_STORE, SalesforceSDKManager.getEncryptionKey());
+        memCachedStore = new MemCachedKeyValueStore(store, NUM_ENTRIES);
+    }
+
+    @After
+    public void tearDown() {
+        store.deleteAll();
+    }
+
+    /** Test saving values and counting them  */
+    @Test
+    public void testSaveValueCount() {
+        for (int i=0; i<NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            Assert.assertEquals("Wrong count before save", i, memCachedStore.count());
+            Assert.assertEquals("Wrong count before save", i, store.count());
+            memCachedStore.saveValue(key, value);
+            Assert.assertEquals("Wrong count after save", i + 1, memCachedStore.count());
+            Assert.assertEquals("Wrong count after save", i + 1, store.count());
+        }
+    }
+
+    /** Test saving from streams and counting them  */
+    @Test
+    public void testSaveStreamCount() throws IOException {
+        for (int i=0; i<NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            InputStream stream = stringToStream("value" + i);
+            Assert.assertEquals("Wrong count before save", i, memCachedStore.count());
+            Assert.assertEquals("Wrong count before save", i, store.count());
+            memCachedStore.saveStream(key, stream);
+            Assert.assertEquals("Wrong count after save", i + 1, memCachedStore.count());
+            Assert.assertEquals("Wrong count after save", i + 1, store.count());
+        }
+    }
+
+    /** Test saving values and getting them back when mem cache hits */
+    @Test
+    public void testSaveValueGetWhenMemCacheHits() {
+        memCachedStore.saveValue("key1", "value1");
+        Assert.assertEquals(1, memCachedStore.memCache.putCount());
+
+        Assert.assertEquals("value1", memCachedStore.getValue("key1"));
+        Assert.assertEquals(1, memCachedStore.memCache.hitCount());
+        Assert.assertEquals("value1", store.getValue("key1"));
+
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(2, memCachedStore.memCache.hitCount());
+        Assert.assertEquals("value1", streamToString(store.getStream("key1")));
+
+        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+    }
+
+    /** Test saving from streams and getting them back when mem cache hits */
+    @Test
+    public void testSaveStreamGetWhenMemCacheHits() throws IOException {
+        memCachedStore.saveStream("key1", stringToStream("value1"));
+        Assert.assertEquals(1, memCachedStore.memCache.putCount());
+
+        Assert.assertEquals("value1", memCachedStore.getValue("key1"));
+        Assert.assertEquals(1, memCachedStore.memCache.hitCount());
+        Assert.assertEquals("value1", store.getValue("key1"));
+
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(2, memCachedStore.memCache.hitCount());
+        Assert.assertEquals("value1", streamToString(store.getStream("key1")));
+
+        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+    }
+
+    /** Test saving values and getting them back when mem cache misses */
+    @Test
+    public void testSaveValueGetWhenMemCacheMisses() {
+        memCachedStore.saveValue("key1", "value1");
+        Assert.assertEquals(1, memCachedStore.memCache.putCount());
+
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals("value1", memCachedStore.getValue("key1"));
+        Assert.assertEquals(1, memCachedStore.memCache.missCount());
+        Assert.assertEquals("value1", store.getValue("key1"));
+
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(2, memCachedStore.memCache.missCount());
+        Assert.assertEquals("value1", streamToString(store.getStream("key1")));
+    }
+
+    /** Test saving from streams and getting them back when mem cache misses */
+    @Test
+    public void testSaveStreamGetWhenMemCacheMisses() throws IOException {
+        memCachedStore.saveStream("key1", stringToStream("value1"));
+        Assert.assertEquals(1, memCachedStore.memCache.putCount());
+
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals("value1", memCachedStore.getValue("key1"));
+        Assert.assertEquals(1, memCachedStore.memCache.missCount());
+        Assert.assertEquals("value1", store.getValue("key1"));
+
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(2, memCachedStore.memCache.missCount());
+        Assert.assertEquals("value1", streamToString(store.getStream("key1")));
+    }
+
+    /** Test that get stream populates mem cache */
+    @Test
+    public void testGetStreamPopulatesMemCache() {
+        memCachedStore.saveValue("key1", "value1");
+        Assert.assertEquals(1, memCachedStore.memCache.putCount());
+
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(1, memCachedStore.memCache.missCount());
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(1, memCachedStore.memCache.hitCount());
+
+        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+    }
+
+    /** Test that get value populates mem cache */
+    @Test
+    public void testGetValuePopulatesMemCache() {
+        memCachedStore.saveValue("key1", "value1");
+        Assert.assertEquals(1, memCachedStore.memCache.putCount());
+
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(1, memCachedStore.memCache.missCount());
+        Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
+        Assert.assertEquals(1, memCachedStore.memCache.hitCount());
+
+        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+    }
+
+    /** Test saving values and deleting them  */
+    @Test
+    public void testSaveValueDelete() {
+        for (int i=0; i<NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            memCachedStore.saveValue(key, value);
+        }
+        for (int i=0; i<NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            Assert.assertNotNull("No value found for key when expected:$key", memCachedStore.getValue(key));
+            Assert.assertEquals("Wrong count before delete", NUM_ENTRIES - i, memCachedStore.count());
+            Assert.assertNotNull("No value found for key when expected:$key", store.getValue(key));
+            Assert.assertEquals("Wrong count before delete", NUM_ENTRIES - i, store.count());
+            memCachedStore.deleteValue(key);
+            Assert.assertNull("Value found for key when not expected:$key", memCachedStore.getValue(key));
+            Assert.assertEquals("Wrong count after delete", NUM_ENTRIES - i - 1, memCachedStore.count());
+            Assert.assertNull("Value found for key when not expected:$key", store.getValue(key));
+            Assert.assertEquals("Wrong count after delete", NUM_ENTRIES - i - 1, store.count());
+        }
+    }
+
+    /** Test saving values and deleting them all at once  */
+    @Test
+    public void testSaveValueDeleteAll() {
+        for (int i=0; i<NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            memCachedStore.saveValue(key, value);
+        }
+
+        Assert.assertEquals("Wrong count before deleteAll", NUM_ENTRIES, memCachedStore.count());
+        Assert.assertEquals("Wrong count before deleteAll", NUM_ENTRIES, store.count());
+        memCachedStore.deleteAll();
+        Assert.assertEquals("Wrong count after deleteAll", 0, memCachedStore.count());
+        Assert.assertEquals("Wrong count after deleteAll", 0, store.count());
+    }
+
+    /** Test new lines are preserved when value retrieved from memory  */
+    @Test
+    public void testNewLinesPreservedWhenMemCacheHits() throws IOException {
+        String codeBlock = "var fun = function() {\r // comment \n var i = 100; } \r\n // comment";
+
+        memCachedStore.saveStream("js1", stringToStream(codeBlock));
+        memCachedStore.saveValue("js2", codeBlock);
+        Assert.assertEquals(codeBlock, memCachedStore.getValue("js1"));
+        Assert.assertEquals(codeBlock, streamToString(memCachedStore.getStream("js1")));
+        Assert.assertEquals(codeBlock, memCachedStore.getValue("js2"));
+        Assert.assertEquals(codeBlock, streamToString(memCachedStore.getStream("js2")));
+        Assert.assertEquals(codeBlock, store.getValue("js1"));
+        Assert.assertEquals(codeBlock, streamToString(store.getStream("js1")));
+        Assert.assertEquals(codeBlock, store.getValue("js2"));
+        Assert.assertEquals(codeBlock, streamToString(store.getStream("js2")));
+    }
+
+    /** Test new lines are preserved when value retrieved from file system  */
+    @Test
+    public void testNewLinesPreservedWhenMemCacheMisses() throws IOException {
+        String codeBlock = "var fun = function() {\r // comment \n var i = 100; } \r\n // comment";
+
+        memCachedStore.saveStream("js1", stringToStream(codeBlock));
+        memCachedStore.saveValue("js2", codeBlock);
+
+        // Evicting all from memCache
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals(codeBlock, memCachedStore.getValue("js1"));
+        Assert.assertEquals(codeBlock, memCachedStore.getValue("js2"));
+
+        // Evicting all from memCache
+        memCachedStore.memCache.evictAll();
+        Assert.assertEquals(codeBlock, streamToString(memCachedStore.getStream("js1")));
+        Assert.assertEquals(codeBlock, streamToString(memCachedStore.getStream("js2")));
+    }
+
+
+    //
+    // Helper methods
+    //
+    private InputStream stringToStream(String value) {
+        return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String streamToString(InputStream inputStream) {
+        if (inputStream == null) {
+            return null;
+        }
+        try {
+            return Encryptor.getStringFromStream(inputStream);
+        } catch (IOException e) {
+            Assert.fail("Failed to read from stream");
+            return null;
+        } finally {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                Assert.fail("Stream failed to close");
+            }
+        }
+    }
+
+}

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/QuerySpecTest.java
@@ -24,13 +24,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.SmallTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
-
+import androidx.test.filters.SmallTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlExternalStorageTest.java
@@ -24,20 +24,14 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.MediumTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
+import androidx.test.filters.MediumTest;
 import com.salesforce.androidsdk.analytics.security.Encryptor;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper.SmartSqlException;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-import com.salesforce.androidsdk.smartstore.store.SoupSpec;
 import com.salesforce.androidsdk.util.JSONTestHelper;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlTest.java
@@ -24,18 +24,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.SmallTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import androidx.test.filters.SmallTest;
 import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper.SmartSqlException;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 import com.salesforce.androidsdk.util.JSONTestHelper;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreAlterTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreAlterTest.java
@@ -24,24 +24,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.database.Cursor;
-import androidx.test.filters.MediumTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.salesforce.androidsdk.smartstore.store.AlterSoupLongOperation;
-import com.salesforce.androidsdk.smartstore.store.DBHelper;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.LongOperation;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
-import com.salesforce.androidsdk.smartstore.store.SmartSqlHelper;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
-import com.salesforce.androidsdk.smartstore.store.SoupSpec;
+import androidx.test.filters.MediumTest;
 import com.salesforce.androidsdk.util.JSONTestHelper;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import net.sqlcipher.database.SQLiteDatabase;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -50,10 +42,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Tests to compare speed of smartstore full-text-search indices with regular indices

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreExternalStorageTest.java
@@ -24,35 +24,25 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.database.Cursor;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
-
 import com.salesforce.androidsdk.analytics.security.Encryptor;
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec.Order;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-import com.salesforce.androidsdk.smartstore.store.SoupSpec;
 import com.salesforce.androidsdk.util.JSONTestHelper;
-
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import net.sqlcipher.database.SQLiteDatabase;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Tests for encrypted smart store with external storage

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFTSExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFTSExternalStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-present, salesforce.com, inc.
+ * Copyright (c) 2016-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -24,47 +24,27 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.LargeTest;
 
-import com.salesforce.androidsdk.analytics.security.Encryptor;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
-import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-import com.salesforce.androidsdk.smartstore.store.SoupSpec;
-
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
- * Set of tests for the smart store loading numerous and/or large entries and querying them back - using external storage
+ * Tests for full-text search in smartstore soups using external storage
  */
-@RunWith(Parameterized.class)
-@LargeTest
-public class SmartStoreLoadExternalStorageTest extends SmartStoreLoadTest {
-
-    @Override
-    protected String getEncryptionKey() {
-        return Encryptor.hash("test123", "hashing-key");
-    }
+@RunWith(AndroidJUnit4.class)
+@MediumTest
+public class SmartStoreFTSExternalStorageTest extends SmartStoreFullTextSearchTest {
 
     @Override
     protected void registerSoup(SmartStore store, String soupName, IndexSpec[] indexSpecs) {
         store.registerSoupWithSpec(new SoupSpec(soupName, SoupSpec.FEATURE_EXTERNAL_STORAGE), indexSpecs);
     }
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{
-//                {"UpsertQuery1StringIndex1000fields1000characters", Type.string, NUMBER_ENTRIES, 1000, 1000, 1}, // to push memory utilization
-                {"UpsertQuery1StringIndex1field20characters", Type.string, NUMBER_ENTRIES, 1, 20, 1},
-                {"UpsertQuery1StringIndex1field1000characters", Type.string, NUMBER_ENTRIES, 1, 1000, 1},
-                {"UpsertQuery1StringIndex10fields20characters", Type.string, NUMBER_ENTRIES, 10, 20, 1},
-                {"UpsertQuery10StringIndexes10fields20characters", Type.string, NUMBER_ENTRIES, 10, 20, 10}
-        });
+    @Override
+    protected String[] getExpectedColumns() {
+        return new String[]{"id", "created", "lastModified", FIRST_NAME_COL, LAST_NAME_COL, EMPLOYEE_ID_COL};
     }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFullTextSearchSpeedTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFullTextSearchSpeedTest.java
@@ -24,15 +24,13 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.LargeTest;
 import android.util.Log;
-
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import androidx.test.filters.LargeTest;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-
+import java.util.Arrays;
+import java.util.Collection;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -40,9 +38,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * Tests to compare speed of smartstore full-text-search indices with regular indices

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFullTextSearchTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFullTextSearchTest.java
@@ -24,20 +24,14 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.database.Cursor;
-import androidx.test.filters.MediumTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.salesforce.androidsdk.smartstore.store.DBHelper;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
+import androidx.test.filters.MediumTest;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-
+import java.util.Arrays;
 import net.sqlcipher.database.SQLiteDatabase;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -46,8 +40,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Arrays;
 
 /**
  * Tests for full-text search with smartstore

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreInspectorActivityTest.java
@@ -24,28 +24,29 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 import android.content.Context;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.filters.MediumTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.widget.ListAdapter;
 import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
-
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.MediumTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.ActivityTestRule;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
 import com.salesforce.androidsdk.smartstore.R;
-import com.salesforce.androidsdk.smartstore.store.DBHelper;
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 import com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity;
-
+import java.util.HashSet;
+import java.util.Set;
 import net.sqlcipher.database.SQLiteOpenHelper;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -53,15 +54,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static androidx.test.espresso.action.ViewActions.replaceText;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 /**
  * Tests for SmartStoreInspectorActivity

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreLoadExternalStorageTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreLoadExternalStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-present, salesforce.com, inc.
+ * Copyright (c) 2011-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -24,33 +24,22 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import androidx.test.filters.LargeTest;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import android.util.Log;
-
 import com.salesforce.androidsdk.analytics.security.Encryptor;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-import com.salesforce.androidsdk.smartstore.store.SoupSpec;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Test;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /**
- * More load tests for smartstore - using external storage
+ * Set of tests for the smart store loading numerous and/or large entries and querying them back - using external storage
  */
-@RunWith(AndroidJUnit4.class)
+@RunWith(Parameterized.class)
 @LargeTest
-public class SmartStoreOtherLoadExternalStorageTest extends SmartStoreOtherLoadTest {
-
-    static final int LARGE_BYTES = 512 * 1024;
+public class SmartStoreLoadExternalStorageTest extends SmartStoreLoadTest {
 
     @Override
     protected String getEncryptionKey() {
@@ -62,36 +51,14 @@ public class SmartStoreOtherLoadExternalStorageTest extends SmartStoreOtherLoadT
         store.registerSoupWithSpec(new SoupSpec(soupName, SoupSpec.FEATURE_EXTERNAL_STORAGE), indexSpecs);
     }
 
-    // Test very large payloads for smartstore
-    @Test
-    public void testUpsertLargePayload() throws JSONException {
-        setupSoup(TEST_SOUP, 1, Type.string);
-        JSONObject entry = new JSONObject();
-        for (int i = 0; i < 5; i++) {
-            StringBuilder sb = new StringBuilder();
-            for (int j = 0; j < LARGE_BYTES; j++) {
-                sb.append(i);
-            }
-            entry.put("value_" + i, sb.toString());
-        }
-
-        // Upsert
-        long start = System.currentTimeMillis();
-        store.upsert(TEST_SOUP, entry);
-        long end = System.currentTimeMillis();
-
-        // Log time taken
-        Log.i("SmartStoreLoadTest", "Upserting 5MB+ payload time taken: " + (end - start) + " ms");
-
-        // Verify
-        JSONArray result = store.retrieve(TEST_SOUP, 1L);
-        for (int i = 0; i < 5; i++) {
-            Assert.assertTrue("Value at index " + i + " is incorrect", result.getJSONObject(0).getString("value_" + i).startsWith("" + i));
-        }
-    }
-
-    @Override
-    public void testAlterSoupJSON1Indexing() throws JSONException {
-        // json1 is not compatible with external storage.
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+//                {"UpsertQuery1StringIndex1000fields1000characters", Type.string, NUMBER_ENTRIES, 1000, 1000, 1}, // to push memory utilization
+                {"UpsertQuery1StringIndex1field20characters", Type.string, NUMBER_ENTRIES, 1, 20, 1},
+                {"UpsertQuery1StringIndex1field1000characters", Type.string, NUMBER_ENTRIES, 1, 1000, 1},
+                {"UpsertQuery1StringIndex10fields20characters", Type.string, NUMBER_ENTRIES, 10, 20, 1},
+                {"UpsertQuery10StringIndexes10fields20characters", Type.string, NUMBER_ENTRIES, 10, 20, 10}
+        });
     }
 }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreLoadTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreLoadTest.java
@@ -24,24 +24,20 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.LargeTest;
 import android.util.Log;
-
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
+import androidx.test.filters.LargeTest;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 
 /**
  * Set of tests for the smart store loading numerous and/or large entries and querying them back

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreLoadTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreLoadTestCase.java
@@ -24,23 +24,17 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.platform.app.InstrumentationRegistry;
 import android.util.Log;
-
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
+import androidx.test.platform.app.InstrumentationRegistry;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Before;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
 
 /**
  * Super class for smartstore load tests

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreOtherLoadTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreOtherLoadTest.java
@@ -24,15 +24,12 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.LargeTest;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.util.Log;
-
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -24,25 +24,19 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.database.Cursor;
 import android.os.SystemClock;
-
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
-
-import com.salesforce.androidsdk.smartstore.store.DBHelper;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec.Order;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
-import com.salesforce.androidsdk.smartstore.store.SoupSpec;
 import com.salesforce.androidsdk.util.JSONTestHelper;
-
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import net.sqlcipher.database.SQLiteDatabase;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -51,10 +45,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Main test suite for SmartStore

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTestCase.java
@@ -24,32 +24,24 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.Context;
 import android.database.Cursor;
 import androidx.test.platform.app.InstrumentationRegistry;
-
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
-import com.salesforce.androidsdk.smartstore.store.DBHelper;
-import com.salesforce.androidsdk.smartstore.store.DBOpenHelper;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONTestHelper;
-
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteOpenHelper;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Abstract super class for smart store tests

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SoupSpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SoupSpecTest.java
@@ -24,13 +24,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
-import androidx.test.filters.SmallTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.salesforce.androidsdk.smartstore.store.SoupSpec;
-
+import androidx.test.filters.SmallTest;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/StoreConfigTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/StoreConfigTest.java
@@ -25,27 +25,22 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.salesforce.androidsdk.store;
+package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.Context;
-import androidx.test.platform.app.InstrumentationRegistry;
-import androidx.test.filters.SmallTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
+import androidx.test.filters.SmallTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 import com.salesforce.androidsdk.MainActivity;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
-import com.salesforce.androidsdk.smartstore.store.IndexSpec;
-import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.ui.LoginActivity;
-
+import java.util.List;
 import org.json.JSONException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest


### PR DESCRIPTION
* Added class MemCacheKeyValueStore (wraps around regular key value store)
* Added interface KeyValueStore (implemented by both KeyValueEncryptedFileStore and MemCacheKeyValueStore)
* Added tests
* Move smartstore tests from package androidsdk.store to androidsdk.smartstore.store to allow access to default members