### PR TITLE
@W-14149830: [MSDK Android] Convert Template Apps To Gradle Kotlin DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,9 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.1.1")
+        classpath("com.android.tools.build:gradle:7.4.2")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.4.2")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.1.1")
+    implementation("com.android.tools.build:gradle:7.4.2")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.10")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.22")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     android
     `kotlin-android`
@@ -30,7 +32,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     android
     `kotlin-android`
@@ -30,7 +32,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.ext["PUBLISH_GROUP_ID"] = "com.salesforce.mobilesdk"
 rootProject.ext["PUBLISH_VERSION"] = "11.1.0"
 rootProject.ext["PUBLISH_ARTIFACT_ID"] = "MobileSync"
@@ -53,7 +55,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.ext["PUBLISH_GROUP_ID"] = "com.salesforce.mobilesdk"
 rootProject.ext["PUBLISH_VERSION"] = "11.1.0"
 rootProject.ext["PUBLISH_ARTIFACT_ID"] = "SalesforceAnalytics"
@@ -52,7 +54,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.ext["PUBLISH_GROUP_ID"] = "com.salesforce.mobilesdk"
 rootProject.ext["PUBLISH_VERSION"] = "11.1.0"
 rootProject.ext["PUBLISH_ARTIFACT_ID"] = "SalesforceHybrid"
@@ -56,7 +58,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import org.apache.tools.ant.taskdefs.condition.Os
 
 /**
@@ -71,7 +73,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.ext["PUBLISH_GROUP_ID"] = "com.salesforce.mobilesdk"
 rootProject.ext["PUBLISH_VERSION"] = "11.1.0"
 rootProject.ext["PUBLISH_ARTIFACT_ID"] = "SalesforceSDK"
@@ -60,7 +62,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 rootProject.ext["PUBLISH_GROUP_ID"] = "com.salesforce.mobilesdk"
 rootProject.ext["PUBLISH_VERSION"] = "11.1.0"
 rootProject.ext["PUBLISH_ARTIFACT_ID"] = "SmartStore"
@@ -57,7 +59,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
             pickFirsts += setOf("protobuf.meta")

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     android
     `kotlin-android`
@@ -30,7 +32,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     android
     `kotlin-android`
@@ -32,7 +34,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/native/NativeSampleApps/MobileSyncExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/MobileSyncExplorer/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     android
     `kotlin-android`
@@ -33,7 +35,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
         }

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
     android
     `kotlin-android`
@@ -58,7 +60,7 @@ android {
         }
     }
 
-    packaging {
+    packagingOptions {
         resources {
             excludes += setOf("META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/DEPENDENCIES", "META-INF/NOTICE")
             pickFirsts += setOf("protobuf.meta")


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

This prepares `SalesforceMobileSDK-Templates` for most of its Gradle Groovy DSL to be converted to Kotlin DSL.  See its [companion pull request](https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/372/files).

Unfortunately, it wasn't possible to coerce React Native nor its community libraries to integrate with Gradle 8 and the Android Gradle Plugin 8, so this rolls that back to 7 here.  The two repositories must remain in sync since they are a composite build.

React Native will be moving to Gradle 8 in the near future, though the timing of community library updates is less clear.

In the end, all the Groovy DSL that is not derived from React Native templates can be migrated to Kotlin DSL, so a large body of work is still possible.  Yay!

All of the templates apps will sync, compile and run based on testing.  Thanks for reading and let me know what else might remain.