### PR TITLE
Adding changedAfterTime to getPrimingRecords

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
@@ -264,7 +264,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
      */
     protected String getIdsFromBriefcases(SyncManager syncManager, TypedIds typedIds, String relayToken, long maxTimeStamp)
         throws JSONException, IOException {
-        RestRequest request = RestRequest.getRequestForPrimingRecords(syncManager.apiVersion, relayToken);
+        RestRequest request = RestRequest.getRequestForPrimingRecords(syncManager.apiVersion, relayToken, maxTimeStamp);
 
         PrimingRecordsResponse response;
         try {
@@ -280,11 +280,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
                 for (List<PrimingRecord> primingRecords : allPrimingRecords.get(info.sobjectType)
                     .values()) {
                     for (PrimingRecord primingRecord : primingRecords) {
-                        // Filtering by maxTimeStamp
-                        // TODO Remove once 238 is GA (filtering will happen on server)
-                        if (primingRecord.systemModstamp.getTime() > maxTimeStamp) {
-                            typedIds.add(info.sobjectType, primingRecord.id);
-                        }
+                        typedIds.add(info.sobjectType, primingRecord.id);
                     }
                 }
             }

--- a/libs/SalesforceSDK/res/values/strings.xml
+++ b/libs/SalesforceSDK/res/values/strings.xml
@@ -12,5 +12,5 @@
     <string name="oauth_display_type">touch</string>
 
     <!-- Default API version used by the SDK and sample apps -->
-    <string name="api_version">v54.0</string>
+    <string name="api_version">v55.0</string>
 </resources>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ApiVersionStrings.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ApiVersionStrings.java
@@ -37,7 +37,7 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
  */
 public class ApiVersionStrings {
 
-    public static final String VERSION_NUMBER = "v54.0";
+    public static final String VERSION_NUMBER = "v55.0";
     public static final String API_PREFIX = "/services/data/";
 
     public static String getBasePath() {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/PrimingRecordsResponse.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/PrimingRecordsResponse.java
@@ -46,7 +46,7 @@ import org.json.JSONObject;
  * PrimingRecordsResponse: Class to represent response for a priming records request.
  */
 public class PrimingRecordsResponse {
-    private static final DateFormat TIMESTAMP_FORMAT;
+    public static final DateFormat TIMESTAMP_FORMAT;
     static {
         // NB can't use RestRequest.ISO8601_DATE_FORMAT it's for timestamp of the form 2001-07-04T12:08:56.235-0700
         TimeZone tz = TimeZone.getTimeZone("UTC");

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -820,15 +820,21 @@ public class RestRequest {
 	 * Request for getting list of record related to offline briefcase
 	 *
 	 * @param apiVersion       Salesforce API version.
-	 * @param relayToken       Relay token (to get next page of results)
+	 * @param relayToken       Relay token (to get next page of results) - or null
+	 * @param changedAfterTime To only get ids of records that changed after given time - or null
 	 *
 	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_briefcase_priming_records.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_briefcase_priming_records.htm</a>
 	 */
-    public static RestRequest getRequestForPrimingRecords(String apiVersion, String relayToken) throws UnsupportedEncodingException {
+    public static RestRequest getRequestForPrimingRecords(String apiVersion, String relayToken, Long changedAfterTime) throws UnsupportedEncodingException {
     	StringBuilder path = new StringBuilder(RestAction.PRIMING_RECORDS.getPath(apiVersion));
     	if (relayToken != null) {
     		path.append("?relayToken=");
     		path.append(URLEncoder.encode(relayToken, UTF_8));
+		}
+    	if (changedAfterTime != null) {
+    		path.append(relayToken != null ? "&" : "?");
+    		path.append("changedAfterTimestamp=");
+    		path.append(URLEncoder.encode(PrimingRecordsResponse.TIMESTAMP_FORMAT.format(new Date(changedAfterTime)), UTF_8));
 		}
 		return new RestRequest(RestMethod.GET, path.toString());
 	}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -1068,7 +1068,15 @@ public class RestClientTest {
 
     @Test
     public void testGetPrimingRecords() throws Exception {
-        RestRequest request = RestRequest.getRequestForPrimingRecords(TestCredentials.API_VERSION, null);
+        RestRequest request = RestRequest.getRequestForPrimingRecords(TestCredentials.API_VERSION, null, null);
+        RestResponse response = restClient.sendSync(request);
+        checkResponse(response, HttpURLConnection.HTTP_OK, false);
+        checkKeys(response.asJSONObject(), "primingRecords", "relayToken", "ruleErrors", "stats");
+    }
+
+    @Test
+    public void testGetPrimingRecordsWithChangedAfterTimestampParameter() throws Exception {
+        RestRequest request = RestRequest.getRequestForPrimingRecords(TestCredentials.API_VERSION, null, new Date().getTime());
         RestResponse response = restClient.sendSync(request);
         checkResponse(response, HttpURLConnection.HTTP_OK, false);
         checkKeys(response.asJSONObject(), "primingRecords", "relayToken", "ruleErrors", "stats");
@@ -1076,7 +1084,7 @@ public class RestClientTest {
 
     @Test
     public void testParsePrimingRecordsResponse() throws Exception {
-        RestRequest request = RestRequest.getRequestForPrimingRecords(TestCredentials.API_VERSION, null);
+        RestRequest request = RestRequest.getRequestForPrimingRecords(TestCredentials.API_VERSION, null, null);
         RestResponse response = restClient.sendSync(request);
         checkResponse(response, HttpURLConnection.HTTP_OK, false);
         try {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
@@ -579,17 +579,34 @@ public class RestRequestTest {
 
     @Test
 	public void testGetRequestForPrimingRecords() throws Exception {
-    	RestRequest request = RestRequest.getRequestForPrimingRecords(TEST_API_VERSION, null);
+    	RestRequest request = RestRequest.getRequestForPrimingRecords(TEST_API_VERSION, null, null);
     	Assert.assertEquals("Wrong method", RestMethod.GET, request.getMethod());
 		Assert.assertEquals("Wrong path", "/services/data/" + TEST_API_VERSION + "/connect/briefcase/priming-records", request.getPath());
 	}
 
 	@Test
 	public void testGetRequestForPrimingRecordsWithRelayToken() throws Exception {
-		RestRequest request = RestRequest.getRequestForPrimingRecords(TEST_API_VERSION, "my-relay-token");
+		RestRequest request = RestRequest.getRequestForPrimingRecords(TEST_API_VERSION, "my-relay-token", null);
 		Assert.assertEquals("Wrong method", RestMethod.GET, request.getMethod());
 		Assert.assertEquals("Wrong path", "/services/data/" + TEST_API_VERSION + "/connect/briefcase/priming-records?relayToken=my-relay-token", request.getPath());
 	}
+
+	@Test
+	public void testGetRequestForPrimingRecordsWithChangedAfterTimestamp() throws Exception {
+    	long timestamp = PrimingRecordsResponse.TIMESTAMP_FORMAT.parse("2022-01-31T03:50:10.000Z").getTime();
+		RestRequest request = RestRequest.getRequestForPrimingRecords(TEST_API_VERSION, null, timestamp);
+		Assert.assertEquals("Wrong method", RestMethod.GET, request.getMethod());
+		Assert.assertEquals("Wrong path", "/services/data/" + TEST_API_VERSION + "/connect/briefcase/priming-records?changedAfterTimestamp=2022-01-31T03%3A50%3A10.000Z", request.getPath());
+	}
+
+	@Test
+	public void testGetRequestForPrimingRecordsWithRelayTokenAndChangedAfterTimestamp() throws Exception {
+		long timestamp = PrimingRecordsResponse.TIMESTAMP_FORMAT.parse("2022-01-31T03:50:10.000Z").getTime();
+		RestRequest request = RestRequest.getRequestForPrimingRecords(TEST_API_VERSION, "my-relay-token", timestamp);
+		Assert.assertEquals("Wrong method", RestMethod.GET, request.getMethod());
+		Assert.assertEquals("Wrong path", "/services/data/" + TEST_API_VERSION + "/connect/briefcase/priming-records?relayToken=my-relay-token&changedAfterTimestamp=2022-01-31T03%3A50%3A10.000Z", request.getPath());
+	}
+
 
 	@Test
 	public void testParsePrimingRecordsResponse() throws Exception {


### PR DESCRIPTION
- Added tests
- Leveraging the new param in BriefcaseSyncDownTarget
- Bumped api version from 54 to 55

(NB: tests will only pass if you go against an instance where 55 is already deployed)