### PR TITLE
Bulk checking last modified date during collection sync up

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/AdvancedSyncUpTask.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/AdvancedSyncUpTask.java
@@ -29,22 +29,17 @@ package com.salesforce.androidsdk.mobilesync.manager;
 
 import com.salesforce.androidsdk.mobilesync.target.AdvancedSyncUpTarget;
 import com.salesforce.androidsdk.mobilesync.target.SyncUpTarget;
-import com.salesforce.androidsdk.mobilesync.util.MobileSyncLogger;
 import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
 import com.salesforce.androidsdk.mobilesync.util.SyncState;
-
 import com.salesforce.androidsdk.mobilesync.util.SyncState.MergeMode;
-import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
-import com.salesforce.androidsdk.util.JSONObjectHelper;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Runnable class responsible for running a sync up that uses and AdvancedSyncUpTarget
@@ -67,17 +62,17 @@ public class AdvancedSyncUpTask extends SyncUpTask {
         updateSync(sync, SyncState.Status.RUNNING, 0, callback);
         List<JSONObject> dirtyRecords = target.getFromLocalStore(syncManager, soupName, dirtyRecordIds);
 
-        // Figuring out what records need to be synched up based on merge mode and last mod date on server
+        // Figuring out what records need to be synced up based on merge mode and last mod date on server
         Map<String, Boolean> recordIdToShouldSyncUp = shouldSyncUpRecords(syncManager, target, dirtyRecords, options);
 
-        // Synching up records
+        // Syncing up records
         for (int i=0; i<totalSize; i++) {
             checkIfStopRequested();
 
             JSONObject record = dirtyRecords.get(i);
             String recordId = record.getString(SmartStore.SOUP_ENTRY_ID);
 
-            if (recordIdToShouldSyncUp.get(recordId)) {
+            if (Boolean.TRUE.equals(recordIdToShouldSyncUp.get(recordId))) {
                 batch.add(record);
             }
 

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/BriefcaseSyncDownTarget.java
@@ -76,7 +76,7 @@ public class BriefcaseSyncDownTarget extends SyncDownTarget {
 
     // Number of records to fetch per call (with ids obtained from priming record api)
     private int countIdsPerRetrieve;
-    private static final int MAX_COUNT_IDS_PER_RETRIEVE = 2000;
+    private static final int MAX_COUNT_IDS_PER_RETRIEVE = RestRequest.MAX_COLLECTION_RETRIEVE_SIZE;
 
     /**
      * Construct BriefcaseSyncDownTarget from json

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -40,6 +40,7 @@ import com.salesforce.androidsdk.mobilesync.util.SOQLBuilder;
 import com.salesforce.androidsdk.mobilesync.util.SyncState;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
+import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -430,6 +431,19 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
                         fields);
             }
         }
+    }
+
+    @Override
+    public Map<String, Boolean> areNewerThanServer(SyncManager syncManager, List<JSONObject> records) throws JSONException, IOException {
+        Map<String, Boolean> storeIdToNewerThanServer = new HashMap<>();
+
+        // XXX  still doing a request per record
+        for (JSONObject record : records) {
+            String storeId = record.getString(SmartStore.SOUP_ENTRY_ID);
+            storeIdToNewerThanServer.put(storeId, isNewerThanServer(syncManager, record));
+        }
+
+        return storeIdToNewerThanServer;
     }
 
     @Override

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/ParentChildrenSyncUpTarget.java
@@ -434,19 +434,6 @@ public class ParentChildrenSyncUpTarget extends SyncUpTarget implements Advanced
     }
 
     @Override
-    public Map<String, Boolean> areNewerThanServer(SyncManager syncManager, List<JSONObject> records) throws JSONException, IOException {
-        Map<String, Boolean> storeIdToNewerThanServer = new HashMap<>();
-
-        // XXX  still doing a request per record
-        for (JSONObject record : records) {
-            String storeId = record.getString(SmartStore.SOUP_ENTRY_ID);
-            storeIdToNewerThanServer.put(storeId, isNewerThanServer(syncManager, record));
-        }
-
-        return storeIdToNewerThanServer;
-    }
-
-    @Override
     public boolean isNewerThanServer(SyncManager syncManager, JSONObject record) throws JSONException, IOException {
         if (isLocallyCreated(record)) {
             return true;

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncTarget.java
@@ -33,6 +33,7 @@ import com.salesforce.androidsdk.mobilesync.util.MobileSyncLogger;
 import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -304,6 +305,21 @@ public abstract class SyncTarget {
      */
     public JSONObject getFromLocalStore(SyncManager syncManager, String soupName, String storeId) throws JSONException {
         return syncManager.getSmartStore().retrieve(soupName, Long.valueOf(storeId)).getJSONObject(0);
+    }
+
+    /**
+     * Get records from local store by storeId
+     * @param syncManager
+     * @param storeIds
+     * @throws  JSONException
+     */
+    public List<JSONObject> getFromLocalStore(SyncManager syncManager, String soupName, List<String> storeIds) throws JSONException {
+        Long[] storeIdsLong = new Long[storeIds.size()];
+        for (int i=0; i<storeIds.size(); i++) {
+            storeIdsLong[i] = Long.valueOf(storeIds.get(i));
+        }
+
+        return JSONObjectHelper.toList(syncManager.getSmartStore().retrieve(soupName, storeIdsLong));
     }
 
     /**

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -27,12 +27,14 @@
 package com.salesforce.androidsdk.mobilesync.target;
 
 import com.salesforce.androidsdk.mobilesync.manager.SyncManager;
+import com.salesforce.androidsdk.mobilesync.manager.SyncManager.MobileSyncException;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.rest.RestRequest;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
 
+import java.util.ArrayList;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -353,6 +355,56 @@ public class SyncUpTarget extends SyncTarget {
     }
 
     /**
+     * Same as fetchLastModifiedDate but operating over a list of records (expected to be of the same sobject type)
+     *
+     * @param syncManager
+     * @param records
+     * @return
+     */
+    protected Map<String, RecordModDate> fetchLastModifiedDates(SyncManager syncManager, List<JSONObject> records) throws JSONException, IOException {
+        Map<String, RecordModDate> recordIdToLastModifiedDate = new HashMap<>();
+
+        int totalSize = records.size();
+        if (totalSize > 0) {
+            int maxCollectionRetrieveSize = 200;
+            String objectType = (String) SmartStore.project(records.get(0), Constants.SOBJECT_TYPE);
+            List<String> batchStoreIds = new ArrayList<>();
+            List<String> batchServerIds = new ArrayList<>();
+
+            for (int i = 0; i < totalSize; i++) {
+                JSONObject record = records.get(i);
+                if (!objectType.equals(SmartStore.project(record, Constants.SOBJECT_TYPE))) {
+                    throw new MobileSyncException("All records should have same sobject type");
+                }
+
+                batchStoreIds.add(record.getString(SmartStore.SOUP_ENTRY_ID));
+                batchServerIds.add(record.getString(getIdFieldName()));
+
+                // Process batch if max batch size reached or at the end of records
+                if (batchServerIds.size() == maxCollectionRetrieveSize || i == totalSize - 1) {
+                    RestRequest request = RestRequest.getRequestForCollectionRetrieve(syncManager.apiVersion, objectType, batchServerIds, Arrays.asList(getModificationDateFieldName()));
+                    RestResponse response = syncManager.sendSyncWithMobileSyncUserAgent(request);
+                    JSONArray responseAsArray = response.asJSONArray();
+                    for (int j = 0; j < responseAsArray.length(); j++) {
+                        String storeId = batchStoreIds.get(j);
+                        JSONObject lastModResponse = responseAsArray.isNull(j) ? null : responseAsArray.getJSONObject(j);
+                        RecordModDate serverModDate = new RecordModDate(
+                            lastModResponse != null ? lastModResponse.getString(getModificationDateFieldName()) : null,
+                            lastModResponse == null
+                        );
+                        recordIdToLastModifiedDate.put(storeId, serverModDate);
+                    }
+
+                    batchServerIds.clear();
+                    batchStoreIds.clear();
+                }
+            }
+        }
+
+        return recordIdToLastModifiedDate;
+    }
+
+    /**
      * Return true if record is more recent than corresponding record on server
      * NB: also return true if both were deleted or if local mod date is missing
      *
@@ -374,6 +426,44 @@ public class SyncUpTarget extends SyncTarget {
         );
         final RecordModDate remoteModDate = fetchLastModifiedDate(syncManager, record);
         return isNewerThanServer(localModDate, remoteModDate);
+    }
+
+    /**
+     * Same as isNewerThanServer but operating over a list of records (expected to be of the same sobject type)
+     * Return map from record store id to boolean
+     *
+     * @param syncManager
+     * @param records
+     * @return
+     * @throws JSONException
+     * @throws IOException
+     */
+    public Map<String, Boolean> areNewerThanServer(SyncManager syncManager, List<JSONObject> records) throws JSONException, IOException {
+        Map<String, Boolean> storeIdToNewerThanServer = new HashMap<>();
+
+        List<JSONObject> nonLocallyCreatedRecords = new ArrayList<>();
+        for (JSONObject record : records) {
+            if (isLocallyCreated(record) || !record.has(getIdFieldName())) {
+                String storeId = record.getString(SmartStore.SOUP_ENTRY_ID);
+                storeIdToNewerThanServer.put(storeId, true);
+            } else {
+                nonLocallyCreatedRecords.add(record);
+            }
+        }
+
+        Map<String, RecordModDate> recordIdToRemoteModDate = fetchLastModifiedDates(syncManager, nonLocallyCreatedRecords);
+
+        for (JSONObject record : nonLocallyCreatedRecords) {
+            String storeId = record.getString(SmartStore.SOUP_ENTRY_ID);
+            RecordModDate localModDate = new RecordModDate(
+                JSONObjectHelper.optString(record, getModificationDateFieldName()),
+                isLocallyDeleted(record)
+            );
+            RecordModDate remoteModDate = recordIdToRemoteModDate.get(storeId);
+            storeIdToNewerThanServer.put(storeId, isNewerThanServer(localModDate, remoteModDate));
+        }
+
+        return storeIdToNewerThanServer;
     }
 
     /**

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -366,7 +366,6 @@ public class SyncUpTarget extends SyncTarget {
 
         int totalSize = records.size();
         if (totalSize > 0) {
-            int maxCollectionRetrieveSize = 200;
             String objectType = (String) SmartStore.project(records.get(0), Constants.SOBJECT_TYPE);
             List<String> batchStoreIds = new ArrayList<>();
             List<String> batchServerIds = new ArrayList<>();
@@ -381,7 +380,7 @@ public class SyncUpTarget extends SyncTarget {
                 batchServerIds.add(record.getString(getIdFieldName()));
 
                 // Process batch if max batch size reached or at the end of records
-                if (batchServerIds.size() == maxCollectionRetrieveSize || i == totalSize - 1) {
+                if (batchServerIds.size() == RestRequest.MAX_COLLECTION_RETRIEVE_SIZE || i == totalSize - 1) {
                     RestRequest request = RestRequest.getRequestForCollectionRetrieve(syncManager.apiVersion, objectType, batchServerIds, Arrays.asList(getModificationDateFieldName()));
                     RestResponse response = syncManager.sendSyncWithMobileSyncUserAgent(request);
                     JSONArray responseAsArray = response.asJSONArray();

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTarget.java
@@ -440,26 +440,9 @@ public class SyncUpTarget extends SyncTarget {
     public Map<String, Boolean> areNewerThanServer(SyncManager syncManager, List<JSONObject> records) throws JSONException, IOException {
         Map<String, Boolean> storeIdToNewerThanServer = new HashMap<>();
 
-        List<JSONObject> nonLocallyCreatedRecords = new ArrayList<>();
         for (JSONObject record : records) {
-            if (isLocallyCreated(record) || !record.has(getIdFieldName())) {
-                String storeId = record.getString(SmartStore.SOUP_ENTRY_ID);
-                storeIdToNewerThanServer.put(storeId, true);
-            } else {
-                nonLocallyCreatedRecords.add(record);
-            }
-        }
-
-        Map<String, RecordModDate> recordIdToRemoteModDate = fetchLastModifiedDates(syncManager, nonLocallyCreatedRecords);
-
-        for (JSONObject record : nonLocallyCreatedRecords) {
             String storeId = record.getString(SmartStore.SOUP_ENTRY_ID);
-            RecordModDate localModDate = new RecordModDate(
-                JSONObjectHelper.optString(record, getModificationDateFieldName()),
-                isLocallyDeleted(record)
-            );
-            RecordModDate remoteModDate = recordIdToRemoteModDate.get(storeId);
-            storeIdToNewerThanServer.put(storeId, isNewerThanServer(localModDate, remoteModDate));
+            storeIdToNewerThanServer.put(storeId, isNewerThanServer(syncManager, record));
         }
 
         return storeIdToNewerThanServer;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -126,6 +126,7 @@ public class RestRequest {
 	public static final int MIN_BATCH_SIZE = 200;
     public static final int MAX_BATCH_SIZE = 2000;
     public static final int DEFAULT_BATCH_SIZE = 2000;
+    public static final int MAX_COLLECTION_RETRIEVE_SIZE = 2000;
 
     /**
      * HTTP date format

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/BatchSyncUpTargetTest.java
@@ -45,7 +45,7 @@ import java.util.List;
 
 /**
  * Test class for BatchSyncUpTarget.
- * Running all the same tests as SyncUpTargetTest but using a BatchSyncUpTarget with batch size of 2
+ * Running all the same tests as SyncUpTargetTest but using a BatchSyncUpTarget
  */
 @RunWith(AndroidJUnit4.class)
 @SmallTest

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/CollectionSyncUpTargetTest.java
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
 
 /**
  * Test class for CollectionSyncUpTarget.
- * Running all the same tests as SyncUpTargetTest but using a CollectionSyncUpTarget with batch size of 2
+ * Running all the same tests as SyncUpTargetTest but using a CollectionSyncUpTarget
  */
 @RunWith(AndroidJUnit4.class)
 @SmallTest

--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/target/SyncUpTargetTest.java
@@ -35,6 +35,7 @@ import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.mobilesync.util.SyncOptions;
 import com.salesforce.androidsdk.mobilesync.util.SyncState;
 
+import com.salesforce.androidsdk.mobilesync.util.SyncState.MergeMode;
 import java.util.ArrayList;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -82,13 +83,13 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
     @Test
     public void testSyncUpWithUpdateFieldList() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.OVERWRITE);
+        trySyncDown(MergeMode.OVERWRITE);
 
         // Update a few entries locally
         Map<String, Map<String, Object>> idToFieldsLocallyUpdated = makeLocalChanges(idToFields, ACCOUNTS_SOUP);
 
         // Sync up with update field list including only name
-        trySyncUp(idToFieldsLocallyUpdated.size(), SyncState.MergeMode.OVERWRITE, null, Arrays.asList(new String[] { Constants.NAME }));
+        trySyncUp(idToFieldsLocallyUpdated.size(), MergeMode.OVERWRITE, null, Arrays.asList(new String[] { Constants.NAME }));
 
         // Check that db doesn't show entries as locally modified anymore
         Set<String> ids = idToFieldsLocallyUpdated.keySet();
@@ -118,7 +119,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         createAccountsLocally(names);
 
         // Sync up with create field list including only name
-        trySyncUp(3, SyncState.MergeMode.OVERWRITE, Arrays.asList(new String[] { Constants.NAME }), null);
+        trySyncUp(3, MergeMode.OVERWRITE, Arrays.asList(new String[] { Constants.NAME }), null);
 
         // Check that db doesn't show entries as locally created anymore and that they use sfdc id
         Map<String, Map<String, Object>> idToFieldsCreated = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{Constants.NAME, Constants.DESCRIPTION}, Constants.NAME, names);
@@ -167,7 +168,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         createAccountsLocally(badNames);
 
         // Sync up
-        trySyncUp(5, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(5, MergeMode.OVERWRITE);
 
         // Check db for records with good names
         Map<String, Map<String, Object>> idToFieldsGoodNames = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{Constants.NAME, Constants.DESCRIPTION}, Constants.NAME, goodNames);
@@ -249,7 +250,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         });
 
         // Sync up
-        trySyncUp(5, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(5, MergeMode.OVERWRITE);
 
         // Check db for records with good names
         Map<String, Map<String, Object>> idToFieldsGoodNames = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{Constants.NAME, Constants.DESCRIPTION}, Constants.NAME, namesGoodRecords);
@@ -288,13 +289,13 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
     @Test
     public void testSyncUpWithLocallyUpdatedRecords() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.OVERWRITE);
+        trySyncDown(MergeMode.OVERWRITE);
 
         // Update a few entries locally
         Map<String, Map<String, Object>> idToFieldsLocallyUpdated = makeLocalChanges(idToFields, ACCOUNTS_SOUP);
 
         // Sync up
-        trySyncUp(3, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(3, MergeMode.OVERWRITE);
 
         // Check that db doesn't show entries as locally modified anymore
         Set<String> ids = idToFieldsLocallyUpdated.keySet();
@@ -311,9 +312,9 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      * Then sync up again with merge mode OVERWRITE, check smartstore and server
      */
     @Test
-    public void testSyncUpWithLocallyUpdatedRecordsWithoutOverwrite() throws Exception {
+    public void testSyncUpWithLocallyUpdatedRemotelyUpdatedRecordsWithoutOverwrite() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncDown(MergeMode.LEAVE_IF_CHANGED);
 
         // Update a few entries locally
         Map<String, Map<String, Object>> idToFieldsLocallyUpdated = makeLocalChanges(idToFields, ACCOUNTS_SOUP);
@@ -334,7 +335,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         updateRecordsOnServer(idToFieldsRemotelyUpdated, Constants.ACCOUNT);
 
         // Sync up with leave-if-changed
-        trySyncUp(3, SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncUp(3, MergeMode.LEAVE_IF_CHANGED);
 
         // Check that db shows entries as locally modified
         checkDbStateFlags(ids, false, true, false, ACCOUNTS_SOUP);
@@ -343,7 +344,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         checkServer(idToFieldsRemotelyUpdated, Constants.ACCOUNT);
 
         // Sync up with overwrite
-        trySyncUp(3, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(3, MergeMode.OVERWRITE);
 
         // Check that db no longer shows entries as locally modified
         checkDbStateFlags(ids, false, false, false, ACCOUNTS_SOUP);
@@ -357,19 +358,19 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      */
     @Test
     public void testSyncUpWithLocallyCreatedRecords() throws Exception {
-        trySyncUpWithLocallyCreatedRecords(3, SyncState.MergeMode.OVERWRITE);
+        trySyncUpWithLocallyCreatedRecords(3, MergeMode.OVERWRITE);
     }
 
 
     /**
-     * Create accounts locally, sync up with mege mode LEAVE_IF_CHANGED, check smartstore and server afterwards
+     * Create accounts locally, sync up with merge mode LEAVE_IF_CHANGED, check smartstore and server afterwards
      */
     @Test
     public void testSyncUpWithLocallyCreatedRecordsWithoutOverwrite() throws Exception {
-        trySyncUpWithLocallyCreatedRecords(3, SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncUpWithLocallyCreatedRecords(3, MergeMode.LEAVE_IF_CHANGED);
     }
 
-    private void trySyncUpWithLocallyCreatedRecords(int countRecords, SyncState.MergeMode syncUpMergeMode) throws Exception {
+    private void trySyncUpWithLocallyCreatedRecords(int countRecords, MergeMode syncUpMergeMode) throws Exception {
         // Create a few entries locally
         List<String> listNames = new ArrayList<>();
         for (int i=0; i<countRecords; i++) {
@@ -398,7 +399,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
     @Test
     public void testSyncUpWithLocallyDeletedRecords() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.OVERWRITE);
+        trySyncDown(MergeMode.OVERWRITE);
 
         // Delete a few entries locally
         String[] allIds = idToFields.keySet().toArray(new String[0]);
@@ -406,7 +407,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         deleteRecordsLocally(ACCOUNTS_SOUP, idsLocallyDeleted);
 
         // Sync up
-        trySyncUp(3, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(3, MergeMode.OVERWRITE);
 
         // Check that db doesn't contain those entries anymore
         checkDbDeleted(ACCOUNTS_SOUP, idsLocallyDeleted, Constants.ID);
@@ -434,7 +435,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         deleteRecordsLocally(ACCOUNTS_SOUP, idsLocallyDeleted);
 
         // Sync up
-        trySyncUp(3, SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncUp(3, MergeMode.LEAVE_IF_CHANGED);
 
         // Check that db doesn't contain those entries anymore
         checkDbDeleted(ACCOUNTS_SOUP, idsLocallyDeleted, Constants.ID);
@@ -447,9 +448,9 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      * Then sync up again with merge mode OVERWRITE, check smartstore and server
      */
     @Test
-    public void testSyncUpWithLocallyDeletedRecordsWithoutOverwrite() throws Exception {
+    public void testSyncUpWithLocallyDeletedRemotelyUpdatedRecordsWithoutOverwrite() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncDown(MergeMode.LEAVE_IF_CHANGED);
 
         // Delete a few entries locally
         String[] allIds = idToFields.keySet().toArray(new String[0]);
@@ -467,7 +468,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         updateRecordsOnServer(idToFieldsRemotelyUpdated, Constants.ACCOUNT);
 
         // Sync up with leave-if-changed
-        trySyncUp(3, SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncUp(3, MergeMode.LEAVE_IF_CHANGED);
 
         // Check that db still contains those entries
         checkDbStateFlags(Arrays.asList(idsLocallyDeleted), false, false, true, ACCOUNTS_SOUP);
@@ -476,7 +477,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         checkServer(idToFieldsRemotelyUpdated, Constants.ACCOUNT);
 
         // Sync up with overwrite
-        trySyncUp(3, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(3, MergeMode.OVERWRITE);
 
         // Check that db no longer contains deleted records
         checkDbDeleted(ACCOUNTS_SOUP, idsLocallyDeleted, Constants.ID);
@@ -490,8 +491,22 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      */
     @Test
     public void testSyncUpWithLocallyDeletedRemotelyDeletedRecords() throws Exception {
+        trySyncUpWithLocallyDeletedRemotelyDeletedRecords(MergeMode.OVERWRITE);
+    }
+
+    /**
+     * Sync down the test accounts, delete record on server and locally,
+     * sync up with merge mode LEAVE_IF_CHANGED,
+     * check smartstore and server afterwards
+     */
+    @Test
+    public void testSyncUpWithLocallyDeletedRemotelyDeletedRecordsWithoutOverwrite() throws Exception {
+        trySyncUpWithLocallyDeletedRemotelyDeletedRecords(MergeMode.LEAVE_IF_CHANGED);
+    }
+
+    public void trySyncUpWithLocallyDeletedRemotelyDeletedRecords(MergeMode mergeMode) throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.OVERWRITE);
+        trySyncDown(MergeMode.OVERWRITE);
 
         // Delete record locally
         String[] allIds = idToFields.keySet().toArray(new String[0]);
@@ -502,7 +517,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         deleteRecordsByIdOnServer(idToFields.keySet(), Constants.ACCOUNT);
 
         // Sync up
-        trySyncUp(3, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(3, mergeMode);
 
         // Check that db doesn't contain those entries anymore
         checkDbDeleted(ACCOUNTS_SOUP, idsLocallyDeleted, Constants.ID);
@@ -517,7 +532,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
     @Test
     public void testSyncUpWithLocallyUpdatedRemotelyDeletedRecords() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.OVERWRITE);
+        trySyncDown(MergeMode.OVERWRITE);
 
         // Update a few entries locally
         Map<String, Map<String, Object>> idToFieldsLocallyUpdated = makeLocalChanges(idToFields, ACCOUNTS_SOUP);
@@ -530,7 +545,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         String locallyUpdatedRemotelyDeletedName = (String) idToFieldsLocallyUpdated.get(remotelyDeletedId).get(Constants.NAME);
 
         // Sync up
-        trySyncUp(3, SyncState.MergeMode.OVERWRITE);
+        trySyncUp(3, MergeMode.OVERWRITE);
 
         // Getting id / fields of updated records looking up by name
         Map<String, Map<String, Object>> idToFieldsUpdated = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{Constants.NAME, Constants.DESCRIPTION}, Constants.NAME, getNamesFromIdToFields(idToFieldsLocallyUpdated));
@@ -570,7 +585,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
     @Test
     public void testSyncUpWithLocallyUpdatedRemotelyDeletedRecordsWithoutOverwrite() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.OVERWRITE);
+        trySyncDown(MergeMode.OVERWRITE);
 
         // Update a few entries locally
         Map<String, Map<String, Object>> idToFieldsLocallyUpdated = makeLocalChanges(idToFields, ACCOUNTS_SOUP);
@@ -580,7 +595,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         deleteRecordsByIdOnServer(new HashSet<String>(Arrays.asList(remotelyDeletedId)), Constants.ACCOUNT);
 
         // Sync up
-        trySyncUp(3, SyncState.MergeMode.LEAVE_IF_CHANGED);
+        trySyncUp(3, MergeMode.LEAVE_IF_CHANGED);
 
         // Getting id / fields of updated records looking up by name
         Map<String, Map<String, Object>> idToFieldsUpdated = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{Constants.NAME, Constants.DESCRIPTION}, Constants.NAME, getNamesFromIdToFields(idToFieldsLocallyUpdated));
@@ -611,7 +626,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
     @Test
     public void testSyncUpWithCreateAndUpdateFieldList() throws Exception {
         // First sync down
-        trySyncDown(SyncState.MergeMode.OVERWRITE);
+        trySyncDown(MergeMode.OVERWRITE);
 
         // Update a few entries locally
         Map<String, Map<String, Object>> idToFieldsLocallyUpdated = makeLocalChanges(idToFields, ACCOUNTS_SOUP);
@@ -624,7 +639,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
         createAccountsLocally(namesOfCreated);
 
         // Sync up with different create and update field lists
-        trySyncUp(namesOfCreated.length + namesOfUpdated.length, SyncState.MergeMode.OVERWRITE, Arrays.asList(new String[]{Constants.NAME}), Arrays.asList(new String[]{Constants.DESCRIPTION}));
+        trySyncUp(namesOfCreated.length + namesOfUpdated.length, MergeMode.OVERWRITE, Arrays.asList(new String[]{Constants.NAME}), Arrays.asList(new String[]{Constants.DESCRIPTION}));
 
         // Check that db doesn't show created entries as locally created anymore and that they use sfdc id
         Map<String, Map<String, Object>> idToFieldsCreated = getIdToFieldsByName(ACCOUNTS_SOUP, new String[]{Constants.NAME, Constants.DESCRIPTION}, Constants.NAME, namesOfCreated);
@@ -723,7 +738,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      */
     @Test
     public void testSyncUpManyLocallyCreatedRecords() throws Exception {
-        trySyncUpWithLocallyCreatedRecords(500, SyncState.MergeMode.OVERWRITE);
+        trySyncUpWithLocallyCreatedRecords(500, MergeMode.OVERWRITE);
     }
 
     /**
@@ -732,7 +747,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      * @param mergeMode
      * @throws JSONException
      */
-    protected void trySyncUp(int numberChanges, SyncState.MergeMode mergeMode) throws JSONException {
+    protected void trySyncUp(int numberChanges, MergeMode mergeMode) throws JSONException {
         trySyncUp(numberChanges, mergeMode, null, null);
     }
 
@@ -742,7 +757,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      * @param mergeMode
      * @throws JSONException
      */
-    protected void trySyncUp(int numberChanges, SyncState.MergeMode mergeMode, List<String> createFieldlist, List<String> updateFieldlist) throws JSONException {
+    protected void trySyncUp(int numberChanges, MergeMode mergeMode, List<String> createFieldlist, List<String> updateFieldlist) throws JSONException {
         SyncOptions options = SyncOptions.optionsForSyncUp(Arrays.asList(new String[] { Constants.NAME, Constants.DESCRIPTION }), mergeMode);
         trySyncUp(numberChanges, options, createFieldlist, updateFieldlist, null);
     }
@@ -765,7 +780,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      * @throws JSONException
      * @param mergeMode
      */
-    protected long trySyncDown(SyncState.MergeMode mergeMode) throws JSONException {
+    protected long trySyncDown(MergeMode mergeMode) throws JSONException {
         return trySyncDown(mergeMode, null);
     }
 
@@ -774,7 +789,7 @@ public class SyncUpTargetTest extends SyncManagerTestCase {
      * @throws JSONException
      * @param mergeMode
      */
-    protected long trySyncDown(SyncState.MergeMode mergeMode, String syncName) throws JSONException {
+    protected long trySyncDown(MergeMode mergeMode, String syncName) throws JSONException {
         final SyncDownTarget target = new SoqlSyncDownTarget("SELECT Id, Name, Description, LastModifiedDate FROM Account WHERE Id IN " + makeInClause(idToFields.keySet()));
         return trySyncDown(mergeMode, target, ACCOUNTS_SOUP, idToFields.size(), 1, syncName);
 


### PR DESCRIPTION
During collection sync up, we no longer check records last modified date one at a time.
Instead we leverage sobject collection retrieve to get last modified date by batches of up to 2000.

