### PR TITLE
@W-14213012: [Android][ReactNative] forcereact generated applications are broken

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,9 +15,11 @@ dependencyResolutionManagement {
     repositories {
         mavenLocal()
         // All of React Native (JS, Objective-C sources, Android binaries) is installed from NPM.
-        maven("${rootProject.projectDir}/libs/SalesforceReact/node_modules/react-native/android")
+        maven("${rootProject.projectDir}/libs/SalesforceReact/node_modules/react-native/android") // For stand-alone MSDK builds.
+        maven("${rootProject.projectDir}/../../node_modules/react-native/android") // For template app builds.
         // Android JSC is installed from NPM.
-        maven("${rootProject.projectDir}/libs/SalesforceReact/node_modules/jsc-android/dist")
+        maven("${rootProject.projectDir}/libs/SalesforceReact/node_modules/jsc-android/dist") // For stand-alone MSDK builds.
+        maven("${rootProject.projectDir}/../../node_modules/jsc-android/dist") // For template app builds.
         google()
         mavenCentral()
     }


### PR DESCRIPTION
⭐️ _Ready for review_ 💫

This resolves an issue where MSDK, when building as a composite build of the template apps, cannot resolve the React Native local Maven repository that is provided by the template.  The template doesn't populate the RN install in `libs` that MSDK itself expects.  MSDK and the template apps install RN to different paths, so this adds a reference to each.  The build safely ignores any repository that is not present.

As a composite build, MSDK and the app enjoy some isolation from each other's build configuration and consistency when building either stand-alone or together.  That's good in the long run plus provides something of a single-source-of-truth when it comes to build expectations.  The only drawback, and probably it's good for build consistency, is that they don't share repositories.

I'm not certain it's possible to use a single path in both MSDK stand-alone builds and template app builds.  The `package.json` resources are in different locations and that would seem to be the home for the `node_modules` root.