### PR TITLE
Bump React Native to 0.67.1.

### DIFF
--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
   api project(':libs:MobileSync')
-  api 'com.facebook.react:react-native:0.67.0'
+  api 'com.facebook.react:react-native:0.67.1'
   androidTestImplementation 'androidx.test:runner:1.4.0'
   androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/libs/SalesforceReact/package.json
+++ b/libs/SalesforceReact/package.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "create-react-class": "^15.7.0",
         "react": "17.0.2",
-        "react-native": "0.67.0",
+        "react-native": "0.67.1",
         "react-native-force": "git+https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative.git#dev"
     },
     "devDependencies": {


### PR DESCRIPTION
This is fixes a crash for Android release builds.