### PR TITLE
Clean ghost tasks was never removed from active sync list

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/CleanSyncGhostsTask.java
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/CleanSyncGhostsTask.java
@@ -76,14 +76,14 @@ public class CleanSyncGhostsTask extends SyncTask {
                 }
             }
 
+            syncManager.removeFromActiveSyncs(this);
             if (cleanSyncCallback != null) {
                 cleanSyncCallback.onSuccess(localIdSize);
             }
 
         } catch (Exception e) {
-
             MobileSyncLogger.e(TAG, "Exception thrown cleaning resync ghosts", e);
-
+            syncManager.removeFromActiveSyncs(this);
             if (cleanSyncCallback != null) {
                 cleanSyncCallback.onError(e);
             }


### PR DESCRIPTION
As a result, running a sync down after running a sync down would throw the "Sync is running" error.