### PR TITLE
Faster regexp for smartsql to sql conversion

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
@@ -164,7 +164,7 @@ public class SmartSqlHelper  {
 		// With json1 support, the column name could be an expression of the form json_extract(soup, '$.x.y.z')
 		// We can't have TABLE_x.json_extract(soup, ...) or table_alias.json_extract(soup, ...) in the sql query
         // Instead we should have json_extract(TABLE_x.soup, ...)
-		sqlStr = sqlStr.replaceAll("([^ ]+)\\.json_extract\\(soup", "json_extract($1.soup");
+		sqlStr = sqlStr.replaceAll("\\s([^ ]+)\\.json_extract\\(soup", " json_extract($1.soup");
 
 		// Done
 		return sqlStr;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
@@ -164,7 +164,7 @@ public class SmartSqlHelper  {
 		// With json1 support, the column name could be an expression of the form json_extract(soup, '$.x.y.z')
 		// We can't have TABLE_x.json_extract(soup, ...) or table_alias.json_extract(soup, ...) in the sql query
         // Instead we should have json_extract(TABLE_x.soup, ...)
-		sqlStr = sqlStr.replaceAll("\\s([^ ]+)\\.json_extract\\(soup", " json_extract($1.soup");
+		sqlStr = sqlStr.replaceAll("([\\w]+)\\.json_extract\\(soup", "json_extract($1.soup");
 
 		// Done
 		return sqlStr;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlTest.java
@@ -132,6 +132,33 @@ public class SmartSqlTest extends SmartStoreTestCase {
 	}
 
 	/**
+	 * Testing smart sql to sql conversion when there is a self join accessing json extracted fields
+	 */
+	@Test
+	public void testConvertSmartSqlWithSelfJoinAndJsonExtractedField() {
+		Assert.assertEquals("select json_extract(mgr.soup, '$.education'), json_extract(e.soup, '$.education') "
+				+ "from TABLE_1 as mgr, TABLE_1 as e "
+				+ "where json_extract(mgr.soup, '$.education') = json_extract(e.soup, '$.education')",
+			store.convertSmartSql("select mgr.{employees:education}, e.{employees:education} "
+				+ "from {employees} as mgr, {employees} as e "
+				+ "where mgr.{employees:education} = e.{employees:education}"));
+	}
+
+	/**
+	 * Testing smart sql to sql conversion when there is a self join accessing json extracted fields
+	 * with no spaces between referenced fields
+	 */
+	@Test
+	public void testConvertSmartSqlWithSelfJoinAndJsonExtractedFieldNoLeadingSpace() {
+		Assert.assertEquals("select json_extract(mgr.soup, '$.education'),json_extract(e.soup, '$.education') "
+				+ "from TABLE_1 as mgr, TABLE_1 as e "
+				+ "where not (json_extract(mgr.soup, '$.education')=json_extract(e.soup, '$.education'))",
+			store.convertSmartSql("select mgr.{employees:education},e.{employees:education} "
+				+ "from {employees} as mgr, {employees} as e "
+				+ "where not (mgr.{employees:education}=e.{employees:education})"));
+	}
+
+	/**
 	 * Testing smart sql to sql conversion when path is: _soup, _soupEntryId or _soupLastModifiedDate
 	 */
     @Test


### PR DESCRIPTION
Before json1, smartstore indexing / querying worked by having dedicated columns for all indexed fields.
So given a query like select {soup:field} from {soup} would turn into select TABLE_0_1 from TABLE_0.
For json1, indexed fields are functional indexes on the json soup field itself e.g. json_extract(soup, $.field).
We have a table to keep track of indexed fields, it contains the column name where the indexed data is extracted. But for json1, it simply contains that expression.

A problem arises for queries with a table specifier e.g, if you do a join: select soupL.{soup:field}, soupR.{soup:field} from {soup} as soupL, {soup} as soupR
If field does not use json1, the generated SQL is select soupL.TABLE_0.TABLE_0_1, soupR.TABLE_0.TABLE_0_1 from TABLE_0 as soupL, TABLE_0 as soupR which is fine.
But if it uses json1, you get: select soupL.json_extract(TABLE_0, $field), soupR.json_extract(TABLE_0, $field) from TABLE_0 as soupL, TABLE_0 as soupR which won't work.

So when smartsql to sql conversion happens, you end up with select TABLE_0.json_extract(soup, $.field)
The conversion method runs regexp fix the SQL in those cases and turn it into select json_extract(soupL.soup, $.field), json_extract(soupR.soup, $.field) from TABLE_0 as soupL, TABLE_0 as soupR

This regexp has proven slow for very long queries (even if they don't use json_extract) and can be sped up by matching <space>{word}.json_extrract instead of {work}.json_extract.