### PR TITLE
Adding Some Enhancements and Fixing Some Issues in Cookie Management

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -29,11 +29,7 @@ package com.salesforce.androidsdk.phonegap.ui;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.KeyEvent;
-import android.view.View;
-import android.webkit.CookieManager;
 import android.webkit.URLUtil;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.HttpAccess.NoNetworkException;
@@ -46,7 +42,6 @@ import com.salesforce.androidsdk.rest.ClientManager.AccountInfoNotFoundException
 import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback;
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.rest.RestClient.AsyncRequestCallback;
-import com.salesforce.androidsdk.rest.RestClient.ClientInfo;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.ui.SalesforceActivityDelegate;
@@ -61,8 +56,6 @@ import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CordovaWebViewEngine;
 import org.apache.cordova.CordovaWebViewImpl;
 import org.json.JSONObject;
-
-import java.net.URI;
 
 import okhttp3.HttpUrl;
 
@@ -373,7 +366,6 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                                      * refreshed, to ensure we use the new access token.
                                      */
                                     SalesforceDroidGapActivity.this.client = SalesforceDroidGapActivity.this.clientManager.peekRestClient();
-                                    loadVFPingPage();
                                     getAuthCredentials(callbackContext);
                                 }
                             });
@@ -453,7 +445,6 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                          */
                         try {
                             SalesforceDroidGapActivity.this.client = SalesforceDroidGapActivity.this.clientManager.peekRestClient();
-                            loadVFPingPage();
                             final String frontDoorUrl = getFrontDoorUrl(url, BootConfig.isAbsoluteUrl(url));
                             loadUrl(frontDoorUrl);
                         } catch (AccountInfoNotFoundException e) {
@@ -474,43 +465,6 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                 }
             }
         });
-    }
-
-    /**
-     * Loads the VF ping page and sets cookies.
-     */
-    private void loadVFPingPage() {
-        if (!bootconfig.isLocal()) {
-            final ClientInfo clientInfo = SalesforceDroidGapActivity.this.client.getClientInfo();
-            URI instanceUrl = null;
-            if (clientInfo != null) {
-                instanceUrl = clientInfo.getInstanceUrl();
-            }
-            setVFCookies(instanceUrl);
-        }
-    }
-
-    /**
-     * Sets VF domain cookies by loading the VF ping page on an invisible WebView.
-     *
-     * @param instanceUrl Instance URL.
-     */
-    private static void setVFCookies(URI instanceUrl) {
-        if (instanceUrl != null) {
-            final WebView view = new WebView(SalesforceSDKManager.getInstance().getAppContext());
-            view.setVisibility(View.GONE);
-            view.setWebViewClient(new WebViewClient() {
-
-                @Override
-                public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                    final CookieManager cookieMgr = CookieManager.getInstance();
-                    cookieMgr.setAcceptCookie(true);
-                    SalesforceSDKManager.getInstance().syncCookies();
-                    return true;
-                }
-            });
-            view.loadUrl(instanceUrl.toString() + "/visualforce/session?url=/apexpages/utils/ping.apexp&autoPrefixVFDomain=true");
-        }
     }
 
     /**

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -28,7 +28,6 @@ package com.salesforce.androidsdk.phonegap.ui;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.SystemClock;
 import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.CookieManager;
@@ -374,7 +373,6 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                                      * refreshed, to ensure we use the new access token.
                                      */
                                     SalesforceDroidGapActivity.this.client = SalesforceDroidGapActivity.this.clientManager.peekRestClient();
-                                    setSidCookies();
                                     loadVFPingPage();
                                     getAuthCredentials(callbackContext);
                                 }
@@ -455,7 +453,6 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                          */
                         try {
                             SalesforceDroidGapActivity.this.client = SalesforceDroidGapActivity.this.clientManager.peekRestClient();
-                            setSidCookies();
                             loadVFPingPage();
                             final String frontDoorUrl = getFrontDoorUrl(url, BootConfig.isAbsoluteUrl(url));
                             loadUrl(frontDoorUrl);
@@ -600,40 +597,6 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
      */
     public CordovaWebView getAppView() {
         return appView;
-    }
-
-    /**
-     * Set cookies on cookie manager.
-     */
-    private void setSidCookies() {
-        SalesforceHybridLogger.i(TAG, "setSidCookies called");
-        CookieManager cookieMgr = CookieManager.getInstance();
-        cookieMgr.setAcceptCookie(true);  // Required to set additional cookies that the auth process will return.
-        SalesforceSDKManager.getInstance().removeSessionCookies();
-        SystemClock.sleep(250); // removeSessionCookies kicks out a thread - let it finish
-        String accessToken = client.getAuthToken();
-        addSidCookieForInstance(cookieMgr, accessToken);
-        SalesforceSDKManager.getInstance().syncCookies();
-    }
-
-    private void addSidCookieForInstance(CookieManager cookieMgr, String sid) {
-        final ClientInfo clientInfo = SalesforceDroidGapActivity.this.client.getClientInfo();
-        URI instanceUrl = null;
-        if (clientInfo != null) {
-            instanceUrl = clientInfo.getInstanceUrl();
-        }
-        String host = null;
-        if (instanceUrl != null) {
-            host = instanceUrl.getHost();
-        }
-        if (host != null) {
-            addSidCookieForDomain(cookieMgr, host, sid);
-        }
-    }
-
-    private void addSidCookieForDomain(CookieManager cookieMgr, String domain, String sid) {
-        String cookieStr = "sid=" + sid;
-        cookieMgr.setCookie(domain, cookieStr);
     }
 
     @Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -775,7 +775,7 @@ public class SalesforceSDKManager {
     protected void startLoginPage() {
 
         // Clears cookies.
-    	removeAllCookies();
+        CookieManager.getInstance().removeAllCookies(null);
 
         // Restarts the application.
         final Intent i = new Intent(context, getMainActivityClass());
@@ -790,7 +790,7 @@ public class SalesforceSDKManager {
     public void startSwitcherActivityIfRequired() {
 
         // Clears cookies.
-    	removeAllCookies();
+        CookieManager.getInstance().removeAllCookies(null);
 
         /*
          * If the number of accounts remaining is 0, shows the login page.
@@ -1197,18 +1197,26 @@ public class SalesforceSDKManager {
         return new ClientManager(getAppContext(), getAccountType(), getLoginOptions(jwt, url), true);
     }
 
+    /**
+     * @deprecated Will be removed in Mobile SDK 10.0.
+     */
 	public void removeAllCookies() {
 		CookieManager.getInstance().removeAllCookies(null);
     }
 
+    /**
+     * @deprecated Will be removed in Mobile SDK 10.0.
+     */
 	public void removeSessionCookies() {
         CookieManager.getInstance().removeSessionCookies(null);
     }
 
+    /**
+     * @deprecated Will be removed in Mobile SDK 10.0.
+     */
 	public void syncCookies() {
         CookieManager.getInstance().flush();
     }
-
 
     /**
      * Show dev support dialog

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -44,6 +44,7 @@ import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
 import android.text.TextUtils;
 import android.webkit.ClientCertRequest;
+import android.webkit.CookieManager;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
@@ -221,7 +222,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     }
 
     public void clearCookies() {
-    	SalesforceSDKManager.getInstance().removeAllCookies();
+        CookieManager.getInstance().removeAllCookies(null);
     }
 
     public void clearView() {


### PR DESCRIPTION
This PR fixes a few issues with the hybrid webview.
- We don't need `loadVFPingPage()` anymore. It's inefficient with the hidden webview loading, and doesn't really do anything much anymore, since the `frontdoor` hops we do cover all the scenarios we need. It also slows down load time in hybrid apps.
- I removed `setSidCookies()` as well. It's not required anymore for a few reasons. One reason is because `frontdoor` does its hops and sets the cookies where required. The second reason is because `Google` discourages cookie manipulation by apps in `Chromium` based webviews. The third, and most important reason is that it was actually causing issues with certain community URLs, because when the URL changes the old URL has the old `sid` and the new URL has the new `sid`. This causes an `Internal Server Error` which took a while to track down. Removing manual cookie management solves all these issues, with `frontdoor` handling setting of cookies wherever they need to be set.
- I deprecated the cookie management `public` APIs for removal in `Mobile SDK 10.0`. I don't think we should be in the business of managing cookies manually anymore. This is in line with Google's recommendations as well.
