### PR TITLE
Remove Maven Central archive classifier

### DIFF
--- a/publish/publish-module.gradle
+++ b/publish/publish-module.gradle
@@ -11,7 +11,6 @@ android {
 
 tasks.register('sourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set(name + '-sources')
 }
 
 artifacts {

--- a/publish/publish-module.gradle
+++ b/publish/publish-module.gradle
@@ -9,9 +9,9 @@ android {
     }
 }
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set('sources')
+    archiveClassifier.set(name + '-sources')
 }
 
 artifacts {
@@ -52,9 +52,14 @@ afterEvaluate {
                             email = 'wmathurin@salesforce.com '
                         }
                         developer {
-                            id = 'bhariharan'
-                            name = 'Bharath Hariharan'
-                            email = 'bhariharan@salesforce.com'
+                            id = 'brianna.birman'
+                            name = 'Brianna Birman'
+                            email = 'brianna.birman@salesforce.com'
+                        }
+                        developer {
+                            id = 'johnson.eric'
+                            name = 'Eric Johnson'
+                            email = 'johnson.eric@salesforce.com'
                         }
                     }
                     scm {


### PR DESCRIPTION
This value is unused, but needs to be unique per library.  Since it is optional it is easiest to just remove it.