### PR TITLE
Making null handling consistent with iOS during sync up

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -413,7 +413,10 @@ public class SyncUpTarget extends SyncTarget {
         Map<String,Object> fields = new HashMap<>();
         for (String fieldName : fieldlist) {
             if (!fieldName.equals(idFieldName) && !fieldName.equals(modificationDateFieldName)) {
-                fields.put(fieldName, SmartStore.project(record, fieldName));
+                Object fieldValue = SmartStore.projectReturningNULLObject(record, fieldName);
+                if (fieldValue != null) {
+                    fields.put(fieldName, fieldValue == JSONObject.NULL ? null : fieldValue);
+                }
             }
         }
         return fields;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -1586,7 +1586,18 @@ public class SmartStore  {
 	 * projectIntoJson(json, "a.b.d.e") = [[1, 2], [3, 4]]                               // new in 4.1
 	 *
      */
-    public static Object project(JSONObject soup, String path) {
+	public static Object project(JSONObject soup, String path) {
+		Object result = projectReturningNULLObject(soup, path);
+		return result == JSONObject.NULL ? null : result;
+	}
+
+	/**
+	 * Same as project but returns JSONObject.NULL if node found but without value and null if node not found
+	 * @param soup
+	 * @param path
+	 * @return
+	 */
+    public static Object projectReturningNULLObject(JSONObject soup, String path) {
         if (soup == null) {
             return null;
         }
@@ -1594,10 +1605,10 @@ public class SmartStore  {
             return soup;
         }
         String[] pathElements = path.split("[.]");
-		return project(soup, pathElements, 0);
+		return projectRecursive(soup, pathElements, 0);
     }
 
-	private static Object project(Object jsonObj, String[] pathElements, int index) {
+	private static Object projectRecursive(Object jsonObj, String[] pathElements, int index) {
 		Object result = null;
 		if (index == pathElements.length) {
 			return jsonObj;
@@ -1608,15 +1619,15 @@ public class SmartStore  {
 
 			if (jsonObj instanceof JSONObject) {
 				JSONObject jsonDict = (JSONObject) jsonObj;
-				Object dictVal = JSONObjectHelper.opt(jsonDict, pathElement);
-				result = project(dictVal, pathElements, index+1);
+				Object dictVal = jsonDict.opt(pathElement);
+				result = projectRecursive(dictVal, pathElements, index+1);
 			}
 			else if (jsonObj instanceof JSONArray) {
 				JSONArray jsonArr = (JSONArray) jsonObj;
 				result = new JSONArray();
 				for (int i=0; i<jsonArr.length(); i++) {
-					Object arrayElt = JSONObjectHelper.opt(jsonArr, i);
-					Object resultPart = project(arrayElt, pathElements, index);
+					Object arrayElt = jsonArr.opt(i);
+					Object resultPart = projectRecursive(arrayElt, pathElements, index);
 					if (resultPart != null) {
 						((JSONArray) result).put(resultPart);
 					}

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/KeyValueStoreInspectorActivity.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/ui/KeyValueStoreInspectorActivity.java
@@ -54,6 +54,7 @@ import com.salesforce.androidsdk.smartstore.store.KeyValueEncryptedFileStore;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -141,6 +142,7 @@ public class KeyValueStoreInspectorActivity extends Activity {
             setCurrentStore(allStores.get(0));
         }
 
+        Collections.sort(allStores);
         ArrayAdapter<String> adapter = new ArrayAdapter<>(this, R.layout.sf__inspector_menu_popup_item, allStores);
         storesDropdown.setAdapter(adapter);
         storesDropdown.setText(allStores.get(0), false);

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -177,6 +177,22 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	}
 
 	/**
+	 * Making sure projectReturningNULLObject:
+	 * - returns JSONObject.NULL if the node is found but has the value null
+	 * - returns null if the node is not found
+	 */
+	@Test
+	public void testProjectMissingVsSetToNull() throws JSONException {
+		JSONObject json = new JSONObject("{\"a\":null, \"b\":{\"bb\":null}, \"c\":{\"cc\":{\"ccc\":null}}}");
+		Assert.assertEquals(JSONObject.NULL, SmartStore.projectReturningNULLObject(json, "a"));
+		Assert.assertEquals(JSONObject.NULL, SmartStore.projectReturningNULLObject(json, "b.bb"));
+		Assert.assertEquals(JSONObject.NULL, SmartStore.projectReturningNULLObject(json, "c.cc.ccc"));
+		Assert.assertEquals(null, SmartStore.projectReturningNULLObject(json, "a1"));
+		Assert.assertEquals(null, SmartStore.projectReturningNULLObject(json, "b.bb1"));
+		Assert.assertEquals(null, SmartStore.projectReturningNULLObject(json, "c.cc.ccc1"));
+	}
+
+	/**
 	 * Check that the meta data table (soup index map) has been created
 	 */
     @Test


### PR DESCRIPTION
The issue was reported here: https://github.com/forcedotcom/SalesforceMobileSDK-Android/issues/2167

If no value is found, no field is sent to the server.
If the node is found but has no value, the field is sent to the server with null as value.

The SyncUpTarget on iOS was already behaving that way, see https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/dev/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m#L233

Instead of changing SmartStore.project to start returning JSONObject.NULL, we introduced a new project method projectReturningNULLObject that has the new behavior. That method is called from SyncUpTarget's buildFieldsMap.