### PR TITLE
Removes deprecated WebSettings app cache methods

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClient.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClient.java
@@ -80,11 +80,7 @@ public class SalesforceWebViewClient extends SystemWebViewClient {
     		final String extendedUserAgentString = uaStr + " Hybrid " + (origUserAgent == null ? "" : origUserAgent);
     		webSettings.setUserAgentString(extendedUserAgentString);
 
-    		// Configure HTML5 cache support.
     		webSettings.setDomStorageEnabled(true);
-    		final String cachePath = SalesforceSDKManager.getInstance().getAppContext().getCacheDir().getAbsolutePath();
-    		webSettings.setAppCachePath(cachePath);
-    		webSettings.setAppCacheEnabled(true);
     		webSettings.setAllowFileAccess(true);
     		webSettings.setCacheMode(WebSettings.LOAD_DEFAULT);
         }


### PR DESCRIPTION
[WebView App Cache is gone](https://web.dev/appcache-removal/) and has been disabled on Chromium-based browsers for about a year now.  Now the deprecated methods regarding App Cache are removed in Android 13, and they have been no-ops for a while now.  This simply removes them so that targeting API 33 builds successfully.