### PR TITLE
Upgrading paperdb lib to 2.7.2

### DIFF
--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     api 'com.squareup:tape:1.2.3'
-    api 'io.github.pilgr:paperdb:2.7.1'
+    api 'io.github.pilgr:paperdb:2.7.2'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'


### PR DESCRIPTION
## Description
Upgrade of paperdb dependency to version 2.7.2.

## Motivation and Context
When R8 is enabled, starting from Android Gradle Plugin 7.0.2, there is a crash when using paperdb. It prevents us from upgrading Android Gradle Plugin to a more recent version. For the full context, see https://github.com/pilgr/Paper/issues/196.

## How Has This Been Tested?
- Generate new archives for the SDK modules
- Use these archives as dependencies
- Update the app to Android Gradle Plugin 7.0.4 
- Generate a new app version in release mode with R8 enabled
- Update existing version of the app using this new version

I have not seen any regressions and this new version of the lib seems to fix the problem. 
I have seen that paperdb is used for Analytics events in the SDK but I may have missed some impacts due to this change. Is it possible that you check everything is good on your side ?