### PR TITLE
Set kdf_iter for current connection, not global default

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -377,9 +377,6 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 
 	static class DBHook implements SQLiteDatabaseHook {
 		public void preKey(SQLiteDatabase database) {
-			// Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
-			// => should open 2.x databases without any migration
-			database.execSQL("PRAGMA cipher_default_kdf_iter = 4000");
 		}
 
 		/**
@@ -387,7 +384,9 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		 * @param database db being processed
 		 */
 		public void postKey(SQLiteDatabase database) {
-			database.rawExecSQL("PRAGMA cipher_migrate");
+			// Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
+			// => should open 2.x databases without any migration
+			database.rawExecSQL("PRAGMA kdf_iter = 4000");
 		}
 	}
 


### PR DESCRIPTION
Using PRAGMA cipher_default_kdf_iter changes the global default value, which affects all databases opened from that point forward. This is dangerous when Mobile SDK is used in an application where any other code uses SQLCipher directly, as connections to those databases will unexpectedly have a non-default value for kdf_iter.

This change sets kdf_iter only for the specific database connection being opened. Per the SQLCipher docs, this needs to happen after the key is set (so in the postKey() hook).

Already done on iOS: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3548