### PR TITLE
Fetching PaperDB from mavenCentral() instead of jCenter()

### DIFF
--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     api 'com.squareup:tape:1.2.3'
-    api 'io.paperdb:paperdb:2.7.1'
+    api 'io.github.pilgr:paperdb:2.7.1'
     androidTestImplementation 'androidx.test:runner:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'


### PR DESCRIPTION
They changed the `groupId` of the artifact on `mavenCentral()`. Details [here](https://github.com/pilgr/Paper#migration-to-maven-central).