### PR TITLE
@W-12610994: [Android] Update reference to SHA1PRNG algorithm

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -41,7 +41,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -60,7 +59,6 @@ public class Encryptor {
     private static final String AES_CBC_CIPHER = "AES/CBC/PKCS5Padding";
     private static final String AES_GCM_CIPHER = "AES/GCM/NoPadding";
     private static final String MAC_TRANSFORMATION = "HmacSHA256";
-    private static final String SHA1PRNG = "SHA1PRNG";
     private static final String RSA_PKCS1 = "RSA/ECB/PKCS1Padding";
     private static final String BOUNCY_CASTLE = "BC";
     private static final int READ_BUFFER_LENGTH = 1024;
@@ -72,7 +70,7 @@ public class Encryptor {
      * @return Initialized cipher.
      */
     public static Cipher getEncryptingCipher(String encryptionKey)
-            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
         final byte[] keyBytes = Base64.decode(encryptionKey, Base64.DEFAULT);
         return getEncryptingCipher(keyBytes, generateInitVector());
     }
@@ -534,8 +532,9 @@ public class Encryptor {
         return null;
     }
 
-    private static byte[] generateInitVector() throws NoSuchAlgorithmException {
-        final SecureRandom random = SecureRandom.getInstance(SHA1PRNG);
+    private static byte[] generateInitVector() {
+        // Create the system recommended secure random number generator provider algorithm.
+        final SecureRandom random = new SecureRandom();
         byte[] iv = new byte[12];
         random.nextBytes(iv);
         return iv;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -60,9 +60,7 @@ public class SalesforceKeyGenerator {
     private static final String ENCRYPTED_ID_SHARED_PREF_KEY = "encrypted_%s";
     private static final String ID_PREFIX = "id_";
     private static final String KEYSTORE_ALIAS = "com.salesforce.androidsdk.security.KEYPAIR";
-    private static final String SHA1 = "SHA-1";
     private static final String SHA256 = "SHA-256";
-    private static final String SHA1PRNG = "SHA1PRNG";
     private static final String AES = "AES";
 
     private static final Map<String, String> CACHED_ENCRYPTION_KEYS = new ConcurrentHashMap<>();
@@ -165,13 +163,9 @@ public class SalesforceKeyGenerator {
         } else {
             String uniqueId;
             try {
-
-                // Uses SecureRandom to generate an AES-256 key.
-                final SecureRandom secureRandom = SecureRandom.getInstance(SHA1PRNG);
-
-                // SecureRandom does not require seeding. It's automatically seeded from system entropy.
+                // Create the key generator with its recommended secure random number generator provider algorithm.
                 final KeyGenerator keyGenerator = KeyGenerator.getInstance(AES);
-                keyGenerator.init(length, secureRandom);
+                keyGenerator.init(length);
 
                 // Generates a 256-bit key.
                 uniqueId = Base64.encodeToString(keyGenerator.generateKey().getEncoded(), Base64.NO_WRAP);

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/security/EncryptorTest.java
@@ -36,7 +36,6 @@ import org.junit.runner.RunWith;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -71,7 +70,7 @@ public class EncryptorTest {
 					Encryptor.encrypt(data, null));
 		}
 	}
-	
+
 	/**
 	 * Test to make sure that decrypt does nothing when given a null key.
 	 */
@@ -114,12 +113,12 @@ public class EncryptorTest {
                 final String decryptedA = Encryptor.decrypt(encryptedA, key);
                 final String encryptedB = Encryptor.encrypt(otherData, key);
                 final String decryptedB = Encryptor.decrypt(encryptedB, key);
-				boolean sameDecrypted = decryptedA.equals(decryptedB); 
+				boolean sameDecrypted = decryptedA.equals(decryptedB);
 				boolean sameData = data.equals(otherData);
                 Assert.assertEquals("Decrypted strings '"
-						+ decryptedA + "','" + decryptedB 
+						+ decryptedA + "','" + decryptedB
 						+ "'  should be different for different strings '"
-						+ data +"','" + otherData + "'", 
+						+ data +"','" + otherData + "'",
 						sameDecrypted, sameData);
 			}
 		}
@@ -144,9 +143,9 @@ public class EncryptorTest {
                     Assert.assertEquals("Decrypted values should be the same", decryptedA, decryptedB);
 					boolean sameEncrypted = encryptedA.equals(encryptedB);
                     Assert.assertEquals("Encrypted strings '"
-							+ encryptedA + "','" + encryptedB 
+							+ encryptedA + "','" + encryptedB
 							+ "'  should be different for different keys '"
-							+ key +"','" + otherKey + "'", 
+							+ key +"','" + otherKey + "'",
 							sameEncrypted, sameKey);
 				}
 			}
@@ -158,7 +157,7 @@ public class EncryptorTest {
 	 */
 	@Test
 	public void testGetEncryptingCipher()
-		throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException {
+		throws InvalidAlgorithmParameterException, InvalidKeyException {
     	Cipher cipher = Encryptor.getEncryptingCipher(makeKey("my-key"));
     	Assert.assertEquals("Wrong algorithm", "AES/GCM/NoPadding", cipher.getAlgorithm());
 		Assert.assertEquals("Wrong iv length", 12, cipher.getIV().length);
@@ -170,7 +169,7 @@ public class EncryptorTest {
 	 */
 	@Test
 	public void testGetDecryptingCipher()
-		throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException {
+		throws InvalidAlgorithmParameterException, InvalidKeyException {
 		Cipher cipher = Encryptor.getDecryptingCipher(makeKey("my-key"), new byte[12]);
 		Assert.assertEquals("Wrong algorithm", "AES/GCM/NoPadding", cipher.getAlgorithm());
 		Assert.assertEquals("Wrong iv length", 12, cipher.getIV().length);
@@ -183,7 +182,7 @@ public class EncryptorTest {
 	 */
 	@Test
 	public void testEncryptDecryptWithCipher()
-		throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, InvalidKeyException,
+		throws InvalidAlgorithmParameterException, InvalidKeyException,
 			BadPaddingException, IllegalBlockSizeException {
     	String key = makeKey("test-key");
     	String originalText = "abcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
🥁 _Ready For Review_ 🎸

This replaces a few explicit references to the deprecated SHA1PRNG random number generation algorithm with APIs that allow the Android system to choose the recommended algorithm.  That should have this code compliant with the current recommendation.

I did some extra verification with both fresh installs of the app an upgrades from `dev` during log on, log out and all the unit tests.

Here's a quick compilation of related research.
👉🏻 https://android-developers.googleblog.com/2013/02/using-cryptography-to-store-credentials.html
👉🏻 https://android-developers.googleblog.com/2016/06/security-crypto-provider-deprecated-in.html
👉🏻 https://developer.android.com/guide/topics/security/cryptography#kotlin