### PR TITLE
Adding support for SOQL batch size in RestRequest and in SOQLSyncDownTarget

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SoqlSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SoqlSyncDownTarget.java
@@ -49,7 +49,10 @@ import java.util.Set;
  */
 public class SoqlSyncDownTarget extends SyncDownTarget {
 
-	public static final String QUERY = "query";
+    public static final String QUERY = "query";
+    public static final String MAX_BATCH_SIZE = "maxBatchSize";
+
+    protected int maxBatchSize;
 	private String query;
     private String nextRecordsUrl;
 
@@ -61,6 +64,7 @@ public class SoqlSyncDownTarget extends SyncDownTarget {
     public SoqlSyncDownTarget(JSONObject target) throws JSONException {
         super(target);
         this.query = modifyQueryIfNeeded(JSONObjectHelper.optString(target, QUERY));
+        this.maxBatchSize = target.optInt(MAX_BATCH_SIZE, RestRequest.DEFAULT_BATCH_SIZE);
     }
 
 	/**
@@ -73,12 +77,26 @@ public class SoqlSyncDownTarget extends SyncDownTarget {
 
     /**
      * Construct SoqlSyncDownTarget from soql query
+     * @param idFieldName
+     * @param modificationDateFieldName
      * @param query
      */
     public SoqlSyncDownTarget(String idFieldName, String modificationDateFieldName, String query) {
+        this(idFieldName, modificationDateFieldName, query, RestRequest.DEFAULT_BATCH_SIZE);
+    }
+
+    /**
+     * Construct SoqlSyncDownTarget from soql query
+     * @param idFieldName
+     * @param modificationDateFieldName
+     * @param query
+     * @param maxBatchSize - must be between 200 and 2000
+     */
+    public SoqlSyncDownTarget(String idFieldName, String modificationDateFieldName, String query, int maxBatchSize) {
         super(idFieldName, modificationDateFieldName);
         this.queryType = QueryType.soql;
         this.query = modifyQueryIfNeeded(query);
+        this.maxBatchSize = maxBatchSize;
     }
 
     private String modifyQueryIfNeeded(String query) {
@@ -127,6 +145,7 @@ public class SoqlSyncDownTarget extends SyncDownTarget {
 	public JSONObject asJSON() throws JSONException {
 		JSONObject target = super.asJSON();
         if (query != null) target.put(QUERY, query);
+        target.put(MAX_BATCH_SIZE, maxBatchSize);
 		return target;
 	}
 
@@ -136,7 +155,7 @@ public class SoqlSyncDownTarget extends SyncDownTarget {
     }
 
     protected JSONArray startFetch(SyncManager syncManager, String query) throws IOException, JSONException {
-        RestRequest request = RestRequest.getRequestForQuery(syncManager.apiVersion, query);
+        RestRequest request = RestRequest.getRequestForQuery(syncManager.apiVersion, query, maxBatchSize);
         RestResponse response = syncManager.sendSyncWithMobileSyncUserAgent(request);
         JSONObject responseJson = getResponseJson(response);
         JSONArray records = getRecordsFromResponseJson(responseJson);

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SoqlSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SoqlSyncDownTarget.java
@@ -53,7 +53,7 @@ public class SoqlSyncDownTarget extends SyncDownTarget {
     public static final String MAX_BATCH_SIZE = "maxBatchSize";
 
     protected int maxBatchSize;
-	private String query;
+    private String query;
     private String nextRecordsUrl;
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -115,12 +115,18 @@ public class RestRequest {
     public static final String TYPE = "type";
     public static final String ATTRIBUTES = "attributes";
     public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
+	public static final String SFORCE_QUERY_OPTIONS = "Sforce-Query-Options";
+	public static final String BATCH_SIZE_OPTION = "batchSize";
+	public static final int MIN_BATCH_SIZE = 200;
+	public static final int MAX_BATCH_SIZE = 2000;
+	public static final int DEFAULT_BATCH_SIZE = 2000;
 
     /**
      * HTTP date format
      */
     public static final DateFormat HTTP_DATE_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
-    static {
+
+	static {
         HTTP_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
     }
 
@@ -531,17 +537,37 @@ public class RestRequest {
 	/**
 	 * Request to execute the specified SOQL query.
 	 *
-     * @param apiVersion    Salesforce API version.
-     * @param q             SOQL query string.
-     * @return              RestRequest object that requests a SOQL query.
+	 * @param apiVersion    Salesforce API version.
+	 * @param q             SOQL query string.
+	 * @return              RestRequest object that requests a SOQL query.
 	 * @throws UnsupportedEncodingException
-     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm</a>
+	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm</a>
 	 */
 	public static RestRequest getRequestForQuery(String apiVersion, String q) throws UnsupportedEncodingException {
+		return getRequestForQuery(apiVersion, q, DEFAULT_BATCH_SIZE);
+	}
+
+	/**
+	 * Request to execute the specified SOQL query.
+	 *
+	 * @param apiVersion    Salesforce API version.
+	 * @param q             SOQL query string.
+	 * @param batchSize     Batch size: number between 200 and 2000 (default).
+	 * @return              RestRequest object that requests a SOQL query.
+	 * @throws UnsupportedEncodingException
+	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm</a>
+	 */
+	public static RestRequest getRequestForQuery(String apiVersion, String q, int batchSize) throws UnsupportedEncodingException {
 		StringBuilder path = new StringBuilder(RestAction.QUERY.getPath(apiVersion));
 		path.append("?q=");
 		path.append(URLEncoder.encode(q, UTF_8));
-		return new RestRequest(RestMethod.GET, path.toString());
+		batchSize = Math.max(Math.min(batchSize, MAX_BATCH_SIZE), MIN_BATCH_SIZE);
+		Map<String, String> headers = null;
+		if (batchSize != DEFAULT_BATCH_SIZE) {
+			headers = new HashMap<>();
+			headers.put(SFORCE_QUERY_OPTIONS, BATCH_SIZE_OPTION + "=" + batchSize);
+		}
+		return new RestRequest(RestMethod.GET, path.toString(), headers);
 	}
 
 	/**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -115,11 +115,11 @@ public class RestRequest {
     public static final String TYPE = "type";
     public static final String ATTRIBUTES = "attributes";
     public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
-	public static final String SFORCE_QUERY_OPTIONS = "Sforce-Query-Options";
-	public static final String BATCH_SIZE_OPTION = "batchSize";
-	public static final int MIN_BATCH_SIZE = 200;
-	public static final int MAX_BATCH_SIZE = 2000;
-	public static final int DEFAULT_BATCH_SIZE = 2000;
+    public static final String SFORCE_QUERY_OPTIONS = "Sforce-Query-Options";
+    public static final String BATCH_SIZE_OPTION = "batchSize";
+    public static final int MIN_BATCH_SIZE = 200;
+    public static final int MAX_BATCH_SIZE = 2000;
+    public static final int DEFAULT_BATCH_SIZE = 2000;
 
     /**
      * HTTP date format

--- a/libs/test/MobileSyncTest/res/raw/usersyncs.json
+++ b/libs/test/MobileSyncTest/res/raw/usersyncs.json
@@ -6,9 +6,9 @@
       "soupName": "accounts",
       "target": {
         "type":"soql",
-        "query":"SELECT Id, Name, LastModifiedDate FROM Account"
+        "query":"SELECT Id, Name, LastModifiedDate FROM Account",
+        "maxBatchSize": 200
       },
-      "maxBatchSize": 2000,
       "options": {
         "mergeMode":"OVERWRITE"
       }
@@ -135,7 +135,6 @@
         "modificationDateFieldName": "LastModifiedDateX",
         "externalIdFieldName": "ExternalIdX"
       },
-      "maxBatchSize": 25,
       "options": {
         "fieldlist": ["Name", "Description"],
         "mergeMode":"OVERWRITE"

--- a/libs/test/MobileSyncTest/res/raw/usersyncs.json
+++ b/libs/test/MobileSyncTest/res/raw/usersyncs.json
@@ -6,6 +6,18 @@
       "soupName": "accounts",
       "target": {
         "type":"soql",
+        "query":"SELECT Id, Name, LastModifiedDate FROM Account"
+      },
+      "options": {
+        "mergeMode":"OVERWRITE"
+      }
+    },
+    {
+      "syncName": "soqlSyncDownWithBatchSize",
+      "syncType": "syncDown",
+      "soupName": "accounts",
+      "target": {
+        "type":"soql",
         "query":"SELECT Id, Name, LastModifiedDate FROM Account",
         "maxBatchSize": 200
       },

--- a/libs/test/MobileSyncTest/res/raw/usersyncs.json
+++ b/libs/test/MobileSyncTest/res/raw/usersyncs.json
@@ -8,6 +8,7 @@
         "type":"soql",
         "query":"SELECT Id, Name, LastModifiedDate FROM Account"
       },
+      "maxBatchSize": 2000,
       "options": {
         "mergeMode":"OVERWRITE"
       }
@@ -134,6 +135,7 @@
         "modificationDateFieldName": "LastModifiedDateX",
         "externalIdFieldName": "ExternalIdX"
       },
+      "maxBatchSize": 25,
       "options": {
         "fieldlist": ["Name", "Description"],
         "mergeMode":"OVERWRITE"

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
@@ -131,9 +131,21 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         SyncState sync = syncManager.getSyncStatus("soqlSyncDown");
         Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
         checkStatus(sync, SyncState.Type.syncDown, sync.getId(),
-                new SoqlSyncDownTarget(null, null, "SELECT Id, Name, LastModifiedDate FROM Account", 200),
+                new SoqlSyncDownTarget(null, null, "SELECT Id, Name, LastModifiedDate FROM Account"),
                 SyncOptions.optionsForSyncDown(MergeMode.OVERWRITE),
                 SyncState.Status.NEW, 0);
+    }
+
+    @Test
+    public void testSoqlSyncDownWithBatchSizeFromConfig() throws JSONException {
+        MobileSyncSDKManager.getInstance().setupUserSyncsFromDefaultConfig();
+
+        SyncState sync = syncManager.getSyncStatus("soqlSyncDownWithBatchSize");
+        Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
+        checkStatus(sync, SyncState.Type.syncDown, sync.getId(),
+            new SoqlSyncDownTarget(null, null, "SELECT Id, Name, LastModifiedDate FROM Account", 200),
+            SyncOptions.optionsForSyncDown(MergeMode.OVERWRITE),
+            SyncState.Status.NEW, 0);
     }
 
     @Test

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
@@ -29,7 +29,6 @@ package com.salesforce.androidsdk.mobilesync.config;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
-
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManagerTestCase;
 import com.salesforce.androidsdk.mobilesync.target.BatchSyncUpTarget;
@@ -42,22 +41,19 @@ import com.salesforce.androidsdk.mobilesync.target.ParentChildrenSyncUpTarget;
 import com.salesforce.androidsdk.mobilesync.target.RefreshSyncDownTarget;
 import com.salesforce.androidsdk.mobilesync.target.SoqlSyncDownTarget;
 import com.salesforce.androidsdk.mobilesync.target.SoslSyncDownTarget;
-import com.salesforce.androidsdk.mobilesync.target.SyncTarget;
 import com.salesforce.androidsdk.mobilesync.target.SyncUpTarget;
 import com.salesforce.androidsdk.mobilesync.util.ChildrenInfo;
 import com.salesforce.androidsdk.mobilesync.util.ParentInfo;
 import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
 import com.salesforce.androidsdk.mobilesync.util.SyncState;
 import com.salesforce.androidsdk.mobilesync.util.SyncState.MergeMode;
-
+import java.util.Arrays;
 import org.json.JSONException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Arrays;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
@@ -42,6 +42,7 @@ import com.salesforce.androidsdk.mobilesync.target.ParentChildrenSyncUpTarget;
 import com.salesforce.androidsdk.mobilesync.target.RefreshSyncDownTarget;
 import com.salesforce.androidsdk.mobilesync.target.SoqlSyncDownTarget;
 import com.salesforce.androidsdk.mobilesync.target.SoslSyncDownTarget;
+import com.salesforce.androidsdk.mobilesync.target.SyncTarget;
 import com.salesforce.androidsdk.mobilesync.target.SyncUpTarget;
 import com.salesforce.androidsdk.mobilesync.util.ChildrenInfo;
 import com.salesforce.androidsdk.mobilesync.util.ParentInfo;
@@ -134,7 +135,7 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         SyncState sync = syncManager.getSyncStatus("soqlSyncDown");
         Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
         checkStatus(sync, SyncState.Type.syncDown, sync.getId(),
-                new SoqlSyncDownTarget("SELECT Id, Name, LastModifiedDate FROM Account"),
+                new SoqlSyncDownTarget(null, null, "SELECT Id, Name, LastModifiedDate FROM Account", 200),
                 SyncOptions.optionsForSyncDown(MergeMode.OVERWRITE),
                 SyncState.Status.NEW, 0);
     }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SoqlSyncDownTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SoqlSyncDownTargetTest.java
@@ -27,15 +27,15 @@
 
 package com.salesforce.androidsdk.mobilesync.target;
 
-import com.salesforce.androidsdk.auth.HttpAccess;
-import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManagerTestCase;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
-
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import java.io.IOException;
+import java.util.Date;
 import okhttp3.Interceptor;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -45,11 +45,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.Date;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.SmallTest;
 
 /**
  * Test class for SoqlSyncDownTarget.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
@@ -366,11 +366,15 @@ public class RestRequestTest {
 	 */
 	@Test
 	public void testGetRequestForQueryWithBatchSize() throws UnsupportedEncodingException {
-		RestRequest request = RestRequest.getRequestForQuery(TEST_API_VERSION, TEST_QUERY, 500);
-		Assert.assertEquals("Wrong method", RestMethod.GET, request.getMethod());
-		Assert.assertEquals("Wrong path", "/services/data/" + TEST_API_VERSION + "/query?q=" + TEST_QUERY, request.getPath());
-		Assert.assertNull("Wrong request entity", request.getRequestBody());
-		Assert.assertEquals("batchSize=500", request.getAdditionalHttpHeaders().get(RestRequest.SFORCE_QUERY_OPTIONS));
+		RestRequest request500 = RestRequest.getRequestForQuery(TEST_API_VERSION, TEST_QUERY, 500);
+		RestRequest request199 = RestRequest.getRequestForQuery(TEST_API_VERSION, TEST_QUERY, 199);
+		RestRequest request2001 = RestRequest.getRequestForQuery(TEST_API_VERSION, TEST_QUERY, 2001);
+		Assert.assertEquals("Wrong method", RestMethod.GET, request500.getMethod());
+		Assert.assertEquals("Wrong path", "/services/data/" + TEST_API_VERSION + "/query?q=" + TEST_QUERY, request500.getPath());
+		Assert.assertNull("Wrong request entity", request500.getRequestBody());
+		Assert.assertEquals("batchSize=500", request500.getAdditionalHttpHeaders().get(RestRequest.SFORCE_QUERY_OPTIONS));
+		Assert.assertEquals("batchSize=200", request199.getAdditionalHttpHeaders().get(RestRequest.SFORCE_QUERY_OPTIONS));
+		Assert.assertNull("Wrong additional headers", request2001.getAdditionalHttpHeaders());
 	}
 
 	/**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
@@ -361,6 +361,19 @@ public class RestRequestTest {
 	}
 
 	/**
+	 * Test for getRequestForQuery specifying a batch size
+	 * @throws UnsupportedEncodingException
+	 */
+	@Test
+	public void testGetRequestForQueryWithBatchSize() throws UnsupportedEncodingException {
+		RestRequest request = RestRequest.getRequestForQuery(TEST_API_VERSION, TEST_QUERY, 500);
+		Assert.assertEquals("Wrong method", RestMethod.GET, request.getMethod());
+		Assert.assertEquals("Wrong path", "/services/data/" + TEST_API_VERSION + "/query?q=" + TEST_QUERY, request.getPath());
+		Assert.assertNull("Wrong request entity", request.getRequestBody());
+		Assert.assertEquals("batchSize=500", request.getAdditionalHttpHeaders().get(RestRequest.SFORCE_QUERY_OPTIONS));
+	}
+
+	/**
 	 * Test for getRequestForSearch
 	 * @throws UnsupportedEncodingException 
 	 */


### PR DESCRIPTION
There is a way to specify a batch size when doing a SOQL query. See https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_queryoptions.htm

With this PR, we are adding:
- a RestRequest.getRequestForQuery factory method that accepts a batchSize
- an option parameter for SOQLSyncDownTarget to use a different batch size from the default