### PR TITLE
Optionally support use custom domain button in webview.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -48,6 +48,7 @@ import android.view.View;
 import android.webkit.CookieManager;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
@@ -100,6 +101,7 @@ import java.util.Locale;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.regex.Pattern;
 
 /**
  * This class serves as an interface to the various
@@ -182,7 +184,7 @@ public class SalesforceSDKManager implements LifecycleObserver {
 
     private boolean useHybridAuthentication = true; // hybrid authentication flows ON by default - but app can opt out by calling setUseHybridAuthentication(false)
 
-    private boolean shouldInferCustomDomain = false; // Do not detect use of Custom Domain input from login webview but app can opt in by calling setInferCustomDomain(ture)
+    private Pattern customDomainInferencePattern;
 
     private Theme theme =  Theme.SYSTEM_DEFAULT;
     private String appName;
@@ -676,20 +678,25 @@ public class SalesforceSDKManager implements LifecycleObserver {
     }
 
     /**
-     * Returns whether the SDK should infer if the user has entered a new login server through
-     * the "Use Custom Domain" button on the login screen.
+     * Returns the pattern used to detect the use of "Use Custom Domain" input from login web view.
+     *
+     * @return pattern if set or null
      */
-    public boolean shouldInferCustomDomain() {
-        return this.shouldInferCustomDomain;
+    public synchronized Pattern getCustomDomainInferencePattern() {
+        return customDomainInferencePattern;
     }
 
     /**
-     * Sets whether the SDK should infer if the user has entered a new login server through
-     * the "Use Custom Domain" button on the login screen.
-     * @param shouldInferCustomDomain
+     *  Detect use of "Use Custom Domain" input from login web view using the given regex.
+     *  Example for a specific org:
+     *    "^https:\\/\\/mobilesdk\\.my\\.salesforce\\.com\\/\\?startURL=%2Fsetup%2Fsecur%2FRemoteAccessAuthorizationPage\\.apexp"
+     *  For any my domain:
+     *    "^https:\\/\\/[a-zA-Z0-9]+\\.my\\.salesforce\\.com/\\?startURL=%2Fsetup%2Fsecur%2FRemoteAccessAuthorizationPage\\.apexp"
+     *
+     * @param pattern regex to use when detecting use of custom domain on login
      */
-    public synchronized void setShouldInferCustomDomain(boolean shouldInferCustomDomain) {
-        this.shouldInferCustomDomain = shouldInferCustomDomain;
+    public synchronized void setCustomDomainInferencePattern(@Nullable Pattern pattern) {
+        this.customDomainInferencePattern = pattern;
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -182,7 +182,7 @@ public class SalesforceSDKManager implements LifecycleObserver {
 
     private boolean useHybridAuthentication = true; // hybrid authentication flows ON by default - but app can opt out by calling setUseHybridAuthentication(false)
 
-    private boolean shouldInferCustomDomain = true; // Detect use of Custom Domain input from login webview - but app  can opt out by calling setInferCustomDomain(false)
+    private boolean shouldInferCustomDomain = false; // Do not detect use of Custom Domain input from login webview but app can opt in by calling setInferCustomDomain(ture)
 
     private Theme theme =  Theme.SYSTEM_DEFAULT;
     private String appName;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -181,6 +181,9 @@ public class SalesforceSDKManager implements LifecycleObserver {
     private boolean useWebServerAuthentication = true; // web server flow ON by default - but app can opt out by calling setUseWebServerAuthentication(false)
 
     private boolean useHybridAuthentication = true; // hybrid authentication flows ON by default - but app can opt out by calling setUseHybridAuthentication(false)
+
+    private boolean shouldInferCustomDomain = true; // Detect use of Custom Domain input from login webview - but app  can opt out by calling setInferCustomDomain(false)
+
     private Theme theme =  Theme.SYSTEM_DEFAULT;
     private String appName;
 
@@ -670,6 +673,23 @@ public class SalesforceSDKManager implements LifecycleObserver {
      */
     public synchronized void setUseHybridAuthentication(boolean useHybridAuthentication) {
         this.useHybridAuthentication = useHybridAuthentication;
+    }
+
+    /**
+     * Returns whether the SDK should infer if the user has entered a new login server through
+     * the "Use Custom Domain" button on the login screen.
+     */
+    public boolean shouldInferCustomDomain() {
+        return this.shouldInferCustomDomain;
+    }
+
+    /**
+     * Sets whether the SDK should infer if the user has entered a new login server through
+     * the "Use Custom Domain" button on the login screen.
+     * @param shouldInferCustomDomain
+     */
+    public synchronized void setShouldInferCustomDomain(boolean shouldInferCustomDomain) {
+        this.shouldInferCustomDomain = shouldInferCustomDomain;
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -576,15 +576,16 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
         private boolean isNewLoginUrl(Uri uri) {
             String host = uri.getHost();
-            String path = uri.getQuery();
+            String query = uri.getQuery();
+            String path = uri.getPath();
 
-            if (host == null || path == null || getLoginUrl().contains(host)) {
+            if (host == null || query == null || path == null || getLoginUrl().contains(host)) {
                 return false;
             }
 
             final String myDomainHost = ".my.salesforce.com";
             final String loginPath = "startURL=/setup/secur/RemoteAccessAuthorizationPage.apexp";
-            return host.endsWith(myDomainHost) && path.startsWith(loginPath);
+            return host.endsWith(myDomainHost) && query.startsWith(loginPath) && path.equals("/");
         }
 
         @Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -550,7 +550,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
 
             String formattedUrl = uri.toString().replace("///", "/").toLowerCase(Locale.US);
             String callbackUrl = loginOptions.getOauthCallbackUrl().replace("///", "/").toLowerCase(Locale.US);
-			boolean authFlowFinished = formattedUrl.startsWith(callbackUrl);
+            boolean authFlowFinished = formattedUrl.startsWith(callbackUrl);
             if (authFlowFinished) {
                 Map<String, String> params = UriFragmentParser.parse(uri);
                 String error = params.get("error");
@@ -569,37 +569,22 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
                         onAuthFlowComplete(tr);
                     }
                 }
-            } else {
-                // Only allow redirect for requests with authorization headers for Salesforce urls.
-                if (request.getRequestHeaders() != null && request.getRequestHeaders().containsKey("Authorization")) {
-                   return isSalesforceUrl(formattedUrl);
-                }
             }
 
             return authFlowFinished;
         }
 
-        // List from https://help.salesforce.com/s/articleView?language=en_US&id=sf.domain_name_url_formats.htm&type=5
-        private boolean isSalesforceUrl(String host) {
-            return (host != null && (host.endsWith(".salesforce.com") ||
-                    host.endsWith(".force.com") ||
-                    host.endsWith(".sfdcopens.com") ||
-                    host.endsWith(".site.com") ||
-                    host.endsWith(".lightning.com") ||
-                    host.endsWith(".salesforce-sites.com") ||
-                    host.endsWith(".force-user-content.com") ||
-                    host.endsWith(".salesforce-experience.com") ||
-                    host.endsWith(".salesforce-scrt.com")));
-        }
-
         private boolean isNewLoginUrl(Uri uri) {
-            if (!uri.toString().contains(getLoginUrl()) && isSalesforceUrl(uri.getHost())) {
-                String path = uri.getQuery();
-                return path != null &&
-                        path.startsWith("startURL=/setup/secur/RemoteAccessAuthorizationPage.apexp?source=");
+            String host = uri.getHost();
+            String path = uri.getQuery();
+
+            if (host == null || path == null || getLoginUrl().contains(host)) {
+                return false;
             }
 
-            return false;
+            final String myDomainHost = ".my.salesforce.com";
+            final String loginPath = "startURL=/setup/secur/RemoteAccessAuthorizationPage.apexp";
+            return host.endsWith(myDomainHost) && path.startsWith(loginPath);
         }
 
         @Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -525,7 +525,7 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             }
 
             // Check if user entered a custom domain
-            if (isNewLoginUrl(uri)) {
+            if (SalesforceSDKManager.getInstance().shouldInferCustomDomain() && isNewLoginUrl(uri)) {
                 try {
                     String baseUrl = "https://" + uri.getHost();
                     LoginServerManager serverManager = SalesforceSDKManager.getInstance().getLoginServerManager();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.java
@@ -100,6 +100,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
 
 import okhttp3.Request;
 import okhttp3.Response;
@@ -525,7 +526,10 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             }
 
             // Check if user entered a custom domain
-            if (SalesforceSDKManager.getInstance().shouldInferCustomDomain() && isNewLoginUrl(uri)) {
+            String host = uri.getHost();
+            Pattern customDomainPattern = SalesforceSDKManager.getInstance().getCustomDomainInferencePattern();
+            if (host != null && !getLoginUrl().contains(host) && customDomainPattern != null
+                    && customDomainPattern.matcher(uri.toString()).find()) {
                 try {
                     String baseUrl = "https://" + uri.getHost();
                     LoginServerManager serverManager = SalesforceSDKManager.getInstance().getLoginServerManager();
@@ -572,20 +576,6 @@ public class OAuthWebviewHelper implements KeyChainAliasCallback {
             }
 
             return authFlowFinished;
-        }
-
-        private boolean isNewLoginUrl(Uri uri) {
-            String host = uri.getHost();
-            String query = uri.getQuery();
-            String path = uri.getPath();
-
-            if (host == null || query == null || path == null || getLoginUrl().contains(host)) {
-                return false;
-            }
-
-            final String myDomainHost = ".my.salesforce.com";
-            final String loginPath = "startURL=/setup/secur/RemoteAccessAuthorizationPage.apexp";
-            return host.endsWith(myDomainHost) && query.startsWith(loginPath) && path.equals("/");
         }
 
         @Override


### PR DESCRIPTION
- Opt-in regex pattern to specify domains.
- If a valid url is entered via the "Use Custom Domain" button on the login page store it in the server list.
- Open custom domain urls in Chrome (advanced auth) if appropriate.
