### PR TITLE
Android 14 requires non-exported receiver to be invoked with explicit intents

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.java
@@ -176,7 +176,7 @@ public class LoginActivity extends AppCompatActivity
             changeServerReceiver = new ChangeServerReceiver();
             final IntentFilter changeServerFilter = new IntentFilter(ServerPickerActivity.CHANGE_SERVER_INTENT);
             ContextCompat.registerReceiver(this, changeServerReceiver, changeServerFilter,
-                    ContextCompat.RECEIVER_EXPORTED);
+                    ContextCompat.RECEIVER_NOT_EXPORTED);
             receiverRegistered = true;
         }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -280,6 +280,9 @@ public class ServerPickerActivity extends AppCompatActivity implements
     public void onAuthConfigFetched() {
         setResult(Activity.RESULT_OK, null);
         final Intent changeServerIntent = new Intent(CHANGE_SERVER_INTENT);
+        // Android 14 requires non-exported receiver to be invoked with explicit intents
+        // See https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents
+        changeServerIntent.setPackage(getPackageName());
         sendBroadcast(changeServerIntent);
         finish();
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/AuthConfigUtil.java
@@ -82,6 +82,9 @@ public class AuthConfigUtil {
             SalesforceSDKLogger.e(TAG, "Auth config request was not successful", e);
         }
         final Intent intent = new Intent(AUTH_CONFIG_COMPLETE_INTENT_ACTION);
+        // Android 14 requires non-exported receiver to be invoked with explicit intents
+        // See https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents
+        intent.setPackage(SalesforceSDKManager.getInstance().getAppContext().getPackageName());
         intent.putExtra(WAS_REQUEST_SUCCESSFUL_EXTRA, authConfig != null);
         SalesforceSDKManager.getInstance().getAppContext().sendBroadcast(intent);
         return authConfig;

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/loaders/ContactListLoader.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/loaders/ContactListLoader.java
@@ -157,6 +157,9 @@ public class ContactListLoader extends AsyncTaskLoader<List<ContactObject>> {
 	 */
 	private void fireLoadCompleteIntent() {
 		final Intent intent = new Intent(LOAD_COMPLETE_INTENT_ACTION);
+		// Android 14 requires non-exported receiver to be invoked with explicit intents
+		// See https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents
+		intent.setPackage(SalesforceSDKManager.getInstance().getAppContext().getPackageName());
 		SalesforceSDKManager.getInstance().getAppContext().sendBroadcast(intent);
 	}
 }

--- a/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
+++ b/native/NativeSampleApps/MobileSyncExplorer/src/com/salesforce/samples/mobilesyncexplorer/ui/MainActivity.java
@@ -170,7 +170,7 @@ public class MainActivity extends SalesforceActivity implements
 			ContextCompat.registerReceiver(this,
 					loadCompleteReceiver,
 					new IntentFilter(ContactListLoader.LOAD_COMPLETE_INTENT_ACTION),
-					ContextCompat.RECEIVER_EXPORTED);
+					ContextCompat.RECEIVER_NOT_EXPORTED);
 		}
 		isRegistered.set(true);
 


### PR DESCRIPTION
See https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents

Other receiver (logout, user switch, cleanup) were already invoked with explicit intents