### PR TITLE
Fixing IOException in RestClientTest happening on API 23 only

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -495,7 +495,7 @@ public class Encryptor {
         finally {
             stream.close();
         }
-        return output.toString(String.valueOf(StandardCharsets.UTF_8));
+        return output.toString(StandardCharsets.UTF_8.name());
     }
 
     /**


### PR DESCRIPTION
### Cause
Exception was thrown by `Encryptor.getStringFromStream()` when doing
```java
return output.toString(String.valueOf(StandardCharsets.UTF_8));
```

- It turns out the implementation of Charset.toString() on [23](https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-23/blob/master/java/nio/charset/Charset.java#L546) is:

```java
return getClass().getName() + "[" + this.canonicalName + "]";
```

- And on [24](https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-24/blob/master/java/nio/charset/Charset.java#L966)+ it is:

```java
return name()
```

### Fix
Call `name()` instead of `toString()` (or `String.valueOf()` which itself calls `toString()`).