### PR TITLE
Login through web view can use "user agent flow" or "web server flow"

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -49,7 +49,6 @@ import android.view.View;
 import android.webkit.CookieManager;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
@@ -172,6 +171,8 @@ public class SalesforceSDKManager implements LifecycleObserver {
     private List<String> additionalOauthKeys;
     private String loginBrand;
     private boolean browserLoginEnabled;
+
+    private boolean useWebServerAuthentication = true; // web server flow ON by default - but app can opt out by calling setUseWebServerAuthentication(false)
     private Theme theme =  Theme.SYSTEM_DEFAULT;
     private String appName;
 
@@ -596,6 +597,23 @@ public class SalesforceSDKManager implements LifecycleObserver {
      */
     public boolean isBrowserLoginEnabled() {
         return browserLoginEnabled;
+    }
+
+    /**
+     * Returns whether web server flow should be used when logging through the WebView
+     *
+     * @return True - if web server flow should be used, False - otherwise.
+     */
+    public boolean shouldUseWebServerAuthentication() {
+        return useWebServerAuthentication;
+    }
+
+    /**
+     * Sets whether web server flow should be used when logging through the WebView
+     * @param useWebServerAuthentication
+     */
+    public synchronized void setUseWebServerAuthentication(boolean useWebServerAuthentication) {
+        this.useWebServerAuthentication = useWebServerAuthentication;
     }
 
     /**
@@ -1246,6 +1264,7 @@ public class SalesforceSDKManager implements LifecycleObserver {
                 "SDK Version", SDK_VERSION,
                 "App Type", getAppType(),
                 "User Agent", getUserAgent(),
+                "Use Web Server Authentication", shouldUseWebServerAuthentication() + "",
                 "Browser Login Enabled", isBrowserLoginEnabled() + "",
                 "IDP Enabled", isIDPLoginFlowEnabled() + "",
                 "Identity Provider", isIdentityProvider() + "",

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
@@ -139,6 +139,7 @@ internal class IDPAuthCodeHelper private constructor(
         val context = SalesforceSDKManager.getInstance().appContext
         val frontdoorUrl = getFrontdoorUrl(
             getAuthorizationUrl(
+                true, // use web server flow
                 URI(userAccount.loginServer),
                 spConfig.oauthClientId,
                 spConfig.oauthCallbackUrl,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
@@ -53,8 +53,7 @@ public class DevInfoActivity extends Activity {
         boolean isDarkTheme = SalesforceSDKManager.getInstance().isDarkTheme();
         setTheme(isDarkTheme ? R.style.SalesforceSDK_Dark : R.style.SalesforceSDK);
 
-        // Title / layout
-        getActionBar().setTitle(R.string.sf__dev_support_title);
+        // Layout
         setContentView(R.layout.sf__dev_info);
 
         // Setup list

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
@@ -31,6 +31,8 @@ import android.os.Bundle;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
 
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
@@ -42,7 +44,7 @@ import java.util.Map;
 /**
  * Dev support activity showing a lot of useful information
  */
-public class DevInfoActivity extends Activity {
+public class DevInfoActivity extends AppCompatActivity {
 
     public static final String NAME = "name";
     public static final String VALUE = "value";
@@ -53,7 +55,8 @@ public class DevInfoActivity extends Activity {
         boolean isDarkTheme = SalesforceSDKManager.getInstance().isDarkTheme();
         setTheme(isDarkTheme ? R.style.SalesforceSDK_Dark : R.style.SalesforceSDK);
 
-        // Layout
+        // Title / layout
+        getSupportActionBar().setTitle(R.string.sf__dev_support_title);
         setContentView(R.layout.sf__dev_info);
 
         // Setup list

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -322,15 +322,18 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     public void loadLoginPage() {
         if (TextUtils.isEmpty(loginOptions.getJwt())) {
             loginOptions.setLoginUrl(getLoginUrl());
-            doLoadPage(false);
+            doLoadPage();
         } else {
             new SwapJWTForAccessTokenTask().execute(loginOptions);
         }
     }
 
-    private void doLoadPage(boolean jwtFlow) {
+    private void doLoadPage() {
         try {
-            URI uri = getAuthorizationUrl(jwtFlow);
+            boolean isBrowserLoginEnabled = SalesforceSDKManager.getInstance().isBrowserLoginEnabled();
+            boolean useWebServerFlowAuthentication = isBrowserLoginEnabled || SalesforceSDKManager.getInstance().shouldUseWebServerAuthentication();
+
+            URI uri = getAuthorizationUrl(useWebServerFlowAuthentication);
             callback.loadingLoginPage(loginOptions.getLoginUrl());
             if (SalesforceSDKManager.getInstance().isBrowserLoginEnabled()) {
                 loadLoginPageInChrome(uri);
@@ -415,12 +418,13 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     	return loginOptions.getOauthClientId();
     }
 
-    protected URI getAuthorizationUrl(Boolean jwtFlow) throws URISyntaxException {
+    protected URI getAuthorizationUrl(boolean useWebServerAuthentication) throws URISyntaxException {
+        boolean jwtFlow = TextUtils.isEmpty(loginOptions.getJwt());
+        Map<String, String> addlParams = jwtFlow ? null : loginOptions.getAdditionalParameters();
+        // NB code verifier / code challenge are only used when useWebServerAuthentication is true
         codeVerifier = SalesforceKeyGenerator.getRandom128ByteKey();
         String codeChallenge = SalesforceKeyGenerator.getSHA256Hash(codeVerifier);
-
-        Map<String, String> addlParams = jwtFlow ? null : loginOptions.getAdditionalParameters();
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(loginOptions.getLoginUrl()), getOAuthClientId(), loginOptions.getOauthCallbackUrl(), loginOptions.getOauthScopes(), getAuthorizationDisplayType(), codeChallenge, addlParams);
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(useWebServerAuthentication, new URI(loginOptions.getLoginUrl()), getOAuthClientId(), loginOptions.getOauthCallbackUrl(), loginOptions.getOauthScopes(), getAuthorizationDisplayType(), codeChallenge, addlParams);
 
         if (jwtFlow) {
             return OAuth2.getFrontdoorUrl(authorizationUrl,
@@ -479,6 +483,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+            boolean useWebFlowAuthentication = SalesforceSDKManager.getInstance().shouldUseWebServerAuthentication();
             Uri uri = request.getUrl();
 
             // Login webview embedded button has sent the signal to show the biometric prompt.
@@ -505,8 +510,13 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                 }
                 // Or succeed?
                 else {
-                    String code = params.get("code");
-                    onWebServerFlowComplete(code);
+                    if (useWebFlowAuthentication) {
+                        String code = params.get("code");
+                        onWebServerFlowComplete(code);
+                    } else {
+                        TokenEndpointResponse tr = new TokenEndpointResponse(params);
+                        onAuthFlowComplete(tr);
+                    }
                 }
             }
             return isDone;
@@ -601,9 +611,9 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             }
             if (tr != null && tr.authToken != null) {
                 loginOptions.setJwt(tr.authToken);
-                doLoadPage(true);
+                doLoadPage();
             } else {
-                doLoadPage(false);
+                doLoadPage();
                 handleJWTError();
             }
             loginOptions.setJwt(null);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -41,6 +41,7 @@ import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
 import com.salesforce.androidsdk.util.test.TestCredentials;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,6 +75,11 @@ public class OAuth2Test {
 		TestCredentials.init(InstrumentationRegistry.getInstrumentation().getContext());
 		httpAccess = new HttpAccess(null, "dummy-agent");		
 	}
+
+    @After
+    public void tearDown() {
+        SalesforceSDKManager.getInstance().setLoginBrand(null);
+    }
 
 	/**
 	 * Testing getAuthorizationUrl.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -83,14 +83,14 @@ public class OAuth2Test {
     @Test
 	public void testGetAuthorizationUrl() throws URISyntaxException {
 		String callbackUrl = "sfdc://callback";
-		URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+		URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
 		URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
 				SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-		authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+		authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
 		expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=code&client_id=" +
@@ -111,7 +111,7 @@ public class OAuth2Test {
 		params.put("param1", "val1");
 		params.put("param2", "val2");
 		params.put("param3", null);
-		URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+		URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", params);
         Assert.assertTrue("Wrong authorization url", authorizationUrl.getRawQuery().indexOf("&param1=val1") > 0);
         Assert.assertTrue("Wrong authorization url", authorizationUrl.getRawQuery().indexOf("&param2=val2") > 0);
@@ -128,14 +128,14 @@ public class OAuth2Test {
         String callbackUrl = "sfdc://callback";
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
                 SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+        authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
@@ -154,14 +154,14 @@ public class OAuth2Test {
         String callbackUrl = "sfdc://callback";
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
                 SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+        authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
@@ -180,14 +180,14 @@ public class OAuth2Test {
         String callbackUrl = "sfdc://callback";
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
                 SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+        authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
@@ -196,9 +196,33 @@ public class OAuth2Test {
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
     }
 
+    /**
+     * Testing getAuthorizationUrl with web server authenticated set to false.
+     *
+     * @throws URISyntaxException See {@link URISyntaxException}.
+     */
+    @Test
+    public void testGetAuthorizationUrlForUserAgentFlow() throws URISyntaxException {
+        String callbackUrl = "sfdc://callback";
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(false, new URI(TestCredentials.LOGIN_URL),
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
+        URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
+                "/services/oauth2/authorize?display=touch&response_type=hybrid_token&client_id=" +
+                TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
+                SalesforceSDKManager.getInstance().getDeviceId());
+        Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
+        authorizationUrl = OAuth2.getAuthorizationUrl(false, new URI(TestCredentials.LOGIN_URL),
+                TestCredentials.CLIENT_ID, callbackUrl, null, "touch", null, null);
+        expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
+                "/services/oauth2/authorize?display=touch&response_type=hybrid_token&client_id=" +
+                TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
+                SalesforceSDKManager.getInstance().getDeviceId());
+        Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
+    }
+
     private void tryScopes(String[] scopes, String expectedScopeParamValue) throws URISyntaxException {
         String callbackUrl = "sfdc://callback";
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID,callbackUrl, scopes, null, "some-challenge", null);
         HttpUrl url = HttpUrl.get(authorizationUrl);
         boolean scopesFound = false;


### PR DESCRIPTION
- By default it will use "web server flow".
- By calling SalesforceSDKManager.getInstance().setUseWebServerAuthentication(false), an app can opt to use the (deprecated) user agent flow instead. 
- The selected flow is shown in the dev info screen.