### PR TITLE
Attempts to fetch the auth config will now send a broadcast after they complete.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
@@ -26,8 +26,10 @@
  */
 package com.salesforce.androidsdk.util;
 
+import android.content.Intent;
 import android.text.TextUtils;
 
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.HttpAccess;
 import com.salesforce.androidsdk.rest.RestResponse;
 
@@ -46,6 +48,9 @@ import okhttp3.Response;
  * @author bhariharan
  */
 public class AuthConfigUtil {
+
+    public static final String AUTH_CONFIG_COMPLETE_INTENT_ACTION = "com.salesforce.AUTH_CONFIG_COMPLETE";
+    public static final String WAS_REQUEST_SUCCESSFUL_EXTRA = "com.salesforce.WAS_REQUEST_SUCCESSFUL";
 
     private static final String FORWARD_SLASH = "/";
     private static final String MY_DOMAIN_AUTH_CONFIG_ENDPOINT = "/.well-known/auth-configuration";
@@ -76,6 +81,9 @@ public class AuthConfigUtil {
         } catch (Exception e) {
             SalesforceSDKLogger.e(TAG, "Auth config request was not successful", e);
         }
+        final Intent intent = new Intent(AUTH_CONFIG_COMPLETE_INTENT_ACTION);
+        intent.putExtra(WAS_REQUEST_SUCCESSFUL_EXTRA, authConfig != null);
+        SalesforceSDKManager.getInstance().getAppContext().sendBroadcast(intent);
         return authConfig;
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -26,12 +26,24 @@
  */
 package com.salesforce.androidsdk.util;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
+
+import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 
 /**
  * Tests for AuthConfigUtil.
@@ -46,6 +58,19 @@ public class AuthConfigUtilTest {
     private static final String ALTERNATE_MY_DOMAIN_ENDPOINT = "https://powerofus.force.com";
     private static final String SANDBOX_ENDPOINT = "https://test.salesforce.com";
     private static final String FORWARD_SLASH = "/";
+
+    private static class TestBroadcastReceiver extends BroadcastReceiver {
+        private final CompletableFuture<Intent> intentFuture = new CompletableFuture<>();
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            intentFuture.complete(intent);
+        }
+
+        Future<Intent> getIntent() {
+            return intentFuture;
+        }
+    }
 
     @Test
     public void testGetAuthConfigWithoutForwardSlash() {
@@ -92,5 +117,36 @@ public class AuthConfigUtilTest {
     public void testGetNoAuthConfig() {
         final AuthConfigUtil.MyDomainAuthConfig authConfig = AuthConfigUtil.getMyDomainAuthConfig(SANDBOX_ENDPOINT);
         Assert.assertNull("Auth config should be null", authConfig);
+    }
+
+    @Test(timeout = 5_000)
+    public void testBroadcastSucceeds() throws ExecutionException, InterruptedException {
+        testBroadcast(MY_DOMAIN_ENDPOINT, true);
+    }
+
+    @Test(timeout = 5_000)
+    public void testBroadcastFails() throws ExecutionException, InterruptedException {
+        testBroadcast(SANDBOX_ENDPOINT, false);
+    }
+
+    private void testBroadcast(String endpoint, Boolean expected) throws InterruptedException, ExecutionException {
+        final TestBroadcastReceiver receiver = new TestBroadcastReceiver();
+        SalesforceSDKManager.getInstance().getAppContext().registerReceiver(receiver,
+                new IntentFilter(AuthConfigUtil.AUTH_CONFIG_COMPLETE_INTENT_ACTION));
+        try {
+            AuthConfigUtil.getMyDomainAuthConfig(endpoint);
+
+            final Intent intent = receiver.getIntent().get();
+            Assert.assertTrue("The intent extra should be set", intent.hasExtra(AuthConfigUtil.WAS_REQUEST_SUCCESSFUL_EXTRA));
+
+            final boolean extra = intent.getBooleanExtra(AuthConfigUtil.WAS_REQUEST_SUCCESSFUL_EXTRA, !expected);
+            if (expected) {
+                Assert.assertTrue("The auth config request should succeed", extra);
+            } else {
+                Assert.assertFalse("The auth config request should fail", extra);
+            }
+        } finally {
+            SalesforceSDKManager.getInstance().getAppContext().unregisterReceiver(receiver);
+        }
     }
 }


### PR DESCRIPTION
This change allow sequential app-level code to be built around the `FetchAuthConfigTask` (or any other usage of `getMyDomainAuthConfig`)

For instance, one can listen for broadcasts in a subclass of SalesforceDroidGapActivity:

```kotlin
class MainActivity: SalesforceDroidGapActivity {
   private val receiver = object : BroadcastReceiver() {
      override fun onReceive(context: Context?, intent: Intent?) {
         if (intent != null && intent.hasExtra(WAS_REQUEST_SUCCESSFUL_EXTRA)) {
            onAuthConfigComplete(intent.getBooleanExtra(WAS_REQUEST_SUCCESSFUL_EXTRA, false))
         }
      }
   }
   
   override fun onStart() {
      // Register a receiver before getMyDomainAuthConfig is called in onResume()
      registerReceiver(receiver, IntentFilter(AUTH_CONFIG_COMPLETE_INTENT_ACTION))
   }
   
   private fun onAuthConfigComplete() { ... }
}
```