### PR TITLE
Not allowing arbitrary websites in the login web view

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -40,11 +40,11 @@ import android.os.Looper;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
-import com.salesforce.androidsdk.analytics.security.Encryptor;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.AuthenticatorService;
 import com.salesforce.androidsdk.auth.HttpAccess;
 import com.salesforce.androidsdk.auth.OAuth2;
+import com.salesforce.androidsdk.config.LoginServerManager;
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
@@ -847,6 +847,11 @@ public class ClientManager {
             return bundle;
         }
 
+        /**
+         * Build a LoginOptions from the given bundle
+         * @param options - bundle
+         * @return
+         */
         public static LoginOptions fromBundle(Bundle options) {
             Map<String, String> additionalParameters = null;
             final Serializable serializable = options.getSerializable(KEY_ADDL_PARAMS);
@@ -859,6 +864,21 @@ public class ClientManager {
                                     options.getStringArray(OAUTH_SCOPES),
                                     options.getString(JWT),
                                     additionalParameters);
+        }
+
+        /**
+         * Build a LoginOptions from the given bundle
+         * If the loginUrl in options is not one of the login servers, then the selected login server is used instead.
+         * @param options - bundle
+         * @return
+         */
+        public static LoginOptions fromBundleWithSafeLoginUrl(Bundle options) {
+            LoginOptions loginOptions = fromBundle(options);
+            LoginServerManager loginServerManager = SalesforceSDKManager.getInstance().getLoginServerManager();
+            if (loginServerManager.getLoginServerFromURL(loginOptions.getLoginUrl()) == null) {
+                loginOptions.setLoginUrl(loginServerManager.getSelectedLoginServer().url);
+            }
+            return loginOptions;
         }
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -68,7 +68,6 @@ import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.analytics.SalesforceAnalyticsManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.idp.interfaces.SPManager;
-import com.salesforce.androidsdk.config.LoginServerManager;
 import com.salesforce.androidsdk.config.RuntimeConfig;
 import com.salesforce.androidsdk.config.RuntimeConfig.ConfigKey;
 import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
@@ -120,15 +119,7 @@ public class LoginActivity extends AppCompatActivity
         SalesforceSDKManager.getInstance().setViewNavigationVisibility(this);
 
         // Getting login options from intent's extras.
-        final LoginOptions loginOptions = LoginOptions.fromBundle(getIntent().getExtras());
-
-        // Not allowing arbitrary website to be loaded in webview
-        // If the intent contains a login url that is not one of the known login server
-        // Then use the selected login server instead
-        LoginServerManager loginServerManager = SalesforceSDKManager.getInstance().getLoginServerManager();
-        if (loginServerManager.getLoginServerFromURL(loginOptions.getLoginUrl()) == null) {
-            loginOptions.setLoginUrl(loginServerManager.getSelectedLoginServer().url);
-        }
+        final LoginOptions loginOptions = LoginOptions.fromBundleWithSafeLoginUrl(getIntent().getExtras());
 
         // Protect against screenshots.
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -68,6 +68,7 @@ import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.analytics.SalesforceAnalyticsManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.idp.interfaces.SPManager;
+import com.salesforce.androidsdk.config.LoginServerManager;
 import com.salesforce.androidsdk.config.RuntimeConfig;
 import com.salesforce.androidsdk.config.RuntimeConfig.ConfigKey;
 import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
@@ -120,6 +121,14 @@ public class LoginActivity extends AppCompatActivity
 
         // Getting login options from intent's extras.
         final LoginOptions loginOptions = LoginOptions.fromBundle(getIntent().getExtras());
+
+        // Not allowing arbitrary website to be loaded in webview
+        // If the intent contains a login url that is not one of the known login server
+        // Then use the selected login server instead
+        LoginServerManager loginServerManager = SalesforceSDKManager.getInstance().getLoginServerManager();
+        if (loginServerManager.getLoginServerFromURL(loginOptions.getLoginUrl()) == null) {
+            loginOptions.setLoginUrl(loginServerManager.getSelectedLoginServer().url);
+        }
 
         // Protect against screenshots.
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,


### PR DESCRIPTION
Added helper method `fromBundleWithSafeLoginUrl` on `LoginOptions` that builds a `LoginOptions` from the provided bundle but checks the loginUrl. If it is not one of the login servers, then the selected login server is used instead.

This is to address W-11369931