### PR TITLE
@W-13473746: [Android] Server switching not happening anymore when expected

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -80,7 +80,7 @@ public class ServerPickerActivity extends AppCompatActivity implements
      */
     @Override
     public void onBackPressed() {
-        (new AuthConfigTask(this)).execute();
+        reconfigureAuthorization();
     }
 
     @Override
@@ -173,6 +173,7 @@ public class ServerPickerActivity extends AppCompatActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
+            reconfigureAuthorization();
             finish();
             return true;
         } else if (item.getItemId() == R.id.sf__menu_clear_custom_url) {
@@ -204,6 +205,13 @@ public class ServerPickerActivity extends AppCompatActivity implements
      */
     public CustomServerUrlEditor getCustomServerUrlEditor() {
         return urlEditDialog;
+    }
+
+    /**
+     * Refreshes the authorization configuration.
+     */
+    private void reconfigureAuthorization() {
+        (new AuthConfigTask(this)).execute();
     }
 
     /**


### PR DESCRIPTION
This is a simple bug fix to have both the app bar back and system back perform the same authorization selection action.  This corrects an earlier regression during AppCompat migration.  Thanks for catching it!