### PR TITLE
Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 cdvCompileSdkVersion=30
 cdvMinSdkVersion=23
 android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
There are no more dependencies on support libraries, everything is using
AndroidX.
Bye Bye Jetifier! :wave: