### PR TITLE
Returning at most countIdsPerSoql records from startFetch / continueFetch

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
@@ -181,12 +181,12 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
 
     @Override
     public Set<String> getIdsToSkip(SyncManager syncManager, String soupName) throws JSONException {
-        Set<String> idsToSkip = new HashSet<>();
+        Set<String> dirtyRecordIds = new HashSet<>();
         // Aggregating ids of dirty records across all the soups
         for (BriefcaseObjectInfo info : infos) {
-            idsToSkip.addAll(getDirtyRecordIds(syncManager, info.soupName, info.idFieldName));
+            dirtyRecordIds.addAll(getDirtyRecordIds(syncManager, info.soupName, info.idFieldName));
         }
-        return idsToSkip;
+        return dirtyRecordIds;
     }
 
     @Override

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk.mobilesync.target;
 
 import android.text.TextUtils;
-import android.util.Log;
 import com.salesforce.androidsdk.mobilesync.app.Features;
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
@@ -246,10 +245,6 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
             totalSize = fetchedTypedIds.size();
         }
 
-        Log.d("SOQL-->", "size = " + fetchedTypedIds.size());
-        Log.d("SOQL-->", "number slices = " + fetchedTypedIds.countSlices(countIdsPerSoql));
-        Log.d("SOQL-->", "index = " + currentSliceIndex);
-
         // Incrementing current slice index and checking if we have reached the end
         currentSliceIndex++;
         if (currentSliceIndex >= fetchedTypedIds.countSlices(countIdsPerSoql)) {
@@ -307,8 +302,6 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
 
         final String whereClause = ""
             + getIdFieldName() + " IN ('" + TextUtils.join("', '", ids) + "')";
-
-        Log.d("SOQL-->", whereClause);
 
         final String soql = SOQLBuilder.getInstanceWithFields(fieldlist).from(sobjectType).where(whereClause).build();
         final RestRequest request = RestRequest.getRequestForQuery(syncManager.apiVersion, soql);

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
@@ -27,28 +27,21 @@
 package com.salesforce.androidsdk.mobilesync.manager;
 
 import android.text.TextUtils;
-
+import com.salesforce.androidsdk.mobilesync.target.SyncDownTarget;
+import com.salesforce.androidsdk.mobilesync.target.SyncTarget;
+import com.salesforce.androidsdk.mobilesync.target.SyncUpTarget;
+import com.salesforce.androidsdk.mobilesync.util.Constants;
+import com.salesforce.androidsdk.mobilesync.util.JSONTestHelper;
+import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
+import com.salesforce.androidsdk.mobilesync.util.SyncState;
+import com.salesforce.androidsdk.mobilesync.util.SyncUpdateCallbackQueue;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.smartstore.store.IndexSpec;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
-import com.salesforce.androidsdk.mobilesync.target.SyncDownTarget;
-import com.salesforce.androidsdk.mobilesync.target.SyncTarget;
-import com.salesforce.androidsdk.mobilesync.target.SyncUpTarget;
-import com.salesforce.androidsdk.mobilesync.util.Constants;
-import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
-import com.salesforce.androidsdk.mobilesync.util.SyncState;
-import com.salesforce.androidsdk.mobilesync.util.SyncUpdateCallbackQueue;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
-import com.salesforce.androidsdk.mobilesync.util.JSONTestHelper;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.junit.Assert;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -57,6 +50,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
 
 /**
  * Abstract super class for all SyncManager test classes.

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTargetTest.java
@@ -172,8 +172,7 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
     // And that it took the multiple call to continueFetch
     @Test
     public void testSyncDownFetchingOneObjectTypeWithMultipleSOQLCalls() throws Exception {
-        trySyncDownFetchingOneObjectType(11, 2, 6);
-        // using a number of accounts that is not a multiple of countIdsPerSoql to make sure the last slice is correctly fetched
+        trySyncDownFetchingOneObjectType(12, 2, 6);
     }
 
     // Create accounts on server
@@ -239,11 +238,11 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
     // And that it took the multiple call to continueFetch
     @Test
     public void testSyncDownFetchingTwoObjectTypesWithMultipleSOQLCalls() throws Exception {
-        trySyncDownFetchingTwoObjectTypes(12, 11, 2, 12);
+        trySyncDownFetchingTwoObjectTypes(12, 12, 3, 8);
     }
 
     // Create accounts and contacts on server
-    // Run a sync with a BriefcaseSyncDownTarget that is interested in accounts and conotacts
+    // Run a sync with a BriefcaseSyncDownTarget that is interested in accounts and contacts
     // Make sure we get the created accounts and contacts in the database
     // Delete some accounts and contacts from server
     // Create some accounts and contacts locally
@@ -307,7 +306,7 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
         checkDbExist(ACCOUNTS_SOUP, new String[] {localAccounts[0].getString(Constants.ID), localAccounts[1].getString(Constants.ID)}, Constants.ID);
         checkDbExist(CONTACTS_SOUP, new String[] {localContacts[0].getString(Constants.ID), localContacts[1].getString(Constants.ID)}, Constants.ID);
     }
-
+    
     protected String createRecordName(String objectType) {
         return String.format(Locale.US, "BriefcaseTest_%s_%d", objectType, System.nanoTime());
     }


### PR DESCRIPTION
To avoid too much memory usage.

If you have
```
typejA -> idA1 ... idAn
typeB -> idB1 ... idBn
etc
```
We are building a list that looks like `[idA1 ... idAn idB1 ... idBn ... ]`
And chunking that list, so if there are a lot of A's, we might do only A's in the first round, but if there are less than 500 A's we might do all the A's and some B's etc - but always no more than 500 records.

The new class `TypedIds` is a helper class that has methods for "chunking" and also for going back to the map of object type to list of ids.