### PR TITLE
Key value inspector now accepts partial key for search

### DIFF
--- a/libs/SmartStore/res/layout/sf__key_value_inspector.xml
+++ b/libs/SmartStore/res/layout/sf__key_value_inspector.xml
@@ -44,7 +44,7 @@
             android:layout_weight="1"
             android:layout_height="match_parent"
             android:layout_marginBottom="0dp"
-            android:hint="@string/sf__inspector_key"
+            android:hint="@string/sf__inspector_key_hint"
             android:drawableLeft="@drawable/sf__inspector_key_icon"
             android:drawablePadding="10dp"
             style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"

--- a/libs/SmartStore/res/values/sf__strings.xml
+++ b/libs/SmartStore/res/values/sf__strings.xml
@@ -22,6 +22,6 @@
     <string name="sf__inspector_no_soups_found">No soups found</string>
 
     <!--       KeyValueStore Inspector       -->
-    <string name="sf__inspector_key">Key</string>
+    <string name="sf__inspector_key_hint">Exact or partial key (for partial use *)</string>
     <string name="sf__inspector_get_value_button">Get Value(s)</string>
 </resources>

--- a/libs/SmartStore/res/values/sf__strings.xml
+++ b/libs/SmartStore/res/values/sf__strings.xml
@@ -23,5 +23,5 @@
 
     <!--       KeyValueStore Inspector       -->
     <string name="sf__inspector_key">Key</string>
-    <string name="sf__inspector_get_value_button">Get Value</string>
+    <string name="sf__inspector_get_value_button">Get Value(s)</string>
 </resources>

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/KeyValueStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/KeyValueStoreInspectorActivity.java
@@ -53,7 +53,9 @@ import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 import com.salesforce.androidsdk.smartstore.store.KeyValueEncryptedFileStore;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class KeyValueStoreInspectorActivity extends Activity {
     // Keys for extras bundle
@@ -155,17 +157,32 @@ public class KeyValueStoreInspectorActivity extends Activity {
     }
 
     public void onGetValueClick(View v) {
-        String key = keyInput.getText().toString();
+        String typedKey = keyInput.getText().toString();
         setCurrentStore(storesDropdown.getText().toString());
-        String value = currentStore.getValue(key);
+        // v1 kv store: we simply lookup the given key
+        if (currentStore.getStoreVersion() == 1) {
+            String value = currentStore.getValue(typedKey);
 
-        if (value == null) {
-            new AlertDialog.Builder(this).setTitle(ERROR_DIALOG_TITLE)
+            if (value == null) {
+                new AlertDialog.Builder(this).setTitle(ERROR_DIALOG_TITLE)
                     .setMessage(ERROR_DIALOG_MESSAGE).show();
-        } else {
-            keyValueList.add(0, new KeyValuePair(key, value));
-            listAdapter.notifyDataSetChanged();
-            keyInput.setText("");
+            } else {
+                keyValueList.add(0, new KeyValuePair(typedKey, value));
+                listAdapter.notifyDataSetChanged();
+                keyInput.setText("");
+            }
+        }
+        // v2 kv store: we return all key/value where key contains the typed text
+        else {
+            keyValueList.clear();
+            String[] allKeys = currentStore.keySet().toArray(new String[0]);
+            Arrays.sort(allKeys);
+            for (String key : allKeys) {
+                if (key.contains(typedKey)) {
+                    keyValueList.add(new KeyValuePair(key, currentStore.getValue(key)));
+                    listAdapter.notifyDataSetChanged();
+                }
+            }
         }
     }
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/KeyValueStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/KeyValueStoreInspectorActivity.java
@@ -166,10 +166,9 @@ public class KeyValueStoreInspectorActivity extends Activity {
         }
 
         // Return all key/value pairs were key matches typedKey
-        // if v2 kv store AND typedKey starts or ends with *
-        if (currentStore.getStoreVersion() == 2 && (typedKey.startsWith("*") || typedKey.endsWith("*"))) {
-
-            String[] allKeys = currentStore.keySet().toArray(new String[0]);
+        // if v2 kv store AND typedKey contains a *
+        if (currentStore.getStoreVersion() == 2 && typedKey.contains("*")) {
+            String[] allKeys = currentStore.keySet().toArray(new String[0]); 
             Arrays.sort(allKeys);
 
             for (String key : allKeys) {
@@ -197,14 +196,8 @@ public class KeyValueStoreInspectorActivity extends Activity {
     }
 
     private boolean matches(String typedKey, String key) {
-        if (typedKey.equals("*")) {
-            return true;
-        } else if(typedKey.startsWith("*") && typedKey.endsWith("*")) {
-            return key.contains(typedKey.substring(1, typedKey.length()-1));
-        } else if (typedKey.startsWith("*")) {
-            return key.endsWith(typedKey.substring(1));
-        } else if (typedKey.endsWith("*")) {
-            return key.startsWith(typedKey.substring(0, typedKey.length()-1));
+        if (typedKey.contains("*")) {
+            return key.matches(typedKey.replaceAll("\\*", ".*"));
         } else {
             return key.equals(typedKey);
         }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueStoreInspectorActivityTest.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.smartstore.store;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
@@ -62,8 +63,10 @@ public class KeyValueStoreInspectorActivityTest {
     private final String STORE_2 = "store2";
     private final String KEY_1 = "firstKey";
     private final String KEY_2 = "secondKey";
+    private final String KEY_3 = "keyThree";
     private final String VALUE_1 = "this is a value in ";
     private final String VALUE_2 = "this is a different value in ";
+    private final String VALUE_3 = "this is a third value in ";
     private final String GLOBAL_STORE_TEXT = KeyValueStoreInspectorActivity.GLOBAL_STORE;
 
     @Rule
@@ -90,7 +93,7 @@ public class KeyValueStoreInspectorActivityTest {
      * Test single KeyValueEncryptedFileStore
      */
     @Test
-    public void testSingeStore() {
+    public void testSingleStore() {
         createKeyValueStore(STORE_1);
         keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
         Assert.assertEquals("Wrong Store name shown.",
@@ -98,10 +101,10 @@ public class KeyValueStoreInspectorActivityTest {
         Assert.assertTrue("Get Value Button should be enabled.", isGetValueButtonEnabled());
         writeKey(KEY_1);
         tapGetValueButton();
-        checkResults(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairShown(KEY_1, VALUE_1 + STORE_1);
         writeKey(KEY_2);
         tapGetValueButton();
-        checkResults(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairShown(KEY_2, VALUE_2 + STORE_1);
     }
 
     /**
@@ -119,7 +122,7 @@ public class KeyValueStoreInspectorActivityTest {
                 STORE_2 + GLOBAL_STORE_TEXT, getCurrentStoreName());
         writeKey(KEY_1);
         tapGetValueButton();
-        checkResults(KEY_1, VALUE_1 + STORE_2);
+        checkKeyValuePairShown(KEY_1, VALUE_1 + STORE_2);
     }
 
     /**
@@ -134,10 +137,112 @@ public class KeyValueStoreInspectorActivityTest {
         checkForKeyNotFoundDialog();
     }
 
+    /**
+     * Test * query
+     */
+    @Test
+    public void testStarQuery() {
+        createKeyValueStore(STORE_1);
+        keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
+        writeKey("*");
+        tapGetValueButton();
+        checkKeyValuePairShown(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairShown(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairShown(KEY_3, VALUE_3 + STORE_1);
+    }
+
+    /**
+     * Test query ending with * matching one
+     */
+    @Test
+    public void testQueryEndingWithStarMatchingOne() {
+        createKeyValueStore(STORE_1);
+        keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
+        writeKey("f*");
+        tapGetValueButton();
+        checkKeyValuePairShown(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairNotShown(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairNotShown(KEY_3, VALUE_3 + STORE_1);
+    }
+
+    /**
+     * Test query ending with * matching none
+     */
+    @Test
+    public void testQueryEndingWithStarMatchingNone() {
+        createKeyValueStore(STORE_1);
+        keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
+        writeKey("x*");
+        tapGetValueButton();
+        checkForKeyNotFoundDialog();
+        checkKeyValuePairNotShown(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairNotShown(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairNotShown(KEY_3, VALUE_3 + STORE_1);
+    }
+
+    /**
+     * Test query starting with * matching two
+     */
+    @Test
+    public void testQueryStartingWithStarMatchingTwo() {
+        createKeyValueStore(STORE_1);
+        keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
+        writeKey("*Key");
+        tapGetValueButton();
+        checkKeyValuePairShown(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairShown(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairNotShown(KEY_3, VALUE_3 + STORE_1);
+    }
+
+    /**
+     * Test query ending with * matching two
+     */
+    @Test
+    public void testQueryEndingWithStarMatchingTwo() {
+        createKeyValueStore(STORE_1);
+        keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
+        writeKey("*x");
+        tapGetValueButton();
+        checkForKeyNotFoundDialog();
+        checkKeyValuePairNotShown(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairNotShown(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairNotShown(KEY_3, VALUE_3 + STORE_1);
+    }
+
+    /**
+     * Test query starting and ending with * matching two
+     */
+    @Test
+    public void testQueryStartingAndEndingWithStarMatchingTwo() {
+        createKeyValueStore(STORE_1);
+        keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
+        writeKey("*r*");
+        tapGetValueButton();
+        checkKeyValuePairShown(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairNotShown(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairShown(KEY_3, VALUE_3 + STORE_1);
+    }
+
+    /**
+     * Test query starting and ending with * matching none
+     */
+    @Test
+    public void testQueryStartingAndEndingWithStarMatchingNone() {
+        createKeyValueStore(STORE_1);
+        keyValueStoreInspectorActivityTestRule.launchActivity(new Intent());
+        writeKey("*zz*");
+        tapGetValueButton();
+        checkForKeyNotFoundDialog();
+        checkKeyValuePairNotShown(KEY_1, VALUE_1 + STORE_1);
+        checkKeyValuePairNotShown(KEY_2, VALUE_2 + STORE_1);
+        checkKeyValuePairNotShown(KEY_3, VALUE_3 + STORE_1);
+    }
+
     private void createKeyValueStore(String storeName) {
         KeyValueEncryptedFileStore store = SmartStoreSDKManager.getInstance().getGlobalKeyValueStore(storeName);
         store.saveValue(KEY_1, VALUE_1 + storeName);
         store.saveValue(KEY_2, VALUE_2 + storeName);
+        store.saveValue(KEY_3, VALUE_3 + storeName);
     }
 
     private String getCurrentStoreName() {
@@ -160,9 +265,14 @@ public class KeyValueStoreInspectorActivityTest {
         onView(withId(R.id.sf__inspector_get_value_button)).perform(click());
     }
 
-    private void checkResults(String key, String value) {
+    private void checkKeyValuePairShown(String key, String value) {
         onView(allOf(withId(R.id.sf__inspector_key), withText(key))).check(matches(isDisplayed()));
         onView(allOf(withId(R.id.sf__inspector_value), withText(value))).check(matches(isDisplayed()));
+    }
+
+    private void checkKeyValuePairNotShown(String key, String value) {
+        onView(allOf(withId(R.id.sf__inspector_key), withText(key))).check(doesNotExist());
+        onView(allOf(withId(R.id.sf__inspector_value), withText(value))).check(doesNotExist());
     }
 
     private void changeStore(String newStore) {


### PR DESCRIPTION
Search field can take an exact key or a partial key (using * at the start/end or middle).
When using a partial key, all matching key/value pairs are returned.

![Screen Shot 2021-03-01 at 2 47 12 PM](https://user-images.githubusercontent.com/1012459/109569374-33a77a00-7a9d-11eb-8b27-f967ba7e81b4.png)
