### PR TITLE
Not using get user info for our "cheap rest call" to refresh access token

### DIFF
--- a/hybrid/HybridSampleApps/NoteSync/src/com/salesforce/samples/notesync/ContentSoqlSyncDownTarget.java
+++ b/hybrid/HybridSampleApps/NoteSync/src/com/salesforce/samples/notesync/ContentSoqlSyncDownTarget.java
@@ -97,7 +97,7 @@ public class ContentSoqlSyncDownTarget extends SoqlSyncDownTarget {
     @Override
     public JSONArray startFetch(SyncManager syncManager, long maxTimeStamp) throws IOException, JSONException {
         String queryToRun = maxTimeStamp > 0 ? SoqlSyncDownTarget.addFilterForReSync(getQuery(maxTimeStamp), getModificationDateFieldName(), maxTimeStamp) : getQuery(maxTimeStamp);
-        syncManager.getRestClient().sendSync(RestRequest.getRequestForUserInfo()); // cheap call to refresh session
+        syncManager.getRestClient().sendSync(RestRequest.getRequestForLimits(ApiVersionStrings.VERSION_NUMBER)); // cheap call to refresh session
         RestRequest request = buildQueryRequest(syncManager.getRestClient().getAuthToken(), queryToRun);
         RestResponse response = syncManager.sendSyncWithMobileSyncUserAgent(request);
         JSONArray records = parseSoapResponse(response);

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java
@@ -37,6 +37,7 @@ import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.config.LoginServerManager;
 import com.salesforce.androidsdk.phonegap.app.SalesforceHybridSDKManager;
 import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger;
+import com.salesforce.androidsdk.rest.ApiVersionStrings;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.ClientManager.AccountInfoNotFoundException;
 import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback;
@@ -349,7 +350,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
                      * but a stale session ID will cause the WebView to redirect
                      * to the web login.
                      */
-                    SalesforceDroidGapActivity.this.client.sendAsync(RestRequest.getRequestForUserInfo(), new AsyncRequestCallback() {
+                    SalesforceDroidGapActivity.this.client.sendAsync(RestRequest.getRequestForLimits(ApiVersionStrings.VERSION_NUMBER), new AsyncRequestCallback() {
 
                         @Override
                         public void onSuccess(RestRequest request, RestResponse response) {
@@ -422,7 +423,7 @@ public class SalesforceDroidGapActivity extends CordovaActivity implements Sales
             });
             return;
         }
-        client.sendAsync(RestRequest.getRequestForUserInfo(), new AsyncRequestCallback() {
+        client.sendAsync(RestRequest.getRequestForLimits(ApiVersionStrings.VERSION_NUMBER), new AsyncRequestCallback() {
 
             @Override
             public void onSuccess(RestRequest request, RestResponse response) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
@@ -39,6 +39,7 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.OAuth2.getAuthorizationUrl
 import com.salesforce.androidsdk.auth.OAuth2.getFrontdoorUrl
 import com.salesforce.androidsdk.config.BootConfig
+import com.salesforce.androidsdk.rest.ApiVersionStrings
 import com.salesforce.androidsdk.rest.ClientManager
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestRequest
@@ -119,7 +120,7 @@ internal class IDPAuthCodeHelper private constructor(
         SalesforceSDKLogger.d(TAG, "Obtaining valid access token")
         buildRestClient()?.let {restClient ->
             val restResponse = try {
-                restClient.sendSync(RestRequest.getRequestForUserInfo())
+                restClient.sendSync(RestRequest.getRequestForLimits(ApiVersionStrings.VERSION_NUMBER))
             } catch (e: IOException) {
                 SalesforceSDKLogger.e(TAG, "Failed to obtain valid access token", e)
                 null

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -29,13 +29,10 @@ package com.salesforce.androidsdk.rest;
 import android.net.Uri;
 import android.text.TextUtils;
 
-import com.salesforce.androidsdk.app.SalesforceSDKManager;
-import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.rest.BatchRequest.BatchRequestBuilder;
 import com.salesforce.androidsdk.rest.CompositeRequest.CompositeRequestBuilder;
 import com.salesforce.androidsdk.rest.files.ConnectUriBuilder;
 import com.salesforce.androidsdk.util.JSONObjectHelper;
-import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -55,7 +52,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import okhttp3.FormBody;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 
@@ -189,7 +185,8 @@ public class RestRequest {
 		SOBJECT_COLLECTION_UPSERT(SERVICES_DATA + "%s/composite/sobjects/%s/%s"),
         NOTIFICATIONS_STATUS(SERVICES_DATA + "%s/connect/notifications/status"),
 		NOTIFICATIONS(SERVICES_DATA + "%s/connect/notifications/%s"),
-		PRIMING_RECORDS(SERVICES_DATA + "%s/connect/briefcase/priming-records");
+		PRIMING_RECORDS(SERVICES_DATA + "%s/connect/briefcase/priming-records"),
+		LIMITS(SERVICES_DATA + "%s/limits");
 
 		private final String pathTemplate;
 
@@ -947,6 +944,17 @@ public class RestRequest {
 		path.append("?allOrNone=" + allOrNone + "&ids=");
 		path.append(URLEncoder.encode(TextUtils.join(",", objectIds), UTF_8));
 		return new RestRequest(RestMethod.DELETE, path.toString());
+	}
+
+	/**
+	 * Request for getting information about limits in your org
+	 *
+	 * @param apiVersion    Salesforce API version.
+	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm</a>
+	 */
+	public static RestRequest getRequestForLimits(String apiVersion) {
+		StringBuilder path = new StringBuilder(RestAction.LIMITS.getPath(apiVersion));
+		return new RestRequest(RestMethod.GET, path.toString());
 	}
 
     /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -1445,6 +1445,18 @@ public class RestClientTest {
         Assert.assertEquals("ALL_OR_NONE_OPERATION_ROLLED_BACK", parsedResponse.subResponses.get(1).errors.get(0).statusCode);
     }
 
+    /**
+     * Testing a limits call to the server - check response
+     * @throws Exception
+     */
+    @Test
+    public void testLimits() throws Exception {
+        RestResponse response = restClient.sendSync(RestRequest.getRequestForLimits(TestCredentials.API_VERSION));
+        checkResponse(response, HttpURLConnection.HTTP_OK, false);
+        JSONObject jsonResponse = response.asJSONObject();
+        checkKeys(jsonResponse, "DailyApiRequests");
+    }
+
     //
     // Helper methods
     //


### PR DESCRIPTION
User info is a /services/oauth2 end point, not /services/data one. It returns a 403 for an invalid access token which we don't handle automatically. See end of that [doc](https://help.salesforce.com/s/articleView?language=en_US&id=sf.remoteaccess_using_userinfo_endpoint.htm&type=5). Initially, we would refresh the access token upon getting a 401 or 403, but certain clients relied on that 403 to determinate if their token was invalid, so we had it controlled by a flag, and then we got rid of the flag but we kept using the calls to user info for our "cheap rest call" to refresh the access token.

In this PR, we are adding a wrapper for "limits" (with a test). And we are now using a call to "limits" as our "cheap rest call" (in the IDP code and in SalesforceDroidGapActivity)