### PR TITLE
Removing completed syncs from active tasks before calling callback

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/SyncTask.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/SyncTask.java
@@ -93,8 +93,6 @@ public abstract class SyncTask implements Runnable {
             sync.setError(e.getMessage());
             // Update status to failed
             updateSync(sync, SyncState.Status.FAILED, UNCHANGED, callback);
-        } finally {
-            syncManager.removeFromActiveSyncs(this);
         }
     }
 
@@ -141,6 +139,11 @@ public abstract class SyncTask implements Runnable {
         } catch (SmartStore.SmartStoreException e) {
             MobileSyncLogger.e(TAG, "Unexpected smart store error for sync: " + sync.getId(), e);
         } finally {
+            // Removing from active syncs before calling callback
+            if (!sync.isRunning()) {
+                syncManager.removeFromActiveSyncs(this);
+            }
+
             if (callback != null) {
                 callback.onUpdate(sync);
             }


### PR DESCRIPTION
Otherwise, calling clean sync ghost in call back when done status detected will complain that sync is still running