### PR TITLE
Improving key value store read performance

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -463,13 +463,7 @@ public class KeyValueEncryptedFileStore implements KeyValueStore {
     }
 
     void encryptStreamToFile(File file, InputStream stream, String encryptionKey) throws IOException {
-        final ByteArrayOutputStream b = new ByteArrayOutputStream();
-        int nextByte = stream.read();
-        while (nextByte != -1) {
-            b.write(nextByte);
-            nextByte = stream.read();
-        }
-        byte[] content = b.toByteArray();
+        byte[] content = Encryptor.getByteArrayStreamFromStream(stream).toByteArray();
         encryptBytesToFile(file, content, encryptionKey);
     }
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStore.java
@@ -36,7 +36,6 @@ import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 import com.salesforce.androidsdk.util.ManagedFilesHelper;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -53,6 +53,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Random;
 
 @RunWith(AndroidJUnit4.class)
 public class KeyValueEncryptedFileStoreTest {
@@ -251,6 +253,8 @@ public class KeyValueEncryptedFileStoreTest {
         }
     }
 
+
+
     /** Test saving from streams and getting them back as values */
     @Test
     public void testSaveStreamGetValue() {
@@ -265,6 +269,32 @@ public class KeyValueEncryptedFileStoreTest {
             Assert.assertEquals(
                 "Wrong value for key: " + key, expectedValue, keyValueStore.getValue(key));
         }
+    }
+
+    @Test
+    public void testSaveStreamGetLargeValue() {
+        for (int i = 0; i < 24; i++) {
+            String key = "key" + i;
+            String value = getLargeString((int) Math.pow(2, i));
+            InputStream stream = stringToStream(value);
+            keyValueStore.saveStream(key, stream);
+            Assert.assertEquals(
+                    "Wrong value for key: " + key, value, keyValueStore.getValue(key));
+        }
+    }
+
+    private String getLargeString(int size) {
+        final String CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder(size);
+
+        for (int i = 0; i < size; i++) {
+            int randomIndex = random.nextInt(CHARACTERS.length());
+            char randomChar = CHARACTERS.charAt(randomIndex);
+            sb.append(randomChar);
+        }
+
+        return sb.toString();
     }
 
     /** Test saving values and getting them back as streams */

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -53,7 +53,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Random;
 
 @RunWith(AndroidJUnit4.class)


### PR DESCRIPTION
Running the new test with some logging and different buffer size gave the following results.
NB: the test uses a ByteArrayInputStream, performance could be even worse if reading directly from a file.

```
1 byte at a time (original code)
Reading bytes    (131072) => 5120.792 micro-seconds
Encrypting bytes (131072) => 646.958 micro-seconds
Reading bytes    (262144) => 9547.917 micro-seconds
Encrypting bytes (262144) => 820.625 micro-seconds
Reading bytes    (524288) => 19174.5 micro-seconds
Encrypting bytes (524288) => 1612.125 micro-seconds
Reading bytes    (1048576) => 37353.083 micro-seconds
Encrypting bytes (1048576) => 1702.458 micro-seconds
Reading bytes    (2097152) => 73364.916 micro-seconds
Encrypting bytes (2097152) => 3351.584 micro-seconds
Reading bytes    (4194304) => 145086.166 micro-seconds
Encrypting bytes (4194304) => 6250.292 micro-seconds
Reading bytes    (8388608) => 293881.25 micro-seconds
Encrypting bytes (8388608) => 12651.334 micro-seconds

1024 bytes at a time
Reading bytes    (131072) => 174.5 micro-seconds
Encrypting bytes (131072) => 841.084 micro-seconds
Reading bytes    (262144) => 318.834 micro-seconds
Encrypting bytes (262144) => 771.625 micro-seconds
Reading bytes    (524288) => 479.541 micro-seconds
Encrypting bytes (524288) => 1063.292 micro-seconds
Reading bytes    (1048576) => 802.958 micro-seconds
Encrypting bytes (1048576) => 1449.875 micro-seconds
Reading bytes    (2097152) => 1524.792 micro-seconds
Encrypting bytes (2097152) => 3264.25 micro-seconds
Reading bytes    (4194304) => 3298.833 micro-seconds
Encrypting bytes (4194304) => 6653.584 micro-seconds
Reading bytes    (8388608) => 7082.084 micro-seconds
Encrypting bytes (8388608) => 11848.125 micro-seconds

4096 bytes at a time
Reading bytes    (131072) => 121.375 micro-seconds
Encrypting bytes (131072) => 341.958 micro-seconds
Reading bytes    (262144) => 259.5 micro-seconds
Encrypting bytes (262144) => 574.084 micro-seconds
Reading bytes    (524288) => 587.75 micro-seconds
Encrypting bytes (524288) => 1193.75 micro-seconds
Reading bytes    (1048576) => 952.0 micro-seconds
Encrypting bytes (1048576) => 2014.083 micro-seconds
Reading bytes    (2097152) => 1398.666 micro-seconds
Encrypting bytes (2097152) => 3014.584 micro-seconds
Reading bytes    (4194304) => 3340.292 micro-seconds
Encrypting bytes (4194304) => 6108.541 micro-seconds
Reading bytes    (8388608) => 6843.542 micro-seconds
Encrypting bytes (8388608) => 12806.625 micro-seconds
```