### PR TITLE
Faster has soup when soup does not exist

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -472,6 +472,9 @@ public class SmartStore  {
             // Add to soupNameToTableNamesMap
             DBHelper.getInstance(db).cacheTableName(soupName, soupTableName);
 
+			// Add to soupNameToExistMap
+			DBHelper.getInstance(db).cacheHasSoup(soupName, true);
+
             // Add to soupNameToIndexSpecsMap
             DBHelper.getInstance(db).cacheIndexSpecs(soupName, indexSpecsToCache);
         } finally {
@@ -712,7 +715,7 @@ public class SmartStore  {
     public boolean hasSoup(String soupName) {
     	final SQLiteDatabase db = getDatabase();
     	synchronized(db) {
-    		return DBHelper.getInstance(db).getSoupTableName(db, soupName) != null;
+    		return DBHelper.getInstance(db).hasSoup(db, soupName);
     	}
     }
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -61,35 +61,35 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	@Before
 	public void setUp() throws Exception {
 		super.setUp();
-        store.setCaptureExplainQueryPlan(true);
-        Assert.assertFalse("Table for test_soup should not exist", hasTable("TABLE_1"));
-        Assert.assertFalse("Soup test_soup should not exist", store.hasSoup(TEST_SOUP));
-		registerSoup(store, TEST_SOUP, new IndexSpec[] { new IndexSpec("key", Type.string) });
-        Assert.assertEquals("Table for test_soup was expected to be called TABLE_1", "TABLE_1", getSoupTableName(TEST_SOUP));
-        Assert.assertTrue("Table for test_soup should now exist", hasTable("TABLE_1"));
-        Assert.assertTrue("Soup test_soup should now exist", store.hasSoup(TEST_SOUP));
+		store.setCaptureExplainQueryPlan(true);
+		Assert.assertFalse("Table for test_soup should not exist", hasTable("TABLE_1"));
+		Assert.assertFalse("Soup test_soup should not exist", store.hasSoup(TEST_SOUP));
+		registerSoup(store, TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.string)});
+		Assert.assertEquals("Table for test_soup was expected to be called TABLE_1", "TABLE_1", getSoupTableName(TEST_SOUP));
+		Assert.assertTrue("Table for test_soup should now exist", hasTable("TABLE_1"));
+		Assert.assertTrue("Soup test_soup should now exist", store.hasSoup(TEST_SOUP));
 	}
 
 	@After
 	public void tearDown() throws Exception {
-	    super.tearDown();
-    }
+		super.tearDown();
+	}
 
-    @Override
-    protected String getEncryptionKey() {
-        return "test123";
-    }
+	@Override
+	protected String getEncryptionKey() {
+		return "test123";
+	}
 
-    /**
+	/**
 	 * Checking compile options
 	 */
-    @Test
+	@Test
 	public void testCompileOptions() {
 		List<String> compileOptions = store.getCompileOptions();
-        Assert.assertTrue("ENABLE_FTS4 flag not found in compile options", compileOptions.contains("ENABLE_FTS4"));
-        Assert.assertTrue("ENABLE_FTS3_PARENTHESIS flag not found in compile options", compileOptions.contains("ENABLE_FTS3_PARENTHESIS"));
-        Assert.assertTrue("ENABLE_FTS5 flag not found in compile options", compileOptions.contains("ENABLE_FTS5"));
-        Assert.assertTrue("ENABLE_JSON1 flag not found in compile options", compileOptions.contains("ENABLE_JSON1"));
+		Assert.assertTrue("ENABLE_FTS4 flag not found in compile options", compileOptions.contains("ENABLE_FTS4"));
+		Assert.assertTrue("ENABLE_FTS3_PARENTHESIS flag not found in compile options", compileOptions.contains("ENABLE_FTS3_PARENTHESIS"));
+		Assert.assertTrue("ENABLE_FTS5 flag not found in compile options", compileOptions.contains("ENABLE_FTS5"));
+		Assert.assertTrue("ENABLE_JSON1 flag not found in compile options", compileOptions.contains("ENABLE_JSON1"));
 	}
 
 	/**
@@ -124,47 +124,50 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 	/**
 	 * Testing method with paths to top level string/integer/array/map as well as edge cases (null object/null or empty path)
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testProjectTopLevel() throws JSONException {
 		JSONObject json = new JSONObject("{'a':'va', 'b':2, 'c':[0,1,2], 'd': {'d1':'vd1', 'd2':'vd2', 'd3':[1,2], 'd4':{'e':5}}}");
 
 		// Null object
-        Assert.assertNull("Should have been null", SmartStore.project(null, "path"));
-		
+		Assert.assertNull("Should have been null", SmartStore.project(null, "path"));
+
 		// Root
 		JSONTestHelper.assertSameJSON("Should have returned whole object", json, SmartStore.project(json, null));
 		JSONTestHelper.assertSameJSON("Should have returned whole object", json, SmartStore.project(json, ""));
-		
+
 		// Top-level elements
-        Assert.assertEquals("Wrong value for key a", "va", SmartStore.project(json, "a"));
-        Assert.assertEquals("Wrong value for key b", 2, SmartStore.project(json, "b"));
+		Assert.assertEquals("Wrong value for key a", "va", SmartStore.project(json, "a"));
+		Assert.assertEquals("Wrong value for key b", 2, SmartStore.project(json, "b"));
 		JSONTestHelper.assertSameJSON("Wrong value for key c", new JSONArray("[0,1,2]"), SmartStore.project(json, "c"));
 		JSONTestHelper.assertSameJSON("Wrong value for key d", new JSONObject("{'d1':'vd1','d2':'vd2','d3':[1,2],'d4':{'e':5}}"), (JSONObject) SmartStore.project(json, "d"));
 	}
 
 	/**
 	 * Testing method with paths to non-top level string/integer/array/map
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testProjectNested() throws JSONException {
 		JSONObject json = new JSONObject("{'a':'va', 'b':2, 'c':[0,1,2], 'd': {'d1':'vd1', 'd2':'vd2', 'd3':[1,2], 'd4':{'e':5}}}");
-		
+
 		// Nested elements
-        Assert.assertEquals("Wrong value for key d.d1", "vd1", SmartStore.project(json, "d.d1"));
-        Assert.assertEquals("Wrong value for key d.d2", "vd2", SmartStore.project(json, "d.d2"));
+		Assert.assertEquals("Wrong value for key d.d1", "vd1", SmartStore.project(json, "d.d1"));
+		Assert.assertEquals("Wrong value for key d.d2", "vd2", SmartStore.project(json, "d.d2"));
 		JSONTestHelper.assertSameJSON("Wrong value for key d.d3", new JSONArray("[1,2]"), SmartStore.project(json, "d.d3"));
 		JSONTestHelper.assertSameJSON("Wrong value for key d.d4", new JSONObject("{'e':5}"), SmartStore.project(json, "d.d4"));
-        Assert.assertEquals("Wrong value for key d.d4.e", 5, SmartStore.project(json, "d.d4.e"));
+		Assert.assertEquals("Wrong value for key d.d4.e", 5, SmartStore.project(json, "d.d4.e"));
 	}
 
 	/**
 	 * Testing method with path through arrays
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testProjectThroughArrays() throws JSONException {
 		JSONObject json = new JSONObject("{\"a\":\"a1\", \"b\":2, \"c\":[{\"cc\":\"cc1\"}, {\"cc\":2}, {\"cc\":[1,2,3]}, {}, {\"cc\":{\"cc5\":5}}], \"d\":[{\"dd\":[{\"ddd\":\"ddd11\"},{\"ddd\":\"ddd12\"}]}, {\"dd\":[{\"ddd\":\"ddd21\"}]}, {\"dd\":[{\"ddd\":\"ddd31\"},{\"ddd3\":\"ddd32\"}]}]}");
 		JSONTestHelper.assertSameJSON("Wrong value for key c", new JSONArray("[{\"cc\":\"cc1\"}, {\"cc\":2}, {\"cc\":[1,2,3]}, {}, {\"cc\":{\"cc5\":5}}]"), SmartStore.project(json, "c"));
@@ -195,131 +198,132 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	/**
 	 * Check that the meta data table (soup index map) has been created
 	 */
-    @Test
+	@Test
 	public void testMetaDataTableCreated() {
-        Assert.assertTrue("Table soup_index_map not found", hasTable("soup_index_map"));
+		Assert.assertTrue("Table soup_index_map not found", hasTable("soup_index_map"));
 	}
 
 	/**
 	 * Test register/drop soup
 	 */
-    @Test
+	@Test
 	public void testRegisterDropSoup() {
 
 		// Before
-        Assert.assertNull("getSoupTableName should have returned null", getSoupTableName(THIRD_TEST_SOUP));
-        Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
-		
+		Assert.assertNull("getSoupTableName should have returned null", getSoupTableName(THIRD_TEST_SOUP));
+		Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
+
 		// Register
-		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[] { new IndexSpec("key", Type.string), new IndexSpec("value", Type.string) });
+		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.string), new IndexSpec("value", Type.string)});
 		String soupTableName = getSoupTableName(THIRD_TEST_SOUP);
-        Assert.assertEquals("getSoupTableName should have returned TABLE_2", "TABLE_2", soupTableName);
-        Assert.assertTrue("Table for soup third_test_soup does exist", hasTable(soupTableName));
-        Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
+		Assert.assertEquals("getSoupTableName should have returned TABLE_2", "TABLE_2", soupTableName);
+		Assert.assertTrue("Table for soup third_test_soup does exist", hasTable(soupTableName));
+		Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
 
-        // Check soup indexes
-        final IndexSpec[] indexSpecs = store.getSoupIndexSpecs(THIRD_TEST_SOUP);
-        Assert.assertEquals("Wrong path", "key", indexSpecs[0].path);
-        Assert.assertEquals("Wrong type", Type.string, indexSpecs[0].type);
-        Assert.assertEquals("Wrong column name", soupTableName + "_0", indexSpecs[0].columnName);
-        Assert.assertEquals("Wrong path", "value", indexSpecs[1].path);
-        Assert.assertEquals("Wrong type", Type.string, indexSpecs[1].type);
-        Assert.assertEquals("Wrong column name", soupTableName + "_1", indexSpecs[1].columnName);
+		// Check soup indexes
+		final IndexSpec[] indexSpecs = store.getSoupIndexSpecs(THIRD_TEST_SOUP);
+		Assert.assertEquals("Wrong path", "key", indexSpecs[0].path);
+		Assert.assertEquals("Wrong type", Type.string, indexSpecs[0].type);
+		Assert.assertEquals("Wrong column name", soupTableName + "_0", indexSpecs[0].columnName);
+		Assert.assertEquals("Wrong path", "value", indexSpecs[1].path);
+		Assert.assertEquals("Wrong type", Type.string, indexSpecs[1].type);
+		Assert.assertEquals("Wrong column name", soupTableName + "_1", indexSpecs[1].columnName);
 
-        // Check db indexes
-        checkDatabaseIndexes(soupTableName, Arrays.asList(new String[] {
-                "CREATE INDEX " + soupTableName + "_0_idx on " + soupTableName + " ( " + soupTableName + "_0 )",
-                "CREATE INDEX " + soupTableName + "_1_idx on " + soupTableName + " ( " + soupTableName + "_1 )",
-                "CREATE INDEX " + soupTableName + "_created_idx on " + soupTableName + " ( created )",
-                "CREATE INDEX " + soupTableName + "_lastModified_idx on " + soupTableName + " ( lastModified )"
-        }));
+		// Check db indexes
+		checkDatabaseIndexes(soupTableName, Arrays.asList(new String[]{
+				"CREATE INDEX " + soupTableName + "_0_idx on " + soupTableName + " ( " + soupTableName + "_0 )",
+				"CREATE INDEX " + soupTableName + "_1_idx on " + soupTableName + " ( " + soupTableName + "_1 )",
+				"CREATE INDEX " + soupTableName + "_created_idx on " + soupTableName + " ( created )",
+				"CREATE INDEX " + soupTableName + "_lastModified_idx on " + soupTableName + " ( lastModified )"
+		}));
 
 		// Drop
 		store.dropSoup(THIRD_TEST_SOUP);
-		
+
 		// After
-        Assert.assertFalse("Soup third_test_soup should no longer exist", store.hasSoup(THIRD_TEST_SOUP));
-        Assert.assertNull("getSoupTableName should have returned null", getSoupTableName(THIRD_TEST_SOUP));
-        Assert.assertFalse("Table for soup third_test_soup does exist", hasTable(soupTableName));
+		Assert.assertFalse("Soup third_test_soup should no longer exist", store.hasSoup(THIRD_TEST_SOUP));
+		Assert.assertNull("getSoupTableName should have returned null", getSoupTableName(THIRD_TEST_SOUP));
+		Assert.assertFalse("Table for soup third_test_soup does exist", hasTable(soupTableName));
 	}
 
 	/**
 	 * Testing getAllSoupNames: register a new soup and then drop it and call getAllSoupNames before and after
 	 */
-    @Test
+	@Test
 	public void testGetAllSoupNames() {
 
 		// Before
-        Assert.assertEquals("One soup name expected", 1, store.getAllSoupNames().size());
-        Assert.assertTrue(TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(TEST_SOUP));
+		Assert.assertEquals("One soup name expected", 1, store.getAllSoupNames().size());
+		Assert.assertTrue(TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(TEST_SOUP));
 
 		// Register another soup
-		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[] { new IndexSpec("key", Type.string), new IndexSpec("value", Type.string) });
-        Assert.assertEquals("Two soup names expected", 2, store.getAllSoupNames().size());
-        Assert.assertTrue(TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(TEST_SOUP));
-        Assert.assertTrue(THIRD_TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(THIRD_TEST_SOUP));
+		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.string), new IndexSpec("value", Type.string)});
+		Assert.assertEquals("Two soup names expected", 2, store.getAllSoupNames().size());
+		Assert.assertTrue(TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(TEST_SOUP));
+		Assert.assertTrue(THIRD_TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(THIRD_TEST_SOUP));
 
 		// Drop the latest soup
 		store.dropSoup(THIRD_TEST_SOUP);
-        Assert.assertEquals("One soup name expected", 1, store.getAllSoupNames().size());
-        Assert.assertTrue(TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(TEST_SOUP));
+		Assert.assertEquals("One soup name expected", 1, store.getAllSoupNames().size());
+		Assert.assertTrue(TEST_SOUP + " should have been returned by getAllSoupNames", store.getAllSoupNames().contains(TEST_SOUP));
 	}
-	
+
 	/**
 	 * Testing dropAllSoups: register a couple of soups then drop them all
 	 */
-    @Test
+	@Test
 	public void testDropAllSoups() {
 
 		// Register another soup
-        Assert.assertEquals("One soup name expected", 1, store.getAllSoupNames().size());
-		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[] { new IndexSpec("key", Type.string), new IndexSpec("value", Type.string) });
-        Assert.assertEquals("Two soup names expected", 2, store.getAllSoupNames().size());
+		Assert.assertEquals("One soup name expected", 1, store.getAllSoupNames().size());
+		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.string), new IndexSpec("value", Type.string)});
+		Assert.assertEquals("Two soup names expected", 2, store.getAllSoupNames().size());
 
 		// Drop all
 		store.dropAllSoups();
-        Assert.assertEquals("No soup name expected", 0, store.getAllSoupNames().size());
-        Assert.assertFalse("Soup " + THIRD_TEST_SOUP + " should no longer exist", store.hasSoup(THIRD_TEST_SOUP));
-        Assert.assertFalse("Soup " + TEST_SOUP + " should no longer exist", store.hasSoup(TEST_SOUP));
+		Assert.assertEquals("No soup name expected", 0, store.getAllSoupNames().size());
+		Assert.assertFalse("Soup " + THIRD_TEST_SOUP + " should no longer exist", store.hasSoup(THIRD_TEST_SOUP));
+		Assert.assertFalse("Soup " + TEST_SOUP + " should no longer exist", store.hasSoup(TEST_SOUP));
 	}
 
 	/**
 	 * Testing create: create a single element with a single index pointing to a top level attribute
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testCreateOne() throws JSONException {
 		JSONObject soupElt = new JSONObject("{'key':'ka', 'value':'va'}");
 		JSONObject soupEltCreated = store.create(TEST_SOUP, soupElt);
-		
+
 		// Check DB
 		Cursor c = null;
 		try {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, null, null, null);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected one soup element only", 1, c.getCount());
-            Assert.assertEquals("Wrong id", idOf(soupEltCreated), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupEltCreated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Wrong value in index column", "ka", c.getString(c.getColumnIndex(soupTableName + "_0")));
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected one soup element only", 1, c.getCount());
+			Assert.assertEquals("Wrong id", idOf(soupEltCreated), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupEltCreated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Wrong value in index column", "ka", c.getString(c.getColumnIndex(soupTableName + "_0")));
 			assertSameSoupAsDB(soupEltCreated, c, soupTableName, idOf(soupEltCreated));
-            Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")),  c.getLong(c.getColumnIndex("lastModified")));
-		}
-		finally {
+			Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")), c.getLong(c.getColumnIndex("lastModified")));
+		} finally {
 			safeClose(c);
 		}
 	}
 
 	/**
-	 * Testing create: create multiple elements with multiple indices not just pointing to top level attributes 
-	 * @throws JSONException 
+	 * Testing create: create multiple elements with multiple indices not just pointing to top level attributes
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testCreateMultiple() throws JSONException {
-        Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
-		registerSoup(store, OTHER_TEST_SOUP, new IndexSpec[] { new IndexSpec("lastName", Type.string), new IndexSpec("address.city", Type.string) });
-        Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
+		Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
+		registerSoup(store, OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("lastName", Type.string), new IndexSpec("address.city", Type.string)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
 		JSONObject soupElt1 = new JSONObject("{'lastName':'Doe', 'address':{'city':'San Francisco','street':'1 market'}}");
 		JSONObject soupElt2 = new JSONObject("{'lastName':'Jackson', 'address':{'city':'Los Angeles','street':'100 mission'}}");
 		JSONObject soupElt3 = new JSONObject("{'lastName':'Watson', 'address':{'city':'London','street':'50 market'}}");
@@ -331,40 +335,40 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		Cursor c = null;
 		try {
 			String soupTableName = getSoupTableName(OTHER_TEST_SOUP);
-            Assert.assertEquals("Table for other_test_soup was expected to be called TABLE_2", "TABLE_2", soupTableName);
-            Assert.assertTrue("Table for other_test_soup should now exist", hasTable("TABLE_2"));
+			Assert.assertEquals("Table for other_test_soup was expected to be called TABLE_2", "TABLE_2", soupTableName);
+			Assert.assertTrue("Table for other_test_soup should now exist", hasTable("TABLE_2"));
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected three soup elements", 3, c.getCount());
-            Assert.assertEquals("Wrong id", idOf(soupElt1Created), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt1Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Wrong value in index column", "Doe", c.getString(c.getColumnIndex(soupTableName + "_0")));
-            Assert.assertEquals("Wrong value in index column", "San Francisco", c.getString(c.getColumnIndex(soupTableName + "_1")));
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected three soup elements", 3, c.getCount());
+			Assert.assertEquals("Wrong id", idOf(soupElt1Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt1Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Wrong value in index column", "Doe", c.getString(c.getColumnIndex(soupTableName + "_0")));
+			Assert.assertEquals("Wrong value in index column", "San Francisco", c.getString(c.getColumnIndex(soupTableName + "_1")));
 			assertSameSoupAsDB(soupElt1Created, c, soupTableName, idOf(soupElt1Created));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt2Created), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt2Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Wrong value in index column", "Jackson", c.getString(c.getColumnIndex(soupTableName + "_0")));
-            Assert.assertEquals("Wrong value in index column", "Los Angeles", c.getString(c.getColumnIndex(soupTableName + "_1")));
+			Assert.assertEquals("Wrong id", idOf(soupElt2Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt2Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Wrong value in index column", "Jackson", c.getString(c.getColumnIndex(soupTableName + "_0")));
+			Assert.assertEquals("Wrong value in index column", "Los Angeles", c.getString(c.getColumnIndex(soupTableName + "_1")));
 			assertSameSoupAsDB(soupElt2Created, c, soupTableName, idOf(soupElt2Created));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt3Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Wrong value in index column", "Watson", c.getString(c.getColumnIndex(soupTableName + "_0")));
-            Assert.assertEquals("Wrong value in index column", "London", c.getString(c.getColumnIndex(soupTableName + "_1")));
+			Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt3Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Wrong value in index column", "Watson", c.getString(c.getColumnIndex(soupTableName + "_0")));
+			Assert.assertEquals("Wrong value in index column", "London", c.getString(c.getColumnIndex(soupTableName + "_1")));
 			assertSameSoupAsDB(soupElt3Created, c, soupTableName, idOf(soupElt3Created));
-		}
-		finally {
+		} finally {
 			safeClose(c);
 		}
 	}
 
 	/**
 	 * Testing update: create multiple soup elements and update one of them, check them all
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testUpdate() throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
@@ -386,32 +390,32 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		Cursor c = null;
 		try {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
-			String soupTableName = getSoupTableName(TEST_SOUP);		
+			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected three soup elements", 3, c.getCount());
-            Assert.assertEquals("Wrong id", idOf(soupElt1Created), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt1Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")),  c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected three soup elements", 3, c.getCount());
+			Assert.assertEquals("Wrong id", idOf(soupElt1Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt1Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")), c.getLong(c.getColumnIndex("lastModified")));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt2Created), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt2Updated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertTrue("Last modified date should be more recent than created date", c.getLong(c.getColumnIndex("created")) < c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Wrong id", idOf(soupElt2Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt2Updated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertTrue("Last modified date should be more recent than created date", c.getLong(c.getColumnIndex("created")) < c.getLong(c.getColumnIndex("lastModified")));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt3Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")),  c.getLong(c.getColumnIndex("lastModified")));
-		}
-		finally {
+			Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt3Created.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")), c.getLong(c.getColumnIndex("lastModified")));
+		} finally {
 			safeClose(c);
 		}
 	}
-	
+
 	/**
 	 * Testing upsert: upsert multiple soup elements and re-upsert one of them, check them all
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testUpsert() throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
@@ -428,37 +432,37 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt1Upserted, soupElt1Retrieved);
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt2Updated, soupElt2Retrieved);
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt3Upserted, soupElt3Retrieved);
-		
+
 		// Check DB
 		Cursor c = null;
 		try {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
-			String soupTableName = getSoupTableName(TEST_SOUP);			
+			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected three soup elements", 3, c.getCount());
-            Assert.assertEquals("Wrong id", idOf(soupElt1Upserted), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt1Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")),  c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected three soup elements", 3, c.getCount());
+			Assert.assertEquals("Wrong id", idOf(soupElt1Upserted), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt1Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")), c.getLong(c.getColumnIndex("lastModified")));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt2Upserted), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt2Updated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertTrue("Last modified date should be more recent than created date", c.getLong(c.getColumnIndex("created")) < c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Wrong id", idOf(soupElt2Upserted), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt2Updated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertTrue("Last modified date should be more recent than created date", c.getLong(c.getColumnIndex("created")) < c.getLong(c.getColumnIndex("lastModified")));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt3Upserted), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt3Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")),  c.getLong(c.getColumnIndex("lastModified")));
-		}
-		finally {
+			Assert.assertEquals("Wrong id", idOf(soupElt3Upserted), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt3Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")), c.getLong(c.getColumnIndex("lastModified")));
+		} finally {
 			safeClose(c);
 		}
 	}
 
 	/**
 	 * Testing upsert with external id: upsert multiple soup elements and re-upsert one of them, check them all
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testUpsertWithExternalId() throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
@@ -480,44 +484,45 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		Cursor c = null;
 		try {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
-			String soupTableName = getSoupTableName(TEST_SOUP);			
+			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected three soup elements", 3, c.getCount());
-            Assert.assertEquals("Wrong id", idOf(soupElt1Upserted), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt1Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")),  c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected three soup elements", 3, c.getCount());
+			Assert.assertEquals("Wrong id", idOf(soupElt1Upserted), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt1Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")), c.getLong(c.getColumnIndex("lastModified")));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt2Upserted), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt2Updated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertTrue("Last modified date should be more recent than created date", c.getLong(c.getColumnIndex("created")) < c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Wrong id", idOf(soupElt2Upserted), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt2Updated.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertTrue("Last modified date should be more recent than created date", c.getLong(c.getColumnIndex("created")) < c.getLong(c.getColumnIndex("lastModified")));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt3Upserted), c.getLong(c.getColumnIndex("id")));
-            Assert.assertEquals("Wrong created date", soupElt3Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
-            Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")),  c.getLong(c.getColumnIndex("lastModified")));
-		}
-		finally {
+			Assert.assertEquals("Wrong id", idOf(soupElt3Upserted), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong created date", soupElt3Upserted.getLong(SmartStore.SOUP_LAST_MODIFIED_DATE), c.getLong(c.getColumnIndex("lastModified")));
+			Assert.assertEquals("Created date and last modified date should be equal", c.getLong(c.getColumnIndex("created")), c.getLong(c.getColumnIndex("lastModified")));
+		} finally {
 			safeClose(c);
 		}
 	}
 
 	/**
 	 * Testing upsert passing a non-indexed path for the external id (should fail)
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testUpsertWithNonIndexedExternalId() throws JSONException {
 		JSONObject soupElt = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		try {
 			store.upsert(TEST_SOUP, soupElt, "value");
-            Assert.fail("Exception was expected: value is not an indexed field");
+			Assert.fail("Exception was expected: value is not an indexed field");
 		} catch (RuntimeException e) {
-            Assert.assertTrue("Wrong exception", e.getMessage().contains("does not have an index"));
+			Assert.assertTrue("Wrong exception", e.getMessage().contains("does not have an index"));
 		}
 	}
 
 	/**
 	 * Testing upsert by user-defined external id without value (should fail)
+	 *
 	 * @throws JSONException
 	 */
 	@Test
@@ -535,9 +540,10 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 	/**
 	 * Testing upsert with an external id that is not unique in the soup
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testUpsertWithNonUniqueExternalId() throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka', 'value':'va2'}");
@@ -550,17 +556,18 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt2Upserted, soupElt2Retrieved);
 		try {
 			store.upsert(TEST_SOUP, soupElt3, "key");
-            Assert.fail("Exception was expected: key is not unique in the soup");
+			Assert.fail("Exception was expected: key is not unique in the soup");
 		} catch (RuntimeException e) {
-            Assert.assertTrue("Wrong exception", e.getMessage().contains("are more than one soup elements"));
+			Assert.assertTrue("Wrong exception", e.getMessage().contains("are more than one soup elements"));
 		}
 	}
-	
+
 	/**
 	 * Testing retrieve: create multiple soup elements and retrieves them back
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testRetrieve() throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
@@ -578,9 +585,10 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 	/**
 	 * Testing delete: create soup elements, delete element by id and check database directly that it is in fact gone
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testDelete() throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
@@ -593,20 +601,20 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		JSONArray soupElt2Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt2Created));
 		JSONObject soupElt3Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt3Created)).getJSONObject(0);
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt1Created, soupElt1Retrieved);
-        Assert.assertEquals("Should be empty", 0, soupElt2Retrieved.length());
+		Assert.assertEquals("Should be empty", 0, soupElt2Retrieved.length());
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt3Created, soupElt3Retrieved);
-		
+
 		// Check DB
 		Cursor c = null;
 		try {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected two soup elements", 2, c.getCount());
-            Assert.assertEquals("Wrong id", idOf(soupElt1Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected two soup elements", 2, c.getCount());
+			Assert.assertEquals("Wrong id", idOf(soupElt1Created), c.getLong(c.getColumnIndex("id")));
 			c.moveToNext();
-            Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
 		} finally {
 			safeClose(c);
 		}
@@ -614,19 +622,21 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 	/**
 	 * Testing delete: create soup elements, delete by query and check database directly that deleted entries are in fact gone
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testDeleteByQuery() throws JSONException {
-        tryDeleteByQuery(null, null);
+		tryDeleteByQuery(null, null);
 	}
 
 	/**
-     * Testing delete: create soup elements, delete by query and check database directly that deleted entries are in fact gone
-     * Populate idsDeleted and idsNotDeleted if not null
+	 * Testing delete: create soup elements, delete by query and check database directly that deleted entries are in fact gone
+	 * Populate idsDeleted and idsNotDeleted if not null
+	 *
 	 * @param idsDeleted
-     * @param idsNotDeleted
-     */
+	 * @param idsNotDeleted
+	 */
 	protected void tryDeleteByQuery(List<Long> idsDeleted, List<Long> idsNotDeleted) throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
@@ -642,8 +652,8 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		JSONArray soupElt1Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt1Created));
 		JSONArray soupElt2Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt2Created));
 		JSONObject soupElt3Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt3Created)).getJSONObject(0);
-        Assert.assertEquals("Should be empty", 0, soupElt1Retrieved.length());
-        Assert.assertEquals("Should be empty", 0, soupElt2Retrieved.length());
+		Assert.assertEquals("Should be empty", 0, soupElt1Retrieved.length());
+		Assert.assertEquals("Should be empty", 0, soupElt2Retrieved.length());
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt3Created, soupElt3Retrieved);
 
 		// Check DB
@@ -652,30 +662,31 @@ public class SmartStoreTest extends SmartStoreTestCase {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected one soup elements", 1, c.getCount());
-            Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected one soup elements", 1, c.getCount());
+			Assert.assertEquals("Wrong id", idOf(soupElt3Created), c.getLong(c.getColumnIndex("id")));
 		} finally {
 			safeClose(c);
 		}
 
-        // Populate idsDeleted
-        if (idsDeleted != null) {
-            idsDeleted.add(id1);
-            idsDeleted.add(id2);
-        }
+		// Populate idsDeleted
+		if (idsDeleted != null) {
+			idsDeleted.add(id1);
+			idsDeleted.add(id2);
+		}
 
-        // Populate idsNotDeleted
-        if (idsNotDeleted != null) {
-            idsNotDeleted.add(id3);
-        }
+		// Populate idsNotDeleted
+		if (idsNotDeleted != null) {
+			idsNotDeleted.add(id3);
+		}
 	}
 
 	/**
 	 * Testing clear soup: create soup elements, clear soup and check database directly that there are in fact gone
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testClearSoup() throws JSONException {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
@@ -687,9 +698,9 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		JSONArray soupElt1Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt1Created));
 		JSONArray soupElt2Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt2Created));
 		JSONArray soupElt3Retrieved = store.retrieve(TEST_SOUP, idOf(soupElt3Created));
-        Assert.assertEquals("Should be empty", 0, soupElt1Retrieved.length());
-        Assert.assertEquals("Should be empty", 0, soupElt2Retrieved.length());
-        Assert.assertEquals("Should be empty", 0, soupElt3Retrieved.length());
+		Assert.assertEquals("Should be empty", 0, soupElt1Retrieved.length());
+		Assert.assertEquals("Should be empty", 0, soupElt2Retrieved.length());
+		Assert.assertEquals("Should be empty", 0, soupElt3Retrieved.length());
 
 		// Check DB
 		Cursor c = null;
@@ -697,42 +708,45 @@ public class SmartStoreTest extends SmartStoreTestCase {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
-            Assert.assertFalse("Expected no soup element", c.moveToFirst());
+			Assert.assertFalse("Expected no soup element", c.moveToFirst());
 		} finally {
 			safeClose(c);
 		}
 	}
-	
+
 	/**
 	 * Test query when looking for all elements when soup has string index
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testAllQueryWithStringIndex() throws JSONException {
-        tryAllQuery(Type.string);
-    }
+		tryAllQuery(Type.string);
+	}
 
-    /**
-     * Test query when looking for all elements when soup has json1 index
-     * @throws JSONException
-     */
-    @Test
-    public void testAllQueryWithJSON1Index() throws JSONException {
-        tryAllQuery(Type.json1);
-    }
+	/**
+	 * Test query when looking for all elements when soup has json1 index
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testAllQueryWithJSON1Index() throws JSONException {
+		tryAllQuery(Type.json1);
+	}
 
-    /**
-     * Test query when looking for all elements
-     * @throws JSONException
-     */
-    public void tryAllQuery(Type type) throws JSONException {
+	/**
+	 * Test query when looking for all elements
+	 *
+	 * @throws JSONException
+	 */
+	public void tryAllQuery(Type type) throws JSONException {
 
-        // Before
-        Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
+		// Before
+		Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
 
-        // Register
-        store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[] {new IndexSpec("key", type)});
-        Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
+		// Register
+		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1', 'otherValue':'ova1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2', 'otherValue':'ova2'}");
 		JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3', 'otherValue':'ova3'}");
@@ -742,136 +756,142 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 		// Query all - small page
 		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, "key", Order.ascending, 2),
-                0, false, "SCAN", soupElt1Created, soupElt2Created);
+				QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, "key", Order.ascending, 2),
+				0, false, "SCAN", soupElt1Created, soupElt2Created);
 
 		// Query all - next small page
 		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, "key", Order.ascending, 2),
-                1, false, "SCAN", soupElt3Created);
+				QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, "key", Order.ascending, 2),
+				1, false, "SCAN", soupElt3Created);
 
 		// Query all - large page
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, "key", Order.ascending, 10),
-                0, false, "SCAN", soupElt1Created, soupElt2Created, soupElt3Created);
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
+				QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, "key", Order.ascending, 10),
+				0, false, "SCAN", soupElt1Created, soupElt2Created, soupElt3Created);
 
 		// Query all with select paths
 		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, new String[]{"key"}, "key", Order.ascending, 10),
-                0, type != Type.json1, "SCAN", new JSONArray("['ka1']"),  new JSONArray("['ka2']"),  new JSONArray("['ka3']"));
+				QuerySpec.buildAllQuerySpec(OTHER_TEST_SOUP, new String[]{"key"}, "key", Order.ascending, 10),
+				0, type != Type.json1, "SCAN", new JSONArray("['ka1']"), new JSONArray("['ka2']"), new JSONArray("['ka3']"));
 	}
-	
+
 	/**
 	 * Test query when looking for a specific element with a string index
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testExactQueryWithStringIndex() throws JSONException {
-        tryExactQuery(Type.string);
+		tryExactQuery(Type.string);
 	}
 
-    /**
-     * Test query when looking for a specific element with a json1 index
-     * @throws JSONException
-     */
-    @Test
-    public void testExactQueryWithJSON1Index() throws JSONException {
-        tryExactQuery(Type.json1);
-    }
+	/**
+	 * Test query when looking for a specific element with a json1 index
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testExactQueryWithJSON1Index() throws JSONException {
+		tryExactQuery(Type.json1);
+	}
 
-    private void tryExactQuery(Type type) throws JSONException {
+	private void tryExactQuery(Type type) throws JSONException {
 
-        // Before
-        Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
+		// Before
+		Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
 
-        // Register
-        store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[] {new IndexSpec("key", type)});
-        Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
-        JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1', 'otherValue':'ova1'}");
-        JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2', 'otherValue':'ova2'}");
-        JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3', 'otherValue':'ova3'}");
-        store.create(OTHER_TEST_SOUP, soupElt1);
-        JSONObject soupElt2Created= store.create(OTHER_TEST_SOUP, soupElt2);
-        store.create(OTHER_TEST_SOUP, soupElt3);
+		// Register
+		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
+		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1', 'otherValue':'ova1'}");
+		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2', 'otherValue':'ova2'}");
+		JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3', 'otherValue':'ova3'}");
+		store.create(OTHER_TEST_SOUP, soupElt1);
+		JSONObject soupElt2Created = store.create(OTHER_TEST_SOUP, soupElt2);
+		store.create(OTHER_TEST_SOUP, soupElt3);
 
-        // Exact match
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildExactQuerySpec(OTHER_TEST_SOUP, "key", "ka2", null, null, 10),
-                0, false, "SEARCH", soupElt2Created);
-    }
+		// Exact match
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
+				QuerySpec.buildExactQuerySpec(OTHER_TEST_SOUP, "key", "ka2", null, null, 10),
+				0, false, "SEARCH", soupElt2Created);
+	}
 
-    /**
-     * Query test looking for a range of elements (with ascending or descending ordering) with a string index
-     * @throws JSONException
-     */
-    @Test
-    public void testRangeQueryWithStringIndex() throws JSONException {
-        tryRangeQuery(Type.string);
-    }
+	/**
+	 * Query test looking for a range of elements (with ascending or descending ordering) with a string index
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testRangeQueryWithStringIndex() throws JSONException {
+		tryRangeQuery(Type.string);
+	}
 
 	/**
 	 * Query test looking for a range of elements (with ascending or descending ordering) with a json1 index
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
-    public void testRangeQueryWithJSON1Index() throws JSONException {
-        tryRangeQuery(Type.json1);
-    }
+	@Test
+	public void testRangeQueryWithJSON1Index() throws JSONException {
+		tryRangeQuery(Type.json1);
+	}
 
 	private void tryRangeQuery(Type type) throws JSONException {
 
-        // Before
-        Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
+		// Before
+		Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
 
-        // Register
-        store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[] {new IndexSpec("key", type)});
-        Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
-        JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1', 'otherValue':'ova1'}");
+		// Register
+		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
+		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1', 'otherValue':'ova1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2', 'otherValue':'ova2'}");
 		JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3', 'otherValue':'ova3'}");
-		
+
 		store.create(OTHER_TEST_SOUP, soupElt1);
 		JSONObject soupElt2Created = store.create(OTHER_TEST_SOUP, soupElt2);
 		JSONObject soupElt3Created = store.create(OTHER_TEST_SOUP, soupElt3);
 
 		// Range query
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildRangeQuerySpec(OTHER_TEST_SOUP, "key", "ka2", "ka3", "key", Order.ascending, 10),
-                0, false, "SEARCH", soupElt2Created, soupElt3Created);
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
+				QuerySpec.buildRangeQuerySpec(OTHER_TEST_SOUP, "key", "ka2", "ka3", "key", Order.ascending, 10),
+				0, false, "SEARCH", soupElt2Created, soupElt3Created);
 
 		// Range query - descending order
 		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildRangeQuerySpec(OTHER_TEST_SOUP, "key", "ka2", "ka3", "key", Order.descending, 10),
-                0, false, "SEARCH", soupElt3Created, soupElt2Created);
+				QuerySpec.buildRangeQuerySpec(OTHER_TEST_SOUP, "key", "ka2", "ka3", "key", Order.descending, 10),
+				0, false, "SEARCH", soupElt3Created, soupElt2Created);
 
 		// Range query with select paths
 		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildRangeQuerySpec(OTHER_TEST_SOUP, new String[]{"key"}, "key", "ka2", "ka3", "key", Order.descending, 10),
-                0, type != Type.json1, "SEARCH", new JSONArray("['ka3']"), new JSONArray("['ka2']"));
+				QuerySpec.buildRangeQuerySpec(OTHER_TEST_SOUP, new String[]{"key"}, "key", "ka2", "ka3", "key", Order.descending, 10),
+				0, type != Type.json1, "SEARCH", new JSONArray("['ka3']"), new JSONArray("['ka2']"));
 	}
 
 	/**
 	 * Query test looking using like (with ascending or descending ordering) and a string index
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
-    public void testLikeQueryWithStringIndex() throws JSONException {
-        tryLikeQuery(Type.string);
-    }
+	@Test
+	public void testLikeQueryWithStringIndex() throws JSONException {
+		tryLikeQuery(Type.string);
+	}
 
-    /**
-     * Query test looking using like (with ascending or descending ordering) and a json1 index
-     * @throws JSONException
-     */
-    @Test
-    public void testLikeQueryWithJSON1Index() throws JSONException {
-        tryLikeQuery(Type.json1);
-    }
+	/**
+	 * Query test looking using like (with ascending or descending ordering) and a json1 index
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testLikeQueryWithJSON1Index() throws JSONException {
+		tryLikeQuery(Type.json1);
+	}
 
 	private void tryLikeQuery(Type type) throws JSONException {
-        Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
-        store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[] {new IndexSpec("key", type)});
-        Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
+		Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
+		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
 		JSONObject soupElt1 = new JSONObject("{'key':'abcd', 'value':'va1', 'otherValue':'ova1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'bbcd', 'value':'va2', 'otherValue':'ova2'}");
 		JSONObject soupElt3 = new JSONObject("{'key':'abcc', 'value':'va3', 'otherValue':'ova3'}");
@@ -881,32 +901,33 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		JSONObject soupElt3Created = store.create(OTHER_TEST_SOUP, soupElt3);
 		store.create(OTHER_TEST_SOUP, soupElt4);
 
-        // Like query (starts with)
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "abc%", "key", Order.ascending, 10), 0, false, "SCAN", soupElt3Created, soupElt1Created);
+		// Like query (starts with)
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "abc%", "key", Order.ascending, 10), 0, false, "SCAN", soupElt3Created, soupElt1Created);
 
-        // Like query (ends with)
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bcd", "key", Order.ascending, 10), 0, false, "SCAN", soupElt1Created, soupElt2Created);
+		// Like query (ends with)
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bcd", "key", Order.ascending, 10), 0, false, "SCAN", soupElt1Created, soupElt2Created);
 
-        // Like query (starts with) - descending order
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "abc%", "key", Order.descending, 10), 0, false, "SCAN", soupElt1Created, soupElt3Created);
+		// Like query (starts with) - descending order
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "abc%", "key", Order.descending, 10), 0, false, "SCAN", soupElt1Created, soupElt3Created);
 
-        // Like query (ends with) - descending order
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bcd", "key", Order.descending, 10), 0, false, "SCAN", soupElt2Created, soupElt1Created);
+		// Like query (ends with) - descending order
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bcd", "key", Order.descending, 10), 0, false, "SCAN", soupElt2Created, soupElt1Created);
 
-        // Like query (contains)
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bc%", "key", Order.ascending, 10), 0, false, "SCAN", soupElt3Created, soupElt1Created, soupElt2Created);
+		// Like query (contains)
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bc%", "key", Order.ascending, 10), 0, false, "SCAN", soupElt3Created, soupElt1Created, soupElt2Created);
 
-        // Like query (contains) - descending order
-        runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bc%", "key", Order.descending, 10), 0, false, "SCAN", soupElt2Created, soupElt1Created, soupElt3Created);
+		// Like query (contains) - descending order
+		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP, QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, "key", "%bc%", "key", Order.descending, 10), 0, false, "SCAN", soupElt2Created, soupElt1Created, soupElt3Created);
 
 		// Like query (contains) with select paths
 		runQueryCheckResultsAndExplainPlan(OTHER_TEST_SOUP,
-                QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, new String[] {"key"}, "key", "%bc%", "key", Order.descending, 10), 0, type != Type.json1, "SCAN",
+				QuerySpec.buildLikeQuerySpec(OTHER_TEST_SOUP, new String[]{"key"}, "key", "%bc%", "key", Order.descending, 10), 0, type != Type.json1, "SCAN",
 				new JSONArray("['bbcd']"), new JSONArray("['abcd']"), new JSONArray("['abcc']"));
 	}
 
 	/**
 	 * Test query against soup with special characters when soup has string index
+	 *
 	 * @throws JSONException
 	 */
 	@Test
@@ -916,6 +937,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 	/**
 	 * Test query against soup with special characters when soup has json1 index
+	 *
 	 * @throws JSONException
 	 */
 	@Test
@@ -928,11 +950,11 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
 
 		// Register
-		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[] {new IndexSpec("key", type), new IndexSpec("value", type)});
+		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type), new IndexSpec("value", type)});
 		Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
 
 		StringBuffer value = new StringBuffer();
-		for (int i=1; i<1000; i++) {
+		for (int i = 1; i < 1000; i++) {
 			value.append(new Character((char) i));
 		}
 		String valueForAbcd = "abcd" + value;
@@ -956,28 +978,28 @@ public class SmartStoreTest extends SmartStoreTestCase {
 				new JSONArray(Collections.singletonList(valueForAbcd)), new JSONArray(Collections.singletonList(valueForDefg)));
 	}
 
-    protected void runQueryCheckResultsAndExplainPlan(String soupName, QuerySpec querySpec, int page, boolean covering, String expectedDbOperation, JSONObject... expectedResults) throws JSONException {
+	protected void runQueryCheckResultsAndExplainPlan(String soupName, QuerySpec querySpec, int page, boolean covering, String expectedDbOperation, JSONObject... expectedResults) throws JSONException {
 
-        // Run query
-        JSONArray result = store.query(querySpec, page);
-
-        // Check results
-        Assert.assertEquals("Wrong number of results", expectedResults.length, result.length());
-        for (int i=0; i<expectedResults.length; i++) {
-            JSONTestHelper.assertSameJSON("Wrong result for query", expectedResults[i], result.getJSONObject(i));
-        }
-
-        // Check explain plan and make sure index was used
-        checkExplainQueryPlan(soupName, 0, covering, expectedDbOperation);
-    }
-
-	private void runQueryCheckResultsAndExplainPlan(String soupName, QuerySpec querySpec, int page, boolean covering, String expectedDbOperation, JSONArray... expectedRows) throws JSONException {
-
-        // Run query
+		// Run query
 		JSONArray result = store.query(querySpec, page);
 
 		// Check results
-        Assert.assertEquals("Wrong number of rows", expectedRows.length, result.length());
+		Assert.assertEquals("Wrong number of results", expectedResults.length, result.length());
+		for (int i = 0; i < expectedResults.length; i++) {
+			JSONTestHelper.assertSameJSON("Wrong result for query", expectedResults[i], result.getJSONObject(i));
+		}
+
+		// Check explain plan and make sure index was used
+		checkExplainQueryPlan(soupName, 0, covering, expectedDbOperation);
+	}
+
+	private void runQueryCheckResultsAndExplainPlan(String soupName, QuerySpec querySpec, int page, boolean covering, String expectedDbOperation, JSONArray... expectedRows) throws JSONException {
+
+		// Run query
+		JSONArray result = store.query(querySpec, page);
+
+		// Check results
+		Assert.assertEquals("Wrong number of rows", expectedRows.length, result.length());
 		for (int i = 0; i < expectedRows.length; i++) {
 			JSONTestHelper.assertSameJSON("Wrong result for query", expectedRows[i], result.getJSONArray(i));
 		}
@@ -990,12 +1012,13 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 	/**
 	 * Test smart sql returning entire soup elements (i.e. select {soup:_soup} from {soup})
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testSelectUnderscoreSoup() throws JSONException {
 
-	    // Create soup elements
+		// Create soup elements
 		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
 		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
 		JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3'}");
@@ -1007,16 +1030,17 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		final String smartSql = "SELECT {" + TEST_SOUP + ":_soup} FROM {" + TEST_SOUP + "} ORDER BY {" + TEST_SOUP + ":key}";
 		final QuerySpec querySpec = QuerySpec.buildSmartQuerySpec(smartSql, 25);
 		final JSONArray result = store.query(querySpec, 0);
-        Assert.assertNotNull("Result should not be null", result);
-        Assert.assertEquals("Four results expected", 4, result.length());
-		JSONTestHelper.assertSameJSON("Wrong result for query - row 0", new JSONArray(new JSONObject[] { soupElt1Created}), result.get(0));
-        JSONTestHelper.assertSameJSON("Wrong result for query - row 1", new JSONArray(new JSONObject[] { soupElt2Created}), result.get(1));
-        JSONTestHelper.assertSameJSON("Wrong result for query - row 2", new JSONArray(new JSONObject[] { soupElt3Created}), result.get(2));
-        JSONTestHelper.assertSameJSON("Wrong result for query - row 3", new JSONArray(new JSONObject[] { soupElt4Created}), result.get(3));
+		Assert.assertNotNull("Result should not be null", result);
+		Assert.assertEquals("Four results expected", 4, result.length());
+		JSONTestHelper.assertSameJSON("Wrong result for query - row 0", new JSONArray(new JSONObject[]{soupElt1Created}), result.get(0));
+		JSONTestHelper.assertSameJSON("Wrong result for query - row 1", new JSONArray(new JSONObject[]{soupElt2Created}), result.get(1));
+		JSONTestHelper.assertSameJSON("Wrong result for query - row 2", new JSONArray(new JSONObject[]{soupElt3Created}), result.get(2));
+		JSONTestHelper.assertSameJSON("Wrong result for query - row 3", new JSONArray(new JSONObject[]{soupElt4Created}), result.get(3));
 	}
 
 	/**
 	 * Test smart sql returning entire soup elements from multiple soups
+	 *
 	 * @throws JSONException
 	 */
 	@Test
@@ -1025,7 +1049,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		JSONObject soupElt1 = new JSONObject("{'key':'ka', 'value':'va'}");
 		JSONObject soupElt1Created = store.create(TEST_SOUP, soupElt1);
 
-		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[] {new IndexSpec("key", Type.string)});
+		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.string)});
 		JSONObject soupElt2 = new JSONObject("{'key':'abcd', 'value':'va1', 'otherValue':'ova1'}");
 		JSONObject soupElt2Created = store.create(OTHER_TEST_SOUP, soupElt2);
 
@@ -1040,19 +1064,21 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	}
 
 	/**
-	 *  Test smart sql select with null value in string indexed field
-	 *  @throws JSONException
+	 * Test smart sql select with null value in string indexed field
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testSelectWithNullInStringIndexedField() throws JSONException {
 		trySelectWithNullInIndexedField(Type.string);
 	}
 
 	/**
-	 *  Test smart sql select with null value in json1 indexed field
-	 *  @throws JSONException
+	 * Test smart sql select with null value in json1 indexed field
+	 *
+	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testSelectWithNullInJSON1IndexedField() throws JSONException {
 		trySelectWithNullInIndexedField(Type.json1);
 	}
@@ -1060,11 +1086,11 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	private void trySelectWithNullInIndexedField(Type type) throws JSONException {
 
 		// Before
-        Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
+		Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
 
 		// Register
-		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[] { new IndexSpec("key", type), new IndexSpec("value", type) });
-        Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
+		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type), new IndexSpec("value", type)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
 
 		// Upsert
 		JSONObject soupElt1 = new JSONObject("{'key':'ka', 'value':null}");
@@ -1076,44 +1102,46 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		final JSONArray result = store.query(querySpec, 0);
 
 		// Check
-        Assert.assertNotNull("Result should not be null", result);
-        Assert.assertEquals("One result expected", 1, result.length());
+		Assert.assertNotNull("Result should not be null", result);
+		Assert.assertEquals("One result expected", 1, result.length());
 		JSONTestHelper.assertSameJSON("Wrong result for query", new JSONArray("[[null, 'ka']]"), result);
 	}
 
 	/**
 	 * Test upsert soup element with null value in string indexed field
-	 * @throws JSONException 
+	 *
+	 * @throws JSONException
 	 */
-    @Test
-    public void testUpsertWithNullInStringIndexedField() throws JSONException {
-        tryUpsertWithNullInIndexedField(Type.string);
-    }
+	@Test
+	public void testUpsertWithNullInStringIndexedField() throws JSONException {
+		tryUpsertWithNullInIndexedField(Type.string);
+	}
 
-    /**
-     * Test upsert soup element with null value in json1 indexed field
-     * @throws JSONException
-     */
-    @Test
-    public void testUpsertWithNullInJSON1IndexedField() throws JSONException {
-        tryUpsertWithNullInIndexedField(Type.json1);
-    }
+	/**
+	 * Test upsert soup element with null value in json1 indexed field
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testUpsertWithNullInJSON1IndexedField() throws JSONException {
+		tryUpsertWithNullInIndexedField(Type.json1);
+	}
 
 	private void tryUpsertWithNullInIndexedField(Type type) throws JSONException {
 
 		// Before
-        Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
+		Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
 
 		// Register
-		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[] { new IndexSpec("key", type), new IndexSpec("value", type) });
-        Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
+		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type), new IndexSpec("value", type)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
 
 		// Upsert
 		JSONObject soupElt1 = new JSONObject("{'key':'ka', 'value':null}");
 		JSONObject soupElt1Upserted = store.upsert(THIRD_TEST_SOUP, soupElt1);
-		
+
 		// Check
-		JSONObject soupElt1Retrieved = store.retrieve(THIRD_TEST_SOUP, idOf(soupElt1Upserted)).getJSONObject(0);		
+		JSONObject soupElt1Retrieved = store.retrieve(THIRD_TEST_SOUP, idOf(soupElt1Upserted)).getJSONObject(0);
 		JSONTestHelper.assertSameJSON("Retrieve mismatch", soupElt1Upserted, soupElt1Retrieved);
 	}
 
@@ -1122,94 +1150,94 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	 *
 	 * @throws JSONException
 	 */
-    @Test
-    public void testAggregateQueryOnFloatingIndexedField() throws JSONException {
-        tryAggregateQueryOnIndexedField(Type.floating);
-    }
+	@Test
+	public void testAggregateQueryOnFloatingIndexedField() throws JSONException {
+		tryAggregateQueryOnIndexedField(Type.floating);
+	}
 
-    /**
-     * Test to verify an aggregate query on floating point values indexed as JSON1.
-     *
-     * @throws JSONException
-     */
-    @Test
-    public void testAggregateQueryOnJSON1IndexedField() throws JSONException {
-        tryAggregateQueryOnIndexedField(Type.json1);
-    }
+	/**
+	 * Test to verify an aggregate query on floating point values indexed as JSON1.
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testAggregateQueryOnJSON1IndexedField() throws JSONException {
+		tryAggregateQueryOnIndexedField(Type.json1);
+	}
 
 	private void tryAggregateQueryOnIndexedField(Type type) throws JSONException {
 		final JSONObject soupElt1 = new JSONObject("{'amount':10.2}");
 		final JSONObject soupElt2 = new JSONObject("{'amount':9.9}");
-		final IndexSpec[] indexSpecs = { new IndexSpec("amount", type) };
+		final IndexSpec[] indexSpecs = {new IndexSpec("amount", type)};
 		registerSoup(store, FOURTH_TEST_SOUP, indexSpecs);
-        Assert.assertTrue("Soup " + FOURTH_TEST_SOUP + " should have been created", store.hasSoup(FOURTH_TEST_SOUP));
+		Assert.assertTrue("Soup " + FOURTH_TEST_SOUP + " should have been created", store.hasSoup(FOURTH_TEST_SOUP));
 		store.upsert(FOURTH_TEST_SOUP, soupElt1);
 		store.upsert(FOURTH_TEST_SOUP, soupElt2);
 		final String smartSql = "SELECT SUM({" + FOURTH_TEST_SOUP + ":amount}) FROM {" + FOURTH_TEST_SOUP + "}";
 		final QuerySpec querySpec = QuerySpec.buildSmartQuerySpec(smartSql, 1);
 		final JSONArray result = store.query(querySpec, 0);
-        Assert.assertNotNull("Result should not be null", result);
-        Assert.assertEquals("One result expected", 1, result.length());
-        Assert.assertEquals("Incorrect result received", 20.1, result.getJSONArray(0).getDouble(0), 0);
+		Assert.assertNotNull("Result should not be null", result);
+		Assert.assertEquals("One result expected", 1, result.length());
+		Assert.assertEquals("Incorrect result received", 20.1, result.getJSONArray(0).getDouble(0), 0);
 		store.dropSoup(FOURTH_TEST_SOUP);
-        Assert.assertFalse("Soup " + FOURTH_TEST_SOUP + " should have been deleted", store.hasSoup(FOURTH_TEST_SOUP));
+		Assert.assertFalse("Soup " + FOURTH_TEST_SOUP + " should have been deleted", store.hasSoup(FOURTH_TEST_SOUP));
 	}
 
-    /**
-     * Test to verify an count query for a query with group by when the soup uses string indexes.
-     *
-     * @throws JSONException
-     */
-    @Test
-    public void testCountQueryWithGroupByUsingStringIndexes() throws JSONException {
-        tryCountQueryWithGroupBy(Type.string);
-    }
+	/**
+	 * Test to verify an count query for a query with group by when the soup uses string indexes.
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testCountQueryWithGroupByUsingStringIndexes() throws JSONException {
+		tryCountQueryWithGroupBy(Type.string);
+	}
 
-    /**
-     * Test to verify an count query for a query with group by when the soup uses json1 indexes.
-     *
-     * @throws JSONException
-     */
-    @Test
-    public void testCountQueryWithGroupByUsingJSON1Indexes() throws JSONException {
-        tryCountQueryWithGroupBy(Type.json1);
-    }
+	/**
+	 * Test to verify an count query for a query with group by when the soup uses json1 indexes.
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testCountQueryWithGroupByUsingJSON1Indexes() throws JSONException {
+		tryCountQueryWithGroupBy(Type.json1);
+	}
 
-    private void tryCountQueryWithGroupBy(Type type) throws JSONException {
+	private void tryCountQueryWithGroupBy(Type type) throws JSONException {
 
-        // Before
-        Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
+		// Before
+		Assert.assertFalse("Soup third_test_soup should not exist", store.hasSoup(THIRD_TEST_SOUP));
 
-        // Register
-        registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[] { new IndexSpec("key", type), new IndexSpec("value", type) });
-        Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
-        JSONObject soupElt1 = new JSONObject("{'key':'a', 'value':'va1'}");
-        JSONObject soupElt2 = new JSONObject("{'key':'b', 'value':'va1'}");
-        JSONObject soupElt3 = new JSONObject("{'key':'c', 'value':'va2'}");
-        JSONObject soupElt4 = new JSONObject("{'key':'d', 'value':'va3'}");
-        JSONObject soupElt5 = new JSONObject("{'key':'e', 'value':'va3'}");
-        store.create(THIRD_TEST_SOUP, soupElt1);
-        store.create(THIRD_TEST_SOUP, soupElt2);
-        store.create(THIRD_TEST_SOUP, soupElt3);
+		// Register
+		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", type), new IndexSpec("value", type)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(THIRD_TEST_SOUP));
+		JSONObject soupElt1 = new JSONObject("{'key':'a', 'value':'va1'}");
+		JSONObject soupElt2 = new JSONObject("{'key':'b', 'value':'va1'}");
+		JSONObject soupElt3 = new JSONObject("{'key':'c', 'value':'va2'}");
+		JSONObject soupElt4 = new JSONObject("{'key':'d', 'value':'va3'}");
+		JSONObject soupElt5 = new JSONObject("{'key':'e', 'value':'va3'}");
+		store.create(THIRD_TEST_SOUP, soupElt1);
+		store.create(THIRD_TEST_SOUP, soupElt2);
+		store.create(THIRD_TEST_SOUP, soupElt3);
 		store.create(THIRD_TEST_SOUP, soupElt4);
-        store.create(THIRD_TEST_SOUP, soupElt5);
-        final String smartSql = "SELECT {" + THIRD_TEST_SOUP + ":value}, count(*) FROM {" + THIRD_TEST_SOUP + "} GROUP BY {" + THIRD_TEST_SOUP + ":value} ORDER BY {" + THIRD_TEST_SOUP + ":value}";
-        final QuerySpec querySpec = QuerySpec.buildSmartQuerySpec(smartSql, 25);
-        final JSONArray result = store.query(querySpec, 0);
-        Assert.assertNotNull("Result should not be null", result);
-        Assert.assertEquals("Three results expected", 3, result.length());
-        JSONTestHelper.assertSameJSON("Wrong result for query", new JSONArray("[['va1', 2], ['va2', 1], ['va3', 2]]"), result);
-        final int count = store.countQuery(querySpec);
-        Assert.assertEquals("Incorrect count query", "SELECT count(*) FROM (" + smartSql + ")", querySpec.countSmartSql);
-        Assert.assertEquals("Incorrect count", 3, count);
-    }
+		store.create(THIRD_TEST_SOUP, soupElt5);
+		final String smartSql = "SELECT {" + THIRD_TEST_SOUP + ":value}, count(*) FROM {" + THIRD_TEST_SOUP + "} GROUP BY {" + THIRD_TEST_SOUP + ":value} ORDER BY {" + THIRD_TEST_SOUP + ":value}";
+		final QuerySpec querySpec = QuerySpec.buildSmartQuerySpec(smartSql, 25);
+		final JSONArray result = store.query(querySpec, 0);
+		Assert.assertNotNull("Result should not be null", result);
+		Assert.assertEquals("Three results expected", 3, result.length());
+		JSONTestHelper.assertSameJSON("Wrong result for query", new JSONArray("[['va1', 2], ['va2', 1], ['va3', 2]]"), result);
+		final int count = store.countQuery(querySpec);
+		Assert.assertEquals("Incorrect count query", "SELECT count(*) FROM (" + smartSql + ")", querySpec.countSmartSql);
+		Assert.assertEquals("Incorrect count", 3, count);
+	}
 
 	/**
 	 * Test to verify proper indexing of integer and longs
 	 */
-    @Test
+	@Test
 	public void testIntegerIndexedField() throws JSONException {
-		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[] { new IndexSpec("amount", Type.integer) });
+		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[]{new IndexSpec("amount", Type.integer)});
 		tryNumber(Type.integer, Integer.MIN_VALUE, Integer.MIN_VALUE);
 		tryNumber(Type.integer, Integer.MAX_VALUE, Integer.MAX_VALUE);
 		tryNumber(Type.integer, Long.MIN_VALUE, Long.MIN_VALUE);
@@ -1221,9 +1249,9 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	/**
 	 * Test to verify proper indexing of doubles
 	 */
-    @Test
+	@Test
 	public void testFloatingIndexedField() throws JSONException {
-		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[] { new IndexSpec("amount", Type.floating) });
+		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[]{new IndexSpec("amount", Type.floating)});
 		tryNumber(Type.floating, Integer.MIN_VALUE, (double) Integer.MIN_VALUE);
 		tryNumber(Type.floating, Integer.MAX_VALUE, (double) Integer.MAX_VALUE);
 		tryNumber(Type.floating, Long.MIN_VALUE, (double) Long.MIN_VALUE);
@@ -1234,11 +1262,12 @@ public class SmartStoreTest extends SmartStoreTestCase {
 
 	/**
 	 * Helper method for testIntegerIndexedField and testFloatingIndexedField
-	 * Insert soup element with number and check db 
+	 * Insert soup element with number and check db
+	 *
 	 * @param fieldType
 	 * @param valueIn
 	 * @param valueOut
-	 * @throws JSONException 
+	 * @throws JSONException
 	 */
 	private void tryNumber(Type fieldType, Number valueIn, Number valueOut) throws JSONException {
 		JSONObject elt = new JSONObject();
@@ -1249,24 +1278,24 @@ public class SmartStoreTest extends SmartStoreTestCase {
 			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
 			String soupTableName = getSoupTableName(FOURTH_TEST_SOUP);
 			String amountColumnName = store.getSoupIndexSpecs(FOURTH_TEST_SOUP)[0].columnName;
-			c = DBHelper.getInstance(db).query(db, soupTableName, new String[] { amountColumnName }, null, null, "id = " + id);
-            Assert.assertTrue("Expected a soup element", c.moveToFirst());
-            Assert.assertEquals("Expected one soup element", 1, c.getCount());
+			c = DBHelper.getInstance(db).query(db, soupTableName, new String[]{amountColumnName}, null, null, "id = " + id);
+			Assert.assertTrue("Expected a soup element", c.moveToFirst());
+			Assert.assertEquals("Expected one soup element", 1, c.getCount());
 			if (fieldType == Type.integer)
-                Assert.assertEquals("Not the value expected", valueOut.longValue(), c.getLong(0));
+				Assert.assertEquals("Not the value expected", valueOut.longValue(), c.getLong(0));
 			else if (fieldType == Type.floating)
-                Assert.assertEquals("Not the value expected", valueOut.doubleValue(), c.getDouble(0), 0);
+				Assert.assertEquals("Not the value expected", valueOut.doubleValue(), c.getDouble(0), 0);
 		} finally {
 			safeClose(c);
 		}
 	}
-	
+
 	/**
 	 * Test using smart sql to retrieve integer indexed fields
 	 */
-    @Test
+	@Test
 	public void testIntegerIndexedFieldWithSmartSql() throws JSONException {
-		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[] { new IndexSpec("amount", Type.integer) });
+		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[]{new IndexSpec("amount", Type.integer)});
 		tryNumberWithSmartSql(Type.integer, Integer.MIN_VALUE, Integer.MIN_VALUE);
 		tryNumberWithSmartSql(Type.integer, Integer.MAX_VALUE, Integer.MAX_VALUE);
 		tryNumberWithSmartSql(Type.integer, Long.MIN_VALUE, Long.MIN_VALUE);
@@ -1279,9 +1308,9 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	 * Test using smart sql to retrieve indexed fields holding doubles
 	 * NB smart sql will return a long when querying a double field that contains a long
 	 */
-    @Test
+	@Test
 	public void testFloatingIndexedFieldWithSmartSql() throws JSONException {
-		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[] { new IndexSpec("amount", Type.floating) });
+		registerSoup(store, FOURTH_TEST_SOUP, new IndexSpec[]{new IndexSpec("amount", Type.floating)});
 		tryNumberWithSmartSql(Type.floating, Integer.MIN_VALUE, Integer.MIN_VALUE);
 		tryNumberWithSmartSql(Type.floating, Integer.MAX_VALUE, Integer.MAX_VALUE);
 		tryNumberWithSmartSql(Type.floating, Long.MIN_VALUE, Long.MIN_VALUE);
@@ -1290,26 +1319,27 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		tryNumberWithSmartSql(Type.floating, Double.MAX_VALUE, Double.MAX_VALUE);
 	}
 
-    /**
-     * Test using smart sql to retrieve number fields indexed with json1
-     */
-    @Test
-    public void testNumberFieldWithJSON1IndexWithSmartSql() throws JSONException {
-        store.registerSoup(FOURTH_TEST_SOUP, new IndexSpec[] { new IndexSpec("amount", Type.json1) });
-        tryNumberWithSmartSql(Type.integer, Integer.MIN_VALUE, Integer.MIN_VALUE);
-        tryNumberWithSmartSql(Type.integer, Integer.MAX_VALUE, Integer.MAX_VALUE);
-        tryNumberWithSmartSql(Type.integer, Long.MIN_VALUE, Long.MIN_VALUE);
-        tryNumberWithSmartSql(Type.integer, Long.MIN_VALUE, Long.MIN_VALUE);
-        tryNumberWithSmartSql(Type.floating, Math.PI, Math.PI);
-    }
+	/**
+	 * Test using smart sql to retrieve number fields indexed with json1
+	 */
+	@Test
+	public void testNumberFieldWithJSON1IndexWithSmartSql() throws JSONException {
+		store.registerSoup(FOURTH_TEST_SOUP, new IndexSpec[]{new IndexSpec("amount", Type.json1)});
+		tryNumberWithSmartSql(Type.integer, Integer.MIN_VALUE, Integer.MIN_VALUE);
+		tryNumberWithSmartSql(Type.integer, Integer.MAX_VALUE, Integer.MAX_VALUE);
+		tryNumberWithSmartSql(Type.integer, Long.MIN_VALUE, Long.MIN_VALUE);
+		tryNumberWithSmartSql(Type.integer, Long.MIN_VALUE, Long.MIN_VALUE);
+		tryNumberWithSmartSql(Type.floating, Math.PI, Math.PI);
+	}
 
-    /**
+	/**
 	 * Helper method for testIntegerIndexedFieldWithSmartSql and testFloatingIndexedFieldWithSmartSql
 	 * Insert soup element with number and retrieve it back using smartsql
+	 *
 	 * @param fieldType
 	 * @param valueIn
 	 * @param valueOut
-	 * @throws JSONException 
+	 * @throws JSONException
 	 */
 	private void tryNumberWithSmartSql(Type fieldType, Number valueIn, Number valueOut) throws JSONException {
 		String smartSql = "SELECT {" + FOURTH_TEST_SOUP + ":amount} FROM {" + FOURTH_TEST_SOUP + "} WHERE {" + FOURTH_TEST_SOUP + ":_soupEntryId} = ";
@@ -1318,210 +1348,213 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		Long id = store.upsert(FOURTH_TEST_SOUP, elt).getLong(SmartStore.SOUP_ENTRY_ID);
 		Number actualValueOut = (Number) store.query(QuerySpec.buildSmartQuerySpec(smartSql + id, 1), 0).getJSONArray(0).get(0);
 		if (fieldType == Type.integer)
-            Assert.assertEquals("Not the value expected", valueOut.longValue(), actualValueOut.longValue());
+			Assert.assertEquals("Not the value expected", valueOut.longValue(), actualValueOut.longValue());
 		else if (fieldType == Type.floating)
-            Assert.assertEquals("Not the value expected", valueOut.doubleValue(), actualValueOut.doubleValue(), 0);
+			Assert.assertEquals("Not the value expected", valueOut.doubleValue(), actualValueOut.doubleValue(), 0);
 	}
 
 	/**
 	 * Test for getDatabaseSize
-	 * 
+	 *
 	 * @throws JSONException
 	 */
-    @Test
+	@Test
 	public void testGetDatabaseSize() throws JSONException {
 		int initialSize = store.getDatabaseSize();
-		for (int i=0; i<100; i++) {
+		for (int i = 0; i < 100; i++) {
 			JSONObject soupElt = new JSONObject("{'key':'abcd" + i + "', 'value':'va" + i + "', 'otherValue':'ova" + i + "'}");
 			store.create(TEST_SOUP, soupElt);
 		}
 
-        Assert.assertTrue("Database should be larger now", store.getDatabaseSize() > initialSize);
+		Assert.assertTrue("Database should be larger now", store.getDatabaseSize() > initialSize);
 	}
 
 	/**
 	 * Test registerSoup with json1 indexes
-     * Register soup with multiple json1 indexes and a string index, check the underlying table and indexes in the database
+	 * Register soup with multiple json1 indexes and a string index, check the underlying table and indexes in the database
 	 */
-    @Test
-    public void testRegisterSoupWithJSON1() throws JSONException {
-        Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
-        store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[] {new IndexSpec("lastName", Type.json1), new IndexSpec("address.city", Type.json1), new IndexSpec("address.zipcode", Type.string)});
-        Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
+	@Test
+	public void testRegisterSoupWithJSON1() throws JSONException {
+		Assert.assertFalse("Soup other_test_soup should not exist", store.hasSoup(OTHER_TEST_SOUP));
+		store.registerSoup(OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("lastName", Type.json1), new IndexSpec("address.city", Type.json1), new IndexSpec("address.zipcode", Type.string)});
+		Assert.assertTrue("Register soup call failed", store.hasSoup(OTHER_TEST_SOUP));
 
-        // Check columns of soup table
-        String soupTableName = getSoupTableName(OTHER_TEST_SOUP);
-        checkColumns(soupTableName, Arrays.asList(new String[] {"id", "soup", "created", "lastModified", soupTableName + "_2"}));
+		// Check columns of soup table
+		String soupTableName = getSoupTableName(OTHER_TEST_SOUP);
+		checkColumns(soupTableName, Arrays.asList(new String[]{"id", "soup", "created", "lastModified", soupTableName + "_2"}));
 
-        // Check soup indexes
-        final IndexSpec[] indexSpecs = store.getSoupIndexSpecs(OTHER_TEST_SOUP);
-        Assert.assertEquals("Wrong path", "lastName", indexSpecs[0].path);
-        Assert.assertEquals("Wrong type", Type.json1, indexSpecs[0].type);
-        Assert.assertEquals("Wrong column name", "json_extract(soup, '$.lastName')", indexSpecs[0].columnName);
-        Assert.assertEquals("Wrong path", "address.city", indexSpecs[1].path);
-        Assert.assertEquals("Wrong type", Type.json1, indexSpecs[1].type);
-        Assert.assertEquals("Wrong column name", "json_extract(soup, '$.address.city')", indexSpecs[1].columnName);
-        Assert.assertEquals("Wrong path", "address.zipcode", indexSpecs[2].path);
-        Assert.assertEquals("Wrong type", Type.string, indexSpecs[2].type);
-        Assert.assertEquals("Wrong column name", soupTableName + "_2", indexSpecs[2].columnName);
+		// Check soup indexes
+		final IndexSpec[] indexSpecs = store.getSoupIndexSpecs(OTHER_TEST_SOUP);
+		Assert.assertEquals("Wrong path", "lastName", indexSpecs[0].path);
+		Assert.assertEquals("Wrong type", Type.json1, indexSpecs[0].type);
+		Assert.assertEquals("Wrong column name", "json_extract(soup, '$.lastName')", indexSpecs[0].columnName);
+		Assert.assertEquals("Wrong path", "address.city", indexSpecs[1].path);
+		Assert.assertEquals("Wrong type", Type.json1, indexSpecs[1].type);
+		Assert.assertEquals("Wrong column name", "json_extract(soup, '$.address.city')", indexSpecs[1].columnName);
+		Assert.assertEquals("Wrong path", "address.zipcode", indexSpecs[2].path);
+		Assert.assertEquals("Wrong type", Type.string, indexSpecs[2].type);
+		Assert.assertEquals("Wrong column name", soupTableName + "_2", indexSpecs[2].columnName);
 
-        // Check db indexes
-        checkDatabaseIndexes(soupTableName, Arrays.asList(new String[] {
-            "CREATE INDEX " + soupTableName + "_0_idx on " + soupTableName + " ( json_extract(soup, '$.lastName') )",
-            "CREATE INDEX " + soupTableName + "_1_idx on " + soupTableName + " ( json_extract(soup, '$.address.city') )",
-            "CREATE INDEX " + soupTableName + "_2_idx on " + soupTableName + " ( " + soupTableName + "_2 )",
-            "CREATE INDEX " + soupTableName + "_created_idx on " + soupTableName + " ( created )",
-            "CREATE INDEX " + soupTableName + "_lastModified_idx on " + soupTableName + " ( lastModified )"
-        }));
-    }
+		// Check db indexes
+		checkDatabaseIndexes(soupTableName, Arrays.asList(new String[]{
+				"CREATE INDEX " + soupTableName + "_0_idx on " + soupTableName + " ( json_extract(soup, '$.lastName') )",
+				"CREATE INDEX " + soupTableName + "_1_idx on " + soupTableName + " ( json_extract(soup, '$.address.city') )",
+				"CREATE INDEX " + soupTableName + "_2_idx on " + soupTableName + " ( " + soupTableName + "_2 )",
+				"CREATE INDEX " + soupTableName + "_created_idx on " + soupTableName + " ( created )",
+				"CREATE INDEX " + soupTableName + "_lastModified_idx on " + soupTableName + " ( lastModified )"
+		}));
+	}
 
 	/**
-     * Testing Delete: create multiple soup elements and alter the soup, after that delete a entry, then check them all
-     * @throws JSONException
-     */
-    @Test
-    public void testDeleteAgainstChangedSoup() throws JSONException {
+	 * Testing Delete: create multiple soup elements and alter the soup, after that delete a entry, then check them all
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testDeleteAgainstChangedSoup() throws JSONException {
 
-        //create a new soup with multiple entries
-        JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
-        JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
-        JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3'}");
-        JSONObject soupElt4 = new JSONObject("{'key':'ka4', 'value':'va4'}");
-        JSONObject soupElt1Created = store.create(TEST_SOUP, soupElt1);
-        JSONObject soupElt2Created = store.create(TEST_SOUP, soupElt2);
-        JSONObject soupElt3Created = store.create(TEST_SOUP, soupElt3);
-        JSONObject soupElt4Created = store.create(TEST_SOUP, soupElt4);
+		//create a new soup with multiple entries
+		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
+		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
+		JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3'}");
+		JSONObject soupElt4 = new JSONObject("{'key':'ka4', 'value':'va4'}");
+		JSONObject soupElt1Created = store.create(TEST_SOUP, soupElt1);
+		JSONObject soupElt2Created = store.create(TEST_SOUP, soupElt2);
+		JSONObject soupElt3Created = store.create(TEST_SOUP, soupElt3);
+		JSONObject soupElt4Created = store.create(TEST_SOUP, soupElt4);
 
-        //CASE 1: index spec from key to value
-        tryAllQueryOnChangedSoupWithUpdate(TEST_SOUP, soupElt2Created, "value",
-                new IndexSpec[]{new IndexSpec("value", Type.string)},
-                soupElt1Created, soupElt3Created, soupElt4Created);
+		//CASE 1: index spec from key to value
+		tryAllQueryOnChangedSoupWithUpdate(TEST_SOUP, soupElt2Created, "value",
+				new IndexSpec[]{new IndexSpec("value", Type.string)},
+				soupElt1Created, soupElt3Created, soupElt4Created);
 
-        //CASE 2: index spec from string to json1
-        tryAllQueryOnChangedSoupWithUpdate(TEST_SOUP, soupElt4Created, "key",
-                new IndexSpec[]{new IndexSpec("key", Type.json1)},
-                soupElt1Created, soupElt3Created);
+		//CASE 2: index spec from string to json1
+		tryAllQueryOnChangedSoupWithUpdate(TEST_SOUP, soupElt4Created, "key",
+				new IndexSpec[]{new IndexSpec("key", Type.json1)},
+				soupElt1Created, soupElt3Created);
 
-        //CASE 3: add a index spec field
-        tryAllQueryOnChangedSoupWithUpdate(TEST_SOUP, soupElt4Created, "key",
-                new IndexSpec[]{new IndexSpec("key", Type.json1), new IndexSpec("value", Type.string)},
-                soupElt1Created, soupElt3Created);
-    }
+		//CASE 3: add a index spec field
+		tryAllQueryOnChangedSoupWithUpdate(TEST_SOUP, soupElt4Created, "key",
+				new IndexSpec[]{new IndexSpec("key", Type.json1), new IndexSpec("value", Type.string)},
+				soupElt1Created, soupElt3Created);
+	}
 
-    protected void tryAllQueryOnChangedSoupWithUpdate(String soupName, JSONObject deletedEntry, String orderPath,
-                                                    IndexSpec[] newIndexSpecs, JSONObject... expectedResults) throws JSONException {
+	protected void tryAllQueryOnChangedSoupWithUpdate(String soupName, JSONObject deletedEntry, String orderPath,
+													  IndexSpec[] newIndexSpecs, JSONObject... expectedResults) throws JSONException {
 
-        //alert the soup
-        store.alterSoup(soupName, newIndexSpecs, true);
+		//alert the soup
+		store.alterSoup(soupName, newIndexSpecs, true);
 
-        //delete an entry
-        store.delete(soupName, idOf(deletedEntry));
+		//delete an entry
+		store.delete(soupName, idOf(deletedEntry));
 
-        // Query all - small page
-        runQueryCheckResultsAndExplainPlan(soupName,
-                QuerySpec.buildAllQuerySpec(soupName, orderPath, Order.ascending, 5),
-                0, false, "SCAN", expectedResults);
-    }
+		// Query all - small page
+		runQueryCheckResultsAndExplainPlan(soupName,
+				QuerySpec.buildAllQuerySpec(soupName, orderPath, Order.ascending, 5),
+				0, false, "SCAN", expectedResults);
+	}
 
-    /**
-     * Testing Upsert: create multiple soup elements and alter the soup, after that upsert a entry, then check them all
-     * @throws JSONException
-     */
-    @Test
-    public void testUpsertAgainstChangedSoup() throws JSONException {
+	/**
+	 * Testing Upsert: create multiple soup elements and alter the soup, after that upsert a entry, then check them all
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testUpsertAgainstChangedSoup() throws JSONException {
 
-        //create a new soup with multiple entries
-        JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
-        JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
-        JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3'}");
-        JSONObject soupElt1Created = store.create(TEST_SOUP, soupElt1);
-        JSONObject soupElt2Created = store.create(TEST_SOUP, soupElt2);
-        JSONObject soupElt3Created = store.create(TEST_SOUP, soupElt3);
-        JSONObject soupElt1ForUpsert = new JSONObject("{'key':'ka1u', 'value':'va1u'}");
-        JSONObject soupElt2ForUpsert = new JSONObject("{'key':'ka2u', 'value':'va2u'}");
-        JSONObject soupElt3ForUpsert = new JSONObject("{'key':'ka3u', 'value':'va3u'}");
+		//create a new soup with multiple entries
+		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
+		JSONObject soupElt2 = new JSONObject("{'key':'ka2', 'value':'va2'}");
+		JSONObject soupElt3 = new JSONObject("{'key':'ka3', 'value':'va3'}");
+		JSONObject soupElt1Created = store.create(TEST_SOUP, soupElt1);
+		JSONObject soupElt2Created = store.create(TEST_SOUP, soupElt2);
+		JSONObject soupElt3Created = store.create(TEST_SOUP, soupElt3);
+		JSONObject soupElt1ForUpsert = new JSONObject("{'key':'ka1u', 'value':'va1u'}");
+		JSONObject soupElt2ForUpsert = new JSONObject("{'key':'ka2u', 'value':'va2u'}");
+		JSONObject soupElt3ForUpsert = new JSONObject("{'key':'ka3u', 'value':'va3u'}");
 
-        //CASE 1: index spec from key to value
-        store.alterSoup(TEST_SOUP, new IndexSpec[]{new IndexSpec("value", Type.string)}, true);
+		//CASE 1: index spec from key to value
+		store.alterSoup(TEST_SOUP, new IndexSpec[]{new IndexSpec("value", Type.string)}, true);
 
-        //upsert an entry
-        JSONObject soupElt1Upserted = store.upsert(TEST_SOUP, soupElt1ForUpsert);
+		//upsert an entry
+		JSONObject soupElt1Upserted = store.upsert(TEST_SOUP, soupElt1ForUpsert);
 
-        // Query all - small page
-        runQueryCheckResultsAndExplainPlan(TEST_SOUP,
-                QuerySpec.buildAllQuerySpec(TEST_SOUP, "value", Order.ascending, 10),
-                0, false, "SCAN", soupElt1Created, soupElt1Upserted, soupElt2Created, soupElt3Created);
+		// Query all - small page
+		runQueryCheckResultsAndExplainPlan(TEST_SOUP,
+				QuerySpec.buildAllQuerySpec(TEST_SOUP, "value", Order.ascending, 10),
+				0, false, "SCAN", soupElt1Created, soupElt1Upserted, soupElt2Created, soupElt3Created);
 
-        //CASE 2: index spec from string to json1
-        store.alterSoup(TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.json1)}, true);
+		//CASE 2: index spec from string to json1
+		store.alterSoup(TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.json1)}, true);
 
-        //upsert an entry
-        JSONObject soupElt2Upserted = store.upsert(TEST_SOUP, soupElt2ForUpsert);
+		//upsert an entry
+		JSONObject soupElt2Upserted = store.upsert(TEST_SOUP, soupElt2ForUpsert);
 
-        // Query all - small page
-        runQueryCheckResultsAndExplainPlan(TEST_SOUP,
-                QuerySpec.buildAllQuerySpec(TEST_SOUP, "key", Order.ascending, 10),
-                0, false, "SCAN", soupElt1Created, soupElt1Upserted, soupElt2Created, soupElt2Upserted, soupElt3Created);
+		// Query all - small page
+		runQueryCheckResultsAndExplainPlan(TEST_SOUP,
+				QuerySpec.buildAllQuerySpec(TEST_SOUP, "key", Order.ascending, 10),
+				0, false, "SCAN", soupElt1Created, soupElt1Upserted, soupElt2Created, soupElt2Upserted, soupElt3Created);
 
-        //CASE 3: add a index spec field
-        store.alterSoup(TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.json1), new IndexSpec("value", Type.string)}, true);
+		//CASE 3: add a index spec field
+		store.alterSoup(TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.json1), new IndexSpec("value", Type.string)}, true);
 
-        //upsert an entry
-        JSONObject soupElt3Upserted = store.upsert(TEST_SOUP, soupElt3ForUpsert);
+		//upsert an entry
+		JSONObject soupElt3Upserted = store.upsert(TEST_SOUP, soupElt3ForUpsert);
 
-        // Query all - small page
-        runQueryCheckResultsAndExplainPlan(TEST_SOUP,
-                QuerySpec.buildAllQuerySpec(TEST_SOUP, "key", Order.ascending, 10),
-                0, false, "SCAN", soupElt1Created, soupElt1Upserted, soupElt2Created, soupElt2Upserted, soupElt3Created, soupElt3Upserted);
-    }
+		// Query all - small page
+		runQueryCheckResultsAndExplainPlan(TEST_SOUP,
+				QuerySpec.buildAllQuerySpec(TEST_SOUP, "key", Order.ascending, 10),
+				0, false, "SCAN", soupElt1Created, soupElt1Upserted, soupElt2Created, soupElt2Upserted, soupElt3Created, soupElt3Upserted);
+	}
 
-    /**
-     * Testing Delete: create multiple soup elements and alter the soup, after that delete a entry, then check them all
-     * @throws JSONException
-     */
-    @Test
-    public void testExactQueryAgainstChangedSoup() throws JSONException {
+	/**
+	 * Testing Delete: create multiple soup elements and alter the soup, after that delete a entry, then check them all
+	 *
+	 * @throws JSONException
+	 */
+	@Test
+	public void testExactQueryAgainstChangedSoup() throws JSONException {
 
-        //create a new soup with multiple entries
-        JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
-        JSONObject soupElt2 = new JSONObject("{'key':'ka1-', 'value':'va1*'}");
-        JSONObject soupElt3 = new JSONObject("{'key':'ka1 ', 'value':'va1%'}");
-        JSONObject soupElt1Created = store.create(TEST_SOUP, soupElt1);
-        JSONObject soupElt2Created = store.create(TEST_SOUP, soupElt2);
-        JSONObject soupElt3Created = store.create(TEST_SOUP, soupElt3);
+		//create a new soup with multiple entries
+		JSONObject soupElt1 = new JSONObject("{'key':'ka1', 'value':'va1'}");
+		JSONObject soupElt2 = new JSONObject("{'key':'ka1-', 'value':'va1*'}");
+		JSONObject soupElt3 = new JSONObject("{'key':'ka1 ', 'value':'va1%'}");
+		JSONObject soupElt1Created = store.create(TEST_SOUP, soupElt1);
+		JSONObject soupElt2Created = store.create(TEST_SOUP, soupElt2);
+		JSONObject soupElt3Created = store.create(TEST_SOUP, soupElt3);
 
-        //CASE 1: index spec from key to value
-        tryExactQueryOnChangedSoup(TEST_SOUP, "value", "va1",
-                new IndexSpec[]{new IndexSpec("value", Type.string)},
-                soupElt1Created);
+		//CASE 1: index spec from key to value
+		tryExactQueryOnChangedSoup(TEST_SOUP, "value", "va1",
+				new IndexSpec[]{new IndexSpec("value", Type.string)},
+				soupElt1Created);
 
-        //CASE 2: index spec from string to json1
-        tryExactQueryOnChangedSoup(TEST_SOUP, "key", "ka1",
-                new IndexSpec[]{new IndexSpec("key", Type.json1)},
-                soupElt1Created);
+		//CASE 2: index spec from string to json1
+		tryExactQueryOnChangedSoup(TEST_SOUP, "key", "ka1",
+				new IndexSpec[]{new IndexSpec("key", Type.json1)},
+				soupElt1Created);
 
-        //CASE 3: add a index spec field
-        tryExactQueryOnChangedSoup(TEST_SOUP, "key", "ka1 ",
-                new IndexSpec[]{new IndexSpec("key", Type.json1), new IndexSpec("value", Type.string)},
-                soupElt3Created);
-    }
+		//CASE 3: add a index spec field
+		tryExactQueryOnChangedSoup(TEST_SOUP, "key", "ka1 ",
+				new IndexSpec[]{new IndexSpec("key", Type.json1), new IndexSpec("value", Type.string)},
+				soupElt3Created);
+	}
 
-    protected void tryExactQueryOnChangedSoup(String soupName, String orderPath, String value,
-                                                    IndexSpec[] newIndexSpecs, JSONObject expectedResult) throws JSONException {
+	protected void tryExactQueryOnChangedSoup(String soupName, String orderPath, String value,
+											  IndexSpec[] newIndexSpecs, JSONObject expectedResult) throws JSONException {
 
-        // Alter the soup
-        store.alterSoup(soupName, newIndexSpecs, true);
+		// Alter the soup
+		store.alterSoup(soupName, newIndexSpecs, true);
 
-        // Exact Query
-        runQueryCheckResultsAndExplainPlan(soupName,
-                QuerySpec.buildExactQuerySpec(soupName, orderPath, value, null, null, 5),
-                0, false, "SEARCH", expectedResult);
-    }
+		// Exact Query
+		runQueryCheckResultsAndExplainPlan(soupName,
+				QuerySpec.buildExactQuerySpec(soupName, orderPath, value, null, null, 5),
+				0, false, "SEARCH", expectedResult);
+	}
 
 	/**
 	 * Test updateSoupNamesToAttrs
 	 */
-    @Test
+	@Test
 	public void testUpdateTableNameAndAddColumns() {
 
 		// Setup db and test values
@@ -1532,20 +1565,20 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		db.execSQL("CREATE TABLE " + TEST_TABLE + " (id INTEGER PRIMARY KEY)");
 
 		// Ensure old table doesn't already exist
-		Cursor cursor = db.query("sqlite_master", new String[] { "sql" }, "name = ?", new String[] { NEW_TEST_TABLE }, null, null, null);
-        Assert.assertEquals("New table should not already be in db.", 0, cursor.getCount());
+		Cursor cursor = db.query("sqlite_master", new String[]{"sql"}, "name = ?", new String[]{NEW_TEST_TABLE}, null, null, null);
+		Assert.assertEquals("New table should not already be in db.", 0, cursor.getCount());
 		cursor.close();
 
 		// Test table renamed and column added
-		SmartStore.updateTableNameAndAddColumns(db, TEST_TABLE, NEW_TEST_TABLE, new String[] { NEW_COLUMN });
+		SmartStore.updateTableNameAndAddColumns(db, TEST_TABLE, NEW_TEST_TABLE, new String[]{NEW_COLUMN});
 
 		// Ensure new table has replaced old table
-		cursor = db.query("sqlite_master", new String[] { "sql" }, "name = ?", new String[] { NEW_TEST_TABLE }, null, null, null);
+		cursor = db.query("sqlite_master", new String[]{"sql"}, "name = ?", new String[]{NEW_TEST_TABLE}, null, null, null);
 		cursor.moveToFirst();
 		String schema = cursor.getString(0);
 		cursor.close();
-        Assert.assertTrue("New table not found", schema.contains(NEW_TEST_TABLE));
-        Assert.assertTrue("New column not found", schema.contains(NEW_COLUMN));
+		Assert.assertTrue("New table not found", schema.contains(NEW_TEST_TABLE));
+		Assert.assertTrue("New column not found", schema.contains(NEW_COLUMN));
 
 		// Clean up
 		db.execSQL("DROP TABLE " + NEW_TEST_TABLE);
@@ -1554,10 +1587,10 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	/**
 	 * Ensure correct soup spec is returned from getSoupSpec
 	 */
-    @Test
+	@Test
 	public void testGetSoupSpec() throws JSONException {
 		final String SOUP_SPEC_TEST = "soup_spec_test";
-		IndexSpec[] indexSpecs = new IndexSpec[] {new IndexSpec("index", Type.string)};
+		IndexSpec[] indexSpecs = new IndexSpec[]{new IndexSpec("index", Type.string)};
 		SoupSpec TEST_SPEC = new SoupSpec(SOUP_SPEC_TEST, SoupSpec.FEATURE_EXTERNAL_STORAGE);
 		store.registerSoupWithSpec(TEST_SPEC, indexSpecs);
 
@@ -1565,11 +1598,42 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		SoupSpec result = store.getSoupSpec(TEST_SPEC.getSoupName());
 
 		// Verify the result
-        Assert.assertEquals("Soup name in soup spec is incorrect", SOUP_SPEC_TEST, result.getSoupName());
-        Assert.assertEquals("Feature set in soup spec is incorrect", SoupSpec.FEATURE_EXTERNAL_STORAGE, result.getFeatures().get(0));
+		Assert.assertEquals("Soup name in soup spec is incorrect", SOUP_SPEC_TEST, result.getSoupName());
+		Assert.assertEquals("Feature set in soup spec is incorrect", SoupSpec.FEATURE_EXTERNAL_STORAGE, result.getFeatures().get(0));
 
 		// Verify JSON form
-        Assert.assertEquals("Soup name in json of soup spec is incorrect", SOUP_SPEC_TEST, result.toJSON().getString("name"));
-        Assert.assertEquals("Feature set in json of soup spec is incorrect", SoupSpec.FEATURE_EXTERNAL_STORAGE, result.toJSON().getJSONArray("features").get(0));
+		Assert.assertEquals("Soup name in json of soup spec is incorrect", SOUP_SPEC_TEST, result.toJSON().getString("name"));
+		Assert.assertEquals("Feature set in json of soup spec is incorrect", SoupSpec.FEATURE_EXTERNAL_STORAGE, result.toJSON().getJSONArray("features").get(0));
+	}
+
+	@Test
+	public void testHasSoup() {
+		Assert.assertTrue(store.hasSoup(TEST_SOUP));
+		Assert.assertFalse(store.hasSoup(OTHER_TEST_SOUP));
+		Assert.assertFalse(store.hasSoup(THIRD_TEST_SOUP));
+
+		// Register other soup
+		registerSoup(store, OTHER_TEST_SOUP, new IndexSpec[]{new IndexSpec("lastName", Type.string), new IndexSpec("address.city", Type.string)});
+		Assert.assertTrue(store.hasSoup(TEST_SOUP));
+		Assert.assertTrue(store.hasSoup(OTHER_TEST_SOUP));
+		Assert.assertFalse(store.hasSoup(THIRD_TEST_SOUP));
+
+		// Register third soup
+		registerSoup(store, THIRD_TEST_SOUP, new IndexSpec[]{new IndexSpec("key", Type.string), new IndexSpec("value", Type.string)});
+		Assert.assertTrue(store.hasSoup(TEST_SOUP));
+		Assert.assertTrue(store.hasSoup(OTHER_TEST_SOUP));
+		Assert.assertTrue(store.hasSoup(THIRD_TEST_SOUP));
+
+		// Dropping third soup
+		store.dropSoup(THIRD_TEST_SOUP);
+		Assert.assertTrue(store.hasSoup(TEST_SOUP));
+		Assert.assertTrue(store.hasSoup(OTHER_TEST_SOUP));
+		Assert.assertFalse(store.hasSoup(THIRD_TEST_SOUP));
+
+		// Dropping all soups
+		store.dropAllSoups();
+		Assert.assertFalse(store.hasSoup(TEST_SOUP));
+		Assert.assertFalse(store.hasSoup(OTHER_TEST_SOUP));
+		Assert.assertFalse(store.hasSoup(THIRD_TEST_SOUP));
 	}
 }


### PR DESCRIPTION
Before
Calling `hasSoup` would go to the db every time if the soup did not exist (it would leverage the soupNameToTableNameMap when the soup did exist).

`Now`
Now `hasSoup` avoids going to the db if the soup does not exist (and `hasSoup` was previously called for the same soup name) thanks to a new `soupNameToExistMap` in `DBHelper`.