### PR TITLE
Moving to SQLCipher 4.5.0

### DIFF
--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     api project(':libs:SalesforceSDK')
-    api 'net.zetetic:android-database-sqlcipher:4.4.3'
+    api 'net.zetetic:android-database-sqlcipher:4.5.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -112,7 +112,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	 */
 	@Test
 	public void testSQLCipherVersion() {
-		Assert.assertEquals("Wrong sqlcipher version", "4.4.3 community", store.getSQLCipherVersion());
+		Assert.assertEquals("Wrong sqlcipher version", "4.5.0 community", store.getSQLCipherVersion());
 	}
 
 	/**

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTestCase.java
@@ -180,9 +180,9 @@ public abstract class SmartStoreTestCase {
         JSONObject explainQueryPlan = store.getLastExplainQueryPlan();
         String soupTableName = getSoupTableName(soupName);
         String indexName = soupTableName + "_" + index + "_idx";
-        String expectedDetailPrefix = String.format("%s TABLE %s USING %sINDEX %s", dbOperation, soupTableName, covering ? "COVERING " : "", indexName);
+        String expectedDetailPrefix = String.format("%s %s USING %sINDEX %s", dbOperation, soupTableName, covering ? "COVERING " : "", indexName);
         String detail = explainQueryPlan.getJSONArray(DBHelper.EXPLAIN_ROWS).getJSONObject(0).getString("detail");
-		Assert.assertTrue("Wrong query plan:" + detail, detail.startsWith(expectedDetailPrefix));
+		Assert.assertTrue("Query plan: " + detail + " - not starting with " + expectedDetailPrefix, detail.startsWith(expectedDetailPrefix));
     }
 
 	protected void checkFileSystem(String soupName, long[] expectedIds, boolean shouldExist) {


### PR DESCRIPTION
Only issues encountered in tests, the explain query plan is a bit different e.g. saying "SCAN tableName ..." instead of "SCAN table tableName etc".