### PR TITLE
Add Kotlin dependency.  Bump grade version and all other dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,9 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.2.1'
+    classpath 'com.android.tools.build:gradle:7.3.1'
     classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21"
   }
 }
 
@@ -31,5 +32,14 @@ allprojects {
     }
     google()
     mavenCentral()
+  }
+
+  // Ensure that we do not use newer language features that would make the SDK incompatible with
+  // apps that do not target the latest version of Kotlin.
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+      apiVersion = "1.6"
+      languageVersion = "1.6"
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-cdvCompileSdkVersion=32
+cdvCompileSdkVersion=33
 cdvMinSdkVersion=24
 android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:SalesforceHybrid')
+  implementation 'androidx.core:core-ktx:1.9.0'
 }
 
 android {
-  compileSdkVersion 32
+  compileSdkVersion 33
 
   defaultConfig {
-    targetSdkVersion 32
+    targetSdkVersion 33
     minSdkVersion 24
   }
 

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:SalesforceHybrid')
+    implementation 'androidx.core:core-ktx:1.9.0'
 }
 
 android {
-  compileSdkVersion 32
+  compileSdkVersion 33
 
   defaultConfig {
-    targetSdkVersion 32
+    targetSdkVersion 33
     minSdkVersion 24
   }
 

--- a/hybrid/HybridSampleApps/NoteSync/build.gradle
+++ b/hybrid/HybridSampleApps/NoteSync/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:SalesforceHybrid')
-    implementation 'androidx.core:core-ktx:+'
+    implementation 'androidx.core:core-ktx:1.9.0'
 }
 
 android {

--- a/hybrid/HybridSampleApps/NoteSync/build.gradle
+++ b/hybrid/HybridSampleApps/NoteSync/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:SalesforceHybrid')
+    implementation 'androidx.core:core-ktx:+'
 }
 
 android {
-  compileSdkVersion 32
+  compileSdkVersion 33
 
   defaultConfig {
-    targetSdkVersion 32
+    targetSdkVersion 33
     minSdkVersion 24
   }
 

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -11,19 +11,21 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SmartStore')
+    implementation 'androidx.core:core-ktx:+'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
   

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -15,10 +15,10 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SmartStore')
-    implementation 'androidx.core:core-ktx:+'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
 }
 
 android {

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -6,20 +6,22 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api 'com.squareup:tape:1.2.3'
     api 'io.github.pilgr:paperdb:2.7.2'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
 

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -6,24 +6,26 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
-  api project(':libs:MobileSync')
-  api 'org.apache.cordova:framework:11.0.0'
-  api 'androidx.appcompat:appcompat:1.4.0'
-  api 'androidx.appcompat:appcompat-resources:1.4.0'
-  api 'androidx.webkit:webkit:1.4.0'
-  api 'androidx.core:core-splashscreen:1.0.0-rc01'
-  androidTestImplementation 'androidx.test:runner:1.4.0'
-  androidTestImplementation 'androidx.test:rules:1.4.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    api project(':libs:MobileSync')
+    api 'org.apache.cordova:framework:11.0.0'
+    api 'androidx.appcompat:appcompat:1.5.1'
+    api 'androidx.appcompat:appcompat-resources:1.5.1'
+    api 'androidx.webkit:webkit:1.5.0'
+    api 'androidx.core:core-splashscreen:1.0.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
 

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -17,13 +17,15 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
-  api project(':libs:MobileSync')
-  api 'com.facebook.react:react-native:0.70.1'
-  androidTestImplementation 'androidx.test:runner:1.4.0'
-  androidTestImplementation 'androidx.test:rules:1.4.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    api project(':libs:MobileSync')
+    api 'com.facebook.react:react-native:0.70.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
 
     // JSC from node_modules
     if (useIntlJsc) {
@@ -35,10 +37,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
 

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -6,26 +6,29 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SalesforceAnalytics')
     api 'com.squareup.okhttp3:okhttp:4.10.0'
     api 'com.google.firebase:firebase-messaging:20.1.0'
-    api 'androidx.core:core:1.7.0'
+    api 'androidx.core:core:1.9.0'
     api 'androidx.browser:browser:1.4.0'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.biometric:biometric:1.2.0-alpha04'
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.biometric:biometric:1.2.0-alpha05'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    androidTestImplementation 'androidx.test:runner:1.4.0'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    androidTestImplementation 'androidx.test:runner:1.5.1'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
 

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -6,11 +6,13 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SalesforceSDK')
     api 'androidx.sqlite:sqlite:2.0.1'
     api 'net.zetetic:android-database-sqlcipher:4.5.2'
+    implementation 'androidx.core:core-ktx:+'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
@@ -19,10 +21,10 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
   

--- a/native/NativeSampleApps/AppConfigurator/build.gradle
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle
@@ -1,16 +1,20 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SalesforceSDK')
+    implementation 'androidx.core:core-ktx:1.9.0'
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
+
+    
 
     sourceSets {
         main {

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SalesforceSDK')
+    implementation 'androidx.core:core-ktx:+'
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        targetSdkVersion 32
+        targetSdkVersion 33
         minSdkVersion 24
     }
 

--- a/native/NativeSampleApps/MobileSyncExplorer/build.gradle
+++ b/native/NativeSampleApps/MobileSyncExplorer/build.gradle
@@ -1,14 +1,16 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:MobileSync')
+    implementation 'androidx.core:core-ktx:1.9.0'
 }
 
 android {
-  compileSdkVersion 32
+  compileSdkVersion 33
 
   defaultConfig {
-    targetSdkVersion 32
+    targetSdkVersion 33
     minSdkVersion 24
   }
 

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -3,17 +3,17 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:SalesforceSDK')
-    implementation 'androidx.core:core-ktx:+'
-    androidTestImplementation ('androidx.test:runner:1.4.0') {
+    implementation 'androidx.core:core-ktx:1.9.0'
+    androidTestImplementation ('androidx.test:runner:1.5.1') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation ('androidx.test:rules:1.4.0') {
+  androidTestImplementation ('androidx.test:rules:1.5.0') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation ('androidx.test.espresso:espresso-core:3.4.0') {
+  androidTestImplementation ('androidx.test.espresso:espresso-core:3.5.0') {
     exclude module: 'support-annotations'
   }
-  androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+  androidTestImplementation 'androidx.test.ext:junit:1.1.4'
 }
 
 android {

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -1,8 +1,10 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:SalesforceSDK')
-  androidTestImplementation ('androidx.test:runner:1.4.0') {
+    implementation 'androidx.core:core-ktx:+'
+    androidTestImplementation ('androidx.test:runner:1.4.0') {
     exclude module: 'support-annotations'
   }
   androidTestImplementation ('androidx.test:rules:1.4.0') {
@@ -15,10 +17,10 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 32
+  compileSdkVersion 33
 
   defaultConfig {
-    targetSdkVersion 32
+    targetSdkVersion 33
     minSdkVersion 24
   }
   


### PR DESCRIPTION
This allows us to write Kotlin code in the SDK.  I have specified a Kotlin `apiVersion` and `languageVersion` of 1.6 so that is the _minimum_ version consumers must use.  This setting will throw errors if we use newer non-backwards compatible features within the SDK, but we are allowed to take advantage of the bugfixes and perf improvements associated with compiling against latest version of Kotlin (`1.7.21` in this case).  

~~TODO:  Catch the unhelpful error thrown by not specifying a Kotlin version in a pure Java project and re-throw with a message stating that Kotlin 1.6+ is required.~~

Edit: 
```
A problem occurred evaluating project ':libs:MobileSync'.
> Plugin with id 'org.jetbrains.kotlin.android' not found.
```
The above is the **Gradle** error that is thrown in a pure Java app.  AFAIK there is no way to catch this error so we should document it.  