### PR TITLE
@W-11432310: Remove Deprecated Fragment Code

### DIFF
--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -15,8 +15,8 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SmartStore')
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.appcompat:appcompat-resources:1.6.1'
+    api 'androidx.appcompat:appcompat:1.6.1'
+    api 'androidx.appcompat:appcompat-resources:1.6.1'
     implementation 'androidx.core:core-ktx:1.9.0'
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:rules:1.5.0'

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -15,6 +15,8 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SmartStore')
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat-resources:1.6.1'
     implementation 'androidx.core:core-ktx:1.9.0'
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:rules:1.5.0'
@@ -28,7 +30,7 @@ android {
         targetSdkVersion 33
         minSdkVersion 24
     }
-  
+
   buildTypes {
       debug {
          testCoverageEnabled = true

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -11,8 +11,8 @@ apply plugin: 'org.jetbrains.kotlin.android'
 dependencies {
     api project(':libs:MobileSync')
     api 'org.apache.cordova:framework:11.0.0'
-    api 'androidx.appcompat:appcompat:1.6.0'
-    api 'androidx.appcompat:appcompat-resources:1.6.0'
+    api 'androidx.appcompat:appcompat:1.6.1'
+    api 'androidx.appcompat:appcompat-resources:1.6.1'
     api 'androidx.webkit:webkit:1.6.0'
     api 'androidx.core:core-splashscreen:1.0.0'
     implementation 'androidx.core:core-ktx:1.9.0'

--- a/libs/SalesforceSDK/res/values/sf__styles.xml
+++ b/libs/SalesforceSDK/res/values/sf__styles.xml
@@ -2,7 +2,7 @@
 
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="SalesforceSDK">
+    <style name="SalesforceSDK" parent="Theme.AppCompat.DayNight">
         <item name="android:actionBarStyle">@style/SalesforceSDKActionBar</item>
         <item name="android:colorPrimary">@color/sf__primary_color</item>
         <item name="android:colorPrimaryDark">@color/sf__primary_color</item>
@@ -195,6 +195,13 @@
         <item name="android:layout_marginTop">@dimen/sf__screenlock_error_margin_top</item>
         <item name="android:layout_marginLeft">@dimen/sf__screenlock_error_margin_left</item>
         <item name="android:layout_marginRight">@dimen/sf__screenlock_error_margin_right</item>
+    </style>
+
+    <style name="SalesforceSDK_Fullscreen" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowContentOverlay">@null</item>
     </style>
 
 </resources>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -32,7 +32,6 @@ import static androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTI
 
 import android.accounts.AccountAuthenticatorResponse;
 import android.accounts.AccountManager;
-import android.app.ActionBar;
 import android.app.admin.DevicePolicyManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -57,10 +56,11 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import androidx.core.content.ContextCompat;
-import androidx.fragment.app.FragmentActivity;
 
 import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.accounts.UserAccount;
@@ -91,7 +91,7 @@ import java.util.Map;
  *
  * The bulk of the work for this is actually managed by OAuthWebviewHelper class.
  */
-public class LoginActivity extends FragmentActivity
+public class LoginActivity extends AppCompatActivity
 		implements OAuthWebviewHelperEvents {
 
     public static final int PICK_SERVER_REQUEST_CODE = 10;
@@ -363,7 +363,7 @@ public class LoginActivity extends FragmentActivity
 
     @Override
     public void loadingLoginPage(String loginUrl) {
-        final ActionBar ab = getActionBar();
+        final ActionBar ab = getSupportActionBar();
         if (ab != null) {
             ab.setTitle(loginUrl);
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -26,14 +26,15 @@
  */
 package com.salesforce.androidsdk.ui;
 
-import android.app.Activity;
 import android.os.Bundle;
 import android.view.KeyEvent;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Abstract base class for all Salesforce activities.
  */
-public abstract class SalesforceActivity extends Activity implements SalesforceActivityInterface {
+public abstract class SalesforceActivity extends AppCompatActivity implements SalesforceActivityInterface {
 
 	private final SalesforceActivityDelegate delegate;
 
@@ -48,7 +49,7 @@ public abstract class SalesforceActivity extends Activity implements SalesforceA
 		delegate.onCreate();
 	}
 
-	@Override 
+	@Override
 	public void onResume() {
 		super.onResume();
 		delegate.onResume(true);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
@@ -34,7 +34,13 @@ import android.view.KeyEvent;
  * Abstract base class for all Salesforce list activities.
  *
  * @author bhariharan
+ * @deprecated Please note {@link SalesforceListActivity} inherits from the
+ * Android SDK's deprecated {@link android.app.ListActivity}.  Similar to the
+ * instructions in {@link ListActivity}, use {@link SalesforceActivity} with
+ * {@link androidx.recyclerview.widget.RecyclerView} to implement your
+ * Activity instead.
  */
+@Deprecated
 public abstract class SalesforceListActivity extends ListActivity implements SalesforceActivityInterface {
 
 	private final SalesforceActivityDelegate delegate;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
@@ -26,16 +26,17 @@
  */
 package com.salesforce.androidsdk.ui;
 
-import android.app.ListActivity;
 import android.os.Bundle;
 import android.view.KeyEvent;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Abstract base class for all Salesforce list activities.
  *
  * @author bhariharan
  */
-public abstract class SalesforceListActivity extends ListActivity implements SalesforceActivityInterface {
+public abstract class SalesforceListActivity extends AppCompatActivity implements SalesforceActivityInterface {
 
 	private final SalesforceActivityDelegate delegate;
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceListActivity.java
@@ -26,17 +26,16 @@
  */
 package com.salesforce.androidsdk.ui;
 
+import android.app.ListActivity;
 import android.os.Bundle;
 import android.view.KeyEvent;
-
-import androidx.appcompat.app.AppCompatActivity;
 
 /**
  * Abstract base class for all Salesforce list activities.
  *
  * @author bhariharan
  */
-public abstract class SalesforceListActivity extends AppCompatActivity implements SalesforceActivityInterface {
+public abstract class SalesforceListActivity extends ListActivity implements SalesforceActivityInterface {
 
 	private final SalesforceActivityDelegate delegate;
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -26,7 +26,6 @@
  */
 package com.salesforce.androidsdk.ui;
 
-import android.app.ActionBar;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -37,7 +36,8 @@ import android.widget.Button;
 import android.widget.RadioGroup;
 import android.widget.ScrollView;
 
-import androidx.fragment.app.FragmentActivity;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentManager;
 
 import com.salesforce.androidsdk.R;
@@ -56,7 +56,7 @@ import java.util.List;
  *
  * @author bhariharan
  */
-public class ServerPickerActivity extends FragmentActivity implements
+public class ServerPickerActivity extends AppCompatActivity implements
         android.widget.RadioGroup.OnCheckedChangeListener, AuthConfigTask.AuthConfigCallbackInterface {
 
     public static final String CHANGE_SERVER_INTENT = "com.salesforce.SERVER_CHANGED";
@@ -131,7 +131,7 @@ public class ServerPickerActivity extends FragmentActivity implements
         loginServerManager = SalesforceSDKManager.getInstance().getLoginServerManager();
         setContentView(R.layout.sf__server_picker);
 
-        final ActionBar actionBar = getActionBar();
+        final ActionBar actionBar = getSupportActionBar();
         actionBar.setTitle(R.string.sf__server_picker_title);
         actionBar.setDisplayHomeAsUpEnabled(true);
 
@@ -172,7 +172,10 @@ public class ServerPickerActivity extends FragmentActivity implements
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.sf__menu_clear_custom_url) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        } else if (item.getItemId() == R.id.sf__menu_clear_custom_url) {
             clearCustomUrlSetting();
             return true;
         } else {

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
     api project(':libs:SalesforceSDK')
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat-resources:1.6.1'
     implementation 'androidx.core:core-ktx:1.9.0'
 }
 

--- a/native/NativeSampleApps/MobileSyncExplorer/build.gradle
+++ b/native/NativeSampleApps/MobileSyncExplorer/build.gradle
@@ -3,7 +3,10 @@ apply plugin: 'org.jetbrains.kotlin.android'
 
 dependencies {
   api project(':libs:MobileSync')
+  implementation 'androidx.appcompat:appcompat:1.6.1'
+  implementation 'androidx.appcompat:appcompat-resources:1.6.1'
     implementation 'androidx.core:core-ktx:1.9.0'
+  implementation 'androidx.recyclerview:recyclerview:1.3.0'
 }
 
 android {
@@ -25,7 +28,7 @@ android {
       res.srcDirs = ['res']
       assets.srcDirs = ['assets']
     }
-    
+
   }
     packagingOptions {
         resources {

--- a/native/NativeSampleApps/MobileSyncExplorer/res/layout/main.xml
+++ b/native/NativeSampleApps/MobileSyncExplorer/res/layout/main.xml
@@ -7,13 +7,11 @@
     android:background="?android:colorBackground"
     android:id="@+id/root">
 
-    <ListView android:id="@android:id/list"
-        android:layout_height="wrap_content"
+    <androidx.recyclerview.widget.RecyclerView android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:scrollbarStyle="insideInset"
-        android:divider="@color/sf__border_color"/>
+        android:layout_height="wrap_content" />
 
-    <TextView android:id="@android:id/empty"
+    <TextView android:id="@+id/empty"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:text="@string/no_results_found"
@@ -22,4 +20,4 @@
         android:textStyle="bold"
         android:gravity="center"
         android:textSize="18sp" />
-</LinearLayout> 
+</LinearLayout>

--- a/native/NativeSampleApps/MobileSyncExplorer/res/menu/action_bar_menu.xml
+++ b/native/NativeSampleApps/MobileSyncExplorer/res/menu/action_bar_menu.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/action_search"
         android:icon="@drawable/ic_action_search"
         android:title="@string/action_search"
-        android:showAsAction="ifRoom|collapseActionView" />
+        app:showAsAction="ifRoom|collapseActionView" />
     <item android:id="@+id/action_add"
         android:icon="@drawable/ic_action_add_person"
         android:title="@string/action_add"
-        android:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom" />
     <item android:id="@+id/action_refresh"
         android:icon="@drawable/ic_action_refresh"
         android:title="@string/action_refresh"
-        android:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom" />
     <item android:id="@+id/action_logout"
         android:title="@string/logout_button"
-        android:showAsAction="never" />
+        app:showAsAction="never" />
     <item android:id="@+id/action_switch_user"
         android:title="@string/switch_user_button"
-        android:showAsAction="never" />
+        app:showAsAction="never" />
     <item android:id="@+id/action_inspect_db"
         android:title="@string/inspect_db_button"
-        android:showAsAction="never" />
+        app:showAsAction="never" />
 </menu>

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DeleteDialogFragment.kt
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DeleteDialogFragment.kt
@@ -24,49 +24,29 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.samples.mobilesyncexplorer.ui;
+package com.salesforce.samples.mobilesyncexplorer.ui
 
-import android.app.AlertDialog;
-import android.app.Dialog;
-import android.app.DialogFragment;
-import android.content.DialogInterface;
-import android.os.Bundle;
-
-import com.salesforce.androidsdk.app.SalesforceSDKManager;
-import com.salesforce.samples.mobilesyncexplorer.R;
+import android.app.AlertDialog.Builder
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.salesforce.samples.mobilesyncexplorer.R.string.cancel
+import com.salesforce.samples.mobilesyncexplorer.R.string.delete_title
+import com.salesforce.samples.mobilesyncexplorer.R.string.yes
 
 /**
- * A simple dialog fragment to provide options at logout.
- *
- * @deprecated The exact signature of the methods inside of LogoutDialogFragment and its inherited
- * methods may change in Mobile SDK 11.0 when the deprecated base class {@link android.app.DialogFragment} is
- * replaced with {@link androidx.fragment.app.DialogFragment}.
+ * A simple dialog fragment to provide options for deletion.
  */
-@Deprecated
-public class LogoutDialogFragment extends DialogFragment {
+class DeleteDialogFragment : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return Builder(activity)
+            .setTitle(delete_title)
+            .setPositiveButton(yes) { _: DialogInterface?, _: Int ->
 
-	/**
-	 * Default constructor.
-	 */
-	public LogoutDialogFragment() {
-	}
-
-	@Override
-	public Dialog onCreateDialog(Bundle savedInstanceState) {
-		boolean isDarkTheme = SalesforceSDKManager.getInstance().isDarkTheme();
-		return new AlertDialog.Builder(getActivity(), isDarkTheme ?
-				R.style.SalesforceSDK_Dialog_Dark : R.style.SalesforceSDK_Dialog)
-				.setTitle(R.string.logout_title)
-				.setPositiveButton(R.string.yes,
-				new DialogInterface.OnClickListener() {
-
-					@Override
-					public void onClick(DialogInterface dialog,
-							int which) {
-						SalesforceSDKManager.getInstance().logout(getActivity());
-					}
-				})
-				.setNegativeButton(R.string.cancel, null)
-				.create();
-	}
+                (activity as? DetailActivity?)?.deleteOrUndelete()
+            }
+            .setNegativeButton(cancel, null)
+            .create()
+    }
 }

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DetailActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DetailActivity.java
@@ -83,8 +83,8 @@ public class DetailActivity extends SalesforceActivity implements LoaderManager.
 		final Intent launchIntent = getIntent();
 		if (launchIntent != null) {
 			objectId = launchIntent.getStringExtra(MainActivity.OBJECT_ID_KEY);
-			getActionBar().setTitle(launchIntent.getStringExtra(MainActivity.OBJECT_NAME_KEY));
-			getActionBar().setSubtitle(launchIntent.getStringExtra(MainActivity.OBJECT_TITLE_KEY));
+			getSupportActionBar().setTitle(launchIntent.getStringExtra(MainActivity.OBJECT_NAME_KEY));
+			getSupportActionBar().setSubtitle(launchIntent.getStringExtra(MainActivity.OBJECT_TITLE_KEY));
 		}
 		deleteConfirmationDialog = new DeleteDialogFragment();
 	}
@@ -162,7 +162,7 @@ public class DetailActivity extends SalesforceActivity implements LoaderManager.
 		}
 		else {
 			// it's a delete
-			deleteConfirmationDialog.show(getFragmentManager(), "DeleteDialog");
+			deleteConfirmationDialog.show(getSupportFragmentManager(), "DeleteDialog");
 		}
 	}
 

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/LogoutDialogFragment.kt
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/LogoutDialogFragment.kt
@@ -24,46 +24,37 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package com.salesforce.samples.mobilesyncexplorer.ui;
+package com.salesforce.samples.mobilesyncexplorer.ui
 
-import android.app.AlertDialog;
-import android.app.Dialog;
-import android.app.DialogFragment;
-import android.content.DialogInterface;
-import android.os.Bundle;
-
-import com.salesforce.samples.mobilesyncexplorer.R;
+import android.app.AlertDialog.Builder
+import android.app.Dialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.salesforce.androidsdk.app.SalesforceSDKManager.getInstance
+import com.salesforce.samples.mobilesyncexplorer.R.string.cancel
+import com.salesforce.samples.mobilesyncexplorer.R.string.logout_title
+import com.salesforce.samples.mobilesyncexplorer.R.string.yes
+import com.salesforce.samples.mobilesyncexplorer.R.style.SalesforceSDK_Dialog
+import com.salesforce.samples.mobilesyncexplorer.R.style.SalesforceSDK_Dialog_Dark
 
 /**
- * A simple dialog fragment to provide options for deletion.
- *
- * @deprecated The exact signature of the methods inside of DeleteDialogFragment and its inherited
- * methods may change in Mobile SDK 11.0 when the deprecated base class {@link android.app.DialogFragment} is
- * replaced with {@link androidx.fragment.app.DialogFragment}.
+ * A simple dialog fragment to provide options at logout.
  */
-@Deprecated
-public class DeleteDialogFragment extends DialogFragment {
+class LogoutDialogFragment : DialogFragment() {
 
-	/**
-	 * Default constructor.
-	 */
-	public DeleteDialogFragment() {
-	}
-
-	@Override
-	public Dialog onCreateDialog(Bundle savedInstanceState) {
-		return new AlertDialog.Builder(getActivity())
-				.setTitle(R.string.delete_title)
-				.setPositiveButton(R.string.yes,
-				new DialogInterface.OnClickListener() {
-
-					@Override
-					public void onClick(DialogInterface dialog,
-							int which) {
-                        ((DetailActivity) getActivity()).deleteOrUndelete();
-                    }
-				})
-				.setNegativeButton(R.string.cancel, null)
-				.create();
-	}
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return Builder(
+            activity,
+            when (getInstance().isDarkTheme) {
+                true -> SalesforceSDK_Dialog_Dark
+                else -> SalesforceSDK_Dialog
+            }
+        )
+            .setTitle(logout_title)
+            .setPositiveButton(yes) { _, _ ->
+                getInstance().logout(activity)
+            }
+            .setNegativeButton(cancel, null)
+            .create()
+    }
 }

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
@@ -26,7 +26,10 @@
  */
 package com.salesforce.samples.mobilesyncexplorer.ui;
 
+import static android.view.LayoutInflater.from;
+
 import android.accounts.Account;
+import android.annotation.SuppressLint;
 import android.app.LoaderManager;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
@@ -38,21 +41,25 @@ import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MenuItem.OnActionExpandListener;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
 import android.widget.Filter;
 import android.widget.ImageView;
-import android.widget.ListView;
 import android.widget.SearchView;
-import android.widget.SearchView.OnCloseListener;
 import android.widget.SearchView.OnQueryTextListener;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView.Adapter;
+import androidx.recyclerview.widget.RecyclerView.ViewHolder;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
@@ -75,7 +82,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author bhariharan
  */
 public class MainActivity extends SalesforceListActivity implements
-		OnQueryTextListener, OnCloseListener,
+		OnQueryTextListener,
 		LoaderManager.LoaderCallbacks<List<ContactObject>> {
 
 	public static final String OBJECT_ID_KEY = "object_id";
@@ -122,9 +129,21 @@ public class MainActivity extends SalesforceListActivity implements
 		SalesforceSDKManager.getInstance().setViewNavigationVisibility(this);
 
 		setContentView(R.layout.main);
-		getActionBar().setTitle(R.string.main_activity_title);
-		listAdapter = new ContactListAdapter(this, R.layout.list_item);
-		getListView().setAdapter(listAdapter);
+		getSupportActionBar().setTitle(R.string.main_activity_title);
+
+		RecyclerView recyclerView = ((RecyclerView)findViewById(R.id.recycler_view));
+		listAdapter = new ContactListAdapter(
+				R.layout.list_item,
+				this::onListItemClick);
+		LinearLayoutManager layoutManager = new LinearLayoutManager(this);
+		DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(
+				this,
+				layoutManager.getOrientation()
+		);
+		recyclerView.addItemDecoration(dividerItemDecoration);
+		recyclerView.setAdapter(listAdapter);
+		recyclerView.setLayoutManager(layoutManager);
+
 		nameFilter = new NameFieldFilter(listAdapter, null);
 		logoutConfirmationDialog = new LogoutDialogFragment();
 		loadCompleteReceiver = new LoadCompleteReceiver();
@@ -209,8 +228,20 @@ public class MainActivity extends SalesforceListActivity implements
 	    final MenuItem searchItem = menu.findItem(R.id.action_search);
 		final SearchView searchView = new SearchView(this);
 	    searchView.setOnQueryTextListener(this);
-        searchView.setOnCloseListener(this);
-        searchItem.setActionView(searchView);
+		MenuItem searchViewItem = menu.findItem(R.id.action_search);
+		searchViewItem.setOnActionExpandListener(new OnActionExpandListener() {
+			@Override
+			public boolean onMenuItemActionExpand(@NonNull MenuItem item) {
+				return true;
+			}
+
+			@Override
+			public boolean onMenuItemActionCollapse(@NonNull MenuItem item) {
+				MainActivity.this.onQueryTextChange("");
+				return true;
+			}
+		});
+		searchItem.setActionView(searchView);
 	    return super.onCreateOptionsMenu(menu);
 	}
 
@@ -222,7 +253,7 @@ public class MainActivity extends SalesforceListActivity implements
 				requestSync(false /* sync up + sync down */);
 	            return true;
 	        case R.id.action_logout:
-	    		logoutConfirmationDialog.show(getFragmentManager(), "LogoutDialog");
+	    		logoutConfirmationDialog.show(getSupportFragmentManager(), "LogoutDialog");
 	            return true;
 			case R.id.action_switch_user:
 				launchAccountSwitcherActivity();
@@ -267,11 +298,6 @@ public class MainActivity extends SalesforceListActivity implements
 	}
 
 	@Override
-	public boolean onClose() {
-		return true;
-	}
-
-	@Override
 	public boolean onQueryTextSubmit(String query) {
 		nameFilter.setFilterTerm(query);
 		return true;
@@ -283,11 +309,11 @@ public class MainActivity extends SalesforceListActivity implements
 		return true;
     }
 
-	@Override
-	protected void onListItemClick(ListView l, View v, int position, long id) {
-		final ContactObject sObject = listAdapter.getItem(position);
-		launchDetailActivity(sObject.getObjectId(), sObject.getName(),
-				sObject.getTitle());
+	protected void onListItemClick(ContactObject contact) {
+		launchDetailActivity(
+				contact.getObjectId(),
+				contact.getName(),
+				contact.getTitle());
 	}
 
     private void refreshList() {
@@ -314,25 +340,28 @@ public class MainActivity extends SalesforceListActivity implements
 	}
 
 	/**
-	 * Custom array adapter to supply data to the list view.
+	 * Custom recycler view adapter to supply data to the recycler view.
 	 *
 	 * @author bhariharan
 	 */
-	private static class ContactListAdapter extends ArrayAdapter<ContactObject> {
+	private static class ContactListAdapter extends Adapter<ContactListAdapter.ContactViewHolder> {
 
 		private int listItemLayoutId;
 		private List<ContactObject> sObjects;
-		private String filterTerm;
+		private final OnItemClickedListener onClickListener;
 
 		/**
 		 * Parameterized constructor.
 		 *
-		 * @param context Context.
 		 * @param listItemLayoutId List item view resource ID.
 		 */
-		public ContactListAdapter(Context context, int listItemLayoutId) {
-			super(context, listItemLayoutId);
+		public ContactListAdapter(
+				int listItemLayoutId,
+				OnItemClickedListener onClickListener) {
+			super();
+
 			this.listItemLayoutId = listItemLayoutId;
+			this.onClickListener = onClickListener;
 		}
 
 		/**
@@ -340,50 +369,62 @@ public class MainActivity extends SalesforceListActivity implements
 		 *
 		 * @param data Data.
 		 */
+		@SuppressLint("NotifyDataSetChanged")
 		public void setData(List<ContactObject> data) {
-			clear();
 			sObjects = data;
-			if (data != null) {
-				addAll(data);
-				notifyDataSetChanged();
-			}
+			notifyDataSetChanged();
 		}
 
 		@Override
-		public View getView (int position, View convertView, ViewGroup parent) {
-			if (convertView == null) {
-				convertView = LayoutInflater.from(getContext()).inflate(listItemLayoutId, null);
-		    }
-			if (sObjects != null) {
-				final ContactObject sObject = sObjects.get(position);
-				if (sObject != null) {
-			        final TextView objName = (TextView) convertView.findViewById(R.id.obj_name);
-			        final TextView objType = (TextView) convertView.findViewById(R.id.obj_type);
-					final TextView objImage = (TextView) convertView.findViewById(R.id.obj_image);
-			        if (objName != null) {
-			        	objName.setText(sObject.getName());
-			        }
-			        if (objType != null) {
-			        	objType.setText(sObject.getTitle());
-			        }
-			        if (objImage != null) {
-			        	final String firstName = sObject.getFirstName();
-			        	String initials = Constants.EMPTY_STRING;
-			        	if (firstName.length() > 0) {
-			        		initials = firstName.substring(0, 1);
-			        	}
-			        	objImage.setText(initials);
-			        	setBubbleColor(objImage, firstName);
-			        }
-			        final ImageView syncImage = convertView.findViewById(R.id.sync_status_view);
-			        if (syncImage != null && sObject.isLocallyModified()) {
-			        	syncImage.setImageResource(R.drawable.sync_local);
-			        } else {
-			        	syncImage.setImageResource(R.drawable.sync_save);
-			        }
+		public void onBindViewHolder(@NonNull ContactViewHolder holder,
+									 int position) {
+
+			final ContactObject sObject = sObjects.get(position);
+			View itemView = holder.itemView;
+
+			itemView.setOnClickListener(v -> onClickListener.itemClicked(sObject));
+
+			if (sObject != null) {
+				final TextView objName = (TextView) itemView.findViewById(R.id.obj_name);
+				final TextView objType = (TextView) itemView.findViewById(R.id.obj_type);
+				final TextView objImage = (TextView) itemView.findViewById(R.id.obj_image);
+				if (objName != null) {
+					objName.setText(sObject.getName());
+				}
+				if (objType != null) {
+					objType.setText(sObject.getTitle());
+				}
+				if (objImage != null) {
+					final String firstName = sObject.getFirstName();
+					String initials = Constants.EMPTY_STRING;
+					if (firstName.length() > 0) {
+						initials = firstName.substring(0, 1);
+					}
+					objImage.setText(initials);
+					setBubbleColor(objImage, firstName);
+				}
+				final ImageView syncImage = itemView.findViewById(R.id.sync_status_view);
+				if (syncImage != null && sObject.isLocallyModified()) {
+					syncImage.setImageResource(R.drawable.sync_local);
+				} else {
+					syncImage.setImageResource(R.drawable.sync_save);
 				}
 			}
-		    return convertView;
+		}
+
+		@NonNull
+		@Override
+		public ContactViewHolder onCreateViewHolder(@NonNull ViewGroup parent,
+													int viewType) {
+			return new ContactViewHolder(
+					from(parent.getContext()).inflate(
+							listItemLayoutId,
+							null));
+		}
+
+		@Override
+		public int getItemCount() {
+			return sObjects == null ? 0 : sObjects.size();
 		}
 
 		private void setBubbleColor(TextView tv, String firstName) {
@@ -401,6 +442,18 @@ public class MainActivity extends SalesforceListActivity implements
 			drawable.setShape(GradientDrawable.OVAL);
 			tv.setBackground(drawable);
 		}
+
+		static class ContactViewHolder extends ViewHolder {
+
+			public ContactViewHolder(@NonNull View itemView) {
+				super(itemView);
+			}
+		}
+
+		interface OnItemClickedListener {
+
+			void itemClicked(ContactObject contact);
+		}
 	}
 
 	/**
@@ -408,7 +461,7 @@ public class MainActivity extends SalesforceListActivity implements
 	 *
 	 * @author bhariharan
 	 */
-	private static class NameFieldFilter extends Filter {
+	private class NameFieldFilter extends Filter {
 
 		private ContactListAdapter adpater;
 		private List<ContactObject> data;
@@ -476,6 +529,7 @@ public class MainActivity extends SalesforceListActivity implements
 		@Override
 		protected void publishResults(CharSequence constraint, FilterResults results) {
 			if (results != null && results.values != null) {
+				MainActivity.this.findViewById(R.id.empty).setVisibility(results.count > 0 ? View.GONE : View.VISIBLE);
 				adpater.setData((List<ContactObject>) results.values);
 			}
 		}

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
@@ -66,7 +66,7 @@ import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity;
-import com.salesforce.androidsdk.ui.SalesforceListActivity;
+import com.salesforce.androidsdk.ui.SalesforceActivity;
 import com.salesforce.samples.mobilesyncexplorer.R;
 import com.salesforce.samples.mobilesyncexplorer.loaders.ContactListLoader;
 import com.salesforce.samples.mobilesyncexplorer.objects.ContactObject;
@@ -81,7 +81,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author bhariharan
  */
-public class MainActivity extends SalesforceListActivity implements
+public class MainActivity extends SalesforceActivity implements
 		OnQueryTextListener,
 		LoaderManager.LoaderCallbacks<List<ContactObject>> {
 

--- a/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
@@ -14,7 +14,7 @@
 		<!-- Launcher screen -->
 		<activity android:name=".ExplorerActivity"
 		    android:label="@string/app_name"
-			android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+			android:theme="@style/SalesforceSDK_Fullscreen"
 			android:exported="true">
 
 			<intent-filter>

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -7,6 +7,10 @@ dependencies {
     androidTestImplementation ('androidx.test:runner:1.5.1') {
     exclude module: 'support-annotations'
   }
+
+  implementation 'androidx.appcompat:appcompat:1.6.1'
+  implementation 'androidx.appcompat:appcompat-resources:1.6.1'
+
   androidTestImplementation ('androidx.test:rules:1.5.0') {
     exclude module: 'support-annotations'
   }
@@ -23,7 +27,7 @@ android {
     targetSdkVersion 33
     minSdkVersion 24
   }
-  
+
   buildTypes {
       debug {
          testCoverageEnabled = true

--- a/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/ServerPickerActivityTest.java
+++ b/native/NativeSampleApps/test/RestExplorerTest/src/com/salesforce/samples/restexplorer/ServerPickerActivityTest.java
@@ -27,6 +27,7 @@
 package com.salesforce.samples.restexplorer;
 
 import static androidx.test.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -47,7 +48,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
+import androidx.appcompat.widget.MenuPopupWindow.MenuDropDownListView;
 import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
 import androidx.test.rule.ActivityTestRule;
@@ -58,6 +61,7 @@ import com.salesforce.androidsdk.ui.ServerPickerActivity;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
 import com.salesforce.androidsdk.util.test.EventsListenerQueue;
 
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -183,7 +187,7 @@ public class ServerPickerActivityTest {
      * @throws Throwable
      */
     @Test
-    public void testRestButton() throws Throwable {
+    public void testResetButton() throws Throwable {
         String label = "Server%d";
         String url = "https://login.test.com/%d";
         String entry = label + "\n" + url;
@@ -285,8 +289,13 @@ public class ServerPickerActivityTest {
     private static void tapResetButton() {
         openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
         try {
-            onView(allOf(withId(android.R.id.title), withText("Reset"), findUiElement()))
-                    .perform(click());
+            onData(CoreMatchers.anything())
+                    .inRoot(RootMatchers.isPlatformPopup())
+                    .inAdapterView(CoreMatchers.instanceOf(
+                            MenuDropDownListView.class))
+                    .atPosition(0)
+                    .perform(click()
+                    );
         } catch (Throwable t) {
             Assert.fail("Unable to tap reset button.  Error: " + t.getLocalizedMessage());
         }


### PR DESCRIPTION
This effort migrates the final two dialogs from the deprecated `android.app.DialogFragment` to Android Jetpack's `androidx.fragment.app.DialogFragment`.  There are a couple of related migrations to `AppCompatActivity`, `RecyclerView` and new themes as well where the new dialogs needed Jetpack support.

~This is in draft status for some preview discussion.  The sample apps all build and run.  The unit tests need additional local verification.  Also, we could revert a few changes if there's any desire to and a means to run Jetpack dialogs without AppCompatActivity to support them.~

_20230505: 🚀 Ready for review!  All unit and instrumented tests pass on my workstation._

Thanks for reading! ⭐️