### PR TITLE
Fixing bug with Android for Work where addition of accounts is disabled by the admin

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -106,10 +106,16 @@ public class ClientManager {
         // No account found - let's add one - the AuthenticatorService add account method will start the login activity
         if (acc == null) {
             SalesforceSDKLogger.i(TAG, "No account of type " + accountType + " found");
-            accountManager.addAccount(getAccountType(), AccountManager.KEY_AUTHTOKEN, null, options,
-                    activityContext, new AccMgrCallback(restClientCallback), null);
-
+            final Intent i = new Intent(activityContext,
+                    SalesforceSDKManager.getInstance().getLoginActivityClass());
+            i.setPackage(activityContext.getPackageName());
+            i.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            if (options != null) {
+                i.putExtras(options);
+            }
+            activityContext.startActivity(i);
         }
+
         // Account found
         else {
             SalesforceSDKLogger.i(TAG, "Found account of type " + accountType);


### PR DESCRIPTION
`Android for Work` has a relatively new  policy allowing admins to disable users from adding accounts. However, apps should still be allowed to add user accounts, even if this policy is disabled. The correct way to handle this is by ensuring that apps don't call `addAccount` directly, and only call `addAccountExplicitly`. This PR ensures that `Mobile SDK` is compliant with this policy, by only using `addAccountExplicitly` as the API is designed to be used.