### PR TITLE
Support Predictive System Back.

### DIFF
--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
@@ -14,7 +14,8 @@
     <application android:label="@string/app_name"
         android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"
-		android:icon="@drawable/sf__icon">
+		android:icon="@drawable/sf__icon"
+        android:enableOnBackInvokedCallback="@bool/isGraterThan33">
 
         <!--  Main activity -->
         <activity android:label="@string/app_name"

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values-v34/system_back.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values-v34/system_back.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isGraterThan33">true</bool>
+</resources>

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values/system_back.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values/system_back.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isGraterThan33">false</bool>
+</resources>

--- a/libs/SalesforceHybrid/AndroidManifest.xml
+++ b/libs/SalesforceHybrid/AndroidManifest.xml
@@ -4,5 +4,8 @@
     android:versionCode="82"
     android:versionName="11.1.0.dev">
 
-    <application />
+    <application>
+        <activity android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
+            android:enableOnBackInvokedCallback="false" />
+    </application>
 </manifest>

--- a/libs/SalesforceReact/AndroidManifest.xml
+++ b/libs/SalesforceReact/AndroidManifest.xml
@@ -3,6 +3,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     android:versionCode="82"
     android:versionName="11.1.0.dev">
-
-    <application />
+    
+    <application>
+        <activity android:name=".ui.SalesforceReactActivity"
+            android:enableOnBackInvokedCallback="false" />
+    </application>
 </manifest>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
@@ -48,12 +48,15 @@ import android.view.accessibility.AccessibilityManager;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.window.OnBackInvokedDispatcher;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.OptIn;
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.os.BuildCompat;
 import androidx.fragment.app.FragmentActivity;
 
 import com.salesforce.androidsdk.R;
@@ -99,6 +102,14 @@ public class ScreenLockActivity extends FragmentActivity {
         } catch (PackageManager.NameNotFoundException e) {
             SalesforceSDKLogger.e(TAG, "Unable to retrieve host app icon.  NameNotFoundException: " + e.getMessage());
             appIcon.setImageDrawable(ResourcesCompat.getDrawable(getResources(), R.drawable.sf__salesforce_logo, null));
+        }
+
+        // TODO:  Remove this when min API > 33
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                    OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+                    () -> { /* purposefully blank */ }
+            );
         }
 
         presentAuth();

--- a/native/NativeSampleApps/MobileSyncExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/MobileSyncExplorer/AndroidManifest.xml
@@ -8,7 +8,8 @@
 	<application android:icon="@drawable/sf__icon"
 	    android:label="@string/app_name"
 		android:name="com.salesforce.samples.mobilesyncexplorer.MobileSyncExplorerApp"
-		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
+		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"
+		android:enableOnBackInvokedCallback="true">
 
 		<!-- Launcher screen -->
 		<activity android:name="com.salesforce.samples.mobilesyncexplorer.ui.MainActivity"


### PR DESCRIPTION
I tried to implement this about a year ago when it was first announced.  At that time, users could opt-in via a setting in the developer options of their API 33 (Android 13) device and enable it with a manifest option to test their apps, but the feature wouldn't be forced on for all apps until API 34 (Android 14).  I was able to work around the issue it caused for our Screen Lock (a.k.a passcode) feature but not the lack of support from Cordova and React Native.  Because in app back navigation completely broke for those skews we deferred support until API 34.  

Since then, Google has changed the strategy somewhat.  As of the last Android 14 beta the visual impact of the feature still cannot be seen without the user opting in through developer options (maybe it will be in the final release or pixel exclusive for a year? who knows).  **However**, even without the visual goodness the side effects of breaking functionality still remain if enabled!  Google has also carried the API 33 opt-in manifest setting forward and make the feature opt-in (instead of forced on) in API 34.  In addition, the feature can now be toggled on or off per activity which unblocks the issues we faced last year.  

TL;DR:  Google made it opt-in and configurable per activity.  I fixed the issues it caused for Screen Lock + Biometric Auth and disabled it for Cordova + React Native apps.

Testing Matrix:
| | API 24-32 | API 33 | API 34 |
| :--- | :---: | :---: | :---: |
| Native |  :white_check_mark: | :white_check_mark: | :white_check_mark: |
| Screen Lock | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| Biometric Unlock | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| Cordova | :white_check_mark: | :x: * | :white_check_mark: |
| React Native | :white_check_mark: | :x: * |  |

* It appears Google has not fixed the issue with API 33 that we experienced last year (in app back navigation is broken).  I have added an example of setting the manifest opt-in value conditionally based on API level in MobileSyncExplorerHybrid. 