### PR TITLE
@W-12727938: Crash after login if first backgrounded. Android Debug build only.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -113,7 +113,7 @@ public class ClientManager {
             if (options != null) {
                 i.putExtras(options);
             }
-            activityContext.startActivity(i);
+            activityContext.startActivityForResult(i, 0);
         }
 
         // Account found

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -113,6 +113,22 @@ public class ClientManager {
             if (options != null) {
                 i.putExtras(options);
             }
+            /*
+             * Special Note: `LoginActivity` does not actually return a result.
+             * However, it does start broadcast intents that need to be received
+             * by the starting activity.  Since login activity is started in a
+             * new task, the starting activity would become available to be
+             * destroyed which unregisters its broadcast intent receivers.
+             *
+             * Using `startActivityForResult` starts a new task with the
+             * starting activity as the "base" intent with login activity as its
+             * "visible" sub-activity.  This keeps the starting activity from
+             * being eagerly destroyed and sets it as the activity to be started
+             * if the user returns the this task after it may have been fully
+             * destroyed due to memory pressure.
+             *
+             * TODO: This short term solution will be replaced in a future release.
+             */
             activityContext.startActivityForResult(i, 0);
         }
 


### PR DESCRIPTION
🚀 _Ready for review._ ⭐️

This is an investigation into the stack track in [W-12727938](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NgIPYYA3/view) and related the related [Github Issue](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/issues/317).  What I've seen consistently in my attempts to replicate the test is _slightly_ different.  My React Native app allows log in and out perfectly so long as the app is never paused while the login activity is displayed.  A pause can be triggered by returning to the Android launcher, for instance.

If the app is paused while the login activity is displayed, the `MainActivity` instance is destroyed which unregisters the broadcast intent receiver that login completion depends on.  On login, the app simply finishes with login activity finish and there's nothing to receive the broadcast intent and start the next activity.  The user simply drops to the launcher.  Maybe a white screen could happen if a custom app had logic wired in the various `onUserSwitched` methods but was missing the actual authentication event like this?

It seems we'll need a system level hint to keep the activity where the broadcast intent receivers are registered from being destroyed while the user is working with login activity, even on app pause.

I've used `startActivityForResult` in place of broadcast intents quite a bit in the past, which does accomplish this.  Here's one change in `ClientManager` that resolved the occurrence of the issue I was experiencing.

According to our discussion from draft status, this is a short-term solution for 11.0.  A more comprehensive solution will be crafted in a future release using the team's ideas.