### PR TITLE
@W-15060758: [MSDK Android] Exceptions In SalesforceSDKManager.getBuildConfigValue When Main Application Class Isn't In Default Package

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1301,7 +1301,7 @@ open class SalesforceSDKManager protected constructor(
         @Suppress("SameParameterValue") fieldName: String
     ) = runCatching {
         Class.forName(
-            "${context.javaClass.getPackage()?.name ?: ""}.BuildConfig"
+            "${context.packageName ?: ""}.BuildConfig"
         ).getField(
             fieldName
         )[null]


### PR DESCRIPTION
🎸_Ready For Review!_🥁

  This easy bug fix allows apps to place their main application class in any package they wish by eliminating Salesforce SDK Manager's use of that class's package name to find the generated build config.  The build config is now located using a more precise lookup.

  To test this, one does need to create an app from the templates and move the main application class to another package.  I did this with the Mobile Sync Explorer Kotlin Template.