### PR TITLE
BriefcaseSyncDownTarget chunks up ids when getting records

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
@@ -62,7 +62,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
     private static final String TAG = "BriefcaseSyncDownTarget";
 
     public static final String INFOS = "infos";
-    public static final String COUNT_IDS_PER_SOQL = "coundIdsPerSoql";
+    public static final String COUNT_IDS_PER_SOQL = "countIdsPerSoql";
 
     private List<BriefcaseObjectInfo> infos;
     private Map<String, BriefcaseObjectInfo> infosMap;
@@ -74,7 +74,6 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
 
     // Number of records to fetch per SOQL call (with ids obtained from priming record api)
     private int countIdsPerSoql;
-    private static final int defaultCountIdsPerSoql = 500;
     private static final int MAX_COUNT_IDS_PER_SOQL = 2000;
 
 
@@ -86,7 +85,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
     public BriefcaseSyncDownTarget(JSONObject target) throws JSONException {
         this(
             BriefcaseObjectInfo.fromJSONArray(target.getJSONArray(INFOS)),
-            target.optInt(COUNT_IDS_PER_SOQL, defaultCountIdsPerSoql)
+            target.optInt(COUNT_IDS_PER_SOQL, MAX_COUNT_IDS_PER_SOQL)
         );
     }
 
@@ -96,7 +95,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
      * @param infos
      */
     public BriefcaseSyncDownTarget(List<BriefcaseObjectInfo> infos) {
-        this(infos, defaultCountIdsPerSoql);
+        this(infos, MAX_COUNT_IDS_PER_SOQL);
     }
 
     BriefcaseSyncDownTarget(List<BriefcaseObjectInfo> infos, int countIdsPerSoql) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/JSONObjectHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/JSONObjectHelper.java
@@ -191,4 +191,16 @@ public class JSONObjectHelper {
 		return result;
 	}
 
+	/**
+	 * Add all elements from array to destinationArray
+	 *
+	 * @param destinationArray
+	 * @param array
+	 */
+	public static void addAll(JSONArray destinationArray, JSONArray array) throws JSONException {
+		for (int i=0; i<array.length(); i++) {
+			destinationArray.put(array.getJSONObject(i));
+		}
+	}
+
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTargetTest.java
@@ -187,6 +187,33 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
     }
 
     // Create accounts on server
+    // Run a sync with a BriefcaseSyncDownTarget with countIdsPerSoql of 2
+    // Make sure we get the created accounts in the database
+    @Test
+    public void testSyncDownFetchingWithMultipleSOQLCalls() throws Exception {
+        final int numberAccounts = 11; // using a number that is not a multiple of countIdsPerSoql to make sure the last slice is correctly fetched
+        final Map<String, String> accounts = createRecordsOnServer(numberAccounts, Constants.ACCOUNT);
+        Assert.assertEquals("Wrong number of accounts created", numberAccounts, accounts.size());
+        final String[] accountIds = accounts.keySet().toArray(new String[0]);
+
+        // Builds briefcase sync down target to fetch the accounts with SOQL queries using 2 ids at a time
+        BriefcaseSyncDownTarget target = new BriefcaseSyncDownTarget(
+            Arrays.asList(new BriefcaseObjectInfo(
+                ACCOUNTS_SOUP,
+                Constants.ACCOUNT,
+                Arrays.asList(Constants.NAME, Constants.DESCRIPTION)
+            )),
+            2
+        );
+
+        // Run sync
+        trySyncDown(MergeMode.LEAVE_IF_CHANGED, target, ACCOUNTS_SOUP, accounts.size(), 1, null);
+
+        // Check database
+        checkDbExist(ACCOUNTS_SOUP, accountIds, Constants.ID);
+    }
+
+    // Create accounts on server
     // Run a sync with a BriefcaseSyncDownTarget that is only interested in accounts
     // Make sure we get the created accounts in the database
     // Delete some accounts from server


### PR DESCRIPTION
BEFORE
When fetching records using the ids returned by the priming records api, we currently build the SOQL query with all the ids in the where clause.
However the priming records api could return up to 50,000 ids at once, so the SOQL query could exceed its maximum length (100,000 characters) or returned results over multiple pages (which the code currently does not expect).

NOW
We chunk the ids in group of 2000 so as to not exceed SOQL query maximum length and avoid paged responses.