### PR TITLE
Enables WAL in SmartStore

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -197,6 +197,11 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	}
 
 	@Override
+	public void onConfigure(final SQLiteDatabase db) {
+		db.enableWriteAheadLogging();
+	}
+
+	@Override
 	public void onCreate(SQLiteDatabase db) {
 
 		/*

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -1335,6 +1335,12 @@ public class SmartStoreTest extends SmartStoreTestCase {
 			JSONObject soupElt = new JSONObject("{'key':'abcd" + i + "', 'value':'va" + i + "', 'otherValue':'ova" + i + "'}");
 			store.create(TEST_SOUP, soupElt);
 		}
+
+		// With WAL enabled we must force a WAL checkpoint if we want the actual DB file to reflect the new content:
+		store.getDatabase()
+				.query("PRAGMA wal_checkpoint(FULL);")
+				.moveToNext();
+
         Assert.assertTrue("Database should be larger now", store.getDatabaseSize() > initialSize);
 	}
 


### PR DESCRIPTION
The SQLite Write Ahead Logging is enabled for all SmartStore DB objects.

## Overview

This is a small but impactful change to how the underlying SQLite DB objects function.  The benefits seem to be measurable, repeatable, and significant.  The head of my [sandbox/perf-testing](https://github.com/gkotula/SalesforceMobileSDK-Android/tree/sandbox/perf-testing) has a [simple upsert test](https://github.com/gkotula/SalesforceMobileSDK-Android/blob/f8b6740afc5a407f77fead8e02306d266804f3be/benchmarking/src/androidTest/java/com/salesforce/androidsdk/benchmarking/SmartStoreBenchmark.kt#L63) in a tight loop which sees a ~5x average speed increase with WAL enabled compared to without.

Further investigation for the performance impacts could be done, but between these results and the work that others have done, it seems clear that there is a very tangible performance benefit to enabling WAL.  It seems unlikely that cases would exist where enabling WAL will negatively impact performance, but further testing would be required to determine if there are such cases.

These runs were done using Jetpack's Benchmarking library which stabilizes CPU, thermals, JIT, and a host of other factors to make testing performance as repeatable as possible.  It also runs the test code 50 times and aggregates the data to generate a report.

### Test Runs

| Run # | WAL Enabled? | Median Runtime (ms) | Min Runtime (ms) | Max Runtime (ms) | Standard Deviation (ms) |
| :---: | :----------: | :-----------------: | :--------------: | :--------------: | :---------------------: |
|   1   |      ❌      |       1657 ms       |       952 ms     |      3075 ms     |         472 ms          |
|   2   |      ✅      |        255 ms       |       221 ms     |       513 ms     |          78 ms          |
|   3   |      ❌      |       1291 ms       |      1147 ms     |      1584 ms     |         106 ms          |
|   4   |      ✅      |        247 ms       |       218 ms     |       534 ms     |          62 ms          |

## Caveats

All tests were run locally and were shown to be passing, but there was one exception.  As you can see in the PR, there was one test that needed modification to pass, and this is confirmed to be caused by enabling WAL.  This change was required because of 1) the nature of the test, and 2) how WAL works at a low level.

The test is fairly simple, just ensuring the DB file increases in size with new records inserted, and this began failing after enabling WAL.  This is because WAL writes changes to a separate "WAL file" separate from the main DB file before checkpointing the changes back to the DB.  This checkpointing is scheduled automatically _once the WAL file reaches a certain **page** size_.  This test was not reaching that page threshold, and thus the test failed because the DB file never received the updates from the WAL file.

The fact that enabling WAL changed existing behavior should be called out as risk.  There could be subtle and difficult-to-diagnose bugs introduced into consumer apps with this change depending on how much they interact with SmartStore directly.