### PR TITLE
Deprecate getPushNotificationClientId.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/BootConfig.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/BootConfig.java
@@ -355,7 +355,10 @@ public class BootConfig {
 	 * Returns the push notification client ID.
 	 *
 	 * @return Push notification client ID.
+	 *
+	 * @deprecated Will be removed in 11.0 in favor of Firebase google-services.json file.
 	 */
+	@Deprecated
 	public String getPushNotificationClientId() {
 		return pushNotificationClientId;
 	}


### PR DESCRIPTION
This is the only method that is for sure going away.  It seems unlikely that methods in `PushMessages.java` will change signature based on my initial testing. 