### PR TITLE
Bugfix: RestClientCallback now properly invoked after login

### DIFF
--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.biometric:biometric:1.2.0-alpha04'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'


### PR DESCRIPTION
Rewrites the implementation of this method:

`ClientManager#getRestClient(Activity, RestClientCallback)`

...to fix the bug here: https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/issues/247.  The old `getRestClient` method is now deprecated with the replacement being a new method with almost the same signature: 

`ClientManager#getRestClient(ComponentActivity, RestClientCallback)`

The key difference between the two is the use of `androidx.activity.ComponentActivity` versus `android.app.Activity` where the former is the base class for all AndroidX-era Activities.  Using `ComponentActivity` gives us access to the calling Activity's `Lifecycle`, which is required for this solution if we are to register callbacks across Activity boundaries.

The deprecated method is altered slightly to route any possible calls to the new method if the provided `Activity` is actually a `ComponentActivity`.  This means that any client code will automagically start using the new method even if they are calling the old one (provided they are actually using an AndroidX Activity).

Strictly speaking, this is not the most accurate solution for the use-case of, "asynchronously get the `RestClient`."  It does, however, stay as close as possible to the original behavior before the bug was introduced.  A better solution would involve much more work and would likely require us to break away from the ClientManager-instance-method approach.  Several avenues were explored, and the one I spent the most time on is documented here just for reference.

### Activity Result APIs

https://developer.android.com/training/basics/intents/result#register

This was the most tantalizing solution as it would gracefully deliver the result of the `LoginActivity` even across process death; however, there are several problems with this approach.

These APIs _enforce_ that each `ActivityResultContract` is registered before the Activity reaches `STARTED` state.  This fails to meet the method contract of `getRestClient` because we cannot enforce that `getRestClient` be called in every Activity's `onCreate()`.

It is _technically_ possible to manually handle registration and unregistration of these `ActivityResultContracts`, but going outside the lifecycle-bound APIs again breaks the original `getRestClient` method contract.  Stable keys are needed for this approach to match which callback should be invoked for which pending `ActivityResult`.  It was determined that creating a solution to transparently generate these keys was out of scope for this bug fix.

On top of all this, the final nail in the coffin was that using the Activity Result APIs _requires_ that we use an Activity to fulfill the login.  Requiring ourselves to use an Activity seemed like not a good idea for future maintainability.

Hence, Activity Result APIs were ruled out.