### PR TITLE
Adding keySet() method to key store

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -161,7 +161,7 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
             return false;
         }
         try {
-            encryptStringToFile(getKeyFile(key), key, encryptionKey);
+            if (kvVersion >= 2) encryptStringToFile(getKeyFile(key), key, encryptionKey);
             encryptStringToFile(getValueFile(key), value, encryptionKey);
             return true;
         } catch (Exception e) {
@@ -188,7 +188,7 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
             return false;
         }
         try {
-            encryptStringToFile(getKeyFile(key), key, encryptionKey);
+            if (kvVersion >=2) encryptStringToFile(getKeyFile(key), key, encryptionKey);
             encryptStreamToFile(getValueFile(key), stream, encryptionKey);
             return true;
         } catch (Exception e) {
@@ -256,7 +256,8 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
         if (!isKeyValid(key, "deleteValue")) {
             return false;
         }
-        return getKeyFile(key).delete() && getValueFile(key).delete(); // XXX What if only one succeeds?
+        if (kvVersion >= 2)  getKeyFile(key).delete();
+        return getValueFile(key).delete();
     }
 
     /** Deletes all stored values. */
@@ -277,12 +278,12 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
 
     /**
      * Get all keys.
-     * NB: will return null if values were inserted with SDK 9.0 or if an error occurs reading a key
+     * NB: will throw UnsupportedOperationException for a v1 store
      */
     @Override
-    public Set<String> keySet() {
-        if (kvVersion < 2) {
-            return null;
+    public Set<String> keySet()  {
+        if (kvVersion == 1) {
+            throw new UnsupportedOperationException("keySet() not supported on v1 stores");
         }
 
         HashSet<String> keys = new HashSet<>();

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -326,6 +326,13 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
     }
 
     /**
+     * @return store version
+     */
+    public int getStoreVersion() {
+        return kvVersion;
+    }
+
+    /**
      * Change encryption key
      * All files are read/decrypted with old key and encrypted/written back with new key
      * @param newEncryptionKey

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -91,10 +91,6 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
             throw new IllegalArgumentException("Invalid store name: " + storeName);
         }
         storeDir = new File(parentDir, storeName);
-        if (storeDir.exists() && !storeDir.isDirectory()) {
-            throw new IllegalArgumentException("Cannot create directory for: " + storeName);
-        }
-
         this.encryptionKey = encryptionKey;
 
         if (!storeDir.exists()) {
@@ -103,6 +99,10 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
             kvVersion = KV_VERSION;
         } else {
             kvVersion = readVersion();
+        }
+
+        if (!storeDir.exists() || !storeDir.isDirectory()) {
+            throw new IllegalArgumentException("Failed to create directory for: " + storeName);
         }
     }
 
@@ -262,9 +262,16 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
     /** Deletes all stored values. */
     @Override
     public void deleteAll() {
-        for (File file : safeListFiles(null /* all */)) {
-            SmartStoreLogger.i(TAG, "deleting file :" + file.getName());
-            file.delete();
+        if (kvVersion == 1) {
+            for (File file : safeListFiles(null)) {
+                SmartStoreLogger.i(TAG, "deleting file :" + file.getName());
+                file.delete();
+            }
+        } else {
+            for (String key : keySet()) {
+                SmartStoreLogger.i(TAG, "deleting key :" + key);
+                deleteValue(key);
+            }
         }
     }
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueStore.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.smartstore.store;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
 
 public interface KeyValueStore {
 
@@ -43,6 +44,8 @@ public interface KeyValueStore {
     boolean deleteValue(String key);
 
     void deleteAll();
+
+    Set<String> keySet();
 
     int count();
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStore.java
@@ -33,6 +33,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 /**
  * Key value store that keeps recently accessed values in a in-memory lru cache for faster access
@@ -96,6 +97,11 @@ public class MemCachedKeyValueStore implements KeyValueStore {
     public void deleteAll() {
         memCache.evictAll();
         keyValueStore.deleteAll();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return keyValueStore.keySet();
     }
 
     @Override

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -87,6 +87,26 @@ public class KeyValueEncryptedFileStoreTest {
         ManagedFilesHelper.deleteFile(getStoreDir(TEST_STORE));
     }
 
+    /** Test getStoreVersion() */
+    @Test
+    public void testGetStoreVersion() {
+        Assert.assertEquals("Wrong kv store version", KeyValueEncryptedFileStore.KV_VERSION,
+            keyValueStore.getStoreVersion());
+    }
+
+    /** Test getStoreVersion() when there is on version file (v1 store) */
+    @Test
+    public void testGetStoreVersionWithoutVersionFile() {
+        File versionFile = new File(getStoreDir(TEST_STORE), "version");
+        Assert.assertTrue(versionFile.exists());
+        versionFile.delete();
+        KeyValueEncryptedFileStore keyValueStoreWithoutVersionFile =
+            new KeyValueEncryptedFileStore(
+                context, TEST_STORE, SalesforceSDKManager.getEncryptionKey());
+        Assert.assertEquals("Wrong kv store version", 1, keyValueStoreWithoutVersionFile.getStoreVersion());
+        Assert.assertFalse(versionFile.exists());
+    }
+
     /** Test isValidStoreName() */
     @Test
     public void isValidStoreName() {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -33,6 +33,7 @@ import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
+import com.salesforce.androidsdk.util.ManagedFilesHelper;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -80,8 +81,7 @@ public class KeyValueEncryptedFileStoreTest {
 
     @After
     public void tearDown() {
-        keyValueStore.deleteAll();
-        getStoreDir(TEST_STORE).delete();
+        ManagedFilesHelper.deleteFile(getStoreDir(TEST_STORE));
     }
 
     /** Test isValidStoreName() */
@@ -148,6 +148,7 @@ public class KeyValueEncryptedFileStoreTest {
     @Test
     public void testFailedCreateFileExist() throws IOException {
         File file = getStoreDir("file");
+        file.delete(); // starting clean
         Assert.assertTrue("Test file creation failed", file.createNewFile());
         try {
             new KeyValueEncryptedFileStore(context, "file", "");
@@ -318,7 +319,7 @@ public class KeyValueEncryptedFileStoreTest {
     /** Making sure various operations won't NPE if storeDir was deleted */
     @Test
     public void testNoNPEIfStoreDirDeleted() {
-        keyValueStore.getStoreDir().delete();
+        ManagedFilesHelper.deleteFile(keyValueStore.getStoreDir());
         Assert.assertNull("Expected null for files in deleted stored dir", keyValueStore.getStoreDir().listFiles());
         try {
             Assert.assertEquals(TEST_STORE, keyValueStore.getStoreName());
@@ -371,7 +372,7 @@ public class KeyValueEncryptedFileStoreTest {
         keyValueStore.saveValue("key2", "value2");
         // Look at the raw content of files
         File[] files = keyValueStore.getStoreDir().listFiles();
-        Assert.assertEquals("Wrong number of files", 2, files.length);
+        Assert.assertEquals("Wrong number of files", 5 /* 2 keys, 2 values, 1 version*/, files.length);
         String file1raw = streamToString(new FileInputStream(files[0]));
         String file2raw = streamToString(new FileInputStream(files[1]));
         // Make sure the actual value can't be found
@@ -391,7 +392,7 @@ public class KeyValueEncryptedFileStoreTest {
         Assert.assertEquals("Wrong value for key1", "value2", keyValueStore.getValue("key2"));
         // Getting raw content of files
         File[] files = keyValueStore.getStoreDir().listFiles();
-        Assert.assertEquals("Wrong number of files", 2, files.length);
+        Assert.assertEquals("Wrong number of files", 5 /* 2 keys, 2 values, 1 version*/, files.length);
         String file1raw = streamToString(new FileInputStream(files[0]));
         String file2raw = streamToString(new FileInputStream(files[1]));
         // Generate new key

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -411,6 +411,69 @@ public class KeyValueEncryptedFileStoreTest {
         keyValueStore.deleteAll();
         Assert.assertEquals(1 /* version file */, getStoreDir(TEST_STORE).list().length);
     }
+
+
+    /** Test saving values and calling keySet() */
+    @Test
+    public void testSaveValueKeySet() {
+        for (int i = 0; i < NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            Assert.assertEquals(i, keyValueStore.keySet().size());
+            Assert.assertFalse(keyValueStore.keySet().contains(key));
+            keyValueStore.saveValue(key, value);
+            Assert.assertTrue(keyValueStore.keySet().contains(key));
+            Assert.assertEquals(i+1, keyValueStore.keySet().size());
+        }
+    }
+
+    /** Test saving streams and calling keySet() */
+    @Test
+    public void testSaveStreamKeySet() {
+        for (int i = 0; i < NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            InputStream stream = stringToStream("value" + i);
+            Assert.assertEquals(i, keyValueStore.keySet().size());
+            Assert.assertFalse(keyValueStore.keySet().contains(key));
+            keyValueStore.saveStream(key, stream);
+            Assert.assertTrue(keyValueStore.keySet().contains(key));
+            Assert.assertEquals(i+1, keyValueStore.keySet().size());
+        }
+    }
+
+    /** Test calling keySet() after saving then deleting values */
+    @Test
+    public void testSaveDeleteKeySet() {
+        Assert.assertTrue(keyValueStore.keySet().isEmpty());
+        for (int i = 0; i < NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            keyValueStore.saveValue(key, value);
+        }
+        for (int i = 0; i < NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            Assert.assertEquals(NUM_ENTRIES - i, keyValueStore.keySet().size());
+            Assert.assertTrue(keyValueStore.keySet().contains(key));
+            keyValueStore.deleteValue(key);
+            Assert.assertFalse(keyValueStore.keySet().contains(key));
+            Assert.assertEquals(NUM_ENTRIES - (i+1), keyValueStore.keySet().size());
+        }
+    }
+
+    /** Test calling keySet() after saving then deleting all values */
+    @Test
+    public void testSaveDeleteAllKeySet() {
+        Assert.assertTrue(keyValueStore.keySet().isEmpty());
+        for (int i = 0; i < NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            keyValueStore.saveValue(key, value);
+        }
+        Assert.assertEquals(NUM_ENTRIES, keyValueStore.keySet().size());
+        keyValueStore.deleteAll();
+        Assert.assertTrue(keyValueStore.keySet().isEmpty());
+    }
+
     /** Making sure various operations won't NPE if storeDir was deleted */
     @Test
     public void testNoNPEIfStoreDirDeleted() {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
@@ -46,7 +46,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class MemCachedKeyValueStoreTest {
     static final String TEST_STORE = "TEST_STORE";
-    static final int NUM_ENTRIES = 100;
+    static final int NUM_ENTRIES = 25;
+    static final int CACHE_SIZE = 10;
 
     private KeyValueEncryptedFileStore store;
     private MemCachedKeyValueStore memCachedStore;
@@ -69,7 +70,7 @@ public class MemCachedKeyValueStoreTest {
         
         SmartStoreSDKManager.initNative(context, null);
         store = new KeyValueEncryptedFileStore(context, TEST_STORE, SalesforceSDKManager.getEncryptionKey());
-        memCachedStore = new MemCachedKeyValueStore(store, NUM_ENTRIES);
+        memCachedStore = new MemCachedKeyValueStore(store, CACHE_SIZE);
     }
 
     @After

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
@@ -278,6 +278,28 @@ public class MemCachedKeyValueStoreTest {
         Assert.assertEquals(codeBlock, streamToString(memCachedStore.getStream("js2")));
     }
 
+    /** Test calling keySet() after saving and deleting values */
+    @Test
+    public void testSaveDeleteKeySet() {
+        Assert.assertTrue(memCachedStore.keySet().isEmpty());
+        for (int i = 0; i < NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            Assert.assertEquals(i, memCachedStore.keySet().size());
+            Assert.assertFalse(memCachedStore.keySet().contains(key));
+            memCachedStore.saveValue(key, value);
+            Assert.assertTrue(memCachedStore.keySet().contains(key));
+            Assert.assertEquals(i+1, memCachedStore.keySet().size());
+        }
+        for (int i = 0; i < NUM_ENTRIES; i++) {
+            String key = "key" + i;
+            Assert.assertEquals(NUM_ENTRIES - i, memCachedStore.keySet().size());
+            Assert.assertTrue(memCachedStore.keySet().contains(key));
+            memCachedStore.deleteValue(key);
+            Assert.assertFalse(memCachedStore.keySet().contains(key));
+            Assert.assertEquals(NUM_ENTRIES - (i+1), memCachedStore.keySet().size());
+        }
+    }
 
     //
     // Helper methods


### PR DESCRIPTION
- Storing values in `<hash(key)>.value` and keys in `<hash<(key)>.key` => `keySet()` simply gets all the `*.key` files and read their content.
- To be backwards compatible, also added a version file (version is now 2, stores without a version file will be considered to be version 1). Operations behavior depends on store version => `keySet()` throws an `UnsupportedOperationException` for a v1 store.
- Added tests for new operations and also to make sure v1 stores are still supported.

TODO (in a separate PR/story): enhance kv store inspector to take advantage of `keySet()` e.g. the key input field could work like a search field with the list below showing all the key/value fields matching the partially typed key.
