### PR TITLE
Moving to SQLCipher 4.5.5

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SmartStorePlugin.java
@@ -57,7 +57,7 @@ import com.salesforce.androidsdk.smartstore.store.SmartStore.SmartStoreException
 import com.salesforce.androidsdk.smartstore.store.StoreCursor;
 import com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.PluginResult;

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
@@ -44,7 +44,7 @@ import com.salesforce.androidsdk.smartstore.store.QuerySpec;
 import com.salesforce.androidsdk.smartstore.store.SmartStore;
 import com.salesforce.androidsdk.smartstore.store.StoreCursor;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -13,8 +13,8 @@ plugins {
 dependencies {
     api(project(":libs:SalesforceSDK"))
     //noinspection GradleDependency -  Needs to line up with supported SQLCipher version.
-    api("androidx.sqlite:sqlite:2.0.1")
-    api("net.zetetic:android-database-sqlcipher:4.5.4")
+    api("androidx.sqlite:sqlite:2.2.0")
+    api("net.zetetic:sqlcipher-android:4.5.5")
     implementation("androidx.core:core-ktx:1.9.0")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -47,7 +47,7 @@ import com.salesforce.androidsdk.util.EventsObservable;
 import com.salesforce.androidsdk.util.EventsObservable.EventType;
 import com.salesforce.androidsdk.util.ManagedFilesHelper;
 
-import net.sqlcipher.database.SQLiteOpenHelper;
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -159,9 +159,9 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
         if (TextUtils.isEmpty(dbName)) {
             dbName = DBOpenHelper.DEFAULT_DB_NAME;
         }
-        final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(context,
+        final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(getEncryptionKey(), context,
                 dbName, null, null);
-        return new SmartStore(dbOpenHelper, getEncryptionKey());
+        return new SmartStore(dbOpenHelper);
     }
 
     /**
@@ -210,9 +210,9 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
             dbNamePrefix = DBOpenHelper.DEFAULT_DB_NAME;
         }
         SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_SMART_STORE_USER);
-        final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(context,
+        final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(getEncryptionKey(), context,
                 dbNamePrefix, account, communityId);
-        SmartStore store = new SmartStore(dbOpenHelper, getEncryptionKey());
+        SmartStore store = new SmartStore(dbOpenHelper);
 
         return store;
     }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/AlterSoupLongOperation.java
@@ -32,7 +32,7 @@ import android.text.TextUtils;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.SmartStoreException;
 import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBHelper.java
@@ -39,9 +39,9 @@ import com.salesforce.androidsdk.smartstore.store.SmartStore.SmartStoreException
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 
-import net.sqlcipher.DatabaseUtils.InsertHelper;
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteStatement;
+import net.zetetic.database.DatabaseUtils.InsertHelper;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteStatement;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -34,9 +34,11 @@ import com.salesforce.androidsdk.analytics.EventBuilderHelper;
 import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 import com.salesforce.androidsdk.util.ManagedFilesHelper;
 
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteDatabaseHook;
-import net.sqlcipher.database.SQLiteOpenHelper;
+import net.zetetic.database.DatabaseErrorHandler;
+import net.zetetic.database.sqlcipher.SQLiteConnection;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabaseHook;
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -45,6 +47,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Helper class to manage SmartStore's database creation and version management.
@@ -56,14 +59,13 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	// 3 --> starting at 4.3 (soup_names table changes to soup_attr)
 	public static final int DB_VERSION = 3;
 	public static final String DEFAULT_DB_NAME = "smartstore";
-	public static final String SOUP_ELEMENT_PREFIX = "soupelt_";
 	private static final String TAG = "DBOpenHelper";
 	private static final String DB_NAME_SUFFIX = ".db";
 	private static final String ORG_KEY_PREFIX = "00D";
-	private static final String EXTERNAL_BLOBS_SUFFIX = "_external_soup_blobs/";
 	public static final String DATABASES = "databases";
-	private static String dataDir;
 	private String dbName;
+
+	private static AtomicBoolean libsLoaded = new AtomicBoolean(false);
 
 	/*
 	 * Cache for the helper instances
@@ -103,43 +105,49 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 	/**
 	 * Returns the DBOpenHelper instance associated with this user account.
 	 *
-	 * @param ctx Context.
-	 * @param account User account.
+	 * @param encryptionKey Password for database.
+	 * @param ctx           Context.
+	 * @param account       User account.
 	 * @return DBOpenHelper instance.
 	 */
-	public static synchronized DBOpenHelper getOpenHelper(Context ctx,
-			UserAccount account) {
-		return getOpenHelper(ctx, account, null);
+	public static synchronized DBOpenHelper getOpenHelper(String encryptionKey, Context ctx,
+														  UserAccount account) {
+		return getOpenHelper(encryptionKey, ctx, account, null);
 	}
 
 	/**
 	 * Returns the DBOpenHelper instance associated with this user and community.
 	 *
-	 * @param ctx Context.
-	 * @param account User account.
-	 * @param communityId Community ID.
+	 * @param encryptionKey Password for database.
+	 * @param ctx           Context.
+	 * @param account       User account.
+	 * @param communityId   Community ID.
 	 * @return DBOpenHelper instance.
 	 */
-	public static synchronized DBOpenHelper getOpenHelper(Context ctx,
-			UserAccount account, String communityId) {
-		return getOpenHelper(ctx, DEFAULT_DB_NAME, account, communityId);
+	public static synchronized DBOpenHelper getOpenHelper(String encryptionKey, Context ctx,
+														  UserAccount account, String communityId) {
+		return getOpenHelper(encryptionKey, ctx, DEFAULT_DB_NAME, account, communityId);
 	}
 
 	/**
 	 * Returns the DBOpenHelper instance for the given database name.
 	 *
-	 * @param ctx Context.
-	 * @param dbNamePrefix The database name. This must be a valid file name without a
-	 *                     filename extension such as ".db".
-	 * @param account User account. If this method is called before authentication,
-	 * 				we will simply return the smart store DB, which is not associated
-	 * 				with any user account. Otherwise, we will return a unique
-	 * 				database at the community level.
-	 * @param communityId Community ID.
+	 * @param encryptionKey password for database.
+	 * @param ctx           Context.
+	 * @param dbNamePrefix  The database name. This must be a valid file name without a
+	 *                      filename extension such as ".db".
+	 * @param account       User account. If this method is called before authentication,
+	 *                      we will simply return the smart store DB, which is not associated
+	 *                      with any user account. Otherwise, we will return a unique
+	 *                      database at the community level.
+	 * @param communityId   Community ID.
 	 * @return DBOpenHelper instance.
 	 */
-	public static DBOpenHelper getOpenHelper(Context ctx, String dbNamePrefix,
-			UserAccount account, String communityId) {
+	public static DBOpenHelper getOpenHelper(String encryptionKey,
+											 Context ctx,
+											 String dbNamePrefix,
+											 UserAccount account,
+											 String communityId) {
 		final StringBuilder dbName = new StringBuilder(dbNamePrefix);
 
 		// If we have account information, we will use it to create a database suffix for the user.
@@ -171,21 +179,22 @@ public class DBOpenHelper extends SQLiteOpenHelper {
                 SmartStoreLogger.e(TAG, "Error occurred while creating JSON", e);
 			}
 			EventBuilderHelper.createAndStoreEvent(eventName, account, TAG, storeAttributes);
-			helper = new DBOpenHelper(ctx, fullDBName);
+			loadLibsIfNeeded(ctx);
+			helper = new DBOpenHelper(encryptionKey, ctx, fullDBName);
 			openHelpers.put(fullDBName, helper);
 		}
 		return helper;
 	}
 
-	protected DBOpenHelper(Context context, String dbName) {
-		super(context, dbName, null, DB_VERSION, new DBHook());
-		this.loadLibs(context);
+	protected DBOpenHelper(String encryptionKey, Context context, String dbName) {
+ 		super(context, dbName, encryptionKey, null, DB_VERSION, DB_VERSION, new DBErrorHandler(), new DBHook(), false);
 		this.dbName = dbName;
-		dataDir = context.getApplicationInfo().dataDir;
 	}
 
-	protected void loadLibs(Context context) {
-		SQLiteDatabase.loadLibs(context);
+	protected static void loadLibsIfNeeded(Context context) {
+		if (libsLoaded.compareAndSet(false, true)) {
+			 System.loadLibrary("sqlcipher");
+		}
 	}
 
 	@Override
@@ -362,18 +371,25 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 		return ctx.getDatabasePath(dbName.toString()).exists();
 	}
 
+	static class DBErrorHandler implements DatabaseErrorHandler {
+		@Override
+		public void onCorruption(SQLiteDatabase dbObj) {
+			throw new SmartStore.SmartStoreException("Database is corrupted");
+		}
+	}
+
 	static class DBHook implements SQLiteDatabaseHook {
-		public void preKey(SQLiteDatabase database) {
+		public void preKey(SQLiteConnection connection) {
 		}
 
 		/**
 		 * Need to migrate for SqlCipher 4.x
-		 * @param database db being processed
+		 * @param connection db connection being processed
 		 */
-		public void postKey(SQLiteDatabase database) {
+		public void postKey(SQLiteConnection connection) {
 			// Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
 			// => should open 2.x databases without any migration
-			database.rawExecSQL("PRAGMA kdf_iter = 4000");
+			connection.executeRaw("PRAGMA kdf_iter = 4000", new Object[]{}, null);
 		}
 	}
 

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
@@ -28,7 +28,7 @@ package com.salesforce.androidsdk.smartstore.store;
 
 import com.salesforce.androidsdk.smartstore.store.SmartStore.SmartStoreException;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import java.util.HashMap;
 import java.util.Locale;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -38,8 +38,8 @@ import com.salesforce.androidsdk.smartstore.store.LongOperation.LongOperationTyp
 import com.salesforce.androidsdk.smartstore.store.QuerySpec.QueryType;
 import com.salesforce.androidsdk.smartstore.util.SmartStoreLogger;
 
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteOpenHelper;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -109,7 +109,6 @@ public class SmartStore  {
 
 	// Backing database
 	protected SQLiteOpenHelper dbOpenHelper;
-	protected String encryptionKey;
 
 	// Flag indicating if database was just opened
 	AtomicBoolean dbJustOpened = new AtomicBoolean(true);
@@ -196,18 +195,16 @@ public class SmartStore  {
      * Relies on SQLiteOpenHelper for database handling.
      *
      * @param dbOpenHelper DB open helper.
-     * @param encryptionKey Encryption key.
      */
-    public SmartStore(SQLiteOpenHelper dbOpenHelper, String encryptionKey) {
+    public SmartStore(SQLiteOpenHelper dbOpenHelper) {
     	this.dbOpenHelper = dbOpenHelper;
-        this.encryptionKey = encryptionKey;
     }
 
     /**
      * Return db
      */
     public SQLiteDatabase getDatabase() {
-		SQLiteDatabase db = this.dbOpenHelper.getWritableDatabase(encryptionKey);
+		SQLiteDatabase db = this.dbOpenHelper.getWritableDatabase();
 		if (dbJustOpened.compareAndSet(true, false)) {
 			resumeLongOperations();
 		}

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelperTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelperTest.java
@@ -37,7 +37,7 @@ import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
 import com.salesforce.androidsdk.analytics.security.Encryptor;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -87,8 +87,8 @@ public class DBOpenHelperTest {
 	 */
     @Test
 	public void testGetHelperForNullAccountNullCommunityId() {
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, "somedb", null, null);
-		SQLiteDatabase db = helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, "somedb", null, null);
+		SQLiteDatabase db = helper.getWritableDatabase();
 		String dbName = getBaseName(db);
         Assert.assertEquals("Database name is not correct.","somedb.db", dbName);
 	}
@@ -99,8 +99,8 @@ public class DBOpenHelperTest {
     @Test
 	public void testGetHelperForAccountNullCommunityId() {
 		UserAccount testAcct = getTestUserAccount();
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, "somedb", testAcct, null);
-		SQLiteDatabase db = helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, "somedb", testAcct, null);
+		SQLiteDatabase db = helper.getWritableDatabase();
 		String dbName = getBaseName(db);
         Assert.assertTrue("Database name does not contain org id.",dbName.contains(TEST_ORG_ID));
         Assert.assertTrue("Database name does not contain user id.",dbName.contains(TEST_USER_ID));
@@ -112,8 +112,8 @@ public class DBOpenHelperTest {
 	 */
     @Test
 	public void testGetHelperIsCached() {
-		DBOpenHelper helper1 = DBOpenHelper.getOpenHelper(targetContext, "somedb", null, null);
-		DBOpenHelper helper2 = DBOpenHelper.getOpenHelper(targetContext, "somedb", null, null);
+		DBOpenHelper helper1 = DBOpenHelper.getOpenHelper("", targetContext, "somedb", null, null);
+		DBOpenHelper helper2 = DBOpenHelper.getOpenHelper("", targetContext, "somedb", null, null);
         Assert.assertSame("Helpers should be cached.", helper1, helper2);
 	}
 
@@ -123,8 +123,8 @@ public class DBOpenHelperTest {
     @Test
 	public void testGetHelperUsesDefaultDatabaseName() {
 		UserAccount testAcct = getTestUserAccount();
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, testAcct, TEST_COMMUNITY_ID);
-		SQLiteDatabase db = helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, testAcct, TEST_COMMUNITY_ID);
+		SQLiteDatabase db = helper.getWritableDatabase();
 		String dbName = getBaseName(db);
         Assert.assertTrue("Database name is not correct.", dbName.startsWith(DBOpenHelper.DEFAULT_DB_NAME));
         Assert.assertTrue("Database name does not contain org id.",dbName.contains(TEST_ORG_ID));
@@ -139,8 +139,8 @@ public class DBOpenHelperTest {
 	public void testDeleteDatabaseDefault() {
 
 		// create db
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, null);
-		SQLiteDatabase db = helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, null);
+		SQLiteDatabase db = helper.getWritableDatabase();
 		String dbName = getBaseName(db);
 		DBOpenHelper.deleteDatabase(targetContext, null);
         Assert.assertFalse("Database should not exist.", databaseExists(targetContext, dbName));
@@ -155,20 +155,20 @@ public class DBOpenHelperTest {
 		final UserAccount testAcct = getTestUserAccount();
 
 		// Create a user database we want to ensure is deleted.
-		final DBOpenHelper helper1 = DBOpenHelper.getOpenHelper(targetContext,
+		final DBOpenHelper helper1 = DBOpenHelper.getOpenHelper("", targetContext,
 				testAcct, TEST_COMMUNITY_ID);
-		final SQLiteDatabase db1 = helper1.getWritableDatabase("");
+		final SQLiteDatabase db1 = helper1.getWritableDatabase();
 		final String dbName1 = getBaseName(db1);
 
 		// Create another user database we want to ensure is deleted.
-		final DBOpenHelper helper2 = DBOpenHelper.getOpenHelper(targetContext,
+		final DBOpenHelper helper2 = DBOpenHelper.getOpenHelper("", targetContext,
 				testAcct, "other_community_id");
-		final SQLiteDatabase db2 = helper2.getWritableDatabase("");
+		final SQLiteDatabase db2 = helper2.getWritableDatabase();
 		final String dbName2 = getBaseName(db2);
 
 		// Create a global database we want to ensure is not deleted.
-		final DBOpenHelper helper3 = DBOpenHelper.getOpenHelper(targetContext, null);
-		final SQLiteDatabase db3 = helper3.getWritableDatabase("");
+		final DBOpenHelper helper3 = DBOpenHelper.getOpenHelper("", targetContext, null);
+		final SQLiteDatabase db3 = helper3.getWritableDatabase();
 		final String dbName3 = getBaseName(db3);
 
 		// Delete all user databases.
@@ -195,9 +195,9 @@ public class DBOpenHelperTest {
 	 */
     @Test
 	public void testDeleteDatabaseRemovesFromCache() {
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, null);
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, null);
 		DBOpenHelper.deleteDatabase(targetContext, null);
-		DBOpenHelper helperPostDelete = DBOpenHelper.getOpenHelper(targetContext, null);
+		DBOpenHelper helperPostDelete = DBOpenHelper.getOpenHelper("", targetContext, null);
         Assert.assertNotSame("Helpers should be different instances.", helper, helperPostDelete);
 	}
 
@@ -209,12 +209,12 @@ public class DBOpenHelperTest {
 		UserAccount testAcct = getTestUserAccount();
 
 		// create the database we want to ensure is deleted
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, testAcct, TEST_COMMUNITY_ID);
-		helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, testAcct, TEST_COMMUNITY_ID);
+		helper.getWritableDatabase();
 		
 		// create another database for this account which should not be deleted.
-		DBOpenHelper dontDeleteHelper = DBOpenHelper.getOpenHelper(targetContext, testAcct, "other_community_id");
-		SQLiteDatabase dontDeleteDb = dontDeleteHelper.getWritableDatabase("");
+		DBOpenHelper dontDeleteHelper = DBOpenHelper.getOpenHelper("", targetContext, testAcct, "other_community_id");
+		SQLiteDatabase dontDeleteDb = dontDeleteHelper.getWritableDatabase();
 		String dontDeleteDbName = getBaseName(dontDeleteDb);
 
 		// now, delete the first database and make sure we didn't remove the second.
@@ -222,9 +222,9 @@ public class DBOpenHelperTest {
         Assert.assertTrue("Database should not have been deleted.", databaseExists(targetContext, dontDeleteDbName));
 		
 		// 1st helper should not be cached, but 2nd should still be cached
-		DBOpenHelper helperNew = DBOpenHelper.getOpenHelper(targetContext, testAcct, TEST_COMMUNITY_ID);
+		DBOpenHelper helperNew = DBOpenHelper.getOpenHelper("", targetContext, testAcct, TEST_COMMUNITY_ID);
         Assert.assertNotSame("Helper should have been removed from cache.", helper, helperNew);
-		DBOpenHelper dontDeleteHelperCached = DBOpenHelper.getOpenHelper(targetContext, testAcct, "other_community_id");
+		DBOpenHelper dontDeleteHelperCached = DBOpenHelper.getOpenHelper("", targetContext, testAcct, "other_community_id");
         Assert.assertSame("Helper should be same instance.", dontDeleteHelper, dontDeleteHelperCached);
 	}
 
@@ -236,13 +236,13 @@ public class DBOpenHelperTest {
 		UserAccount testAcct = getTestUserAccount();
 
 		// create the database we want to ensure is deleted
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, testAcct, TEST_COMMUNITY_ID);
-		SQLiteDatabase db = helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, testAcct, TEST_COMMUNITY_ID);
+		SQLiteDatabase db = helper.getWritableDatabase();
 		String dbName = getBaseName(db);
 		
 		// create another database for this account which should not be deleted.
-		DBOpenHelper helper2 = DBOpenHelper.getOpenHelper(targetContext, testAcct, "other_community_id");
-		SQLiteDatabase db2 = helper2.getWritableDatabase("");
+		DBOpenHelper helper2 = DBOpenHelper.getOpenHelper("", targetContext, testAcct, "other_community_id");
+		SQLiteDatabase db2 = helper2.getWritableDatabase();
 		String dbName2 = getBaseName(db2);
 
 		// now, delete all databases related to accounts and ensure they no longer exist
@@ -251,8 +251,8 @@ public class DBOpenHelperTest {
         Assert.assertFalse("Database should not exist.", databaseExists(targetContext, dbName2));
 		
 		// also make sure references to the helpers no longer exist
-		DBOpenHelper helperNew = DBOpenHelper.getOpenHelper(targetContext, testAcct, TEST_COMMUNITY_ID);
-		DBOpenHelper helperNew2 = DBOpenHelper.getOpenHelper(targetContext, testAcct, "other_community_id");
+		DBOpenHelper helperNew = DBOpenHelper.getOpenHelper("", targetContext, testAcct, TEST_COMMUNITY_ID);
+		DBOpenHelper helperNew2 = DBOpenHelper.getOpenHelper("", targetContext, testAcct, "other_community_id");
         Assert.assertNotSame("Helper should have been removed from cache.", helper, helperNew);
         Assert.assertNotSame("Helper should have been removed from cache.", helper2, helperNew2);
 	}
@@ -263,8 +263,8 @@ public class DBOpenHelperTest {
     @Test
 	public void testHasSmartStoreIsTrueForDefaultDatabase() {
 		UserAccount testAcct = getTestUserAccount(); 
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, testAcct);
-		helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, testAcct);
+		helper.getWritableDatabase();
         Assert.assertTrue("SmartStore for account should exist.",
 				DBOpenHelper.smartStoreExists(targetContext, testAcct, null));
 	}
@@ -284,8 +284,8 @@ public class DBOpenHelperTest {
     @Test
 	public void testHasSmartStoreIsTrueForSpecifiedDatabase() {
 		UserAccount testAcct = getTestUserAccount(); 
-		DBOpenHelper helper = DBOpenHelper.getOpenHelper(targetContext, "testdb", testAcct, null);
-		helper.getWritableDatabase("");
+		DBOpenHelper helper = DBOpenHelper.getOpenHelper("", targetContext, "testdb", testAcct, null);
+		helper.getWritableDatabase();
         Assert.assertTrue("SmartStore for account should exist.",
 				DBOpenHelper.smartStoreExists(targetContext, "testdb", testAcct, null));
 	}

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreAlterTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreAlterTest.java
@@ -33,7 +33,7 @@ import androidx.test.filters.MediumTest;
 
 import com.salesforce.androidsdk.util.JSONTestHelper;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -314,7 +314,7 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
 
         // Drop db indexes on created and lastModified to simulate soup having been created before SDK 4.2
         String dropIndexSqlFormat = "DROP INDEX %s_%s_idx";
-        final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+        final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
         db.execSQL(String.format(dropIndexSqlFormat, TEST_SOUP_TABLE_NAME, "created"));
         db.execSQL(String.format(dropIndexSqlFormat, TEST_SOUP_TABLE_NAME, "lastModified"));
 
@@ -393,7 +393,7 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         // Check rows of soup table
         Cursor c = null;
         try {
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
             c = DBHelper.getInstance(db).query(db, TEST_SOUP_TABLE_NAME, expectedColumnNames.toArray(new String[0]), "id ASC", null, null);
             Assert.assertTrue("Expected a row", c.moveToFirst());
             Assert.assertEquals("Wrong number of rows", expectedIds.length, c.getCount());
@@ -425,7 +425,7 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
 
         // Check rows of fts table
         try {
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
             expectedFtsColumnNames.add(0, "rowid");
             c = DBHelper.getInstance(db).query(db, TEST_SOUP_TABLE_NAME + SmartStore.FTS_SUFFIX, expectedFtsColumnNames.toArray(new String[0]), "rowid ASC", null, null);
             Assert.assertTrue("Expected a row", c.moveToFirst());
@@ -473,7 +473,7 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         // Check DB
         Cursor c = null;
         try {
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
             String soupTableName = getSoupTableName(TEST_SOUP);
             Assert.assertEquals("Wrong table for test_soup", TEST_SOUP_TABLE_NAME, soupTableName);
             Assert.assertTrue("Table for test_soup should now exist", hasTable(TEST_SOUP_TABLE_NAME));
@@ -630,7 +630,7 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
      * @throws JSONException
      */
     private void tryAlterSoupInterruptResume(AlterSoupLongOperation.AlterSoupStep toStep) throws JSONException {
-        SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+        SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
         Assert.assertFalse("Soup test_soup should not exist", store.hasSoup(TEST_SOUP));
         IndexSpec[] indexSpecs = new IndexSpec[] {new IndexSpec("lastName", SmartStore.Type.string)};
         store.registerSoup(TEST_SOUP, indexSpecs);
@@ -710,8 +710,8 @@ public class SmartStoreAlterTest extends SmartStoreTestCase {
         Assert.assertFalse("Database should be closed", db.isOpen());
 
         // Re-open db
-        dbHelper = DBHelper.getInstance(dbOpenHelper.getWritableDatabase(getEncryptionKey()));
-        store = new SmartStore(dbOpenHelper, getEncryptionKey());
+        dbHelper = DBHelper.getInstance(dbOpenHelper.getWritableDatabase());
+        store = new SmartStore(dbOpenHelper);
         SQLiteDatabase newDb = store.getDatabase(); // should trigger a resumeLongOperations
         Assert.assertTrue("Database should be opened", newDb.isOpen());
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFullTextSearchTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreFullTextSearchTest.java
@@ -33,7 +33,7 @@ import androidx.test.filters.MediumTest;
 
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -168,7 +168,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
             Assert.assertEquals("getSoupTableName should have returned TABLE_1", "TABLE_1", soupTableName);
             Assert.assertTrue("Table for soup employees does exist", hasTable(soupTableName));
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 
             // Check soup table
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
@@ -245,7 +245,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         Cursor c = null;
         try {
             String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 
             // Check soup table
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
@@ -268,7 +268,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         // Check DB
         try {
             String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 
             // Check soup table
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
@@ -293,7 +293,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         // Check DB
         try {
             String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 
             // Check soup table
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
@@ -336,7 +336,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         Cursor c = null;
         try {
             String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 
             // Check soup table
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
@@ -359,7 +359,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
         // Check DB
         try {
             String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 
             // Check soup table
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
@@ -411,7 +411,7 @@ public class SmartStoreFullTextSearchTest extends SmartStoreTestCase {
             String soupTableName = getSoupTableName(EMPLOYEES_SOUP);
             Assert.assertEquals("getSoupTableName should have returned TABLE_1", "TABLE_1", soupTableName);
             Assert.assertTrue("Table for soup employees does exist", hasTable(soupTableName));
-            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+            final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 
             // Check soup table
             c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreInspectorActivityTest.java
@@ -47,7 +47,7 @@ import com.salesforce.androidsdk.smartstore.R;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 import com.salesforce.androidsdk.smartstore.ui.SmartStoreInspectorActivity;
 
-import net.sqlcipher.database.SQLiteOpenHelper;
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -226,9 +226,9 @@ public class SmartStoreInspectorActivityTest {
 	}
 
 	private void createStore() {
-		final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(targetContext, null);
-		DBHelper.getInstance(dbOpenHelper.getWritableDatabase("")).clearMemoryCache();
-		store = new SmartStore(dbOpenHelper, "");
+		final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper("", targetContext, null);
+		DBHelper.getInstance(dbOpenHelper.getWritableDatabase()).clearMemoryCache();
+		store = new SmartStore(dbOpenHelper);
 		store.dropAllSoups();
 	}
 

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -36,7 +36,7 @@ import com.salesforce.androidsdk.smartstore.store.QuerySpec.Order;
 import com.salesforce.androidsdk.smartstore.store.SmartStore.Type;
 import com.salesforce.androidsdk.util.JSONTestHelper;
 
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -116,7 +116,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	 */
 	@Test
 	public void testSQLCipherVersion() {
-		Assert.assertEquals("Wrong sqlcipher version", "4.5.4 community", store.getSQLCipherVersion());
+		Assert.assertEquals("Wrong sqlcipher version", "4.5.5 community", store.getSQLCipherVersion());
 	}
 
 	/**
@@ -303,7 +303,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, null, null, null);
 			Assert.assertTrue("Expected a soup element", c.moveToFirst());
@@ -341,7 +341,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 			String soupTableName = getSoupTableName(OTHER_TEST_SOUP);
 			Assert.assertEquals("Table for other_test_soup was expected to be called TABLE_2", "TABLE_2", soupTableName);
 			Assert.assertTrue("Table for other_test_soup should now exist", hasTable("TABLE_2"));
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			Assert.assertTrue("Expected a soup element", c.moveToFirst());
 			Assert.assertEquals("Expected three soup elements", 3, c.getCount());
@@ -393,7 +393,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			Assert.assertTrue("Expected a soup element", c.moveToFirst());
@@ -440,7 +440,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			Assert.assertTrue("Expected a soup element", c.moveToFirst());
@@ -487,7 +487,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			Assert.assertTrue("Expected a soup element", c.moveToFirst());
@@ -611,7 +611,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			Assert.assertTrue("Expected a soup element", c.moveToFirst());
@@ -663,7 +663,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			Assert.assertTrue("Expected a soup element", c.moveToFirst());
@@ -709,7 +709,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		// Check DB
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(TEST_SOUP);
 			c = DBHelper.getInstance(db).query(db, soupTableName, null, "id ASC", null, null);
 			Assert.assertFalse("Expected no soup element", c.moveToFirst());
@@ -1279,7 +1279,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 		Long id = store.upsert(FOURTH_TEST_SOUP, elt).getLong(SmartStore.SOUP_ENTRY_ID);
 		Cursor c = null;
 		try {
-			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+			final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 			String soupTableName = getSoupTableName(FOURTH_TEST_SOUP);
 			String amountColumnName = store.getSoupIndexSpecs(FOURTH_TEST_SOUP)[0].columnName;
 			c = DBHelper.getInstance(db).query(db, soupTableName, new String[]{amountColumnName}, null, null, "id = " + id);
@@ -1562,7 +1562,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	public void testUpdateTableNameAndAddColumns() {
 
 		// Setup db and test values
-		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 		final String TEST_TABLE = "test_table";
 		final String NEW_TEST_TABLE = "new_test_table";
 		final String NEW_COLUMN = "new_column";

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTestCase.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTestCase.java
@@ -34,8 +34,8 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
 import com.salesforce.androidsdk.util.JSONTestHelper;
 
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteOpenHelper;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteOpenHelper;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -61,9 +61,9 @@ public abstract class SmartStoreTestCase {
 	public void setUp() throws Exception {
 		EventBuilderHelper.enableDisable(false);
 		targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-		dbOpenHelper = DBOpenHelper.getOpenHelper(targetContext, null);
-		dbHelper = DBHelper.getInstance(dbOpenHelper.getWritableDatabase(getEncryptionKey()));
-		store = new SmartStore(dbOpenHelper, getEncryptionKey());
+		dbOpenHelper = DBOpenHelper.getOpenHelper(getEncryptionKey(), targetContext, null);
+		dbHelper = DBHelper.getInstance(dbOpenHelper.getWritableDatabase());
+		store = new SmartStore(dbOpenHelper);
 	}
 
 	protected abstract String getEncryptionKey();
@@ -83,7 +83,7 @@ public abstract class SmartStoreTestCase {
 	 */
 	protected boolean hasTable(String tableName) {
 		Cursor c = null;
-		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 		try {
 			c = DBHelper.getInstance(db).query(db, "sqlite_master", null, null, null, "type = ? and name = ?", "table", tableName);
 			return c.getCount() == 1;
@@ -100,7 +100,7 @@ public abstract class SmartStoreTestCase {
      */
 	protected void checkColumns(String tableName, List<String> expectedColumnNames) {
 		Cursor c = null;
-		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 		try {
 			List<String> actualColumnNames = new ArrayList<>();
 			c = db.rawQuery(String.format("PRAGMA table_info(%s)", tableName), null);
@@ -132,7 +132,7 @@ public abstract class SmartStoreTestCase {
 	 */
 	protected void checkCreateTableStatement(String tableName, String subStringExpected) {
 		Cursor c = null;
-		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 		try {
 			List<String> actualSqlStatements = new ArrayList<>();
 			c = db.rawQuery(String.format("SELECT sql FROM sqlite_master WHERE type='table' AND tbl_name='%s' ORDER BY name", tableName), null);
@@ -156,7 +156,7 @@ public abstract class SmartStoreTestCase {
      */
     protected void checkDatabaseIndexes(String tableName, List<String> expectedSqlStatements) {
         Cursor c = null;
-        final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+        final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
         try {
             List<String> actualSqlStatements = new ArrayList<>();
             c = db.rawQuery(String.format("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name='%s' ORDER BY name", tableName), null);
@@ -204,7 +204,7 @@ public abstract class SmartStoreTestCase {
 	 * @return table name for soup
 	 */
 	protected String getSoupTableName(String soupName) {
-		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase(getEncryptionKey());
+		final SQLiteDatabase db = dbOpenHelper.getWritableDatabase();
 		return DBHelper.getInstance(db).getSoupTableName(db, soupName);
 	}
 


### PR DESCRIPTION
Notable changes:
- packages have moved from `net.sqlcipher.database` to `net.zetetic.database.sqlcipher`
- library is loaded with a different call: `System.loadLibrary("sqlcipher")` instead of `SQLiteDatabase.loadLibs(context)`
- DBOpenHelper needs the encryption key at creation time (previously the key was provided when opening the database): a few public APIs had to be changed to accommodate the new behavior

To do:
- fix a few test failures (the explain plan is a bit different in some cases)
- **relax concurrency restriction in SmartStore** (<- that's the big one that will give us performance improvement but require significant testing)