### PR TITLE
Adding required flags by API 31 for PendingIntent

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
@@ -188,7 +188,8 @@ public class PushService extends JobIntentService {
             retryIntent.putExtra(PushMessaging.ACCOUNT_BUNDLE_KEY, account.toBundle());
         }
         final PendingIntent retryPIntent = PendingIntent.getBroadcast(SalesforceSDKManager.getInstance().getAppContext(),
-        		1, retryIntent, PendingIntent.FLAG_ONE_SHOT);
+        		1, retryIntent,
+				PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
         final AlarmManager am = (AlarmManager) SalesforceSDKManager.getInstance().getAppContext().getSystemService(Context.ALARM_SERVICE);
         am.set(AlarmManager.RTC_WAKEUP, cal.getTimeInMillis(), retryPIntent);
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -340,7 +340,8 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
         // Adds a menu item to change server.
         final Intent changeServerIntent = new Intent(activity, ServerPickerActivity.class);
         final PendingIntent changeServerPendingIntent = PendingIntent.getActivity(activity,
-                LoginActivity.PICK_SERVER_REQUEST_CODE, changeServerIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+                LoginActivity.PICK_SERVER_REQUEST_CODE, changeServerIntent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         intentBuilder.addMenuItem(activity.getString(R.string.sf__pick_server), changeServerPendingIntent);
         final CustomTabsIntent customTabsIntent = intentBuilder.build();
 


### PR DESCRIPTION
With `targetApi = 31`, we now need to explicitly specify if a `PendingIntent` is  mutable or immutable, otherwise it will cause a runtime crash. We would use `FLAG_IMMUTABLE` in most cases, except for use cases like message bubbles where the contents need to be frequently updated.

The crash would look like this:
```
java.lang.IllegalArgumentException: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent. Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
```