### PR TITLE
Fixing sample hybrid apps with new cordova

### DIFF
--- a/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
@@ -21,8 +21,8 @@
         <activity android:label="@string/app_name"
             android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
             android:configChanges="orientation|keyboardHidden"
-            android:theme="@style/Theme.AppCompat.DayNight"
-            android:exported="false">
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:exported="true">
 
             <intent-filter >
                 <action android:name="android.intent.action.MAIN" />

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
@@ -21,8 +21,8 @@
         <activity android:label="@string/app_name"
             android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
             android:configChanges="orientation|keyboardHidden"
-            android:theme="@style/Theme.AppCompat.DayNight"
-            android:exported="false">
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:exported="true">
 
             <intent-filter >
                 <action android:name="android.intent.action.MAIN" />

--- a/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
@@ -21,8 +21,8 @@
         <activity android:label="@string/app_name"
             android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
             android:configChanges="orientation|keyboardHidden"
-            android:theme="@style/Theme.AppCompat.DayNight"
-            android:exported="false">
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:exported="true">
 
             <intent-filter >
                 <action android:name="android.intent.action.MAIN" />

--- a/libs/SalesforceHybrid/res/xml/config.xml
+++ b/libs/SalesforceHybrid/res/xml/config.xml
@@ -3,6 +3,8 @@
     id        = "com.salesforce.androidsdk"
     version   = "9.2.0">
 
+    <content src="index.html" />
+
     <!-- To allow XHR requests with the new Whitelist plugin -->
     <allow-navigation href="https://localhost" />
     <allow-navigation href="https://*.force.com" />


### PR DESCRIPTION
- main activity cannot be exported false
- config.xml needs (dummy) content property otherwise one gets a NPE at runtime (because of change introduced by https://github.com/apache/cordova-android/pull/1298)
- CordovaActivity extends AppCompatActivity so must use AppCompat theme (see https://github.com/apache/cordova-android/pull/1052)