### PR TITLE
Removing potential sensitive URLs from being logged

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -473,7 +473,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
     public void loadLocalStartPage() {
         assert bootconfig.isLocal();
         String startPage = bootconfig.getStartPage();
-        SalesforceHybridLogger.i(TAG, "loadLocalStartPage called - loading: " + startPage);
+        SalesforceHybridLogger.i(TAG, "loadLocalStartPage called - loading!");
         loadUrl("file:///android_asset/www/" + startPage);
         webAppLoaded = true;
     }
@@ -496,7 +496,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
         if (loadThroughFrontDoor) {
             url = getFrontDoorUrl(url, BootConfig.isAbsoluteUrl(url));
         }
-        SalesforceHybridLogger.i(TAG, "loadRemoteStartPage called - loading: " + url);
+        SalesforceHybridLogger.i(TAG, "loadRemoteStartPage called - loading!");
         loadUrl(url);
         webAppLoaded = true;
     }

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
@@ -34,7 +34,6 @@ import android.text.TextUtils;
 import android.webkit.WebView;
 
 import com.salesforce.androidsdk.config.BootConfig;
-import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger;
 import com.salesforce.androidsdk.util.AuthConfigUtil;
 import com.salesforce.androidsdk.util.EventsObservable;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
@@ -97,7 +96,6 @@ public class SalesforceWebViewClientHelper {
         // The first URL that's loaded that's not one of the URLs used in the bootstrap process will
         // be considered the "app home URL", which can be loaded directly in the event that the app is offline.
         if (!isReservedUrl(url)) {
-            SalesforceHybridLogger.i(TAG, "Setting '" + url + "' as the home page URL for this app");
             SharedPreferences sp = ctx.getSharedPreferences(SFDC_WEB_VIEW_CLIENT_SETTINGS, Context.MODE_PRIVATE);
             Editor e = sp.edit();
             e.putString(APP_HOME_URL_PROP_KEY, url);


### PR DESCRIPTION
Sometimes the URL is a `frontdoor` URL, which can contain the `sid`.