### PR TITLE
Specify export behavior for broadcast receivers.

### DIFF
--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.accounteditor"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
-        targetSdk = 33
+        compileSdk = 34
         minSdk = 24
     }
 

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.mobilesyncexplorerhybrid"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
-        targetSdk = 33
+        compileSdk = 34
         minSdk = 24
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java
@@ -321,7 +321,8 @@ public class SalesforceSDKManager implements LifecycleObserver {
 
         // If your app runs in multiple processes, all the SalesforceSDKManager need to run cleanup during a logout
         final CleanupReceiver cleanupReceiver = new CleanupReceiver();
-        context.registerReceiver(cleanupReceiver, new IntentFilter(SalesforceSDKManager.CLEANUP_INTENT_ACTION));
+        ContextCompat.registerReceiver(context, cleanupReceiver,
+                new IntentFilter(SalesforceSDKManager.CLEANUP_INTENT_ACTION), RECEIVER_NOT_EXPORTED);
         new Handler(Looper.getMainLooper()).post(() -> {
             ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
         });
@@ -1052,7 +1053,7 @@ public class SalesforceSDKManager implements LifecycleObserver {
                 }
             }
         };
-        context.registerReceiver(pushUnregisterReceiver, intentFilter);
+        ContextCompat.registerReceiver(context, pushUnregisterReceiver, intentFilter, RECEIVER_NOT_EXPORTED);
 
         // Unregisters from notifications on logout.
 		final UserAccount userAcc = getUserAccountManager().buildUserAccount(account);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -175,7 +175,8 @@ public class LoginActivity extends AppCompatActivity
         if (!receiverRegistered) {
             changeServerReceiver = new ChangeServerReceiver();
             final IntentFilter changeServerFilter = new IntentFilter(ServerPickerActivity.CHANGE_SERVER_INTENT);
-            registerReceiver(changeServerReceiver, changeServerFilter);
+            ContextCompat.registerReceiver(this, changeServerReceiver, changeServerFilter,
+                    ContextCompat.RECEIVER_NOT_EXPORTED);
             receiverRegistered = true;
         }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
@@ -30,6 +30,9 @@ import android.app.Activity;
 import android.content.IntentFilter;
 import android.view.KeyEvent;
 
+import androidx.core.content.ContextCompat;
+import static androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED;
+
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.rest.ClientManager;
@@ -55,9 +58,11 @@ public class SalesforceActivityDelegate {
 
     public void onCreate() {
         userSwitchReceiver = new ActivityUserSwitchReceiver();
-        activity.registerReceiver(userSwitchReceiver, new IntentFilter(UserAccountManager.USER_SWITCH_INTENT_ACTION));
+        ContextCompat.registerReceiver(activity, userSwitchReceiver,
+                new IntentFilter(UserAccountManager.USER_SWITCH_INTENT_ACTION), RECEIVER_NOT_EXPORTED);
         logoutCompleteReceiver = new ActivityLogoutCompleteReceiver();
-        activity.registerReceiver(logoutCompleteReceiver, new IntentFilter(SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION));
+        ContextCompat.registerReceiver(activity, logoutCompleteReceiver,
+                new IntentFilter(SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION), RECEIVER_NOT_EXPORTED);
 
         // Lets observers know that activity creation is complete.
         EventsObservable.get().notifyEvent(EventsObservable.EventType.MainActivityCreateComplete, this);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/LogoutCompleteReceiver.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/LogoutCompleteReceiver.java
@@ -32,6 +32,8 @@ import android.content.Intent;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 
+import java.util.Objects;
+
 /**
  * Listens for the logout complete event, and acts on it.
  *
@@ -41,7 +43,7 @@ public abstract class LogoutCompleteReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (intent != null && intent.getAction().equals(SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION)) {
+        if (Objects.equals(intent.getAction(), SalesforceSDKManager.LOGOUT_COMPLETE_INTENT_ACTION)) {
             onLogoutComplete();
         }
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/UserSwitchReceiver.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/UserSwitchReceiver.java
@@ -32,6 +32,8 @@ import android.content.Intent;
 
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 
+import java.util.Objects;
+
 /**
  * Listens for the user switch event, and acts on it.
  *
@@ -41,7 +43,7 @@ public abstract class UserSwitchReceiver extends BroadcastReceiver {
 
 	@Override
 	public void onReceive(Context context, Intent intent) {
-		if (intent != null && intent.getAction().equals(UserAccountManager.USER_SWITCH_INTENT_ACTION)) {
+		if (Objects.equals(intent.getAction(), UserAccountManager.USER_SWITCH_INTENT_ACTION)) {
 			onUserSwitch();
 		}
 	}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -30,6 +30,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+
+import androidx.core.content.ContextCompat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
@@ -128,8 +130,9 @@ public class AuthConfigUtilTest {
 
     private void testBroadcast(String endpoint, Boolean expected) throws InterruptedException, ExecutionException {
         final TestBroadcastReceiver receiver = new TestBroadcastReceiver();
-        SalesforceSDKManager.getInstance().getAppContext().registerReceiver(receiver,
-                new IntentFilter(AuthConfigUtil.AUTH_CONFIG_COMPLETE_INTENT_ACTION));
+        ContextCompat.registerReceiver(SalesforceSDKManager.getInstance().getAppContext(), receiver,
+                new IntentFilter(AuthConfigUtil.AUTH_CONFIG_COMPLETE_INTENT_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED);
+
         try {
             AuthConfigUtil.getMyDomainAuthConfig(endpoint);
 

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.appconfigurator"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
-        targetSdk = 33
+        compileSdk = 34
         minSdk = 24
     }
 

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.configuredapp"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
-        targetSdk = 33
+        compileSdk = 34
         minSdk = 24
     }
 

--- a/native/NativeSampleApps/MobileSyncExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/MobileSyncExplorer/build.gradle.kts
@@ -16,10 +16,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.mobilesyncexplorer"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
-        targetSdk = 33
+        targetSdk = 34
         minSdk = 24
     }
 

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
@@ -58,6 +58,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -167,8 +168,8 @@ public class MainActivity extends SalesforceActivity implements
 		// Loader initialization and receiver registration
 		getLoaderManager().initLoader(CONTACT_LOADER_ID, null, this);
 		if (!isRegistered.get()) {
-			registerReceiver(loadCompleteReceiver,
-					new IntentFilter(ContactListLoader.LOAD_COMPLETE_INTENT_ACTION));
+			ContextCompat.registerReceiver(this, loadCompleteReceiver,
+					new IntentFilter(ContactListLoader.LOAD_COMPLETE_INTENT_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED);
 		}
 		isRegistered.set(true);
 

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -28,10 +28,10 @@ android {
     namespace = "com.salesforce.samples.restexplorer"
     testNamespace = "com.salesforce.samples.restexplorer.tests"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
-        targetSdk = 33
+        compileSdk = 34
         minSdk = 24
     }
 


### PR DESCRIPTION
Apps targeting API 34 are **required** to specify export behavior for all broadcast receivers; failing to do so causes a runtime exception.  

-   Using `ContextCompat.registerReceiver`, just like Eric did for the Dev Support notification, because it prevents having to write if build version > 33 each time which still leaves a warning for the < 33 case.
- All broadcast use cases (login server, switch user, logout, cleanup, etc) work without being exported, which is a security win for API 33+.
- Bump sample apps (but not libraries) in repo to API 34 to ensure we don't miss other issues like this.