### PR TITLE
Deprecate classes that extend the old DialogFragment.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/CustomServerUrlEditor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/CustomServerUrlEditor.java
@@ -48,7 +48,12 @@ import okhttp3.HttpUrl;
 
 /**
  * Custom dialog fragment to allow the user to set a label and URL to use for the login.
+ *
+ * @deprecated The exact signature of the methods inside of CustomServerUrlEditor and its inherited
+ * methods may change in Mobile SDK 11.0 when the deprecated base class {@link android.app.DialogFragment} is
+ * replaced with {@link androidx.fragment.app.DialogFragment}.
  */
+@Deprecated
 public class CustomServerUrlEditor extends DialogFragment {
 
 	private LoginServerManager loginServerManager;

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DeleteDialogFragment.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DeleteDialogFragment.java
@@ -36,7 +36,12 @@ import com.salesforce.samples.mobilesyncexplorer.R;
 
 /**
  * A simple dialog fragment to provide options for deletion.
+ *
+ * @deprecated The exact signature of the methods inside of DeleteDialogFragment and its inherited
+ * methods may change in Mobile SDK 11.0 when the deprecated base class {@link android.app.DialogFragment} is
+ * replaced with {@link androidx.fragment.app.DialogFragment}.
  */
+@Deprecated
 public class DeleteDialogFragment extends DialogFragment {
 
 	/**

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/LogoutDialogFragment.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/LogoutDialogFragment.java
@@ -37,7 +37,12 @@ import com.salesforce.samples.mobilesyncexplorer.R;
 
 /**
  * A simple dialog fragment to provide options at logout.
+ *
+ * @deprecated The exact signature of the methods inside of LogoutDialogFragment and its inherited
+ * methods may change in Mobile SDK 11.0 when the deprecated base class {@link android.app.DialogFragment} is
+ * replaced with {@link androidx.fragment.app.DialogFragment}.
  */
+@Deprecated
 public class LogoutDialogFragment extends DialogFragment {
 
 	/**

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/LogoutDialogFragment.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/LogoutDialogFragment.java
@@ -28,9 +28,10 @@ package com.salesforce.samples.restexplorer;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.DialogFragment;
-import android.content.DialogInterface;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
@@ -39,29 +40,20 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
  */
 public class LogoutDialogFragment extends DialogFragment {
 
-	private AlertDialog logoutConfirmationDialog;
-
 	/**
 	 * Default constructor.
 	 */
 	public LogoutDialogFragment() {
 	}
 
+	@NonNull
 	@Override
 	public Dialog onCreateDialog(Bundle savedInstanceState) {
-		logoutConfirmationDialog = new AlertDialog.Builder(getActivity())
+		return new AlertDialog.Builder(getActivity())
 				.setTitle(R.string.logout_title)
 				.setPositiveButton(R.string.logout_yes,
-				new DialogInterface.OnClickListener() {
-
-					@Override
-					public void onClick(DialogInterface dialog,
-							int which) {
-						SalesforceSDKManager.getInstance().logout(getActivity());
-					}
-				})
+						(dialog, which) -> SalesforceSDKManager.getInstance().logout(getActivity()))
 				.setNegativeButton(R.string.logout_cancel, null)
 				.create();
-		return logoutConfirmationDialog;
 	}
 }


### PR DESCRIPTION
I chose to deprecate instead of just updating this now because `android.app.DialogFragment` and `androidx.fragment.app.DialogFragment` are not exactly the same; meaning some apps existing overrides could break.  