### PR TITLE
MemCacheKeyValueStore can now handle binaries + new method contains on KeyValueStore

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -459,8 +459,6 @@ public class Encryptor {
         return output.toString(StandardCharsets.UTF_8.name());
     }
 
-
-
     /**
      * Retrieves data from an InputStream.  Guaranteed to close the InputStream.
      *

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -459,6 +459,8 @@ public class Encryptor {
         return output.toString(StandardCharsets.UTF_8.name());
     }
 
+
+
     /**
      * Retrieves data from an InputStream.  Guaranteed to close the InputStream.
      *

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -29,10 +29,12 @@ package com.salesforce.androidsdk.smartstore.store;
 
 import android.content.Context;
 import android.text.TextUtils;
+
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 import com.salesforce.androidsdk.util.ManagedFilesHelper;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -142,6 +144,20 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
     public static boolean isValidStoreName(String storeName) {
         return storeName != null && storeName.length() > 0 && storeName.length() <= MAX_STORE_NAME_LENGTH
             && storeName.matches("^[a-zA-Z0-9_]*$");
+    }
+
+    /**
+     * Return true if store contains a file for the given key
+     * @param key
+     * @return
+     */
+    @Override
+    public boolean contains(String key) {
+        if (!isKeyValid(key, "contains")) {
+            return false;
+        }
+
+        return getKeyFile(key).exists() && getValueFile(key).exists();
     }
 
     /**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueStore.java
@@ -33,6 +33,8 @@ import java.util.Set;
 
 public interface KeyValueStore {
 
+    boolean contains(String key);
+
     String getValue(String key);
 
     InputStream getStream(String key);

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -29,13 +29,22 @@ package com.salesforce.androidsdk.smartstore.store;
 import static com.salesforce.androidsdk.smartstore.tests.R.drawable.sf__icon;
 
 import android.content.Context;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
 import com.salesforce.androidsdk.util.ManagedFilesHelper;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -44,11 +53,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 @RunWith(AndroidJUnit4.class)
 public class KeyValueEncryptedFileStoreTest {

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -757,6 +757,43 @@ public class KeyValueEncryptedFileStoreTest {
         }
     }
 
+    @Test
+    public void testContains() {
+        Assert.assertFalse(keyValueStore.contains("key1"));
+        Assert.assertFalse(keyValueStore.contains("key2"));
+        Assert.assertFalse(keyValueStore.contains("key3"));
+
+        // Save one
+        keyValueStore.saveValue("key1", "value1");
+        Assert.assertTrue(keyValueStore.contains("key1"));
+        Assert.assertFalse(keyValueStore.contains("key2"));
+        Assert.assertFalse(keyValueStore.contains("key3"));
+
+        // Save another
+        keyValueStore.saveValue("key2", "value2");
+        Assert.assertTrue(keyValueStore.contains("key1"));
+        Assert.assertTrue(keyValueStore.contains("key2"));
+        Assert.assertFalse(keyValueStore.contains("key3"));
+
+        // Save third
+        keyValueStore.saveValue("key3", "value3");
+        Assert.assertTrue(keyValueStore.contains("key1"));
+        Assert.assertTrue(keyValueStore.contains("key2"));
+        Assert.assertTrue(keyValueStore.contains("key3"));
+
+        // Delete one
+        keyValueStore.deleteValue("key1");
+        Assert.assertFalse(keyValueStore.contains("key1"));
+        Assert.assertTrue(keyValueStore.contains("key2"));
+        Assert.assertTrue(keyValueStore.contains("key3"));
+
+        // Delete all
+        keyValueStore.deleteAll();
+        Assert.assertFalse(keyValueStore.contains("key1"));
+        Assert.assertFalse(keyValueStore.contains("key2"));
+        Assert.assertFalse(keyValueStore.contains("key3"));
+    }
+
     //
     // Helper methods
     //

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
@@ -26,24 +26,27 @@
  */
 package com.salesforce.androidsdk.smartstore.store;
 
+import static com.salesforce.androidsdk.smartstore.tests.R.drawable.sf__icon;
+
 import android.content.Context;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.smartstore.app.SmartStoreSDKManager;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-import java.util.Random;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 /** Tests for MemCachedKeyValueStore */
 @RunWith(AndroidJUnit4.class)
@@ -52,6 +55,7 @@ public class MemCachedKeyValueStoreTest {
     static final int NUM_ENTRIES = 25;
     static final int CACHE_SIZE = 10;
 
+    private Context context;
     private KeyValueEncryptedFileStore store;
     private MemCachedKeyValueStore memCachedStore;
 
@@ -66,7 +70,7 @@ public class MemCachedKeyValueStoreTest {
             throw new RuntimeException(e);
         }
 
-        Context context =
+        context =
             InstrumentationRegistry.getInstrumentation()
                 .getTargetContext()
                 .getApplicationContext();
@@ -304,9 +308,89 @@ public class MemCachedKeyValueStoreTest {
         }
     }
 
+    /**
+     * Read some binary file from assets, save it to the key value store then get it back
+     * Make sure it's identical to the original file
+     */
+    @Test
+    public void testBinaryStorage() throws IOException {
+        // Saving resource icon to key value store
+        memCachedStore.saveStream("icon", getResourceIconStream());
+
+        // Retrieving icon back from key value store
+        byte[] savedIconBytes = Encryptor.getByteArrayStreamFromStream(memCachedStore.getStream("icon")).toByteArray();
+
+        // Comparing bytes
+        byte[] resourceIconBytes = Encryptor.getByteArrayStreamFromStream(getResourceIconStream()).toByteArray();
+        Assert.assertEquals(resourceIconBytes.length, savedIconBytes.length);
+        for (int i=0; i<resourceIconBytes.length; i++) {
+            Assert.assertEquals(resourceIconBytes[i], savedIconBytes[i]);
+        }
+    }
+
+    /** Test calling contains after saving and deleting values */
+    @Test
+    public void testContains() {
+        Assert.assertFalse(memCachedStore.contains("key1"));
+        Assert.assertFalse(memCachedStore.contains("key2"));
+        Assert.assertFalse(memCachedStore.contains("key3"));
+        Assert.assertFalse(store.contains("key1"));
+        Assert.assertFalse(store.contains("key2"));
+        Assert.assertFalse(store.contains("key3"));
+
+        // Save one
+        memCachedStore.saveValue("key1", "value1");
+        Assert.assertTrue(memCachedStore.contains("key1"));
+        Assert.assertFalse(memCachedStore.contains("key2"));
+        Assert.assertFalse(memCachedStore.contains("key3"));
+        Assert.assertTrue(store.contains("key1"));
+        Assert.assertFalse(store.contains("key2"));
+        Assert.assertFalse(store.contains("key3"));
+
+        // Save another into underlying store directly
+        store.saveValue("key2", "value2");
+        Assert.assertTrue(memCachedStore.contains("key1"));
+        Assert.assertTrue(memCachedStore.contains("key2"));
+        Assert.assertFalse(memCachedStore.contains("key3"));
+        Assert.assertTrue(store.contains("key1"));
+        Assert.assertTrue(store.contains("key2"));
+        Assert.assertFalse(store.contains("key3"));
+
+        // Save third
+        memCachedStore.saveValue("key3", "value3");
+        Assert.assertTrue(memCachedStore.contains("key1"));
+        Assert.assertTrue(memCachedStore.contains("key2"));
+        Assert.assertTrue(memCachedStore.contains("key3"));
+        Assert.assertTrue(store.contains("key1"));
+        Assert.assertTrue(store.contains("key2"));
+        Assert.assertTrue(store.contains("key3"));
+
+        // Delete one
+        memCachedStore.deleteValue("key1");
+        Assert.assertFalse(memCachedStore.contains("key1"));
+        Assert.assertTrue(memCachedStore.contains("key2"));
+        Assert.assertTrue(memCachedStore.contains("key3"));
+        Assert.assertFalse(store.contains("key1"));
+        Assert.assertTrue(store.contains("key2"));
+        Assert.assertTrue(store.contains("key3"));
+
+        // Delete all
+        memCachedStore.deleteAll();
+        Assert.assertFalse(memCachedStore.contains("key1"));
+        Assert.assertFalse(memCachedStore.contains("key2"));
+        Assert.assertFalse(memCachedStore.contains("key3"));
+        Assert.assertFalse(store.contains("key1"));
+        Assert.assertFalse(store.contains("key2"));
+        Assert.assertFalse(store.contains("key3"));
+    }
+
     //
     // Helper methods
     //
+    private InputStream getResourceIconStream() {
+        return context.getResources().openRawResource(sf__icon);
+    }
+
     private InputStream stringToStream(String value) {
         return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
     }

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/MemCachedKeyValueStoreTest.java
@@ -36,6 +36,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Random;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -120,7 +123,7 @@ public class MemCachedKeyValueStoreTest {
         Assert.assertEquals(2, memCachedStore.memCache.hitCount());
         Assert.assertEquals("value1", streamToString(store.getStream("key1")));
 
-        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+        Assert.assertEquals("value1", new String(memCachedStore.memCache.get("key1"), StandardCharsets.UTF_8));
     }
 
     /** Test saving from streams and getting them back when mem cache hits */
@@ -137,7 +140,7 @@ public class MemCachedKeyValueStoreTest {
         Assert.assertEquals(2, memCachedStore.memCache.hitCount());
         Assert.assertEquals("value1", streamToString(store.getStream("key1")));
 
-        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+        Assert.assertEquals("value1", new String(memCachedStore.memCache.get("key1"), StandardCharsets.UTF_8));
     }
 
     /** Test saving values and getting them back when mem cache misses */
@@ -186,7 +189,7 @@ public class MemCachedKeyValueStoreTest {
         Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
         Assert.assertEquals(1, memCachedStore.memCache.hitCount());
 
-        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+        Assert.assertEquals("value1", new String(memCachedStore.memCache.get("key1"), StandardCharsets.UTF_8));
     }
 
     /** Test that get value populates mem cache */
@@ -201,7 +204,7 @@ public class MemCachedKeyValueStoreTest {
         Assert.assertEquals("value1", streamToString(memCachedStore.getStream("key1")));
         Assert.assertEquals(1, memCachedStore.memCache.hitCount());
 
-        Assert.assertEquals("value1", memCachedStore.memCache.get("key1"));
+        Assert.assertEquals("value1", new String(memCachedStore.memCache.get("key1"), StandardCharsets.UTF_8));
     }
 
     /** Test saving values and deleting them  */


### PR DESCRIPTION
- MemCacheKeyValueStore had in map of String to String to speed up retrieval of values that only handles strings, now it is a map of String to bytes[].
- KeyValueStore and its implementation (KeyValueEncryptedFileStore and MemCacheKeyValueStore) have a contains() method.
- New tests.