### PR TITLE
Configurable authentication flow

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -179,6 +179,8 @@ public class SalesforceSDKManager implements LifecycleObserver {
     private boolean blockSalesforceIntegrationUser = false; // Default to false as Salesforce-authored apps are the primary audience for this option.  This functionality will eventually be provided by the backend.
 
     private boolean useWebServerAuthentication = true; // web server flow ON by default - but app can opt out by calling setUseWebServerAuthentication(false)
+
+    private boolean useHybridAuthentication = true; // hybrid authentication flows ON by default - but app can opt out by calling setUseHybridAuthentication(false)
     private Theme theme =  Theme.SYSTEM_DEFAULT;
     private String appName;
 
@@ -651,6 +653,23 @@ public class SalesforceSDKManager implements LifecycleObserver {
         } else {
             SalesforceSDKManager.getInstance().unregisterUsedAppFeature(Features.FEATURE_BROWSER_LOGIN);
         }
+    }
+
+    /**
+     * Returns whether hybrid authentication flow should be used
+     *
+     * @return True - if hybrid authentication flow should be used, False - otherwise.
+     */
+    public boolean shouldUseHybridAuthentication() {
+        return useHybridAuthentication;
+    }
+
+    /**
+     * Sets whether hybrid authentication flow should be used
+     * @param useHybridAuthentication
+     */
+    public synchronized void setUseHybridAuthentication(boolean useHybridAuthentication) {
+        this.useHybridAuthentication = useHybridAuthentication;
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
@@ -141,9 +141,11 @@ internal class IDPAuthCodeHelper private constructor(
     fun makeFrontDoorRequest(accessToken: String, webView: WebView) {
         SalesforceSDKLogger.d(TAG, "Making front door request")
         val context = SalesforceSDKManager.getInstance().appContext
+        val useHybridAuthentication = SalesforceSDKManager.getInstance().shouldUseHybridAuthentication()
         val frontdoorUrl = getFrontdoorUrl(
             getAuthorizationUrl(
                 true, // use web server flow
+                useHybridAuthentication,
                 URI(userAccount.loginServer),
                 spConfig.oauthClientId,
                 spConfig.oauthCallbackUrl,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -335,9 +335,10 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     private void doLoadPage() {
         try {
             boolean isBrowserLoginEnabled = SalesforceSDKManager.getInstance().isBrowserLoginEnabled();
-            boolean useWebServerFlowAuthentication = isBrowserLoginEnabled || SalesforceSDKManager.getInstance().shouldUseWebServerAuthentication();
+            boolean useWebServerAuthentication = isBrowserLoginEnabled || SalesforceSDKManager.getInstance().shouldUseWebServerAuthentication();
+            boolean useHybridAuthentication = SalesforceSDKManager.getInstance().shouldUseHybridAuthentication();
 
-            URI uri = getAuthorizationUrl(useWebServerFlowAuthentication);
+            URI uri = getAuthorizationUrl(useWebServerAuthentication, useHybridAuthentication);
             callback.loadingLoginPage(loginOptions.getLoginUrl());
             if (SalesforceSDKManager.getInstance().isBrowserLoginEnabled()) {
                 if(!SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled()){
@@ -426,13 +427,13 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
     	return loginOptions.getOauthClientId();
     }
 
-    protected URI getAuthorizationUrl(boolean useWebServerAuthentication) throws URISyntaxException {
+    protected URI getAuthorizationUrl(boolean useWebServerAuthentication, boolean useHybridAuthentication) throws URISyntaxException {
         boolean jwtFlow = !TextUtils.isEmpty(loginOptions.getJwt());
         Map<String, String> addlParams = jwtFlow ? null : loginOptions.getAdditionalParameters();
         // NB code verifier / code challenge are only used when useWebServerAuthentication is true
         codeVerifier = SalesforceKeyGenerator.getRandom128ByteKey();
         String codeChallenge = SalesforceKeyGenerator.getSHA256Hash(codeVerifier);
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(useWebServerAuthentication, new URI(loginOptions.getLoginUrl()), getOAuthClientId(), loginOptions.getOauthCallbackUrl(), loginOptions.getOauthScopes(), getAuthorizationDisplayType(), codeChallenge, addlParams);
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(useWebServerAuthentication, useHybridAuthentication, new URI(loginOptions.getLoginUrl()), getOAuthClientId(), loginOptions.getOauthCallbackUrl(), loginOptions.getOauthScopes(), getAuthorizationDisplayType(), codeChallenge, addlParams);
 
         if (jwtFlow) {
             return OAuth2.getFrontdoorUrl(authorizationUrl,

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -89,14 +89,14 @@ public class OAuth2Test {
     @Test
 	public void testGetAuthorizationUrl() throws URISyntaxException {
 		String callbackUrl = "sfdc://callback";
-		URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+		URI authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
 		URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
 				SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-		authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+		authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
 		expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=code&client_id=" +
@@ -117,7 +117,7 @@ public class OAuth2Test {
 		params.put("param1", "val1");
 		params.put("param2", "val2");
 		params.put("param3", null);
-		URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+		URI authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", params);
         Assert.assertTrue("Wrong authorization url", authorizationUrl.getRawQuery().indexOf("&param1=val1") > 0);
         Assert.assertTrue("Wrong authorization url", authorizationUrl.getRawQuery().indexOf("&param2=val2") > 0);
@@ -134,14 +134,14 @@ public class OAuth2Test {
         String callbackUrl = "sfdc://callback";
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
                 SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+        authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
@@ -160,14 +160,14 @@ public class OAuth2Test {
         String callbackUrl = "sfdc://callback";
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
                 SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+        authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
@@ -186,14 +186,14 @@ public class OAuth2Test {
         String callbackUrl = "sfdc://callback";
         final String brandedLoginPath = "BRAND";
         SalesforceSDKManager.getInstance().setLoginBrand(brandedLoginPath);
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
                 SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+        authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize/BRAND?display=touch&response_type=code&client_id=" +
@@ -203,21 +203,21 @@ public class OAuth2Test {
     }
 
     /**
-     * Testing getAuthorizationUrl with web server authenticated set to false.
+     * Testing getAuthorizationUrl with web server authentication OFF.
      *
      * @throws URISyntaxException See {@link URISyntaxException}.
      */
     @Test
     public void testGetAuthorizationUrlForUserAgentFlow() throws URISyntaxException {
         String callbackUrl = "sfdc://callback";
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(false, new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(false, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
         URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=hybrid_token&client_id=" +
                 TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
                 SalesforceSDKManager.getInstance().getDeviceId());
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
-        authorizationUrl = OAuth2.getAuthorizationUrl(false, new URI(TestCredentials.LOGIN_URL),
+        authorizationUrl = OAuth2.getAuthorizationUrl(false, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID, callbackUrl, null, "touch", null, null);
         expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
                 "/services/oauth2/authorize?display=touch&response_type=hybrid_token&client_id=" +
@@ -226,9 +226,57 @@ public class OAuth2Test {
         Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
     }
 
+    /**
+     * Testing getAuthorizationUrl with web server authentication and hybrid authentication OFF.
+     *
+     * @throws URISyntaxException See {@link URISyntaxException}.
+     */
+    @Test
+    public void testGetAuthorizationUrlForUserAgentFlowWithHybridAuthenticationOff() throws URISyntaxException {
+        String callbackUrl = "sfdc://callback";
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(false, false, new URI(TestCredentials.LOGIN_URL),
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, null, null);
+        URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
+                "/services/oauth2/authorize?display=touch&response_type=token&client_id=" +
+                TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
+                SalesforceSDKManager.getInstance().getDeviceId());
+        Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
+        authorizationUrl = OAuth2.getAuthorizationUrl(false, false, new URI(TestCredentials.LOGIN_URL),
+                TestCredentials.CLIENT_ID, callbackUrl, null, "touch", null, null);
+        expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
+                "/services/oauth2/authorize?display=touch&response_type=token&client_id=" +
+                TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
+                SalesforceSDKManager.getInstance().getDeviceId());
+        Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
+    }
+
+    /**
+     * Testing getAuthorizationUrl with web server authentication ON and hybrid authentication OFF.
+     *
+     * @throws URISyntaxException See {@link URISyntaxException}.
+     */
+    @Test
+    public void testGetAuthorizationUrlForWebServerFlowWithHybridAuthenticationOff() throws URISyntaxException {
+        String callbackUrl = "sfdc://callback";
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, false, new URI(TestCredentials.LOGIN_URL),
+                TestCredentials.CLIENT_ID, callbackUrl, null, null, "some-challenge", null);
+        URI expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
+                "/services/oauth2/authorize?display=touch&response_type=code&client_id=" +
+                TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
+                SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
+        Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
+        authorizationUrl = OAuth2.getAuthorizationUrl(true, false, new URI(TestCredentials.LOGIN_URL),
+                TestCredentials.CLIENT_ID, callbackUrl, null, "touch", "some-challenge", null);
+        expectedAuthorizationUrl = new URI(TestCredentials.LOGIN_URL +
+                "/services/oauth2/authorize?display=touch&response_type=code&client_id=" +
+                TestCredentials.CLIENT_ID + "&redirect_uri=" + callbackUrl + "&device_id=" +
+                SalesforceSDKManager.getInstance().getDeviceId() + "&code_challenge=some-challenge");
+        Assert.assertEquals("Wrong authorization url", expectedAuthorizationUrl, authorizationUrl);
+    }
+
     private void tryScopes(String[] scopes, String expectedScopeParamValue) throws URISyntaxException {
         String callbackUrl = "sfdc://callback";
-        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, new URI(TestCredentials.LOGIN_URL),
+        URI authorizationUrl = OAuth2.getAuthorizationUrl(true, true, new URI(TestCredentials.LOGIN_URL),
                 TestCredentials.CLIENT_ID,callbackUrl, scopes, null, "some-challenge", null);
         HttpUrl url = HttpUrl.get(authorizationUrl);
         boolean scopesFound = false;


### PR DESCRIPTION
SalesforceSDKManager has a new flag: useHybridAuthentication (defaulting to true) that causes us to use:
- when true: hybrid_token (authorization user agent flow), hybrid_auth_code (code exchange during web server flow) and hybrid_refresh (refresh flow)
- when false: token (authorization user agent flow), authorization_code (code exchange) and refresh_token (refresh flow)