### PR TITLE
Deprecate JobIntentService classes to migrate to WorkManager in 11.0.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublisherService.java
@@ -37,7 +37,11 @@ import com.salesforce.androidsdk.accounts.UserAccountManager;
  * A service that publishes stored data when an intent is triggered.
  *
  * @author bhariharan
+ *
+ * @deprecated This class will be drastically altered or replaced in Mobile SDK 11.0 when the deprecated
+ * {@link androidx.core.app.JobIntentService} base is replaced with a WorkManager Worker class.
  */
+@Deprecated
 public class AnalyticsPublisherService extends JobIntentService {
 
     private static final String ACTION_PUBLISH = "com.salesforce.androidsdk.analytics.action.ANALYTICS_PUBLISH";

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.java
@@ -70,7 +70,11 @@ import java.util.Map;
  *
  * @author bhariharan
  * @author ktanna
+ *
+ * @deprecated This class will be drastically altered or replaced in Mobile SDK 11.0 when the deprecated
+ * {@link androidx.core.app.JobIntentService} base is replaced with a WorkManager Worker class.
  */
+@Deprecated
 public class PushService extends JobIntentService {
 
 	private static final String TAG = "PushService";

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/SFDCRegistrationIntentService.java
@@ -37,6 +37,11 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
+/**
+ * @deprecated This class will be drastically altered or replaced in Mobile SDK 11.0 when the deprecated
+ * {@link androidx.core.app.JobIntentService} base is replaced with a WorkManager Worker class.
+ */
+@Deprecated
 public class SFDCRegistrationIntentService extends JobIntentService {
 
     private static final String TAG = "RegIntentService";


### PR DESCRIPTION
I chose to deprecating entire classes because it gives us a lot of freedom with our 11.0 implementation.  Rewriting these classes altogether in Kotlin (with coroutines) looks to be a promising option.  