### PR TITLE
Using prompt=login during advanced authentication so that user must re-enter credentials

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -620,7 +620,7 @@ public class SalesforceSDKManager implements LifecycleObserver {
     /**
      * Returns whether share browser session is enabled.
      *
-     * @return True - if share browser session is enabled, False - otherwise..
+     * @return True - if share browser session is enabled, False - otherwise.
      */
     public boolean isShareBrowserSessionEnabled() {
         return shareBrowserSessionEnabled;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -171,6 +171,7 @@ public class SalesforceSDKManager implements LifecycleObserver {
     private List<String> additionalOauthKeys;
     private String loginBrand;
     private boolean browserLoginEnabled;
+    private boolean shareBrowserSessionEnabled;
 
     private boolean useWebServerAuthentication = true; // web server flow ON by default - but app can opt out by calling setUseWebServerAuthentication(false)
     private Theme theme =  Theme.SYSTEM_DEFAULT;
@@ -617,13 +618,23 @@ public class SalesforceSDKManager implements LifecycleObserver {
     }
 
     /**
+     * Returns whether share browser session is enabled.
+     *
+     * @return True - if share browser session is enabled, False - otherwise..
+     */
+    public boolean isShareBrowserSessionEnabled() {
+        return shareBrowserSessionEnabled;
+    }
+
+    /**
      * Sets whether browser based login should be used instead of WebView. This should NOT be used
      * directly by apps, this is meant for internal use, based on the value configured on the server.
      *
      * @param browserLoginEnabled True - if Chrome should be used for login, False - otherwise.
      */
-    public synchronized void setBrowserLoginEnabled(boolean browserLoginEnabled) {
+    public synchronized void setBrowserLoginEnabled(boolean browserLoginEnabled, boolean shareBrowserSessionEnabled) {
         this.browserLoginEnabled = browserLoginEnabled;
+        this.shareBrowserSessionEnabled = shareBrowserSessionEnabled;
         if (browserLoginEnabled) {
             SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_BROWSER_LOGIN);
         } else {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -121,6 +121,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     public static final String BIOMETRIC_PROMPT = "mobilesdk://biometric/authentication/prompt";
     private static final String TAG = "OAuthWebViewHelper";
     private static final String ACCOUNT_OPTIONS = "accountOptions";
+    private static final String PROMPT_LOGIN = "&prompt=login";
     private String codeVerifier;
 
     // background executor
@@ -336,6 +337,10 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             URI uri = getAuthorizationUrl(useWebServerFlowAuthentication);
             callback.loadingLoginPage(loginOptions.getLoginUrl());
             if (SalesforceSDKManager.getInstance().isBrowserLoginEnabled()) {
+                if(!SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled()){
+                    String urlString = uri.toString();
+                    uri = new URI(urlString.concat(PROMPT_LOGIN));
+                }
                 loadLoginPageInChrome(uri);
             } else {
                 webview.loadUrl(uri.toString());

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigTask.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigTask.java
@@ -71,15 +71,17 @@ public class AuthConfigTask extends AsyncTask<Void, Void, Void> {
         if (loginServer.equals(LoginServerManager.PRODUCTION_LOGIN_URL) ||
                 loginServer.equals(LoginServerManager.SANDBOX_LOGIN_URL) ||
                 !URLUtil.isHttpsUrl(loginServer) || HttpUrl.parse(loginServer) == null) {
-            SalesforceSDKManager.getInstance().setBrowserLoginEnabled(false);
+            SalesforceSDKManager.getInstance().setBrowserLoginEnabled(false, false);
             return null;
         }
         final AuthConfigUtil.MyDomainAuthConfig authConfig = AuthConfigUtil.getMyDomainAuthConfig(loginServer);
         boolean browserLoginEnabled = false;
+        boolean shareBrowserSessionEnabled = false;
         if (authConfig != null) {
             browserLoginEnabled = authConfig.isBrowserLoginEnabled();
+            shareBrowserSessionEnabled = authConfig.isShareBrowserSessionEnabled();
         }
-        SalesforceSDKManager.getInstance().setBrowserLoginEnabled(browserLoginEnabled);
+        SalesforceSDKManager.getInstance().setBrowserLoginEnabled(browserLoginEnabled, shareBrowserSessionEnabled);
         return null;
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
@@ -96,6 +96,7 @@ public class AuthConfigUtil {
 
         private static final String MOBILE_SDK_KEY = "MobileSDK";
         private static final String USE_NATIVE_BROWSER_KEY = "UseAndroidNativeBrowserForAuthentication";
+        private static final String SHARE_BROWSER_SESSION_KEY = "shareBrowserSessionAndroid";
         private static final String SAML_PROVIDERS_KEY = "SamlProviders";
         private static final String AUTH_PROVIDERS_KEY = "AuthProviders";
         private static final String SSO_URL_KEY = "SsoUrl";
@@ -104,6 +105,7 @@ public class AuthConfigUtil {
 
         private final JSONObject authConfig;
         private boolean browserLoginEnabled;
+        private boolean shareBrowserSession;
         private List<String> ssoUrls;
         private String loginPageUrl;
 
@@ -119,6 +121,7 @@ public class AuthConfigUtil {
                 final JSONObject mobileSDK = authConfig.optJSONObject(MOBILE_SDK_KEY);
                 if (mobileSDK != null) {
                     browserLoginEnabled = mobileSDK.optBoolean(USE_NATIVE_BROWSER_KEY);
+                    shareBrowserSession = mobileSDK.optBoolean(SHARE_BROWSER_SESSION_KEY);
                 }
 
                 // Parses SAML provider list and adds it to the list of SSO URLs.
@@ -172,6 +175,15 @@ public class AuthConfigUtil {
          */
         public boolean isBrowserLoginEnabled() {
             return browserLoginEnabled;
+        }
+
+        /**
+         * Returns whether share browser session has been enabled in this auth config.
+         *
+         * @return True - if share browser session is enabled, False - otherwise.
+         */
+        public boolean isShareBrowserSessionEnabled() {
+            return shareBrowserSession;
         }
 
         /**


### PR DESCRIPTION
Previously if a user did a logout followed by a login, they would go straight to the allow/deny screen. 

Changes were made initially in the internal fork of the Mobile SDK (see [here](https://git.soma.salesforce.com/Android/SalesforceMobileSDK-Android-Public/pull/283)). 

There is a new property shareBrowserSession (and a method setBrowserLoginEnabled) on SalesforceSDKManager to go back to the old behavior. 

That flag can also be set through the AuthConfig.