### PR TITLE
Getting Ready for Bintray / jCenter Being Sunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ You have arrived at the source repository for the Salesforce Mobile SDK for Andr
 
 - If you'd like to work with the source code of the SDK itself, you've come to the right place! You can browse sample app source code and debug down through the layers to get a feel for how everything works under the covers. Read on for instructions on how to get started with the SDK in your development environment.
 - If you're just eager to start developing your own application, the quickest way is to use our npm binary distribution package, called [forcedroid](https://npmjs.org/package/forcedroid), which is hosted on [npmjs.org](https://npmjs.org/). Getting started is as simple as installing the npm package and launching your template app. You'll find more details on the forcedroid package page.
-- If you'd like to add the SDK to your existing app, the easiest way is to add our libraries as Gradle dependencies from our Maven repo [here](https://bintray.com/forcedotcom/salesforcemobilesdk).
 
 Installation (do this first - really)
 ==

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.2'
+    classpath 'com.android.tools.build:gradle:4.1.3'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -24,6 +24,6 @@ allprojects {
       url("$rootProject.projectDir/libs/SalesforceReact/node_modules/jsc-android/dist")
     }
     google()
-    jcenter()
+    mavenCentral()
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@ buildscript {
   repositories {
     google()
     mavenCentral()
+
+    // FIXME: Keeping this around for now, because some libraries aren't available on 'mavenCentral()'.
+    jcenter()
   }
 
   dependencies {
@@ -25,5 +28,8 @@ allprojects {
     }
     google()
     mavenCentral()
+
+    // FIXME: Keeping this around for now, because some libraries aren't available on 'mavenCentral()'.
+    jcenter()
   }
 }

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -3,16 +3,9 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SmartStore')
@@ -68,69 +61,4 @@ android {
     xmlReport true 
     abortOnError false
   }
-}
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                name 'MobileSync'
-                url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id 'bhariharan'
-                        name 'Bharath Hariharan'
-                        email 'bhariharan@salesforce.com'
-                    }
-                }
-                scm {
-                    connection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    developerConnection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'salesforcemobilesdk'
-        name = 'mobile-sync'
-        userOrg = 'forcedotcom'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-        websiteUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-        issueTrackerUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues'
-        publicDownloadNumbers = true
-        githubRepo = 'forcedotcom/SalesforceMobileSDK-Android'
-        githubReleaseNotesFile = 'README.md'
-        licenses = ['Apache-2.0']
-        labels = ['android', 'salesforce', 'mobilesdk']
-        version {
-            name = '9.1.0'
-            released  = new Date()
-            vcsTag = 'v9.1.0'
-        }
-    }
 }

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -3,16 +3,9 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api 'com.squareup:tape:1.2.3'
@@ -68,69 +61,4 @@ android {
     xmlReport true
     abortOnError false
   }
-}
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                name 'SalesforceAnalytics'
-                url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id 'bhariharan'
-                        name 'Bharath Hariharan'
-                        email 'bhariharan@salesforce.com'
-                    }
-                }
-                scm {
-                    connection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    developerConnection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'salesforcemobilesdk'
-        name = 'salesforce-analytics'
-        userOrg = 'forcedotcom'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-        websiteUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-        issueTrackerUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues'
-        publicDownloadNumbers = true
-        githubRepo = 'forcedotcom/SalesforceMobileSDK-Android'
-        githubReleaseNotesFile = 'README.md'
-        licenses = ['Apache-2.0']
-        labels = ['android', 'salesforce', 'mobilesdk']
-        version {
-            name = '9.1.0'
-            released  = new Date()
-            vcsTag = 'v9.1.0'
-        }
-    }
 }

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -2,6 +2,9 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+
+        // FIXME: Keeping this around for now, because PaperDB isn't available on 'mavenCentral()'.
+        jcenter()
     }
 }
 

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -2,6 +2,9 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+
+        // FIXME: Keeping this around for now, because Cordova isn't available on 'mavenCentral()'.
+        jcenter()
     }
 }
 

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -3,16 +3,9 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 dependencies {
   api project(':libs:MobileSync')
@@ -68,69 +61,4 @@ android {
     xmlReport true
     abortOnError false
   }
-}
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                name 'SalesforceHybrid'
-                url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id 'bhariharan'
-                        name 'Bharath Hariharan'
-                        email 'bhariharan@salesforce.com'
-                    }
-                }
-                scm {
-                    connection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    developerConnection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'salesforcemobilesdk'
-        name = 'salesforce-hybrid'
-        userOrg = 'forcedotcom'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-        websiteUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-        issueTrackerUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues'
-        publicDownloadNumbers = true
-        githubRepo = 'forcedotcom/SalesforceMobileSDK-Android'
-        githubReleaseNotesFile = 'README.md'
-        licenses = ['Apache-2.0']
-        labels = ['android', 'salesforce', 'mobilesdk']
-        version {
-            name = '9.1.0'
-            released  = new Date()
-            vcsTag = 'v9.1.0'
-        }
-    }
 }

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -14,16 +14,9 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 dependencies {
   api project(':libs:MobileSync')
@@ -122,70 +115,5 @@ afterEvaluate {
         preDebugAndroidTestBuild.dependsOn(buildReactTestBundleIfNotExists)
     } catch(Throwable t) {
         println("The preDebugAndroidTestBuild task was not found.")
-    }
-}
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                name 'SalesforceReact'
-                url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id 'bhariharan'
-                        name 'Bharath Hariharan'
-                        email 'bhariharan@salesforce.com'
-                    }
-                }
-                scm {
-                    connection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    developerConnection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'salesforcemobilesdk'
-        name = 'salesforce-react'
-        userOrg = 'forcedotcom'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-        websiteUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-        issueTrackerUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues'
-        publicDownloadNumbers = true
-        githubRepo = 'forcedotcom/SalesforceMobileSDK-Android'
-        githubReleaseNotesFile = 'README.md'
-        licenses = ['Apache-2.0']
-        labels = ['android', 'salesforce', 'mobilesdk']
-        version {
-            name = '9.1.0'
-            released  = new Date()
-            vcsTag = 'v9.1.0'
-        }
     }
 }

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -11,7 +11,8 @@ def useIntlJsc = false
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -13,6 +13,9 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+
+        // FIXME: Keeping this around for now, because some of ReactNative's dependencies aren't available on 'mavenCentral()'.
+        jcenter()
     }
 }
 

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -3,16 +3,9 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SalesforceAnalytics')
@@ -77,69 +70,4 @@ android {
     xmlReport true
     abortOnError false
   }
-}
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                name 'SalesforceSDK'
-                url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id 'bhariharan'
-                        name 'Bharath Hariharan'
-                        email 'bhariharan@salesforce.com'
-                    }
-                }
-                scm {
-                    connection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    developerConnection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'salesforcemobilesdk'
-        name = 'salesforce-sdk'
-        userOrg = 'forcedotcom'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-        websiteUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-        issueTrackerUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues'
-        publicDownloadNumbers = true
-        githubRepo = 'forcedotcom/SalesforceMobileSDK-Android'
-        githubReleaseNotesFile = 'README.md'
-        licenses = ['Apache-2.0']
-        labels = ['android', 'salesforce', 'mobilesdk']
-        version {
-            name = '9.1.0'
-            released  = new Date()
-            vcsTag = 'v9.1.0'
-        }
-    }
 }

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -3,16 +3,9 @@ buildscript {
         google()
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-    }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 dependencies {
     api project(':libs:SalesforceSDK')
@@ -72,69 +65,4 @@ android {
     xmlReport true
     abortOnError false
   }
-}
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                name 'SmartStore'
-                url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                developers {
-                    developer {
-                        id 'bhariharan'
-                        name 'Bharath Hariharan'
-                        email 'bhariharan@salesforce.com'
-                    }
-                }
-                scm {
-                    connection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    developerConnection 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-                    url 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-
-                }
-            }
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_KEY')
-    configurations = ['archives']
-    pkg {
-        repo = 'salesforcemobilesdk'
-        name = 'smart-store'
-        userOrg = 'forcedotcom'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android.git'
-        websiteUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android'
-        issueTrackerUrl = 'https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues'
-        publicDownloadNumbers = true
-        githubRepo = 'forcedotcom/SalesforceMobileSDK-Android'
-        githubReleaseNotesFile = 'README.md'
-        licenses = ['Apache-2.0']
-        labels = ['android', 'salesforce', 'mobilesdk']
-        version {
-            name = '9.1.0'
-            released  = new Date()
-            vcsTag = 'v9.1.0'
-        }
-    }
 }

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
- Removes the publishing module from our library's Gradle files.
- Removes the dependency on the Bintray publish plugin.
- Keeps `jCenter()` in a few places because `Cordova` and `PaperDB` still need it.
- I'll get to removing the remaining instances when I figure out an alternate fetch strategy for `Cordova` and `PaperDB` (we have till early 2022 for this).
- I'll re-add publishing code when we migrate to `mavenCentral()` (probably in a future release).