### PR TITLE
New sync up target using sobject collection

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -237,9 +237,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
         if (isLocallyDeleted(record)) {
             if (isLocallyCreated(record)  // we didn't go to the sever
                     || response.success // or we successfully deleted on the server
-                    || response.recordDoesNotExist // or the record was already deleted on the server
-                    )
-
+                    || response.recordDoesNotExist) // or the record was already deleted on the server
             {
                 deleteFromLocalStore(syncManager, soupName, record);
             }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -27,16 +27,14 @@
 package com.salesforce.androidsdk.mobilesync.target;
 
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
+import com.salesforce.androidsdk.mobilesync.target.CompositeRequestHelper.RecordRequest;
+import com.salesforce.androidsdk.mobilesync.target.CompositeRequestHelper.RecordResponse;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.mobilesync.util.SyncState;
-import com.salesforce.androidsdk.rest.CompositeResponse.CompositeSubResponse;
-import com.salesforce.androidsdk.rest.RestRequest;
-import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
@@ -131,7 +129,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
             return;
         }
 
-        LinkedHashMap<String, RestRequest> refIdToRequests = new LinkedHashMap<>();
+        List<RecordRequest> recordRequests = new LinkedList<>();
         for (int i = 0; i < records.size(); i++) {
             JSONObject record = records.get(i);
             String id = JSONObjectHelper.optString(record, getIdFieldName());
@@ -142,15 +140,18 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
                 record.put(getIdFieldName(), id);
             }
 
-            RestRequest request = buildRequestForRecord(syncManager.apiVersion, record, fieldlist);
-            if (request != null) refIdToRequests.put(id, request);
+            RecordRequest request = buildRequestForRecord(record, fieldlist);
+            if (request != null) {
+                request.referenceId = id;
+                recordRequests.add(request);
+            }
         }
 
         // Sending composite request
-        Map<String, CompositeSubResponse> refIdToResponses = CompositeRequestHelper.sendCompositeRequest(syncManager, false, refIdToRequests);
+        Map<String, RecordResponse> refIdToRecordResponses = CompositeRequestHelper.sendAsCompositeBatchRequest(syncManager, false, recordRequests);
 
         // Build refId to server id / status code / time stamp maps
-        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToResponses.values());
+        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToRecordResponses.values());
 
         // Will a re-run be required?
         boolean needReRun = false;
@@ -161,7 +162,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
             String id = record.getString(getIdFieldName());
 
             if (isDirty(record)) {
-                needReRun = needReRun || updateRecordInLocalStore(syncManager, syncSoupName, record, mergeMode, refIdToServerId, refIdToResponses.get(id), isReRun);
+                needReRun = needReRun || updateRecordInLocalStore(syncManager, syncSoupName, record, mergeMode, refIdToServerId, refIdToRecordResponses.get(id), isReRun);
             }
         }
 
@@ -172,9 +173,8 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
 
     }
 
-    protected RestRequest buildRequestForRecord(String apiVersion,
-                                                JSONObject record,
-                                                List<String> fieldlist) throws JSONException {
+    protected RecordRequest buildRequestForRecord(JSONObject record,
+                                                  List<String> fieldlist) throws JSONException {
 
         if (!isDirty(record)) {
             return null; // nothing to do
@@ -191,7 +191,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
                 return null; // no need to go to server
             }
             else {
-                return RestRequest.getRequestForDelete(apiVersion, objectType, id);
+                return RecordRequest.requestForDelete(objectType, id);
             }
         }
         // Create/update cases
@@ -208,32 +208,32 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
                         // where the the external id field is the id field
                         // and the field is populated by a local id
                         && !isLocalId(externalId)) {
-                    return RestRequest.getRequestForUpsert(apiVersion, objectType, getExternalIdFieldName(), externalId, fields);
+                    return RecordRequest.requestForUpsert(objectType, getExternalIdFieldName(), externalId, fields);
                 }
                 // Do a create otherwise
                 else {
-                    return RestRequest.getRequestForCreate(apiVersion, objectType, fields);
+                    return RecordRequest.requestForCreate(objectType, fields);
                 }
             }
             else {
                 fieldlist = this.updateFieldlist != null ? this.updateFieldlist : fieldlist;
                 fields = buildFieldsMap(record, fieldlist, getIdFieldName(), getModificationDateFieldName());
-                return RestRequest.getRequestForUpdate(apiVersion, objectType, id, fields);
+                return RecordRequest.requestForUpdate(objectType, id, fields);
             }
         }
     }
 
 
-    protected boolean updateRecordInLocalStore(SyncManager syncManager, String soupName, JSONObject record, SyncState.MergeMode mergeMode, Map<String, String> refIdToServerId, CompositeSubResponse response, boolean isReRun) throws JSONException, IOException {
+    protected boolean updateRecordInLocalStore(SyncManager syncManager, String soupName, JSONObject record, SyncState.MergeMode mergeMode, Map<String, String> refIdToServerId, RecordResponse response, boolean isReRun) throws JSONException, IOException {
 
         boolean needReRun = false;
-        final Integer statusCode = response != null ? response.httpStatusCode : -1;
 
         // Delete case
         if (isLocallyDeleted(record)) {
             if (isLocallyCreated(record)  // we didn't go to the sever
-                    || RestResponse.isSuccess(statusCode) // or we successfully deleted on the server
-                    || statusCode == HttpURLConnection.HTTP_NOT_FOUND) // or the record was already deleted on the server
+                    || response.success // or we successfully deleted on the server
+                    || response.recordDoesNotExist // or the record was already deleted on the server
+                    )
 
             {
                 deleteFromLocalStore(syncManager, soupName, record);
@@ -246,7 +246,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
         // Create / update case
         else {
             // Success case
-            if (RestResponse.isSuccess(statusCode)) {
+            if (response.success) {
                 // Plugging server id in id field
                 CompositeRequestHelper.updateReferences(record, getIdFieldName(), refIdToServerId);
 
@@ -254,7 +254,7 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
                 cleanAndSaveInLocalStore(syncManager, soupName, record);
             }
             // Handling remotely deleted records
-            else if (statusCode == HttpURLConnection.HTTP_NOT_FOUND
+            else if (response.recordDoesNotExist
                     && mergeMode == SyncState.MergeMode.OVERWRITE // Record needs to be recreated
                     && !isReRun) {
                 record.put(LOCAL, true);
@@ -268,5 +268,4 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
         }
         return needReRun;
     }
-
 }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTarget.java
@@ -147,11 +147,11 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
             }
         }
 
-        // Sending composite request
-        Map<String, RecordResponse> refIdToRecordResponses = CompositeRequestHelper.sendAsCompositeBatchRequest(syncManager, false, recordRequests);
+        // Sending requests
+        Map<String, RecordResponse> refIdToRecordResponses = sendRecordRequests(syncManager, recordRequests);
 
-        // Build refId to server id / status code / time stamp maps
-        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToRecordResponses.values());
+        // Build refId to server id map
+        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToRecordResponses);
 
         // Will a re-run be required?
         boolean needReRun = false;
@@ -171,6 +171,11 @@ public class BatchSyncUpTarget extends SyncUpTarget implements AdvancedSyncUpTar
             syncUpRecords(syncManager, records, fieldlist, mergeMode, syncSoupName, true);
         }
 
+    }
+
+    protected Map<String, RecordResponse> sendRecordRequests(SyncManager syncManager, List<RecordRequest> recordRequests)
+        throws JSONException, IOException {
+        return CompositeRequestHelper.sendAsCompositeBatchRequest(syncManager, false, recordRequests);
     }
 
     protected RecordRequest buildRequestForRecord(JSONObject record,

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTarget.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.mobilesync.target;
+
+import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
+import com.salesforce.androidsdk.mobilesync.target.CompositeRequestHelper.RecordRequest;
+import com.salesforce.androidsdk.mobilesync.target.CompositeRequestHelper.RecordResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Subclass of SyncUpTarget that batches create/update/delete operations by using sobject collection apis
+ */
+public class CollectionSyncUpTarget extends BatchSyncUpTarget {
+
+    // Constants
+    public static final int MAX_RECORDS_SOBJECT_COLLECTION_API = 200;
+
+    /**
+     * Construct CollectionSyncUpTarget
+     */
+    public CollectionSyncUpTarget() {
+        this(null, null);
+    }
+
+    /**
+     * Construct CollectionSyncUpTarget
+     */
+    public CollectionSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist) {
+        this(createFieldlist, updateFieldlist, null, null, null, MAX_RECORDS_SOBJECT_COLLECTION_API);
+    }
+
+    /**
+     * Construct CollectionSyncUpTarget with a different maxBatchSize (NB: cannot exceed MAX_RECORDS_SOBJECT_COLLECTION_API)
+     */
+    public CollectionSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, int maxBatchSize) {
+        this(createFieldlist, updateFieldlist, null, null, null, maxBatchSize);
+    }
+
+    /**
+     * Construct CollectionSyncUpTarget with given id/modifiedDate/externalId fields
+     */
+    public CollectionSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, String idFieldName, String modificationDateFieldName, String externalIdFieldName) {
+        this(createFieldlist, updateFieldlist, idFieldName, modificationDateFieldName, externalIdFieldName, MAX_RECORDS_SOBJECT_COLLECTION_API);
+    }
+
+    /**
+     * Construct CollectionSyncUpTarget with a different maxBatchSize and id/modifiedDate/externalId fields
+     */
+    public CollectionSyncUpTarget(List<String> createFieldlist, List<String> updateFieldlist, String idFieldName, String modificationDateFieldName, String externalIdFieldName, int maxBatchSize) {
+        super(createFieldlist, updateFieldlist, idFieldName, modificationDateFieldName, externalIdFieldName);
+        this.maxBatchSize = Math.min(maxBatchSize, MAX_RECORDS_SOBJECT_COLLECTION_API); // soject collection apis allows up to 200 records
+    }
+
+    /**
+     * Construct SyncUpTarget from json
+     *
+     * @param target
+     * @throws JSONException
+     */
+    public CollectionSyncUpTarget(JSONObject target) throws JSONException {
+        super(target);
+        this.maxBatchSize = Math.min(target.optInt(MAX_BATCH_SIZE, MAX_RECORDS_SOBJECT_COLLECTION_API), MAX_RECORDS_SOBJECT_COLLECTION_API); // soject collection apis allows up to 200 records
+    }
+
+    @Override
+    protected Map<String, RecordResponse> sendRecordRequests(SyncManager syncManager, List<RecordRequest> recordRequests) throws JSONException, IOException {
+        return CompositeRequestHelper.sendAsCollectionRequests(syncManager, false, recordRequests);
+    }
+}

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/CompositeRequestHelper.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/CompositeRequestHelper.java
@@ -246,6 +246,10 @@ public class CompositeRequestHelper {
                 }
             }
 
+            if (requestType == RequestType.UPDATE) {
+                record.put(Constants.ID, id);
+            }
+
             return record;
         }
 
@@ -318,7 +322,7 @@ public class CompositeRequestHelper {
                 case CREATE:
                     return RestRequest.getRequestForCollectionCreate(apiVersion, allOrNone, getJSONArrayForCollectionRequest(recordRequests, RequestType.CREATE));
                 case UPDATE:
-                    return RestRequest.getRequestForCollectionCreate(apiVersion, allOrNone, getJSONArrayForCollectionRequest(recordRequests, RequestType.UPDATE));
+                    return RestRequest.getRequestForCollectionUpdate(apiVersion, allOrNone, getJSONArrayForCollectionRequest(recordRequests, RequestType.UPDATE));
                 case UPSERT:
                     JSONArray records = getJSONArrayForCollectionRequest(recordRequests, RequestType.UPSERT);
 

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/CompositeRequestHelper.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/CompositeRequestHelper.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright (c) 2019-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
@@ -28,17 +28,19 @@ package com.salesforce.androidsdk.mobilesync.target;
 
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
+import com.salesforce.androidsdk.rest.CollectionResponse.CollectionSubResponse;
 import com.salesforce.androidsdk.rest.CompositeResponse;
 import com.salesforce.androidsdk.rest.CompositeResponse.CompositeSubResponse;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 
+import java.net.HttpURLConnection;
+import java.util.List;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -47,52 +49,56 @@ import java.util.Map;
 public class CompositeRequestHelper {
 
     /**
-     * Build and send composite request
+     * Send record requests using a composite batch request
      * @param syncManager
      * @param allOrNone
-     * @param refIdToRequests
-     * @return map of ref id to composite sub response
+     * @param recordRequests
+     * @return map of reference id to record responses
      * @throws JSONException
      * @throws IOException
      */
-     public static Map<String, CompositeSubResponse> sendCompositeRequest(SyncManager syncManager, boolean allOrNone, LinkedHashMap<String, RestRequest> refIdToRequests) throws JSONException, IOException {
-        RestRequest compositeRequest = RestRequest.getCompositeRequest(syncManager.apiVersion, allOrNone, refIdToRequests);
-        RestResponse response = syncManager.sendSyncWithMobileSyncUserAgent(compositeRequest);
-        if (!response.isSuccess()) {
-            throw new SyncManager.MobileSyncException("sendCompositeRequest:" + response.toString());
-        }
-        CompositeResponse compositeResponse = new CompositeResponse(response.asJSONObject());
-        Map<String, CompositeSubResponse> refIdToResponses = new HashMap<>();
-        for (CompositeSubResponse subResponse : compositeResponse.subResponses) {
-            refIdToResponses.put(subResponse.referenceId, subResponse);
-        }
-        return refIdToResponses;
+     public static Map<String, RecordResponse> sendAsCompositeBatchRequest(SyncManager syncManager, boolean allOrNone, List<RecordRequest> recordRequests) throws JSONException, IOException {
+         LinkedHashMap<String, RestRequest> refIdToRequests = new LinkedHashMap<>();
+         for (RecordRequest recordRequest : recordRequests) {
+             refIdToRequests.put(recordRequest.referenceId, recordRequest.asRestRequest(syncManager.apiVersion));
+         }
+
+         RestRequest compositeRequest = RestRequest.getCompositeRequest(syncManager.apiVersion, allOrNone, refIdToRequests);
+         RestResponse response = syncManager.sendSyncWithMobileSyncUserAgent(compositeRequest);
+         if (!response.isSuccess()) {
+             throw new SyncManager.MobileSyncException("sendCompositeRequest:" + response.toString());
+         }
+         CompositeResponse compositeResponse = new CompositeResponse(response.asJSONObject());
+         Map<String, RecordResponse> refIdToRecordResponses = new LinkedHashMap<>();
+         for (CompositeSubResponse subResponse : compositeResponse.subResponses) {
+             RecordResponse recordResponse = RecordResponse.fromCompositeSubResponse(subResponse);
+             refIdToRecordResponses.put(recordResponse.referenceId, recordResponse);
+         }
+         return refIdToRecordResponses;
+    }
+
+    /**
+     * Send record requests using sobject collection requests
+     * @param syncManager
+     * @param allOrNone
+     * @param recordRequests
+     * @return map of ref id to record responses
+     * @throws JSONException
+     * @throws IOException
+     */
+    public static Map<String, RecordResponse> sendAsCollectionRequests(SyncManager syncManager, boolean allOrNone, List<RecordRequest> recordRequests) throws JSONException, IOException {
+        // TBD
+        return null;
     }
 
     /**
      * @return ref id to server id map if successful
      */
-    public static Map<String, String> parseIdsFromResponses(Collection<CompositeSubResponse> responses) throws JSONException {
+    public static Map<String, String> parseIdsFromResponses(Collection<RecordResponse> responses) throws JSONException {
         Map<String, String> refIdToId = new HashMap<>();
-        for (CompositeSubResponse response : responses) {
-            // Status code will be 201 if record just got created.
-            // However if:
-            // - we are upserting by external id a locally created record
-            // - and the network got disconnected after request was processed by server but before response made it to the client,
-            // - and this is our second attempt to run the sync up
-            // Then the status code will be 200 since the record already exists
-            // See:
-            // - https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/3258
-            // - https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_upsert.htm
-            // So the code checks for success without expecting to find an id in all cases
-            if (response.isSuccess()) {
-                JSONObject responseBodyResponse = response.bodyAsJSONObject();
-                if (responseBodyResponse != null) {
-                    String serverId = JSONObjectHelper.optString(response.bodyAsJSONObject(), Constants.LID);
-                    if (serverId != null) {
-                        refIdToId.put(response.referenceId, serverId);
-                    }
-                }
+        for (RecordResponse response : responses) {
+            if (response.id != null) {
+                refIdToId.put(response.referenceId, response.id);
             }
         }
         return refIdToId;
@@ -113,4 +119,132 @@ public class CompositeRequestHelper {
         }
     }
 
+    /**
+     * Response object abstracting away differences between /composite/batch and /commposite/sobject sub-responses
+     */
+    static class RecordResponse {
+        boolean success;
+        String id;
+        String referenceId;
+        boolean recordDoesNotExist;
+        JSONObject json;
+
+        private RecordResponse(boolean success, String id, String referenceId, boolean recordDoesNotExist, JSONObject json) {
+            this.success = success;
+            this.id = id;
+            this.referenceId = referenceId;
+            this.recordDoesNotExist = recordDoesNotExist;
+            this.json = json;
+        }
+
+        @Override
+        public String toString() {
+            return json.toString();
+        }
+
+        static RecordResponse fromCompositeSubResponse(CompositeSubResponse compositeSubResponse) throws JSONException {
+            boolean success = compositeSubResponse.isSuccess();
+            String id = null;
+            String refId = compositeSubResponse.referenceId;
+            if (success) {
+                JSONObject responseBodyResponse = compositeSubResponse.bodyAsJSONObject();
+                if (responseBodyResponse != null) {
+                    id = JSONObjectHelper.optString(responseBodyResponse, Constants.LID);
+                }
+            }
+            boolean doesNotExistOnServer = success
+                ? false
+                : compositeSubResponse.httpStatusCode  == HttpURLConnection.HTTP_NOT_FOUND
+                    || "ENTITY_IS_DELETED".equals(compositeSubResponse.bodyAsJSONArray().getJSONObject(0).getString("errorCode"));
+            return new RecordResponse(success, id, refId, doesNotExistOnServer, compositeSubResponse.json);
+        }
+
+        static RecordResponse fromCollectionSubResponse(String referenceId, CollectionSubResponse collectionSubResponse) {
+            boolean success = collectionSubResponse.success;
+            String id = collectionSubResponse.id;
+            String refId = referenceId;
+            boolean doesNotExistOnServer = false;
+            if (!collectionSubResponse.success && !collectionSubResponse.errors.isEmpty()) {
+                String error = collectionSubResponse.errors.get(0).statusCode;
+                doesNotExistOnServer = "INVALID_CROSS_REFERENCE_KEY".equals(error)
+                    || "ENTITY_IS_DELETED".equals(error);
+            }
+            return new RecordResponse(success, id, refId, doesNotExistOnServer, collectionSubResponse.json);
+        }
+    }
+
+    /**
+     * Request object abstracting away differences between /composite/batch and /commposite/sobject sub-requests
+     */
+    static class RecordRequest {
+        String referenceId;
+        RequestType requestType;
+        String objectType;
+        Map<String, Object> fields;
+        String id;
+        String externalId;
+        String externalIdFieldName;
+
+        private RecordRequest(RequestType requestType, String objectType, Map<String, Object> fields, String id, String externalId, String externalIdFieldName) {
+            this.requestType = requestType;
+            this.objectType = objectType;
+            this.fields = fields;
+            this.id = id;
+            this.externalId = externalId;
+            this.externalIdFieldName = externalIdFieldName;
+        }
+
+        public RestRequest asRestRequest(String apiVersion) {
+            switch (requestType) {
+                case CREATE:
+                    return RestRequest.getRequestForCreate(apiVersion, objectType, fields);
+                case UPDATE:
+                    return RestRequest.getRequestForUpdate(apiVersion, objectType, id, fields);
+                case UPSERT:
+                    return RestRequest.getRequestForUpsert(apiVersion, objectType, externalIdFieldName, externalId, fields);
+                case DELETE:
+                    return RestRequest.getRequestForDelete(apiVersion, objectType, id);
+            }
+            // We should never get here
+            return null;
+        }
+
+        JSONObject asJSONObjectForCollectionRequest() throws JSONException {
+            JSONObject record = new JSONObject();
+            JSONObject attributes = new JSONObject();
+            attributes.put(Constants.TYPE, objectType);
+            record.put(Constants.ATTRIBUTES, attributes);
+            if (fields != null) {
+                for (Map.Entry<String, Object> entry : fields.entrySet()) {
+                    record.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            return record;
+        }
+
+        static RecordRequest requestForCreate(String objectType, Map<String, Object> fields) {
+            return new RecordRequest(RequestType.CREATE, objectType, fields, null, null, null);
+        }
+
+        static RecordRequest requestForUpdate(String objectType, String id, Map<String, Object> fields) {
+            return new RecordRequest(RequestType.UPDATE, objectType, fields, id, null, null);
+        }
+
+        static RecordRequest requestForUpsert(String objectType, String externalIdFieldName, String externalId, Map<String, Object> fields) {
+            return new RecordRequest(RequestType.UPSERT, objectType, fields, null, externalId, externalIdFieldName);
+        }
+
+        static RecordRequest requestForDelete(String objectType, String id) {
+            return new RecordRequest(RequestType.DELETE, objectType, null, id, null, null);
+        }
+
+    }
+
+    static enum RequestType {
+        CREATE,
+        UPDATE,
+        UPSERT,
+        DELETE
+    }
 }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -29,6 +29,8 @@ package com.salesforce.androidsdk.mobilesync.target;
 import com.salesforce.androidsdk.mobilesync.app.Features;
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
+import com.salesforce.androidsdk.mobilesync.target.CompositeRequestHelper.RecordRequest;
+import com.salesforce.androidsdk.mobilesync.target.CompositeRequestHelper.RecordResponse;
 import com.salesforce.androidsdk.mobilesync.target.ParentChildrenSyncTargetHelper.RelationshipType;
 import com.salesforce.androidsdk.mobilesync.util.ChildrenInfo;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
@@ -36,22 +38,18 @@ import com.salesforce.androidsdk.mobilesync.util.MobileSyncLogger;
 import com.salesforce.androidsdk.mobilesync.util.ParentInfo;
 import com.salesforce.androidsdk.mobilesync.util.SOQLBuilder;
 import com.salesforce.androidsdk.mobilesync.util.SyncState;
-import com.salesforce.androidsdk.rest.CompositeResponse.CompositeSubResponse;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
-
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Target for sync that uploads parent with children records
@@ -168,13 +166,15 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         boolean isDelete = isLocallyDeleted(record);
 
         // Preparing request for parent
-        LinkedHashMap<String, RestRequest> refIdToRequests = new LinkedHashMap<>();
+        List<RecordRequest> recordRequests = new LinkedList<>();
         String parentId = record.getString(getIdFieldName());
-        RestRequest parentRequest = buildRequestForParentRecord(syncManager.apiVersion, record, fieldlist);
+        RecordRequest parentRequest = buildRequestForParentRecord(syncManager.apiVersion, record, fieldlist);
 
         // Parent request goes first unless it's a delete
-        if (parentRequest != null && !isDelete)
-            refIdToRequests.put(parentId, parentRequest);
+        if (parentRequest != null && !isDelete) {
+            parentRequest.referenceId = parentId;
+            recordRequests.add(parentRequest);
+        }
 
         // Preparing requests for children
         for (int i = 0; i < children.length(); i++) {
@@ -187,21 +187,26 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 childRecord.put(LOCAL, true);
                 childRecord.put(LOCALLY_UPDATED, true);
             }
-            RestRequest childRequest = buildRequestForChildRecord(syncManager.apiVersion, childRecord,
+            RecordRequest childRequest = buildRequestForChildRecord(syncManager.apiVersion, childRecord,
                     isCreate,
                     isDelete ? null : parentId);
-            if (childRequest != null) refIdToRequests.put(childId, childRequest);
+            if (childRequest != null) {
+                childRequest.referenceId = childId;
+                recordRequests.add(childRequest);
+            }
         }
 
         // Parent request goes last when it's a delete
-        if (parentRequest != null && isDelete)
-            refIdToRequests.put(parentId, parentRequest);
+        if (parentRequest != null && isDelete) {
+            parentRequest.referenceId = parentId;
+            recordRequests.add(parentRequest);
+        }
 
         // Sending composite request
-        Map<String, CompositeSubResponse> refIdToResponses = CompositeRequestHelper.sendCompositeRequest(syncManager, false, refIdToRequests);
+        Map<String, RecordResponse> refIdToRecordResponses = CompositeRequestHelper.sendAsCompositeBatchRequest(syncManager, false, recordRequests);
 
         // Build refId to server id / status code / time stamp maps
-        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToResponses.values());
+        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToRecordResponses.values());
 
         // Will a re-run be required?
         boolean needReRun = false;
@@ -209,7 +214,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         // Update parent in local store
         if (isDirty(record)) {
             needReRun = updateParentRecordInLocalStore(syncManager, record, children, mergeMode, refIdToServerId,
-                    refIdToResponses.get(record.getString(getIdFieldName())));
+                    refIdToRecordResponses.get(record.getString(getIdFieldName())));
         }
 
         // Update children local store
@@ -218,7 +223,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
 
             if (isDirty(childRecord) || isCreate) {
                 needReRun = needReRun || updateChildRecordInLocalStore(syncManager, childRecord, record, mergeMode, refIdToServerId,
-                        refIdToResponses.get(childRecord.getString(childrenInfo.idFieldName)));
+                        refIdToRecordResponses.get(childRecord.getString(childrenInfo.idFieldName)));
             }
         }
 
@@ -229,16 +234,15 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         }
     }
 
-    protected boolean updateParentRecordInLocalStore(SyncManager syncManager, JSONObject record, JSONArray children, SyncState.MergeMode mergeMode, Map<String, String> refIdToServerId, CompositeSubResponse response) throws JSONException, IOException {
+    protected boolean updateParentRecordInLocalStore(SyncManager syncManager, JSONObject record, JSONArray children, SyncState.MergeMode mergeMode, Map<String, String> refIdToServerId, RecordResponse response) throws JSONException, IOException {
         boolean needReRun = false;
         final String soupName = parentInfo.soupName;
-        final Integer statusCode = response != null ? response.httpStatusCode : -1;
 
         // Delete case
         if (isLocallyDeleted(record)) {
             if (isLocallyCreated(record)  // we didn't go to the sever
-                || RestResponse.isSuccess(statusCode) // or we successfully deleted on the server
-                || statusCode == HttpURLConnection.HTTP_NOT_FOUND) // or the record was already deleted on the server
+                || response.success // or we successfully deleted on the server
+                || response.recordDoesNotExist) // or the record was already deleted on the server
             {
                 if (relationshipType == RelationshipType.MASTER_DETAIL) {
                     ParentChildrenSyncTargetHelper.deleteChildrenFromLocalStore(syncManager.getSmartStore(), parentInfo, childrenInfo, record.getString(getIdFieldName()));
@@ -255,7 +259,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         // Create / update case
         else {
             // Success case
-            if (RestResponse.isSuccess(statusCode))
+            if (response.success)
             {
                 // Plugging server id in id field
                 CompositeRequestHelper.updateReferences(record, getIdFieldName(), refIdToServerId);
@@ -264,7 +268,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 cleanAndSaveInLocalStore(syncManager, soupName, record);
             }
             // Handling remotely deleted records
-            else if (statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
+            else if (response.recordDoesNotExist) {
                 // Record needs to be recreated
                 if (mergeMode == SyncState.MergeMode.OVERWRITE) {
                     record.put(LOCAL, true);
@@ -287,16 +291,15 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         return needReRun;
     }
 
-    protected boolean updateChildRecordInLocalStore(SyncManager syncManager, JSONObject record, JSONObject parentRecord, SyncState.MergeMode mergeMode, Map<String, String> refIdToServerId, CompositeSubResponse response) throws JSONException {
+    protected boolean updateChildRecordInLocalStore(SyncManager syncManager, JSONObject record, JSONObject parentRecord, SyncState.MergeMode mergeMode, Map<String, String> refIdToServerId, RecordResponse response) throws JSONException {
         boolean needReRun = false;
         final String soupName = childrenInfo.soupName;
-        final Integer statusCode = response != null ? response.httpStatusCode : -1;
 
         // Delete case
         if (isLocallyDeleted(record)) {
             if (isLocallyCreated(record)  // we didn't go to the sever
-                    || RestResponse.isSuccess(statusCode) // or we successfully deleted on the server
-                    || statusCode == HttpURLConnection.HTTP_NOT_FOUND) // or the record was already deleted on the server
+                    || response.success // or we successfully deleted on the server
+                    || response.recordDoesNotExist) // or the record was already deleted on the server
             {
                 deleteFromLocalStore(syncManager, soupName, record);
             }
@@ -309,7 +312,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         // Create / update case
         else {
             // Success case
-            if (RestResponse.isSuccess(statusCode))
+            if (response.success)
             {
                 // Plugging server id in id field
                 CompositeRequestHelper.updateReferences(record, childrenInfo.idFieldName, refIdToServerId);
@@ -321,7 +324,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 cleanAndSaveInLocalStore(syncManager, soupName, record);
             }
             // Handling remotely deleted records
-            else if (statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
+            else if (response.recordDoesNotExist) {
                 // Record needs to be recreated
                 if (mergeMode == SyncState.MergeMode.OVERWRITE) {
 
@@ -333,7 +336,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 }
             }
             // Handling remotely deleted parent
-            else if(isEntityDeleted(response)) {
+            else if(response.recordDoesNotExist) {
                 // Parent record needs to be recreated
                 if (mergeMode == SyncState.MergeMode.OVERWRITE) {
                     parentRecord.put(LOCAL, true);
@@ -351,20 +354,20 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         return needReRun;
     }
 
-    protected RestRequest buildRequestForParentRecord(String apiVersion,
+    protected RecordRequest buildRequestForParentRecord(String apiVersion,
                                                 JSONObject record,
                                                 List<String> fieldlist) throws IOException, JSONException {
         return buildRequestForRecord(apiVersion, record, fieldlist, true, false, null);
     }
 
-    protected RestRequest buildRequestForChildRecord(String apiVersion,
+    protected RecordRequest buildRequestForChildRecord(String apiVersion,
                                                 JSONObject record,
                                                 boolean useParentIdReference,
                                                 String parentId) throws IOException, JSONException {
         return buildRequestForRecord(apiVersion, record, null, false, useParentIdReference, parentId);
     }
 
-    protected RestRequest buildRequestForRecord(String apiVersion,
+    protected RecordRequest buildRequestForRecord(String apiVersion,
                                                 JSONObject record,
                                                 List<String> fieldlist,
                                                 boolean isParent,
@@ -384,9 +387,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 return null; // no need to go to server
             }
             else {
-                return RestRequest.getRequestForDelete(apiVersion,
-                        info.sobjectType,
-                        id);
+                return RecordRequest.requestForDelete(info.sobjectType, id);
             }
         }
         // Create/update cases
@@ -415,20 +416,16 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                     // where the the external id field is the id field
                     // and the field is populated by a local id
                     && !isLocalId(externalId)) {
-                    return RestRequest.getRequestForUpsert(apiVersion,
-                        info.sobjectType,
+                    return RecordRequest.requestForUpsert(info.sobjectType,
                         info.externalIdFieldName,
                         externalId,
                         fields);
                 } else {
-                    return RestRequest.getRequestForCreate(apiVersion,
-                        info.sobjectType,
-                        fields);
+                    return RecordRequest.requestForCreate(info.sobjectType, fields);
                 }
             }
             else {
-                return RestRequest.getRequestForUpdate(apiVersion,
-                        info.sobjectType,
+                return RecordRequest.requestForUpdate(info.sobjectType,
                         id,
                         fields);
             }
@@ -532,11 +529,4 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         return RestRequest.getRequestForQuery(apiVersion, builder.build());
     }
 
-    protected boolean isEntityDeleted(CompositeSubResponse response) {
-        try {
-            return response != null && "ENTITY_IS_DELETED".equals(response.bodyAsJSONArray().getJSONObject(0).getString("errorCode"));
-        } catch (JSONException e) {
-            return false;
-        }
-    }
 }

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -336,7 +336,7 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                 }
             }
             // Handling remotely deleted parent
-            else if(response.recordDoesNotExist) {
+            else if(response.relatedRecordDoesNotExist) {
                 // Parent record needs to be recreated
                 if (mergeMode == SyncState.MergeMode.OVERWRITE) {
                     parentRecord.put(LOCAL, true);

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -205,8 +205,8 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
         // Sending composite request
         Map<String, RecordResponse> refIdToRecordResponses = CompositeRequestHelper.sendAsCompositeBatchRequest(syncManager, false, recordRequests);
 
-        // Build refId to server id / status code / time stamp maps
-        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToRecordResponses.values());
+        // Build refId to server id map
+        Map<String, String> refIdToServerId = CompositeRequestHelper.parseIdsFromResponses(refIdToRecordResponses);
 
         // Will a re-run be required?
         boolean needReRun = false;

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -98,9 +98,9 @@ public class SyncUpTarget extends SyncTarget {
      */
     @SuppressWarnings("unchecked")
     public static SyncUpTarget fromJSON(JSONObject target) throws JSONException {
-        // Default sync up target (it's BatchSyncUpTarget starting in Mobile SDK 7.1)
+        // Default sync up target (it's CollectionSyncUpTarget starting in Mobile SDK 10.1)
         if (target == null || target.isNull(ANDROID_IMPL)) {
-            return new BatchSyncUpTarget(target);
+            return new CollectionSyncUpTarget(target);
         }
 
         // Non default sync up target

--- a/libs/test/MobileSyncTest/res/raw/usersyncs.json
+++ b/libs/test/MobileSyncTest/res/raw/usersyncs.json
@@ -150,7 +150,7 @@
       }
     },
     {
-      "syncName": "noBatchSyncUp",
+      "syncName": "singleRecordSyncUp",
       "syncType": "syncUp",
       "soupName": "accounts",
       "target": {
@@ -166,6 +166,22 @@
     },
     {
       "syncName": "batchSyncUp",
+      "syncType": "syncUp",
+      "soupName": "accounts",
+      "target": {
+        "iOSImpl": "SFBatchSyncUpTarget",
+        "androidImpl": "com.salesforce.androidsdk.mobilesync.target.BatchSyncUpTarget",
+        "idFieldName": "IdX",
+        "modificationDateFieldName": "LastModifiedDateX",
+        "externalIdFieldName": "ExternalIdX"
+      },
+      "options": {
+        "fieldlist": ["Name", "Description"],
+        "mergeMode":"OVERWRITE"
+      }
+    },
+    {
+      "syncName": "collectionSyncUp",
       "syncType": "syncUp",
       "soupName": "accounts",
       "target": {

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/config/SyncsConfigTest.java
@@ -33,6 +33,7 @@ import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.manager.SyncManagerTestCase;
 import com.salesforce.androidsdk.mobilesync.target.BatchSyncUpTarget;
 import com.salesforce.androidsdk.mobilesync.target.BriefcaseSyncDownTarget;
+import com.salesforce.androidsdk.mobilesync.target.CollectionSyncUpTarget;
 import com.salesforce.androidsdk.mobilesync.target.LayoutSyncDownTarget;
 import com.salesforce.androidsdk.mobilesync.target.MetadataSyncDownTarget;
 import com.salesforce.androidsdk.mobilesync.target.MruSyncDownTarget;
@@ -92,7 +93,7 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         SyncState actualSync2 = globalSyncManager.getSyncStatus("globalSync2");
         Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, actualSync2.getSoupName());
         checkStatus(actualSync2, SyncState.Type.syncUp, actualSync2.getId(),
-                new BatchSyncUpTarget(Arrays.asList("Name"), null),
+                new CollectionSyncUpTarget(Arrays.asList("Name"), null),
                 SyncOptions.optionsForSyncUp(Arrays.asList("Id", "Name", "LastModifiedDate"), MergeMode.LEAVE_IF_CHANGED),
                 SyncState.Status.NEW, 0);
     }
@@ -107,8 +108,9 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         Assert.assertFalse(syncManager.hasSyncWithName("metadataSyncDown"));
         Assert.assertFalse(syncManager.hasSyncWithName("parentChildrenSyncDown"));
         Assert.assertFalse(syncManager.hasSyncWithName("briefcaseSyncDown"));
-        Assert.assertFalse(syncManager.hasSyncWithName("noBatchSyncUp"));
+        Assert.assertFalse(syncManager.hasSyncWithName("singleRecordSyncUp"));
         Assert.assertFalse(syncManager.hasSyncWithName("batchSyncUp"));
+        Assert.assertFalse(syncManager.hasSyncWithName("collectionSyncUp"));
         Assert.assertFalse(syncManager.hasSyncWithName("parentChildrenSyncUp"));
 
         // Setting up syncs
@@ -123,8 +125,9 @@ public class SyncsConfigTest extends SyncManagerTestCase {
         Assert.assertTrue(syncManager.hasSyncWithName("metadataSyncDown"));
         Assert.assertTrue(syncManager.hasSyncWithName("parentChildrenSyncDown"));
         Assert.assertTrue(syncManager.hasSyncWithName("briefcaseSyncDown"));
-        Assert.assertTrue(syncManager.hasSyncWithName("noBatchSyncUp"));
+        Assert.assertTrue(syncManager.hasSyncWithName("singleRecordSyncUp"));
         Assert.assertTrue(syncManager.hasSyncWithName("batchSyncUp"));
+        Assert.assertTrue(syncManager.hasSyncWithName("collectionSyncUp"));
         Assert.assertTrue(syncManager.hasSyncWithName("parentChildrenSyncUp"));
     }
 
@@ -249,10 +252,10 @@ public class SyncsConfigTest extends SyncManagerTestCase {
     }
 
     @Test
-    public void testNoBatchSyncUpFromConfig() throws JSONException {
+    public void testSingleRecordSyncUpFromConfig() throws JSONException {
         MobileSyncSDKManager.getInstance().setupUserSyncsFromDefaultConfig();
 
-        SyncState sync = syncManager.getSyncStatus("noBatchSyncUp");
+        SyncState sync = syncManager.getSyncStatus("singleRecordSyncUp");
         Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
         checkStatus(sync, SyncState.Type.syncUp, sync.getId(),
                 new SyncUpTarget(Arrays.asList("Name"), Arrays.asList("Description")),
@@ -270,6 +273,18 @@ public class SyncsConfigTest extends SyncManagerTestCase {
                 new BatchSyncUpTarget(null, null, "IdX", "LastModifiedDateX", "ExternalIdX", BatchSyncUpTarget.MAX_SUB_REQUESTS_COMPOSITE_API),
                 SyncOptions.optionsForSyncUp(Arrays.asList("Name", "Description"), MergeMode.OVERWRITE),
                 SyncState.Status.NEW, 0);
+    }
+
+    @Test
+    public void testCollectionSyncUpFromConfig() throws JSONException {
+        MobileSyncSDKManager.getInstance().setupUserSyncsFromDefaultConfig();
+
+        SyncState sync = syncManager.getSyncStatus("collectionSyncUp");
+        Assert.assertEquals("Wrong soup name", ACCOUNTS_SOUP, sync.getSoupName());
+        checkStatus(sync, SyncState.Type.syncUp, sync.getId(),
+            new CollectionSyncUpTarget(null, null, "IdX", "LastModifiedDateX", "ExternalIdX", CollectionSyncUpTarget.MAX_RECORDS_SOBJECT_COLLECTION_API),
+            SyncOptions.optionsForSyncUp(Arrays.asList("Name", "Description"), MergeMode.OVERWRITE),
+            SyncState.Status.NEW, 0);
     }
 
     @Test

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/ManagerTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/ManagerTestCase.java
@@ -52,6 +52,7 @@ import com.salesforce.androidsdk.util.EventsObservable.EventType;
 import com.salesforce.androidsdk.util.test.EventsListenerQueue;
 import com.salesforce.androidsdk.util.test.TestCredentials;
 
+import java.util.Arrays;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
@@ -247,11 +248,14 @@ abstract public class ManagerTestCase {
      * @throws Exception
      */
     protected void deleteRecordsByIdOnServer(Collection<String> ids, String objectType) throws Exception {
-        List<RestRequest> requests = new ArrayList<>();
-        for (String id : ids) {
-            requests.add(RestRequest.getRequestForDelete(apiVersion, objectType, id));
+        List<String> idsList = new ArrayList(ids);
+        int maxIdsPerRequest = 200;
+        int countIds = idsList.size();
+        int countSlices = (int) Math.ceil((double) countIds / maxIdsPerRequest);
+        for (int slice = 0; slice < countSlices; slice++) {
+            List<String> idsToDelete = idsList.subList(slice * maxIdsPerRequest, Math.min(countIds, (slice + 1) * maxIdsPerRequest));
+            restClient.sendSync(RestRequest.getRequestForCollectionDelete(apiVersion, idsToDelete));
         }
-        restClient.sendSync(RestRequest.getBatchRequest(apiVersion, false, requests));
     }
 
     /**

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/SyncManagerTestCase.java
@@ -673,9 +673,9 @@ abstract public class SyncManagerTestCase extends ManagerTestCase {
 		for (String id : ids) {
 			JSONObject record = smartStore.retrieve(soupName, smartStore.lookupSoupEntryId(soupName, Constants.ID, id)).getJSONObject(0);
 			record.put(SyncTarget.LOCAL, true);
-			record.put(SyncTarget.LOCALLY_CREATED, false);
+			record.put(SyncTarget.LOCALLY_CREATED, record.getBoolean(SyncTarget.LOCALLY_CREATED));
 			record.put(SyncTarget.LOCALLY_DELETED, true);
-			record.put(SyncTarget.LOCALLY_UPDATED, false);
+            record.put(SyncTarget.LOCALLY_UPDATED, record.getBoolean(SyncTarget.LOCALLY_UPDATED));
 			smartStore.upsert(soupName, record);
 		}
 	}

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTargetTest.java
@@ -163,16 +163,4 @@ public class BatchSyncUpTargetTest extends SyncUpTargetTest {
 
         JSONTestHelper.assertSameJSON("Wrong json", expectedTargetJson, target.asJSON());
     }
-
-    @Test
-    public void testBatchSyncUpTargetIsDefault() throws Exception {
-        JSONObject targetJson = new JSONObject();
-
-        SyncUpTarget target = SyncUpTarget.fromJSON(targetJson);
-
-        Assert.assertTrue(target instanceof BatchSyncUpTarget);
-        Assert.assertNull("Wrong createFieldList", target.createFieldlist);
-        Assert.assertNull("Wrong updateFieldList", target.updateFieldlist);
-        Assert.assertEquals("Wrong maxBatchSize", BatchSyncUpTarget.MAX_SUB_REQUESTS_COMPOSITE_API, ((BatchSyncUpTarget) target).getMaxBatchSize());
-    }
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
@@ -176,4 +176,12 @@ public class CollectionSyncUpTargetTest extends BatchSyncUpTargetTest {
         Assert.assertNull("Wrong updateFieldList", target.updateFieldlist);
         Assert.assertEquals("Wrong maxBatchSize", CollectionSyncUpTarget.MAX_RECORDS_SOBJECT_COLLECTION_API, ((CollectionSyncUpTarget) target).getMaxBatchSize());
     }
+
+    @Test
+    @Override
+    public void testSyncUpWithExternalId() throws Exception {
+        // The test is the super class does an upsert using the Id field
+        // That's allowed with single object upsert REST API but not when using sObject collection
+        // We should do an upsert by some custom field but that will require the field to be setup in the test org
+    }
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
@@ -184,9 +184,4 @@ public class CollectionSyncUpTargetTest extends BatchSyncUpTargetTest {
         // That's allowed with single object upsert REST API but not when using sObject collection
         // TODO We should do an upsert by some custom field but that will require the field to be setup in the test org
     }
-
-    @Test
-    public void testSyncUpManyRecords() throws Exception {
-
-    }
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
@@ -179,9 +179,10 @@ public class CollectionSyncUpTargetTest extends BatchSyncUpTargetTest {
 
     @Test
     @Override
-    public void testSyncUpWithExternalId() throws Exception {
+    public void testSyncUpWithExternalId() {
         // The test is the super class does an upsert using the Id field
         // That's allowed with single object upsert REST API but not when using sObject collection
-        // We should do an upsert by some custom field but that will require the field to be setup in the test org
+        // TODO We should do an upsert by some custom field but that will require the field to be setup in the test org
+    }
     }
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
@@ -184,5 +184,9 @@ public class CollectionSyncUpTargetTest extends BatchSyncUpTargetTest {
         // That's allowed with single object upsert REST API but not when using sObject collection
         // TODO We should do an upsert by some custom field but that will require the field to be setup in the test org
     }
+
+    @Test
+    public void testSyncUpManyRecords() throws Exception {
+
     }
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-present, salesforce.com, inc.
+ * Copyright (c) 2022-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions
@@ -28,11 +28,11 @@ package com.salesforce.androidsdk.mobilesync.target;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
-
 import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.mobilesync.util.JSONTestHelper;
 import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
-
+import java.util.Arrays;
+import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -40,58 +40,58 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Arrays;
-import java.util.List;
-
 /**
- * Test class for BatchSyncUpTarget.
- * Running all the same tests as SyncUpTargetTest but using a BatchSyncUpTarget with batch size of 2
+ * Test class for CollectionSyncUpTarget.
+ * Running all the same tests as SyncUpTargetTest but using a CollectionSyncUpTarget with batch size of 2
  */
 @RunWith(AndroidJUnit4.class)
 @SmallTest
-public class BatchSyncUpTargetTest extends SyncUpTargetTest {
+public class CollectionSyncUpTargetTest extends BatchSyncUpTargetTest {
 
     @Override
     protected void trySyncUp(int numberChanges, SyncOptions options, List<String> createFieldlist, List<String> updateFieldlist, String externalIdFieldName) throws JSONException {
-        trySyncUp(new BatchSyncUpTarget(createFieldlist, updateFieldlist, null, null, externalIdFieldName), numberChanges, options, false);
+        trySyncUp(new CollectionSyncUpTarget(createFieldlist, updateFieldlist, null, null, externalIdFieldName), numberChanges, options, false);
     }
 
     @Test
+    @Override
     public void testMaxBatchSizeExceedingLimit() {
-        BatchSyncUpTarget target = new BatchSyncUpTarget(null, null, 26);
+        CollectionSyncUpTarget target = new CollectionSyncUpTarget(null, null, 201);
 
-        Assert.assertTrue("Max batch size should be 25", 25 == target.getMaxBatchSize());
+        Assert.assertTrue("Max batch size should be 200", 200 == target.getMaxBatchSize());
     }
 
     @Test
+    @Override
     public void testMaxBatchSizeExceedingLimitInJSON() throws Exception {
         JSONObject targetJson = new JSONObject();
-        targetJson.put(SyncTarget.ANDROID_IMPL, BatchSyncUpTarget.class.getName());
-        targetJson.put(BatchSyncUpTarget.MAX_BATCH_SIZE, 26);
+        targetJson.put(SyncTarget.ANDROID_IMPL, CollectionSyncUpTarget.class.getName());
+        targetJson.put(CollectionSyncUpTarget.MAX_BATCH_SIZE, 201);
 
-        BatchSyncUpTarget target = new BatchSyncUpTarget(targetJson);
+        CollectionSyncUpTarget target = new CollectionSyncUpTarget(targetJson);
 
-        Assert.assertTrue("Max batch size should be 25", 25 == target.getMaxBatchSize());
+        Assert.assertTrue("Max batch size should be 200", 200 == target.getMaxBatchSize());
     }
 
 
     @Test
+    @Override
     public void testConstructors() {
         String[] createdFieldArr = {Constants.NAME};
         String[] updatedFieldArr = {Constants.NAME, Constants.DESCRIPTION};
-        int maxBatchSize = 12;
+        int maxBatchSize = 150;
 
-        BatchSyncUpTarget target = new BatchSyncUpTarget();
+        CollectionSyncUpTarget target = new CollectionSyncUpTarget();
         Assert.assertNull("Wrong createFieldList", target.createFieldlist);
         Assert.assertNull("Wrong updateFieldList", target.updateFieldlist);
-        Assert.assertEquals("Wrong maxBatchSize", 25, target.getMaxBatchSize());
+        Assert.assertEquals("Wrong maxBatchSize", 200, target.getMaxBatchSize());
 
-        target = new BatchSyncUpTarget( Arrays.asList(createdFieldArr),  Arrays.asList(updatedFieldArr));
+        target = new CollectionSyncUpTarget( Arrays.asList(createdFieldArr),  Arrays.asList(updatedFieldArr));
         Assert.assertArrayEquals("Wrong createFieldList", createdFieldArr, target.createFieldlist.toArray(new String[0]));
         Assert.assertArrayEquals("Wrong updateFieldList", updatedFieldArr, target.updateFieldlist.toArray(new String[0]));
-        Assert.assertEquals("Wrong maxBatchSize", 25, target.getMaxBatchSize());
+        Assert.assertEquals("Wrong maxBatchSize", 200, target.getMaxBatchSize());
 
-        target = new BatchSyncUpTarget( Arrays.asList(createdFieldArr),  Arrays.asList(updatedFieldArr), maxBatchSize);
+        target = new CollectionSyncUpTarget( Arrays.asList(createdFieldArr),  Arrays.asList(updatedFieldArr), maxBatchSize);
         Assert.assertArrayEquals("Wrong createFieldList", createdFieldArr, target.createFieldlist.toArray(new String[0]));
         Assert.assertArrayEquals("Wrong updateFieldList", updatedFieldArr, target.updateFieldlist.toArray(new String[0]));
         Assert.assertEquals("Wrong maxBatchSize", maxBatchSize, target.getMaxBatchSize());
@@ -99,18 +99,19 @@ public class BatchSyncUpTargetTest extends SyncUpTargetTest {
 
 
     @Test
+    @Override
     public void testConstructorWithJSON() throws Exception {
         String[] createdFieldArr = {Constants.NAME};
         String[] updatedFieldArr = {Constants.NAME, Constants.DESCRIPTION};
         int maxBatchSize = 12;
 
         JSONObject targetJson = new JSONObject();
-        targetJson.put(SyncTarget.ANDROID_IMPL, BatchSyncUpTarget.class.getName());
+        targetJson.put(SyncTarget.ANDROID_IMPL, CollectionSyncUpTarget.class.getName());
         targetJson.put(SyncUpTarget.CREATE_FIELDLIST, new JSONArray(createdFieldArr));
         targetJson.put(SyncUpTarget.UPDATE_FIELDLIST, new JSONArray(updatedFieldArr));
-        targetJson.put(BatchSyncUpTarget.MAX_BATCH_SIZE, maxBatchSize);
+        targetJson.put(CollectionSyncUpTarget.MAX_BATCH_SIZE, maxBatchSize);
 
-        BatchSyncUpTarget target = new BatchSyncUpTarget(targetJson);
+        CollectionSyncUpTarget target = new CollectionSyncUpTarget(targetJson);
 
         Assert.assertArrayEquals("Wrong createFieldList", createdFieldArr, target.createFieldlist.toArray(new String[0]));
         Assert.assertArrayEquals("Wrong updateFieldList", updatedFieldArr, target.updateFieldlist.toArray(new String[0]));
@@ -121,13 +122,13 @@ public class BatchSyncUpTargetTest extends SyncUpTargetTest {
     @Test
     public void testConstructorWithJSONWithoutOptionalFields() throws Exception {
         JSONObject targetJson = new JSONObject();
-        targetJson.put(SyncTarget.ANDROID_IMPL, BatchSyncUpTarget.class.getName());
+        targetJson.put(SyncTarget.ANDROID_IMPL, CollectionSyncUpTarget.class.getName());
 
-        BatchSyncUpTarget target = new BatchSyncUpTarget(targetJson);
+        CollectionSyncUpTarget target = new CollectionSyncUpTarget(targetJson);
 
         Assert.assertNull("Wrong createFieldList", target.createFieldlist);
         Assert.assertNull("Wrong updateFieldList", target.updateFieldlist);
-        Assert.assertEquals("Wrong maxBatchSize", BatchSyncUpTarget.MAX_SUB_REQUESTS_COMPOSITE_API, target.getMaxBatchSize());
+        Assert.assertEquals("Wrong maxBatchSize", CollectionSyncUpTarget.MAX_RECORDS_SOBJECT_COLLECTION_API, target.getMaxBatchSize());
     }
 
 
@@ -136,43 +137,43 @@ public class BatchSyncUpTargetTest extends SyncUpTargetTest {
         int maxBatchSize = 12;
 
         JSONObject targetJson = new JSONObject();
-        targetJson.put(SyncTarget.ANDROID_IMPL, BatchSyncUpTarget.class.getName());
-        targetJson.put(BatchSyncUpTarget.MAX_BATCH_SIZE, maxBatchSize);
+        targetJson.put(SyncTarget.ANDROID_IMPL, CollectionSyncUpTarget.class.getName());
+        targetJson.put(CollectionSyncUpTarget.MAX_BATCH_SIZE, maxBatchSize);
 
         SyncUpTarget target = SyncUpTarget.fromJSON(targetJson);
 
-        Assert.assertTrue(target instanceof BatchSyncUpTarget);
-        Assert.assertEquals("Wrong maxBatchSize", maxBatchSize, ((BatchSyncUpTarget) target).getMaxBatchSize());
+        Assert.assertTrue(target instanceof CollectionSyncUpTarget);
+        Assert.assertEquals("Wrong maxBatchSize", maxBatchSize, ((CollectionSyncUpTarget) target).getMaxBatchSize());
     }
 
     @Test
     public void testToJSON() throws Exception {
         String[] createdFieldArr = {Constants.NAME};
         String[] updatedFieldArr = {Constants.NAME, Constants.DESCRIPTION};
-        int maxBatchSize = 12;
+        int maxBatchSize = 150;
 
-        BatchSyncUpTarget target = new BatchSyncUpTarget( Arrays.asList(createdFieldArr),  Arrays.asList(updatedFieldArr), maxBatchSize);
+        CollectionSyncUpTarget target = new CollectionSyncUpTarget( Arrays.asList(createdFieldArr),  Arrays.asList(updatedFieldArr), maxBatchSize);
 
         JSONObject expectedTargetJson = new JSONObject();
-        expectedTargetJson.put(SyncTarget.ANDROID_IMPL, BatchSyncUpTarget.class.getName());
+        expectedTargetJson.put(SyncTarget.ANDROID_IMPL, CollectionSyncUpTarget.class.getName());
         expectedTargetJson.put(SyncUpTarget.ID_FIELD_NAME, Constants.ID);
         expectedTargetJson.put(SyncUpTarget.MODIFICATION_DATE_FIELD_NAME, Constants.LAST_MODIFIED_DATE);
         expectedTargetJson.put(SyncUpTarget.CREATE_FIELDLIST, new JSONArray(createdFieldArr));
         expectedTargetJson.put(SyncUpTarget.UPDATE_FIELDLIST, new JSONArray(updatedFieldArr));
-        expectedTargetJson.put(BatchSyncUpTarget.MAX_BATCH_SIZE, maxBatchSize);
+        expectedTargetJson.put(CollectionSyncUpTarget.MAX_BATCH_SIZE, maxBatchSize);
 
         JSONTestHelper.assertSameJSON("Wrong json", expectedTargetJson, target.asJSON());
     }
 
     @Test
-    public void testBatchSyncUpTargetIsDefault() throws Exception {
+    public void testCollectionSyncUpTargetIsDefault() throws Exception {
         JSONObject targetJson = new JSONObject();
 
         SyncUpTarget target = SyncUpTarget.fromJSON(targetJson);
 
-        Assert.assertTrue(target instanceof BatchSyncUpTarget);
+        Assert.assertTrue(target instanceof CollectionSyncUpTarget);
         Assert.assertNull("Wrong createFieldList", target.createFieldlist);
         Assert.assertNull("Wrong updateFieldList", target.updateFieldlist);
-        Assert.assertEquals("Wrong maxBatchSize", BatchSyncUpTarget.MAX_SUB_REQUESTS_COMPOSITE_API, ((BatchSyncUpTarget) target).getMaxBatchSize());
+        Assert.assertEquals("Wrong maxBatchSize", CollectionSyncUpTarget.MAX_RECORDS_SOBJECT_COLLECTION_API, ((CollectionSyncUpTarget) target).getMaxBatchSize());
     }
 }

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
@@ -263,7 +263,11 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
             String name = (String) fields.get(Constants.NAME);
             String lastError = (String) fields.get(SyncTarget.LAST_ERROR);
             if (setNamesBadRecords.contains(name)) {
-                Assert.assertTrue("Wrong error: " + lastError, lastError.contains("The requested resource does not exist"));
+                Assert.assertTrue("Wrong error: " + lastError,
+                    lastError.contains("The requested resource does not exist") // older end point error
+                    || lastError.contains("sObject type 'badType' is not supported.") // sobject collection error with bad type
+                    || lastError.contains("sObject type 'null' is not supported.")    // sobject collection error with no type
+                );
             }
             else {
                 Assert.fail("Unexpected record found: " + name);

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
@@ -35,6 +35,7 @@ import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
 import com.salesforce.androidsdk.mobilesync.util.SyncState;
 
+import java.util.ArrayList;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -356,7 +357,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      */
     @Test
     public void testSyncUpWithLocallyCreatedRecords() throws Exception {
-        trySyncUpWithLocallyCreatedRecords(SyncState.MergeMode.OVERWRITE);
+        trySyncUpWithLocallyCreatedRecords(3, SyncState.MergeMode.OVERWRITE);
     }
 
 
@@ -365,18 +366,20 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      */
     @Test
     public void testSyncUpWithLocallyCreatedRecordsWithoutOverwrite() throws Exception {
-        trySyncUpWithLocallyCreatedRecords(SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncUpWithLocallyCreatedRecords(3, SyncState.MergeMode.LEAVE_IF_CHANGED);
     }
 
-    private void trySyncUpWithLocallyCreatedRecords(SyncState.MergeMode syncUpMergeMode) throws Exception {
+    private void trySyncUpWithLocallyCreatedRecords(int countRecords, SyncState.MergeMode syncUpMergeMode) throws Exception {
         // Create a few entries locally
-        String[] names = new String[] { createRecordName(Constants.ACCOUNT),
-                createRecordName(Constants.ACCOUNT),
-                createRecordName(Constants.ACCOUNT) };
+        List<String> listNames = new ArrayList<>();
+        for (int i=0; i<countRecords; i++) {
+            listNames.add(createRecordName(Constants.ACCOUNT));
+        }
+        String[] names = listNames.toArray(new String[0]);
         createAccountsLocally(names);
 
         // Sync up
-        trySyncUp(3, syncUpMergeMode);
+        trySyncUp(countRecords, syncUpMergeMode);
 
         // Check that db doesn't show entries as locally created anymore and that they use sfdc id
         Map<String, Map<String, Object>> idToFieldsCreated = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{Constants.NAME, Constants.DESCRIPTION}, Constants.NAME, names);
@@ -713,6 +716,14 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
 
         // Adding to idToFields so that they get deleted in tearDown
         idToFields.putAll(expectedServerIdToFields);
+    }
+
+    /**
+     * Create many accounts locally, sync up with merge mode OVERWRITE, check smartstore and server afterwards
+     */
+    @Test
+    public void testSyncUpManyLocallyCreatedRecords() throws Exception {
+        trySyncUpWithLocallyCreatedRecords(500, SyncState.MergeMode.OVERWRITE);
     }
 
     /**


### PR DESCRIPTION
* New sync up target `CollectionSyncUpTarget` (a subclass of `BatchSyncUpTarget`, itself a subclass of `SyncUpTarget`) uses sobject collection create/update/upsert/delete instead of composite batch.
* It's the new **default** for sync up (when implementation class is not specified) replacing `BatchSyncUpTarget` (which was the default since 7.1).
* Most of the work went into refactoring `CompositeRequestHelper` to allow it to work with requests/responses to/from `composite/batch` or `composite/sobjects`, as a result `CollectionSyncUpTarget` is very short (constructors plus a one line overriding method `sendRecordRequests`).
* New test suite: `CollectionSyncUpTargetTest` (a subclass of `BatchSyncUpTargetTest`, itself a subclass of `SyncUpTargetTest`) so running the same tests as existing sync up tests to make sure parity of behavior.
* Added a test that syncs up "many" (500) records at once, on my machine the sync up ran in:
  *  67646 ms with SyncUpTarget
  * 33338 ms with BatchSyncUpTarget
  * 6165 ms with CollectionSyncUpTarget (**5x faster than batch sync up and 10x faster than single record sync up**)