### PR TITLE
@W-14252627: MobileSyncExplorer does not display contacts for API 34

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -176,7 +176,7 @@ public class LoginActivity extends AppCompatActivity
             changeServerReceiver = new ChangeServerReceiver();
             final IntentFilter changeServerFilter = new IntentFilter(ServerPickerActivity.CHANGE_SERVER_INTENT);
             ContextCompat.registerReceiver(this, changeServerReceiver, changeServerFilter,
-                    ContextCompat.RECEIVER_NOT_EXPORTED);
+                    ContextCompat.RECEIVER_EXPORTED);
             receiverRegistered = true;
         }
 

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
@@ -27,7 +27,6 @@
 package com.salesforce.samples.mobilesyncexplorer.ui;
 
 import static android.view.LayoutInflater.from;
-
 import static com.salesforce.androidsdk.R.style.SalesforceSDK;
 import static com.salesforce.androidsdk.R.style.SalesforceSDK_Dark;
 
@@ -168,8 +167,10 @@ public class MainActivity extends SalesforceActivity implements
 		// Loader initialization and receiver registration
 		getLoaderManager().initLoader(CONTACT_LOADER_ID, null, this);
 		if (!isRegistered.get()) {
-			ContextCompat.registerReceiver(this, loadCompleteReceiver,
-					new IntentFilter(ContactListLoader.LOAD_COMPLETE_INTENT_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED);
+			ContextCompat.registerReceiver(this,
+					loadCompleteReceiver,
+					new IntentFilter(ContactListLoader.LOAD_COMPLETE_INTENT_ACTION),
+					ContextCompat.RECEIVER_EXPORTED);
 		}
 		isRegistered.set(true);
 


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

  This resolves the native MobileSyncExplorer sample app's inability to display contacts on API 34 devices.  Turns out this had to do with how broadcast receivers are exported for use by `LoaderManager` on API 34 compared to previous versions.  The intent is started from another process, so to preserve the behavior as it was on previous API versions, `EXPORTED` is the option that's required.