### PR TITLE
Bump versions of all dependencies.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.4.2")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:7.4.2")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.22")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-cdvCompileSdkVersion=33
+cdvCompileSdkVersion=34
 cdvMinSdkVersion=24
 android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     api(project(":libs:SalesforceHybrid"))
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
 }
 
 android {

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     api(project(":libs:SalesforceHybrid"))
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
 }
 
 android {

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     api(project(":libs:SmartStore"))
     api("androidx.appcompat:appcompat:1.6.1")
     api("androidx.appcompat:appcompat-resources:1.6.1")
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -24,7 +24,7 @@ android {
     namespace = "com.salesforce.androidsdk.mobilesync"
     testNamespace = "com.salesforce.androidsdk.mobilesync.tests"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 dependencies {
     api("com.squareup:tape:1.2.3")
     api("io.github.pilgr:paperdb:2.7.2")
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -23,7 +23,7 @@ android {
     namespace = "com.salesforce.androidsdk.analytics"
     testNamespace = "com.salesforce.androidsdk.analytics.tests"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -15,9 +15,9 @@ dependencies {
     api("org.apache.cordova:framework:12.0.1")
     api("androidx.appcompat:appcompat:1.6.1")
     api("androidx.appcompat:appcompat-resources:1.6.1")
-    api("androidx.webkit:webkit:1.6.0")
-    api("androidx.core:core-splashscreen:1.0.0")
-    implementation("androidx.core:core-ktx:1.9.0")
+    api("androidx.webkit:webkit:1.8.0")
+    api("androidx.core:core-splashscreen:1.0.1")
+    implementation("androidx.core:core-ktx:1.12.0")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -27,7 +27,7 @@ android {
     namespace = "com.salesforce.androidsdk.hybrid"
     testNamespace = "com.salesforce.androidsdk.phonegap"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 dependencies {
     api(project(":libs:MobileSync"))
     api("com.facebook.react:react-native:0.70.14")
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -42,7 +42,7 @@ android {
     namespace = "com.salesforce.androidsdk.reactnative"
     testNamespace = "com.salesforce.androidsdk.reactnative.tests"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     api("com.squareup.okhttp3:okhttp:4.10.0")
     api("com.google.firebase:firebase-messaging:23.3.1")
     api("androidx.core:core:1.12.0")
-    api("androidx.browser:browser:1.6.0")
+    api("androidx.browser:browser:1.7.0")
     api("androidx.work:work-runtime-ktx:2.8.1")
     implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.biometric:biometric:1.2.0-alpha05")

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -14,14 +14,14 @@ dependencies {
     api(project(":libs:SalesforceAnalytics"))
     api("com.squareup.okhttp3:okhttp:4.10.0")
     api("com.google.firebase:firebase-messaging:23.3.1")
-    api("androidx.core:core:1.9.0")
-    api("androidx.browser:browser:1.4.0")
+    api("androidx.core:core:1.12.0")
+    api("androidx.browser:browser:1.6.0")
     api("androidx.work:work-runtime-ktx:2.8.1")
-    implementation("com.google.android.material:material:1.8.0")
+    implementation("com.google.android.material:material:1.10.0")
     implementation("androidx.biometric:biometric:1.2.0-alpha05")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1")
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -31,7 +31,7 @@ android {
     namespace = "com.salesforce.androidsdk"
     testNamespace = "com.salesforce.androidsdk.tests"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -15,19 +15,19 @@ dependencies {
     //noinspection GradleDependency -  Needs to line up with supported SQLCipher version.
     api("androidx.sqlite:sqlite:2.0.1")
     api("net.zetetic:android-database-sqlcipher:4.5.4")
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    implementation("com.google.android.material:material:1.8.0")
+    implementation("com.google.android.material:material:1.10.0")
 }
 
 android {
     namespace = "com.salesforce.androidsdk.smartstore"
     testNamespace = "com.salesforce.androidsdk.smartstore.tests"
 
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     api(project(":libs:SalesforceSDK"))
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
 }
 
 android {

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     api(project(":libs:SalesforceSDK"))
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.appcompat:appcompat-resources:1.6.1")
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
 }
 
 android {

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     implementation(project(":libs:SalesforceSDK"))
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.12.0")
     androidTestImplementation("androidx.test:runner:1.5.1") {
         exclude("com.android.support", "support-annotations")
     }
@@ -21,7 +21,7 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0") {
         exclude("com.android.support", "support-annotations")
     }
-    androidTestImplementation("androidx.test.ext:junit:1.1.4")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
 }
 
 android {


### PR DESCRIPTION
- **compileSdk to `34`**
- **Kotlin to `1.9.20`**
- Kotlin Standard Lib to `1.8.22` (`1.9+` throws an error below Gradle 8.1)
- core-ktx 
- webkit
- splashscreenn
- browser
- material
- lifecycle viewmodel

I left our Kotlin language and API versions (what we code to/our customers minimum version) at `1.6`.  [Here is what we could utilize if we bumped it to 1.7](https://kotlinlang.org/docs/whatsnew17.html).  `1.9` removes support for `1.3` (which was deprecated in `1.6`) and I don't think `1.4` is even deprecated yet so I don't see anything pressing.  