### PR TITLE
Force WAL checkpoint in getDatabaseSize.

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -241,6 +241,8 @@ public class SmartStore  {
      * Get database size
      */
     public int getDatabaseSize() {
+		// With WAL enabled we must force a WAL checkpoint if we want the actual DB file size.
+		getDatabase().query("PRAGMA wal_checkpoint(FULL);").moveToNext();
     	int size =  (int) (new File(getDatabase().getPath()).length()); // XXX That cast will be trouble if the file is more than 2GB
     	if (dbOpenHelper instanceof DBOpenHelper) {
     		size += ((DBOpenHelper) dbOpenHelper).getSizeOfDir(null);

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -1336,11 +1336,6 @@ public class SmartStoreTest extends SmartStoreTestCase {
 			store.create(TEST_SOUP, soupElt);
 		}
 
-		// With WAL enabled we must force a WAL checkpoint if we want the actual DB file to reflect the new content:
-		store.getDatabase()
-				.query("PRAGMA wal_checkpoint(FULL);")
-				.moveToNext();
-
         Assert.assertTrue("Database should be larger now", store.getDatabaseSize() > initialSize);
 	}
 


### PR DESCRIPTION
It stands to reason that if we have a public API to get DB size it should be accurate at the time of calling.  This also fixes a lot of Hybrid Tests.  