### PR TITLE
Using sObject collection retrieve in BriefcaseSyncDownTarget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
                 --directories-to-pull=/sdcard  \
                 --results-dir=<< parameters.lib >>-${CIRCLE_BUILD_NUM}  \
                 --results-history-name=<< parameters.lib >>  \
-                --timeout=15m --no-auto-google-login --no-record-video --no-performance-metrics
+                --timeout=20m --no-auto-google-login --no-record-video --no-performance-metrics
           no_output_timeout: 900
       - run:
           name: Copy test results data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,8 +192,8 @@ jobs:
                 --directories-to-pull=/sdcard  \
                 --results-dir=<< parameters.lib >>-${CIRCLE_BUILD_NUM}  \
                 --results-history-name=<< parameters.lib >>  \
-                --timeout=20m --no-auto-google-login --no-record-video --no-performance-metrics
-          no_output_timeout: 900
+                --timeout=15m --no-auto-google-login --no-record-video --no-performance-metrics
+          no_output_timeout: 1200
       - run:
           name: Copy test results data
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
                 --directories-to-pull=/sdcard  \
                 --results-dir=<< parameters.lib >>-${CIRCLE_BUILD_NUM}  \
                 --results-history-name=<< parameters.lib >>  \
-                --timeout=15m --no-auto-google-login --no-record-video --no-performance-metrics
+                --timeout=20m --no-auto-google-login --no-record-video --no-performance-metrics
           no_output_timeout: 1200
       - run:
           name: Copy test results data

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
@@ -26,14 +26,12 @@
  */
 package com.salesforce.androidsdk.mobilesync.target;
 
-import android.text.TextUtils;
 import com.salesforce.androidsdk.mobilesync.app.Features;
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
 import com.salesforce.androidsdk.mobilesync.util.BriefcaseObjectInfo;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.mobilesync.util.MobileSyncLogger;
-import com.salesforce.androidsdk.mobilesync.util.SOQLBuilder;
 import com.salesforce.androidsdk.rest.PrimingRecordsResponse;
 import com.salesforce.androidsdk.rest.PrimingRecordsResponse.PrimingRecord;
 import com.salesforce.androidsdk.rest.RestRequest;
@@ -63,7 +61,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
     private static final String TAG = "BriefcaseSyncDownTarget";
 
     public static final String INFOS = "infos";
-    public static final String COUNT_IDS_PER_SOQL = "countIdsPerSoql";
+    public static final String COUNT_IDS_PER_RETRIEVE = "countIdsPerRetrieve";
 
     private List<BriefcaseObjectInfo> infos;
     private Map<String, BriefcaseObjectInfo> infosMap;
@@ -76,12 +74,9 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
     protected TypedIds fetchedTypedIds = null;
     protected int currentSliceIndex = 0;
 
-    // Number of records to fetch per SOQL call (with ids obtained from priming record api)
-    private int countIdsPerSoql;
-    private static final int MAX_COUNT_IDS_PER_SOQL = 500;
-    // NB: SOQL query length limit is 100k but not over REST
-    //     Too many ids will cause a "414 - URI Too Long" error
-
+    // Number of records to fetch per call (with ids obtained from priming record api)
+    private int countIdsPerRetrieve;
+    private static final int MAX_COUNT_IDS_PER_RETRIEVE = 2000;
 
     /**
      * Construct BriefcaseSyncDownTarget from json
@@ -91,7 +86,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
     public BriefcaseSyncDownTarget(JSONObject target) throws JSONException {
         this(
             BriefcaseObjectInfo.fromJSONArray(target.getJSONArray(INFOS)),
-            target.optInt(COUNT_IDS_PER_SOQL, MAX_COUNT_IDS_PER_SOQL)
+            target.optInt(COUNT_IDS_PER_RETRIEVE, MAX_COUNT_IDS_PER_RETRIEVE)
         );
     }
 
@@ -101,13 +96,13 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
      * @param infos
      */
     public BriefcaseSyncDownTarget(List<BriefcaseObjectInfo> infos) {
-        this(infos, MAX_COUNT_IDS_PER_SOQL);
+        this(infos, MAX_COUNT_IDS_PER_RETRIEVE);
     }
 
-    BriefcaseSyncDownTarget(List<BriefcaseObjectInfo> infos, int countIdsPerSoql) {
+    BriefcaseSyncDownTarget(List<BriefcaseObjectInfo> infos, int countIdsPerRetrieve) {
         this.infos = infos;
         this.queryType = QueryType.briefcase;
-        this.countIdsPerSoql = Math.min(countIdsPerSoql, MAX_COUNT_IDS_PER_SOQL);
+        this.countIdsPerRetrieve = Math.min(countIdsPerRetrieve, MAX_COUNT_IDS_PER_RETRIEVE);
         MobileSyncSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_RELATED_RECORDS);
 
         // Build infosMap
@@ -128,7 +123,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
             infosJson.put(info.asJSON());
         }
         target.put(INFOS, infosJson);
-        target.put(COUNT_IDS_PER_SOQL, countIdsPerSoql);
+        target.put(COUNT_IDS_PER_RETRIEVE, countIdsPerRetrieve);
         return target;
     }
 
@@ -198,7 +193,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
 
     /**
      * Method that calls the priming records API to get ids to fetch
-     * then use SOQL to get record fields
+     * then use sObject collection retrieve to get record fields
      *
      * @param syncManager
      * @return
@@ -215,9 +210,10 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
         }
 
         // Getting ids of records to fetch in a map
-        Map<String, List<String>> objectTypeToIds = fetchedTypedIds.slice(currentSliceIndex, countIdsPerSoql).toMap();
+        Map<String, List<String>> objectTypeToIds = fetchedTypedIds.slice(currentSliceIndex,
+            countIdsPerRetrieve).toMap();
 
-        // Get records using SOQL one object type at a time
+        // Get records using sObject collection retrieve one object type at a time
         for (Entry<String, List<String>> entry : objectTypeToIds.entrySet()) {
             String objectType = entry.getKey();
             List<String> idsToFetch = entry.getValue();
@@ -247,7 +243,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
 
         // Incrementing current slice index and checking if we have reached the end
         currentSliceIndex++;
-        if (currentSliceIndex >= fetchedTypedIds.countSlices(countIdsPerSoql)) {
+        if (currentSliceIndex >= fetchedTypedIds.countSlices(countIdsPerRetrieve)) {
             fetchedTypedIds = null;
             currentSliceIndex = 0;
         }
@@ -299,15 +295,9 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
 
     protected JSONArray fetchFromServer(SyncManager syncManager, String sobjectType, List<String> ids, List<String> fieldlist) throws IOException, JSONException {
         syncManager.checkAcceptingSyncs();
-
-        final String whereClause = ""
-            + getIdFieldName() + " IN ('" + TextUtils.join("', '", ids) + "')";
-
-        final String soql = SOQLBuilder.getInstanceWithFields(fieldlist).from(sobjectType).where(whereClause).build();
-        final RestRequest request = RestRequest.getRequestForQuery(syncManager.apiVersion, soql);
+        final RestRequest request = RestRequest.getRequestForCollectionRetrieve(syncManager.apiVersion, sobjectType, ids, fieldlist);
         final RestResponse response = syncManager.sendSyncWithMobileSyncUserAgent(request);
-        JSONObject responseJson = response.asJSONObject();
-        return responseJson.getJSONArray(Constants.RECORDS);
+        return response.asJSONArray();
     }
 
     /**

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTargetTest.java
@@ -169,11 +169,11 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
     }
 
     // Create accounts on server
-    // Run a sync with a BriefcaseSyncDownTarget with countIdsPerSoql of 2
+    // Run a sync with a BriefcaseSyncDownTarget with 2 of 2
     // Make sure we get the created accounts in the database
     // And that it took the multiple call to continueFetch
     @Test
-    public void testSyncDownFetchingOneObjectTypeWithMultipleSOQLCalls() throws Exception {
+    public void testSyncDownFetchingOneObjectTypeWithMultipleRetrieveCalls() throws Exception {
         trySyncDownFetchingOneObjectType(12, 2, 6);
     }
 
@@ -235,11 +235,11 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
     }
 
     // Create accounts and contacts on server
-    // Run a sync with a BriefcaseSyncDownTarget with countIdsPerSoql of 2
+    // Run a sync with a BriefcaseSyncDownTarget with countIdsPerRetrieve of 2
     // Make sure we get the created accounts and contacts in the database
     // And that it took the multiple call to continueFetch
     @Test
-    public void testSyncDownFetchingTwoObjectTypesWithMultipleSOQLCalls() throws Exception {
+    public void testSyncDownFetchingTwoObjectTypesWithMultipleRetrieveCalls() throws Exception {
         trySyncDownFetchingTwoObjectTypes(12, 12, 3, 8);
     }
 
@@ -318,7 +318,7 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
         return String.format(Locale.US, "BriefcaseTest_%s_%d", objectType, System.nanoTime());
     }
 
-    protected void trySyncDownFetchingOneObjectType(int numberAccounts, int countIdsPerSoql, int expectedNumberFetches) throws Exception {
+    protected void trySyncDownFetchingOneObjectType(int numberAccounts, int countIdsPerRetrieve, int expectedNumberFetches) throws Exception {
         final Map<String, String> accounts = createRecordsOnServer(numberAccounts, Constants.ACCOUNT);
         Assert.assertEquals("Wrong number of accounts created", numberAccounts, accounts.size());
         final String[] accountIds = accounts.keySet().toArray(new String[0]);
@@ -330,7 +330,7 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
                 Constants.ACCOUNT,
                 Arrays.asList(Constants.NAME, Constants.DESCRIPTION)
             )),
-            countIdsPerSoql
+            countIdsPerRetrieve
         );
 
         // Run sync
@@ -347,12 +347,12 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
      *
      * @param numberAccounts
      * @param numberContacts
-     * @param countIdsPerSoql
+     * @param countIdsPerRetrieve
      * @param expectedNumberFetches
      * @return pair made of aa pair with accountIds and contactIds created and sync id
      * @throws Exception
      */
-    protected Pair<Pair<String[], String[]>, Long> trySyncDownFetchingTwoObjectTypes(int numberAccounts, int numberContacts, int countIdsPerSoql, int expectedNumberFetches) throws Exception {
+    protected Pair<Pair<String[], String[]>, Long> trySyncDownFetchingTwoObjectTypes(int numberAccounts, int numberContacts, int countIdsPerRetrieve, int expectedNumberFetches) throws Exception {
         final Map<String, String> accounts = createRecordsOnServer(numberAccounts, Constants.ACCOUNT);
         Assert.assertEquals("Wrong number of accounts created", numberAccounts, accounts.size());
         final String[] accountIds = accounts.keySet().toArray(new String[0]);
@@ -373,7 +373,7 @@ public class BriefcaseSyncDownTargetTest extends SyncManagerTestCase {
                     Constants.CONTACT,
                     Arrays.asList(Constants.LAST_NAME))
             ),
-            countIdsPerSoql
+            countIdsPerRetrieve
         );
 
         // Run sync


### PR DESCRIPTION
Using sObject collection retrieve instead of instead of SOQL where ids in xxx:
* we can get 2000 records per call since sObject retrieve uses POST body and therefore avoids 414 error URI too long