### PR TITLE
@W-13924719: [MSDK Android] Native Sample Apps Have In-Operative Menu Items

### DIFF
--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DetailActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/DetailActivity.java
@@ -112,6 +112,10 @@ public class DetailActivity extends SalesforceActivity implements LoaderManager.
 	    logoutItem.setVisible(false);
 	    final MenuItem addItem = menu.findItem(R.id.action_add);
 	    addItem.setVisible(false);
+	    final MenuItem inspectDbItem = menu.findItem(R.id.action_inspect_db);
+	    inspectDbItem.setVisible(false);
+	    final MenuItem switchUserItem = menu.findItem(R.id.action_switch_user);
+	    switchUserItem.setVisible(false);
 	    final MenuItem refreshItem = menu.findItem(R.id.action_refresh);
 	    refreshItem.setIcon(R.drawable.ic_action_save);
 	    return super.onCreateOptionsMenu(menu);


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

This simply hides two options menu items in the Mobile Sync Explorer native sample app that appear to have been show in the detail activity by mistake.