### PR TITLE
@W-14246983: [Android][Hybrid] Hybrid Templates Use Maven Central MSDK Dependencies By Default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ executors:
     docker:
       - image: *cimg
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'
 
 jobs:
   static-analysis:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,15 +1,23 @@
+val nodeModulesMsdk = File("${rootProject.projectDir}/libs/SalesforceReact/node_modules/react-native/android") // For stand-alone MSDK builds.
+val nodeModulesTemplate = File("${rootProject.projectDir}/../../node_modules/react-native/android") // For template app builds.
+val hasNodeModules = nodeModulesMsdk.exists() || nodeModulesTemplate.exists()
+
 include("libs:SalesforceAnalytics")
 include("libs:SalesforceSDK")
 include("libs:SmartStore")
 include("libs:MobileSync")
 include("libs:SalesforceHybrid")
-include("libs:SalesforceReact")
-include("native:NativeSampleApps:RestExplorer")
-include("native:NativeSampleApps:MobileSyncExplorer")
+if (hasNodeModules) {
+    include("libs:SalesforceReact")
+} else {
+    logger.warn("Skipping `SalesforceReact` module since local node repository is missing.  Has `yarn install` been run in the directory containing `package.json`?")
+}
+include("hybrid:HybridSampleApps:AccountEditor")
 include("native:NativeSampleApps:AppConfigurator")
 include("native:NativeSampleApps:ConfiguredApp")
-include("hybrid:HybridSampleApps:AccountEditor")
+include("native:NativeSampleApps:MobileSyncExplorer")
 include("hybrid:HybridSampleApps:MobileSyncExplorerHybrid")
+include("native:NativeSampleApps:RestExplorer")
 
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
🥁 _Ready For Review_ 🎸

  This is a companion to https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin/pull/626

  The update here allows the MSDK Gradle workspace to build even when the React Native local repository is not present.  That is the case when MSDK is a composite build with the hybrid template apps.  A warning is printed to indicate this is the case.