### PR TITLE
@W-13673997: [MSDK Android] Improve Debug Menu Access In Android Emulator

### DIFF
--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -96,6 +96,10 @@
 	<string name="sf__biometric_opt_in_deny">Use Password</string>
 	<string name="sf__biometric_signout_user">Signing out %s.</string>
 
-	<!-- Dev support -->
-	<string name="sf__dev_support_title">Mobile SDK Dev Support</string>
+	<!-- Developer Support -->
+	<string name="sf__dev_support_title">Mobile SDK Developer Support</string>
+	<string name="sf__notifications_local_show_dev_support_action_title">Show Developer Support</string>
+	<string name="sf__notifications_local_show_dev_support_content">Show Salesforce Mobile SDK developer support</string>
+	<string name="sf__notifications_local_show_dev_support_text">Tap to display Salesforce Mobile SDK developer support in the active app.</string>
+	<string name="sf__notifications_local_show_dev_support_title">Salesforce Mobile Developer Support</string>
 </resources>

--- a/libs/SalesforceSDK/res/values/strings.xml
+++ b/libs/SalesforceSDK/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!--
-      These aren't prefixed as they're expected to be overriden   
-      Strings of the SDK that are used by SDK-based applications live in sf__strings.xml
+      These aren't prefixed as they're expected to be overridden Strings of the
+      SDK that are used by SDK-based applications live in sf__strings.xml
     -->
     <string name="app_name">SalesforceSDK</string>
     <string name="account_type">com.salesforce.androidsdk</string>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -26,10 +26,15 @@
  */
 package com.salesforce.androidsdk.app;
 
+import static com.salesforce.androidsdk.R.style.SalesforceSDK_AlertDialog;
+import static com.salesforce.androidsdk.R.style.SalesforceSDK_AlertDialog_Dark;
+
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.Application;
+import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -40,6 +45,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings;
@@ -48,6 +54,7 @@ import android.view.View;
 import android.webkit.CookieManager;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
@@ -71,6 +78,8 @@ import com.salesforce.androidsdk.config.AdminSettingsManager;
 import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.config.LoginServerManager;
 import com.salesforce.androidsdk.config.RuntimeConfig;
+import com.salesforce.androidsdk.developer.support.activities.ShowDeveloperSupportActivity;
+import com.salesforce.androidsdk.developer.support.notifications.local.ShowDeveloperSupportNotifier;
 import com.salesforce.androidsdk.push.PushMessaging;
 import com.salesforce.androidsdk.push.PushNotificationInterface;
 import com.salesforce.androidsdk.push.PushService;
@@ -152,6 +161,19 @@ public class SalesforceSDKManager implements LifecycleObserver {
     protected Context context;
     private LoginOptions loginOptions;
     private final Class<? extends Activity> mainActivityClass;
+
+    /**
+     * Null or an authenticated Activity for private use when developer support
+     * is enabled.
+     */
+    private Activity authenticatedActivityForDeveloperSupport = null;
+
+    /**
+     * Null or the Android Activity lifecycle callbacks object registered when
+     * developer support is enabled.
+     */
+    private ActivityLifecycleCallbacks activityLifecycleCallbacksForDeveloperSupport;
+
     private Class<? extends Activity> loginActivityClass = LoginActivity.class;
     private Class<? extends AccountSwitcherActivity> switcherActivityClass = AccountSwitcherActivity.class;
     private ScreenLockManager screenLockManager;
@@ -395,6 +417,9 @@ public class SalesforceSDKManager implements LifecycleObserver {
         if (!TextUtils.isEmpty(idpAppPackageName)) {
             INSTANCE.setIDPAppPackageName(idpAppPackageName);
         }
+
+        // Set up developer support.
+        setupDeveloperSupport(context);
     }
 
     /**
@@ -868,6 +893,113 @@ public class SalesforceSDKManager implements LifecycleObserver {
         }
 	}
 
+    /**
+     * Updates developer support features to match an Android Activity lifecycle
+     * event, including updating the app's authenticated Android Activity.
+     *
+     * @param authenticatedActivity The new authenticated Android Activity
+     *                              instance, or null
+     * @param lifecycleActivity     The Android Activity instance provided by
+     *                              the Activity lifecycle event
+     */
+    private void updateDeveloperSupportForActivityLifecycle(
+            @Nullable Activity authenticatedActivity,
+            @NonNull Activity lifecycleActivity
+    ) {
+
+        // Show the developer support dialog, if applicable.
+        if (lifecycleActivity.isDestroyed() && lifecycleActivity instanceof ShowDeveloperSupportActivity) {
+            showDevSupportDialog(authenticatedActivityForDeveloperSupport);
+            return;
+        }
+
+        // Assign the authenticated Activity.
+        authenticatedActivityForDeveloperSupport = authenticatedActivity;
+
+        // Display or hide the show developer support notification.
+        if (getUserAccountManager().getCurrentAccount() == null || authenticatedActivityForDeveloperSupport == null) {
+            ShowDeveloperSupportNotifier.Companion.hideDeveloperSupportNotification(
+                    lifecycleActivity
+            );
+        } else {
+            ShowDeveloperSupportNotifier.Companion.showDeveloperSupportNotification(
+                    lifecycleActivity
+            );
+        }
+    }
+
+    /**
+     * Sets up an Android Activity lifecycle callback to maintain the app's
+     * authenticated Android Activity reference used when developer support is
+     * enabled.
+     *
+     * @param context Either of the Android application context or an activity
+     *                context
+     */
+    private static void setupDeveloperSupport(Context context) {
+
+        // Resolve the Android application object from the provided context.
+        final Application application = context instanceof Application ? (Application) context : context instanceof Activity ? ((Activity) context).getApplication() : null;
+
+        // Guards
+        final SalesforceSDKManager salesforceSDKManager = getInstance();
+        if (!salesforceSDKManager.isDevSupportEnabled() || application == null || salesforceSDKManager.activityLifecycleCallbacksForDeveloperSupport != null) return;
+
+        /*
+         * Register an Android Activity lifecycle listener to update the
+         * authenticated  Android Activity at appropriate Activity lifecycle
+         * events.
+         */
+        final ActivityLifecycleCallbacks activityLifecycleCallbacks = new ActivityLifecycleCallbacks() {
+            @Override
+            public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {
+                /* Intentionally Blank */
+            }
+
+            @Override
+            public void onActivityStarted(@NonNull Activity activity) {
+                /* Intentionally Blank */
+            }
+
+            @Override
+            public void onActivityResumed(@NonNull Activity activity) {
+                if (activity.getClass() == salesforceSDKManager.loginActivityClass) {
+                    salesforceSDKManager.updateDeveloperSupportForActivityLifecycle(null, activity);
+                } else {
+                    salesforceSDKManager.updateDeveloperSupportForActivityLifecycle(activity, activity);
+                }
+            }
+
+            @Override
+            public void onActivityPaused(@NonNull Activity activity) {
+                /* Intentionally Blank */
+            }
+
+            @Override
+            public void onActivityStopped(@NonNull Activity activity) {
+                /* Intentionally Blank */
+            }
+
+            @Override
+            public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+                /* Intentionally Blank */
+            }
+
+            @Override
+            public void onActivityDestroyed(@NonNull Activity activity) {
+                // Note: "Destroyed" is only of interest for `ShowDeveloperSupportActivity`.
+                if (activity instanceof ShowDeveloperSupportActivity) {
+                    salesforceSDKManager.updateDeveloperSupportForActivityLifecycle(
+                            null,
+                            activity
+                    );
+                }
+            }
+        };
+        application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks);
+        salesforceSDKManager.activityLifecycleCallbacksForDeveloperSupport = activityLifecycleCallbacks;
+    }
+
     private synchronized void unregisterPush(final ClientManager clientMgr, final boolean showLoginPage,
     		final String refreshToken, final String loginServer,
             final Account account, final Activity frontActivity, boolean isLastAccount) {
@@ -1218,32 +1350,37 @@ public class SalesforceSDKManager implements LifecycleObserver {
     }
 
     /**
-     * Show dev support dialog
+     * Displays developer support for a specified Android activity.
+     *
+     * @param frontActivity The Android activity to chose developer support
+     *                      features for and display the dialog
      */
     public void showDevSupportDialog(final Activity frontActivity) {
         if (!isDevSupportEnabled()) {
             return;
         }
 
-        frontActivity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                final LinkedHashMap<String, DevActionHandler> devActions = getDevActions(frontActivity);
-                final DevActionHandler[] devActionHandlers = devActions.values().toArray(new DevActionHandler[0]);
+        if (devActionsDialog != null) devActionsDialog.dismiss();
 
-                devActionsDialog =
-                        new AlertDialog.Builder(frontActivity)
-                                .setItems(
-                                        devActions.keySet().toArray(new String[0]),
-                                        (dialog, which) -> {
-                                            devActionHandlers[which].onSelected();
-                                            devActionsDialog = null;
-                                        })
-                                .setOnCancelListener(dialog -> devActionsDialog = null)
-                                .setTitle(R.string.sf__dev_support_title)
-                                .create();
-                devActionsDialog.show();
-            }
+        frontActivity.runOnUiThread(() -> {
+            final LinkedHashMap<String, DevActionHandler> devActions = getDevActions(frontActivity);
+            final DevActionHandler[] devActionHandlers = devActions.values().toArray(new DevActionHandler[0]);
+
+            devActionsDialog =
+                    new AlertDialog.Builder(
+                            frontActivity,
+                            isDarkTheme() ? SalesforceSDK_AlertDialog_Dark : SalesforceSDK_AlertDialog
+                    )
+                            .setItems(
+                                    devActions.keySet().toArray(new String[0]),
+                                    (dialog, which) -> {
+                                        devActionHandlers[which].onSelected();
+                                        devActionsDialog = null;
+                                    }
+                            ).setOnCancelListener(dialog -> devActionsDialog = null)
+                            .setTitle(R.string.sf__dev_support_title)
+                            .create();
+            devActionsDialog.show();
         });
     }
 
@@ -1465,6 +1602,13 @@ public class SalesforceSDKManager implements LifecycleObserver {
         ((ScreenLockManager) getScreenLockManager()).onAppBackgrounded();
         ((BiometricAuthenticationManager) getBiometricAuthenticationManager())
                 .onAppBackgrounded();
+
+        // Hide the Salesforce Mobile SDK "Show Developer Support" notification
+        if (authenticatedActivityForDeveloperSupport != null) {
+            ShowDeveloperSupportNotifier.Companion.hideDeveloperSupportNotification(
+                    authenticatedActivityForDeveloperSupport
+            );
+        }
     }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
@@ -1472,5 +1616,12 @@ public class SalesforceSDKManager implements LifecycleObserver {
         ((ScreenLockManager) getScreenLockManager()).onAppForegrounded();
         ((BiometricAuthenticationManager) getBiometricAuthenticationManager())
                 .onAppForegrounded();
+
+        // Display the Salesforce Mobile SDK "Show Developer Support" notification
+        if (getUserAccountManager().getCurrentAccount() != null && authenticatedActivityForDeveloperSupport != null) {
+            ShowDeveloperSupportNotifier.Companion.showDeveloperSupportNotification(
+                    authenticatedActivityForDeveloperSupport
+            );
+        }
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/developer/support/activities/ShowDeveloperSupportActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/developer/support/activities/ShowDeveloperSupportActivity.kt
@@ -1,0 +1,19 @@
+package com.salesforce.androidsdk.developer.support.activities
+
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * An Activity that, when started, finishes immediately and shows the developer
+ * support dialog from the previous Activity.  SalesforceSDKManager implements
+ * the logic for observing the Activity lifecycle and showing the developer
+ * support dialog.
+ */
+class ShowDeveloperSupportActivity : AppCompatActivity() {
+
+    override fun onResume() {
+        super.onResume()
+
+        // Finish immediately.
+        finish()
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/developer/support/notifications/local/ShowDeveloperSupportNotifier.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/developer/support/notifications/local/ShowDeveloperSupportNotifier.kt
@@ -1,0 +1,204 @@
+package com.salesforce.androidsdk.developer.support.notifications.local
+
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.app.Activity
+import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.NotificationManager.IMPORTANCE_DEFAULT
+import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.content.Context.MODE_PRIVATE
+import android.content.Context.NOTIFICATION_SERVICE
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.O
+import android.os.Build.VERSION_CODES.TIRAMISU
+import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.PRIORITY_DEFAULT
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.edit
+import com.salesforce.androidsdk.R.drawable.sf__salesforce_logo
+import com.salesforce.androidsdk.R.string.sf__notifications_local_show_dev_support_action_title
+import com.salesforce.androidsdk.R.string.sf__notifications_local_show_dev_support_content
+import com.salesforce.androidsdk.R.string.sf__notifications_local_show_dev_support_text
+import com.salesforce.androidsdk.R.string.sf__notifications_local_show_dev_support_title
+import com.salesforce.androidsdk.developer.support.activities.ShowDeveloperSupportActivity
+import com.salesforce.androidsdk.developer.support.notifications.local.ShowDeveloperSupportNotifier.Companion.NotificationId.SHOW_DEVELOPER_SUPPORT
+
+/**
+ * Provides the "Show Developer Support" local notification, including
+ * notification permissions and set up.
+ */
+internal class ShowDeveloperSupportNotifier {
+
+    companion object {
+
+        // region Notifications
+
+        /** A shared preferences name for developer support preferences */
+        private const val SFDC_SHARED_PREFERENCES_NAME_DEVELOPER_SUPPORT = "SFDC_SHARED_PREFERENCES_NAME_DEVELOPER_SUPPORT"
+
+        /** A shared preferences key for developer support post notifications permission requested */
+        private const val SFDC_SHARED_PREFERENCES_KEY_DEVELOPER_SUPPORT_POST_NOTIFICATIONS_PERMISSION_REQUESTED = "SFDC_SHARED_PREFERENCES_KEY_DEVELOPER_SUPPORT_POST_NOTIFICATIONS_PERMISSION_REQUESTED"
+
+        /** Notification Channel Ids: Salesforce Mobile SDK Show Developer Support Notification */
+        private const val NOTIFICATION_CHANNEL_ID_SHOW_DEVELOPER_SUPPORT = "NotificationChannelShowDeveloperSupport"
+
+        /** Notification Ids */
+        enum class NotificationId(val id: Int) {
+            SHOW_DEVELOPER_SUPPORT(0)
+        }
+
+        /**
+         * Creates notification channels.
+         *
+         * @param application The Android application
+         */
+        @RequiresApi(O)
+        fun createNotificationChannel(application: Application) =
+            (application.getSystemService(
+                NOTIFICATION_SERVICE
+            ) as? NotificationManager)?.createNotificationChannel(
+                NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID_SHOW_DEVELOPER_SUPPORT,
+                    "Show Developer Support Notification",
+                    IMPORTANCE_DEFAULT
+                )
+            )
+
+        /**
+         * Hides the Salesforce Mobile SDK "Show Developer Support"
+         * notification.
+         * @param activity The Android activity
+         */
+        fun hideDeveloperSupportNotification(activity: Activity?) {
+            // Guards.
+            if (activity == null) return
+
+            // Conveniences.
+            val notificationManager = NotificationManagerCompat.from(activity)
+
+            // Guard such that no notification will be attempted when notifications are disabled.
+            if (!notificationManager.areNotificationsEnabled()) return
+
+            // Build and display the Show Developer Support notification.
+            notificationManager.cancel(SHOW_DEVELOPER_SUPPORT.id)
+        }
+
+        /**
+         * Displays the Salesforce Mobile SDK "Show Developer Support"
+         * notification.
+         * * @param activity The Android activity
+         */
+        fun showDeveloperSupportNotification(activity: Activity?) {
+            // Guards.
+            if (activity == null) return
+
+            // Conveniences.
+            val notificationManager = NotificationManagerCompat.from(activity)
+
+            /*
+             * Review required Android post-notifications permission.
+             * Note: The permission check and return must be in the same method
+             * as the notification manager's "notify" method to pass Android
+             * Studio's inspector.
+             */
+            if (SDK_INT >= TIRAMISU && ActivityCompat.checkSelfPermission(
+                    activity,
+                    POST_NOTIFICATIONS
+                ) != PERMISSION_GRANTED
+            ) {
+                // Guard such that the permissions prompt is only displayed once as a consideration for the user's chosen preferences.
+                activity.getSharedPreferences(
+                    SFDC_SHARED_PREFERENCES_NAME_DEVELOPER_SUPPORT,
+                    MODE_PRIVATE
+                ).run {
+                    val postNotificationsPermissionRequested = getBoolean(
+                        SFDC_SHARED_PREFERENCES_KEY_DEVELOPER_SUPPORT_POST_NOTIFICATIONS_PERMISSION_REQUESTED,
+                        false
+                    )
+                    if (postNotificationsPermissionRequested) return
+
+                    edit {
+                        putBoolean(
+                            SFDC_SHARED_PREFERENCES_KEY_DEVELOPER_SUPPORT_POST_NOTIFICATIONS_PERMISSION_REQUESTED,
+                            true
+                        )
+                        apply()
+                    }
+                }
+
+                // Prompt for the post notifications permission.
+                ActivityCompat.requestPermissions(
+                    activity,
+                    arrayOf(POST_NOTIFICATIONS),
+                    1
+                )
+
+                return
+            }
+
+            // Guard such that no notification will be attempted when notifications are disabled.
+            if (!notificationManager.areNotificationsEnabled()) return
+
+            // Create the notification channel.
+            if (SDK_INT >= O) {
+                createNotificationChannel(activity.application)
+            }
+
+            // Initialize a notification builder for the Show Developer Support local notification.
+            NotificationCompat.Builder(
+                activity,
+                NOTIFICATION_CHANNEL_ID_SHOW_DEVELOPER_SUPPORT
+            ).apply {
+                priority = PRIORITY_DEFAULT
+                addAction(
+                    NotificationCompat.Action(
+                        sf__salesforce_logo,
+                        activity.getString(sf__notifications_local_show_dev_support_action_title),
+                        PendingIntent.getActivity(
+                            activity,
+                            0,
+                            Intent(
+                                activity,
+                                ShowDeveloperSupportActivity::class.java
+                            ).apply {
+                                flags = FLAG_ACTIVITY_SINGLE_TOP
+                            },
+                            FLAG_IMMUTABLE
+                        )
+                    )
+                )
+                setContentTitle(
+                    activity.getString(sf__notifications_local_show_dev_support_title)
+                )
+                setContentText(
+                    activity.getString(sf__notifications_local_show_dev_support_content)
+                )
+                setSilent(true) // Set the Show Developer Support notification to silent.
+                setSmallIcon(sf__salesforce_logo)
+                setStyle(
+                    NotificationCompat.BigTextStyle().bigText(
+                        activity.getString(
+                            sf__notifications_local_show_dev_support_text
+                        )
+                    )
+                )
+            }.also { builder ->
+
+                // Build and display the Show Developer Support notification.
+                notificationManager.notify(
+                    SHOW_DEVELOPER_SUPPORT.id,
+                    builder.build()
+                )
+            }
+        }
+
+        // endregion
+    }
+}

--- a/libs/SalesforceSDK/src/debug/AndroidManifest.xml
+++ b/libs/SalesforceSDK/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Debug-Only: Post notifications permission supports the show developer support notification. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application>
+
+        <!-- Debug-Only: The show developer support activity supports the show developer support notification. -->
+        <activity
+            android:name=".developer.support.activities.ShowDeveloperSupportActivity"
+            android:theme="@style/SalesforceSDK" />
+    </application>
+</manifest>


### PR DESCRIPTION
🥁 _Ready for review!_ 🎸

  This change adds a new "Show Salesforce Mobile SDK Developer Support" local notification for MSDK apps running with the debug build configuration.  The benefits hopefully include more intuitive access to the developer support dialog plus an alternative to the difficult to access shake gesture.

  The shake gesture became more difficult to access since Android Emulator, as an embedded tool window of Android Studio, generally cannot receive general keyboard shortcuts.

  For testing, here's some of the logic I thought of.  More ideas are welcome!
- The notification is only displayed for debug builds when developer support is enabled
  -  Builds other than debug will not show the notification, regardless of developer support enablement, since the manifest will not include the post notification permissions
- The notification should be displayed only while an app is authenticated and in the foreground
- The code around the shake gesture hasn't changed, for those who are familiar with it
- The app will request post notifications on login, but will considerately not re-request this permission if it is declined
  - This is a general guide for permissions management from Google

For extra credit, I also enabled dark mode support for the developer support dialog.

Give it a try and let me know how it looks.  I've testing in native and hybrid apps so far between API 24 and 33.  React Native testing is in the works.