### PR TITLE
@W-13544970: [Android] [SDK Opt-In Parameter] Enable blocking of mobile app access to "salesforce integration" users in Mobile SDK

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -172,6 +172,12 @@ public class SalesforceSDKManager implements LifecycleObserver {
     private boolean browserLoginEnabled;
     private boolean shareBrowserSessionEnabled;
 
+    /**
+     * When true, Salesforce integration users will be prohibited from initial
+     * authentication.  An error message will be displayed.  Defaults to false.
+     */
+    private boolean blockSalesforceIntegrationUser = false; // Default to false as Salesforce-authored apps are the primary audience for this option.  This functionality will eventually be provided by the backend.
+
     private boolean useWebServerAuthentication = true; // web server flow ON by default - but app can opt out by calling setUseWebServerAuthentication(false)
     private Theme theme =  Theme.SYSTEM_DEFAULT;
     private String appName;
@@ -579,6 +585,30 @@ public class SalesforceSDKManager implements LifecycleObserver {
      */
     public boolean isBrowserLoginEnabled() {
         return browserLoginEnabled;
+    }
+
+
+    /**
+     * Determines if Salesforce integration users will be prohibited from
+     * initial authentication.
+     *
+     * @return True indicates authentication is blocked and false indicates
+     * authentication is allowed for Salesforce integration users
+     */
+    public boolean shouldBlockSalesforceIntegrationUser() {
+        return blockSalesforceIntegrationUser;
+    }
+
+    /**
+     * Sets authentication ability for Salesforce integration users.  When true,
+     * Salesforce integration users will be prohibited from initial
+     * authentication and receive an error message.  Defaults to false.
+     *
+     * @param value True blocks authentication or false allows authentication
+     *              for Salesforce integration users
+     */
+    public synchronized void setBlockSalesforceIntegrationUser(boolean value) {
+        blockSalesforceIntegrationUser = value;
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -812,7 +812,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                     HttpAccess.DEFAULT, tr.idUrlWithInstance, tr.authToken);
 
                 // Request the authenticated user's information to determine if it is a Salesforce integration user.  This is a synchronous network request, so it must be performed here in the background stage.
-                isSalesforceIntegrationUser = fetchIsSalesforceIntegrationUser(tr);
+                isSalesforceIntegrationUser = SalesforceSDKManager.getInstance().shouldBlockSalesforceIntegrationUser() && fetchIsSalesforceIntegrationUser(tr);
             } catch (Exception e) {
                 backgroundException = e;
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -647,10 +647,10 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
         protected volatile IdServiceResponse id = null;
 
         /**
-         * Indicates if the authenticated user is a designated Salesforce
-         * integration user
+         * Indicates if authentication is blocked for the current user due to
+         * the block Salesforce integration user option.
          */
-        protected volatile boolean isSalesforceIntegrationUser = false;
+        protected volatile boolean shouldBlockSalesforceIntegrationUser = false;
 
         public BaseFinishAuthFlowTask() {
         }
@@ -674,7 +674,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             final SalesforceSDKManager mgr = SalesforceSDKManager.getInstance();
 
             // Failure cases.
-            if (mgr.shouldBlockSalesforceIntegrationUser() && isSalesforceIntegrationUser) {
+            if (shouldBlockSalesforceIntegrationUser) {
                 /*
                  * Salesforce integration users are prohibited from successfully
                  * completing authentication. This alleviates the Restricted
@@ -812,7 +812,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                     HttpAccess.DEFAULT, tr.idUrlWithInstance, tr.authToken);
 
                 // Request the authenticated user's information to determine if it is a Salesforce integration user.  This is a synchronous network request, so it must be performed here in the background stage.
-                isSalesforceIntegrationUser = SalesforceSDKManager.getInstance().shouldBlockSalesforceIntegrationUser() && fetchIsSalesforceIntegrationUser(tr);
+                shouldBlockSalesforceIntegrationUser = SalesforceSDKManager.getInstance().shouldBlockSalesforceIntegrationUser() && fetchIsSalesforceIntegrationUser(tr);
             } catch (Exception e) {
                 backgroundException = e;
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -674,7 +674,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             final SalesforceSDKManager mgr = SalesforceSDKManager.getInstance();
 
             // Failure cases.
-            if (isSalesforceIntegrationUser) {
+            if (mgr.shouldBlockSalesforceIntegrationUser() && isSalesforceIntegrationUser) {
                 /*
                  * Salesforce integration users are prohibited from successfully
                  * completing authentication. This alleviates the Restricted


### PR DESCRIPTION
This follow-up to #2414 adds an opt-in for the Salesforce integration user authentication block which defaults to `false`.