### PR TITLE
Graceful handling of non-existent IDP app

### DIFF
--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -50,6 +50,7 @@
     <string name="sf__account_selector_text">Select an account to use</string>
 
 	<!-- SP status updates -->
+	<string name="sf__failed_to_send_request_to_idp">Failed to send request to IDP app</string>
 	<string name="sf__login_request_sent_to_idp">Login request sent to IDP app</string>
 	<string name="sf__auth_code_received_from_idp">IDP app successfully obtained authorization code</string>
 	<string name="sf__error_received_from_idp">IDP app failed to obtain authorization code</string>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/interfaces/SPManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/interfaces/SPManager.kt
@@ -33,6 +33,7 @@ import com.salesforce.androidsdk.R
 interface SPManager {
 
     enum class Status(val resIdForDescription:Int) {
+        FAILED_TO_SEND_REQUEST_TO_IDP(R.string.sf__failed_to_send_request_to_idp),
         LOGIN_REQUEST_SENT_TO_IDP(R.string.sf__login_request_sent_to_idp),
         AUTH_CODE_RECEIVED_FROM_IDP(R.string.sf__auth_code_received_from_idp),
         ERROR_RECEIVED_FROM_IDP(R.string.sf__error_received_from_idp),

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/idp/IDPSPManagerTestCase.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/idp/IDPSPManagerTestCase.kt
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.util.LogUtil
 import org.junit.Assert
+import java.lang.RuntimeException
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.TimeUnit
@@ -37,6 +38,10 @@ internal open class IDPSPManagerTestCase {
 
     open fun startActivity(context:Context, intent: Intent) {
         recordEvent("startActivity ${LogUtil.intentToString(intent)}")
+    }
+
+    fun throwOnSend(context: Context, intent: Intent) {
+        throw RuntimeException()
     }
 
     fun waitForEvent(expectedEvent: String) {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/idp/SPManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/idp/SPManagerTest.kt
@@ -119,6 +119,21 @@ internal class SPManagerTest : IDPSPManagerTestCase() {
     }
 
     @Test
+    fun testKickOffSPInitiatedLoginFlowWithNotExistentIDP() {
+        val spManager = SPManager("some-idp", TestSDKMgr(buildUser("some-org-id", "some-user-id")),
+            // the test context is not an activity so sendBroadcast will be used to send the login request to the IDP app
+            // so throwing an exception there
+            this::throwOnSend, this::throwOnSend)
+        spManager.kickOffSPInitiatedLoginFlow(context, TestStatusUpdateCallback())
+
+        // Make sure the sp got a status update indicating a non-existent IDP
+        waitForEvent("status FAILED_TO_SEND_REQUEST_TO_IDP")
+
+        // Make sure there are no more events
+        expectNoEvent()
+    }
+
+    @Test
     fun testIDPInitiatedFlowForExistingUser() {
         // Set up sp manager with a current user
         val spManager = SPManager("some-idp", TestSDKMgr(buildUser("some-org-id", "some-user-id")), this::sendBroadcast, this::startActivity)


### PR DESCRIPTION
During SP initiated login flow, clicking "Login with IDP" will show a toast saying "Failed to send request to IDP app" if IDP is not installed. (Before, the SP app would crash because of the unhandled ActivityNotFoundException)