### PR TITLE
Addressing deprecations during build

### DIFF
--- a/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.samples.accounteditor"
     android:versionCode="1"
     android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 }
 
 android {
+  namespace = "com.salesforce.samples.accounteditor"
+
   compileSdkVersion 33
 
   defaultConfig {

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.samples.mobilesyncexplorerhybrid"
     android:versionCode="1"
     android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 }
 
 android {
+  namespace = "com.salesforce.samples.mobilesyncexplorerhybrid"
+
   compileSdkVersion 33
 
   defaultConfig {

--- a/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/NoteSync/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.samples.notesync"
     android:versionCode="1"
     android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/hybrid/HybridSampleApps/NoteSync/build.gradle
+++ b/hybrid/HybridSampleApps/NoteSync/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 }
 
 android {
+  namespace = "com.salesforce.samples.notesync"
+
   compileSdkVersion 33
 
   defaultConfig {

--- a/libs/MobileSync/AndroidManifest.xml
+++ b/libs/MobileSync/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.androidsdk.mobilesync"
     android:versionCode="80"
     android:versionName="11.0.0.dev">
 

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
 android {
     namespace = "com.salesforce.androidsdk.mobilesync"
+    testNamespace = "com.salesforce.androidsdk.mobilesync.tests"
 
     compileSdkVersion 33
 

--- a/libs/MobileSync/build.gradle
+++ b/libs/MobileSync/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.androidsdk.mobilesync"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/libs/SalesforceAnalytics/AndroidManifest.xml
+++ b/libs/SalesforceAnalytics/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.analytics" 
 	android:versionCode="80"
 	android:versionName="11.0.0.dev">
 

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
 android {
     namespace = "com.salesforce.androidsdk.analytics"
+    testNamespace = "com.salesforce.androidsdk.analytics.tests"
 
     compileSdkVersion 33
 

--- a/libs/SalesforceAnalytics/build.gradle
+++ b/libs/SalesforceAnalytics/build.gradle
@@ -18,6 +18,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.androidsdk.analytics"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/libs/SalesforceHybrid/AndroidManifest.xml
+++ b/libs/SalesforceHybrid/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.androidsdk.hybrid"
     android:versionCode="80"
     android:versionName="11.0.0.dev">
 

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.androidsdk.hybrid"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/libs/SalesforceHybrid/build.gradle
+++ b/libs/SalesforceHybrid/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
 android {
     namespace = "com.salesforce.androidsdk.hybrid"
+    testNamespace = "com.salesforce.androidsdk.phonegap"
 
     compileSdkVersion 33
 

--- a/libs/SalesforceReact/AndroidManifest.xml
+++ b/libs/SalesforceReact/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.androidsdk.reactnative"
     android:versionCode="80"
     android:versionName="11.0.0.dev">
 

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
 android {
     namespace = "com.salesforce.androidsdk.reactnative"
+    testNamespace = "com.salesforce.androidsdk.reactnative.tests"
 
     compileSdkVersion 33
 

--- a/libs/SalesforceReact/build.gradle
+++ b/libs/SalesforceReact/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.androidsdk.reactnative"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -2,7 +2,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.salesforce.androidsdk"
 	android:versionCode="80"
 	android:versionName="11.0.0.dev">
 

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 android {
     namespace = "com.salesforce.androidsdk"
+    testNamespace = "com.salesforce.androidsdk.tests"
 
     compileSdkVersion 33
 

--- a/libs/SalesforceSDK/build.gradle
+++ b/libs/SalesforceSDK/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.androidsdk"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/LogUtil.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/LogUtil.kt
@@ -53,6 +53,7 @@ object LogUtil {
         return objectToString(bundle)
     }
 
+    @Suppress("DEPRECATION")
     private fun objectToString(obj: Any?): String {
         return if (obj == null) {
             "null"

--- a/libs/SmartStore/AndroidManifest.xml
+++ b/libs/SmartStore/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.smartstore"
 	android:versionCode="80"
 	android:versionName="11.0.0.dev">
 

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
 android {
     namespace = "com.salesforce.androidsdk.smartstore"
+    testNamespace = "com.salesforce.androidsdk.smartstore.tests"
 
     compileSdkVersion 33
 

--- a/libs/SmartStore/build.gradle
+++ b/libs/SmartStore/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.androidsdk.smartstore"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/libs/test/MobileSyncTest/AndroidManifest.xml
+++ b/libs/test/MobileSyncTest/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.mobilesync.tests">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.mobilesync.TestForceApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">

--- a/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
+++ b/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.analytics.tests">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application />
 </manifest>

--- a/libs/test/SalesforceHybridTest/AndroidManifest.xml
+++ b/libs/test/SalesforceHybridTest/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.phonegap"
     android:versionName="1.0">
 
     <application android:label="@string/app_name"

--- a/libs/test/SalesforceReactTest/AndroidManifest.xml
+++ b/libs/test/SalesforceReactTest/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.reactnative.tests">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.reactnative.util.SalesforceReactTestApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">

--- a/libs/test/SalesforceSDKTest/AndroidManifest.xml
+++ b/libs/test/SalesforceSDKTest/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.tests">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.TestForceApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">

--- a/libs/test/SmartStoreTest/AndroidManifest.xml
+++ b/libs/test/SmartStoreTest/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.androidsdk.smartstore.tests">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.TestForceApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">

--- a/native/NativeSampleApps/AppConfigurator/AndroidManifest.xml
+++ b/native/NativeSampleApps/AppConfigurator/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.samples.appconfigurator"
     android:versionCode="1"
     android:versionName="1.0">
     

--- a/native/NativeSampleApps/AppConfigurator/build.gradle
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.samples.appconfigurator"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
+++ b/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.samples.configuredapp"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle
@@ -9,6 +9,8 @@ dependencies {
 }
 
 android {
+    namespace = "com.salesforce.samples.configuredapp"
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/native/NativeSampleApps/MobileSyncExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/MobileSyncExplorer/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.samples.mobilesyncexplorer"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/native/NativeSampleApps/MobileSyncExplorer/build.gradle
+++ b/native/NativeSampleApps/MobileSyncExplorer/build.gradle
@@ -10,6 +10,8 @@ dependencies {
 }
 
 android {
+  namespace = "com.salesforce.samples.mobilesyncexplorer"
+
   compileSdkVersion 33
 
   defaultConfig {

--- a/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.salesforce.samples.restexplorer"
 	android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
 android {
   namespace = "com.salesforce.samples.restexplorer"
+  testNamespace = "com.salesforce.samples.restexplorer.tests"
 
   compileSdkVersion 33
 

--- a/native/NativeSampleApps/RestExplorer/build.gradle
+++ b/native/NativeSampleApps/RestExplorer/build.gradle
@@ -21,6 +21,8 @@ dependencies {
 }
 
 android {
+  namespace = "com.salesforce.samples.restexplorer"
+
   compileSdkVersion 33
 
   defaultConfig {

--- a/native/NativeSampleApps/test/RestExplorerTest/AndroidManifest.xml
+++ b/native/NativeSampleApps/test/RestExplorerTest/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.salesforce.samples.restexplorer.tests">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application />
 </manifest>

--- a/publish/publish-module.gradle
+++ b/publish/publish-module.gradle
@@ -1,6 +1,14 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
+android {
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+}
+
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     archiveClassifier.set('sources')


### PR DESCRIPTION
Moved package from AndroidManifest.xml to build.gradle to address
> package="com.salesforce.androidsdk" found in source AndroidManifest.xml: /home/circleci/SalesforceMobileSDK-Package/tmp20230608T035347.445/androidnativekotlin/mobile_sdk/SalesforceMobileSDK-Android/libs/SalesforceSDK/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace

Also addressed
> Addressing "Software Components will not be created automatically for Maven publishing from Android Gradle Plugin 8.0"

