### PR TITLE
Using new cipher for RSA (but trying with old cipher in case of failure)

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -60,6 +60,13 @@ public class Encryptor {
     private static final String AES_GCM_CIPHER = "AES/GCM/NoPadding";
     private static final String MAC_TRANSFORMATION = "HmacSHA256";
     private static final String RSA_PKCS1 = "RSA/ECB/PKCS1Padding";
+
+    // Cipher in use until 248 (API 59)
+    public static final String LEGACY_NOTIFICATION_CIPHER = RSA_PKCS1;
+
+    // Cipher in use starting 250 (API 60)
+    public static final String NOTIFICATION_CIPHER = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding";
+
     private static final String BOUNCY_CASTLE = "BC";
     private static final int READ_BUFFER_LENGTH = 1024;
 
@@ -503,7 +510,7 @@ public class Encryptor {
         return output;
     }
 
-    private static byte[] encryptWithPublicKey(PublicKey publicKey, String data, String cipher) {
+    public static byte[] encryptWithPublicKey(PublicKey publicKey, String data, String cipher) {
         if (publicKey == null || TextUtils.isEmpty(data)) {
             return null;
         }
@@ -517,7 +524,7 @@ public class Encryptor {
         return null;
     }
 
-    private static byte[] decryptWithPrivateKey(PrivateKey privateKey, String data, String cipher) {
+    public static byte[] decryptWithPrivateKey(PrivateKey privateKey, String data, String cipher) {
         if (privateKey == null || TextUtils.isEmpty(data)) {
             return null;
         }
@@ -530,6 +537,16 @@ public class Encryptor {
             SalesforceAnalyticsLogger.e(null, TAG, "Error during asymmetric decryption", e);
         }
         return null;
+    }
+
+    public static byte[] decryptWithNotificationCiphersBytes(PrivateKey privateKey, String data) {
+        byte[] result = Encryptor.decryptWithPrivateKey(privateKey, data, NOTIFICATION_CIPHER);
+        if (result != null) {
+            return result;
+        } else {
+            // try the legacy cipher
+            return Encryptor.decryptWithPrivateKey(privateKey, data, LEGACY_NOTIFICATION_CIPHER);
+        }
     }
 
     private static byte[] generateInitVector() {

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -64,6 +64,15 @@ public class Encryptor {
 
     private static final String BOUNCY_CASTLE = "BC";
 
+
+    // This provider was separated out of AndroidKeyStoreProvider to work around the issue
+    // that Bouncy Castle provider incorrectly declares that it accepts arbitrary keys (incl. Android
+    // KeyStore ones). This causes JCA to select the Bouncy Castle's implementation of JCA crypto
+    // operations for Android KeyStore keys unless Android KeyStore's own implementations are installed
+    // as higher-priority than Bouncy Castle ones. The purpose of this provider is to do just that: to
+    // offer crypto operations operating on Android KeyStore keys and to be installed at higher priority
+    // than the Bouncy Castle provider.
+    // See https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/keystore/java/android/security/keystore2/AndroidKeyStoreBCWorkaroundProvider.java
     private static final String BOUNCY_CASTLE_WORKAROUND = "AndroidKeyStoreBCWorkaround";
     private static final int READ_BUFFER_LENGTH = 1024;
 

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -439,9 +439,9 @@ public class Encryptor {
      * @return Decrypted data.
      */
     public static byte[] decryptWithRSABytes(PrivateKey privateKey, String data) {
-        byte[] result =  decryptWithPrivateKey(privateKey, data, RSA_ECB_OAEP);
+        byte[] result =  decryptWithPrivateKey(privateKey, data, RSA_ECB_OAEP, /* logErrorOnFailure */ false);
         if (result == null) {
-            result = decryptWithPrivateKey(privateKey, data, RSA_PKCS1);
+            result = decryptWithPrivateKey(privateKey, data, RSA_PKCS1, /* logErrorOnFailure */ true);
         }
         return result;
     }
@@ -533,12 +533,12 @@ public class Encryptor {
             cipherInstance.init(Cipher.ENCRYPT_MODE, publicKey);
             return cipherInstance.doFinal(data.getBytes());
         } catch (Exception e) {
-            SalesforceAnalyticsLogger.e(null, TAG, "Error during asymmetric encryption", e);
+            SalesforceAnalyticsLogger.e(null, TAG, "Failed to encrypt with " + cipherMode, e);
         }
         return null;
     }
 
-    public static byte[] decryptWithPrivateKey(PrivateKey privateKey, String data, String cipherMode) {
+    private static byte[] decryptWithPrivateKey(PrivateKey privateKey, String data, String cipherMode, boolean logErrorOnFailure) {
         if (privateKey == null || TextUtils.isEmpty(data)) {
             return null;
         }
@@ -548,7 +548,11 @@ public class Encryptor {
             byte[] decodedBytes = Base64.decode(data.getBytes(),Base64.NO_WRAP | Base64.NO_PADDING);
             return cipherInstance.doFinal(decodedBytes);
         } catch (Exception e) {
-            SalesforceAnalyticsLogger.e(null, TAG, "Error during asymmetric decryption", e);
+            if (logErrorOnFailure) {
+                SalesforceAnalyticsLogger.e(null, TAG, "Failed to decrypt with " + cipherMode, e);
+            } else {
+                SalesforceAnalyticsLogger.w(null, TAG, "Failed to decrypt with " + cipherMode);
+            }
         }
         return null;
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -99,6 +99,7 @@ import com.salesforce.androidsdk.config.RuntimeConfig.getRuntimeConfig
 import com.salesforce.androidsdk.developer.support.notifications.local.ShowDeveloperSupportNotifier.Companion.BROADCAST_INTENT_ACTION_SHOW_DEVELOPER_SUPPORT
 import com.salesforce.androidsdk.developer.support.notifications.local.ShowDeveloperSupportNotifier.Companion.hideDeveloperSupportNotification
 import com.salesforce.androidsdk.developer.support.notifications.local.ShowDeveloperSupportNotifier.Companion.showDeveloperSupportNotification
+import com.salesforce.androidsdk.push.PushMessaging
 import com.salesforce.androidsdk.push.PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT
 import com.salesforce.androidsdk.push.PushMessaging.isRegistered
 import com.salesforce.androidsdk.push.PushMessaging.unregister
@@ -253,6 +254,10 @@ open class SalesforceSDKManager protected constructor(
     @get:Synchronized
     @set:Synchronized
     var pushNotificationReceiver: PushNotificationInterface? = null
+        set(value) {
+            field = value
+            PushMessaging.onPushReceiverSetup(appContext)
+        }
 
     /**
      * The class fulfilling push notification registration features.  A default

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
@@ -302,8 +302,8 @@ public class SalesforceSDKUpgradeManager {
     }
 
     private void updateFromBefore11_1_1() {
-        // Re-register all users for push notifications with new keys
-        PushMessaging.register(SalesforceSDKManager.getInstance().context, null, true);
+        // Re-register all users for push notifications with new keys once push is setup
+        PushMessaging.setReRegistrationRequested(true);
     }
 
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
@@ -38,12 +38,14 @@ import com.salesforce.androidsdk.auth.HttpAccess;
 import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.config.AdminSettingsManager;
 import com.salesforce.androidsdk.config.LegacyAdminSettingsManager;
+import com.salesforce.androidsdk.push.PushMessaging;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
+
 
 /**
  * This class handles upgrades from one version to another.
@@ -124,6 +126,9 @@ public class SalesforceSDKUpgradeManager {
             }
             if (installedVersion.isLessThan(new SdkVersion(11, 0, 0, false))) {
                 updateFromBefore11_0_0();
+            }
+            if (installedVersion.isLessThan(new SdkVersion(11, 1, 1, false))) {
+                updateFromBefore11_1_1();
             }
         } catch (Exception e) {
             SalesforceSDKLogger.e(
@@ -295,4 +300,10 @@ public class SalesforceSDKUpgradeManager {
             }
         }
     }
+
+    private void updateFromBefore11_1_1() {
+        // Re-register all users for push notifications with new keys
+        PushMessaging.register(SalesforceSDKManager.getInstance().context, null, true);
+    }
+
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -49,7 +49,7 @@ import com.salesforce.androidsdk.util.SalesforceSDKLogger
  * retrieval of push notification registration information from a
  * private shared preference file.
  */
-public object PushMessaging {
+object PushMessaging {
     private const val TAG = "PushMessaging"
 
     // Public constants.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -107,8 +107,8 @@ public object PushMessaging {
                 .pushNotificationReceiver?.supplyFirebaseMessaging() ?: FirebaseMessaging.getInstance()
             firebaseMessaging.isAutoInitEnabled = true
 
-            // Delete existing key if recreateKeyAtReRegistration is true
-            // Then sets recreateKeyAtReRegistration to false
+            // Delete existing key if recreateKey is true
+            // That will cause the key to be recreated when registerSFDCPush is called
             if (recreateKey && PushService.pushNotificationKeyName.isNotEmpty()) {
                 KeyStoreWrapper.getInstance().deleteKey(PushService.pushNotificationKeyName)
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -107,12 +107,6 @@ public object PushMessaging {
                 .pushNotificationReceiver?.supplyFirebaseMessaging() ?: FirebaseMessaging.getInstance()
             firebaseMessaging.isAutoInitEnabled = true
 
-            // Delete existing key if recreateKey is true
-            // That will cause the key to be recreated when registerSFDCPush is called
-            if (recreateKey && PushService.pushNotificationKeyName.isNotEmpty()) {
-                KeyStoreWrapper.getInstance().deleteKey(PushService.pushNotificationKeyName)
-            }
-
             /*
              * Performs registration steps if it is a new account, or if the
              * account hasn't been registered yet. Otherwise, performs
@@ -133,6 +127,11 @@ public object PushMessaging {
                     }
                 }
             } else {
+                // Delete existing key if recreateKey is true
+                if (recreateKey) {
+                    KeyStoreWrapper.getInstance().deleteKey(PushService.pushNotificationKeyName)
+                }
+
                 registerSFDCPush(context, account)
             }
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -89,17 +89,20 @@ public object PushMessaging {
      */
     @JvmStatic
     fun register(context: Context, account: UserAccount?, recreateKey: Boolean) {
+        // Delete existing key if recreateKey is true
+        // NB: Not needed (but won't do any harm) if push is not setup
+        //     Having it here rather than within if (isPushSetup(context)) {}
+        //     to make unit testing easier
+        if (recreateKey && PushService.pushNotificationKeyName.isNotEmpty()) {
+            KeyStoreWrapper.getInstance().deleteKey(PushService.pushNotificationKeyName)
+        }
+
         if (isPushSetup(context)) {
             // Ensure Firebase is initialized
             getFirebaseApp(context)
             val firebaseMessaging = SalesforceSDKManager.getInstance()
                 .pushNotificationReceiver?.supplyFirebaseMessaging() ?: FirebaseMessaging.getInstance()
             firebaseMessaging.isAutoInitEnabled = true
-
-            // Delete existing key if recreateKey is true
-            if (recreateKey && PushService.pushNotificationKeyName.isNotEmpty()) {
-                KeyStoreWrapper.getInstance().deleteKey(PushService.pushNotificationKeyName)
-            }
 
             /*
              * Performs registration steps if it is a new account, or if the

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushNotificationDecryptor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushNotificationDecryptor.java
@@ -102,7 +102,7 @@ class PushNotificationDecryptor {
         if (privateKey == null) {
             return data;
         }
-        byte[] symmetricKey = Encryptor.decryptWithRSABytes(privateKey, encryptedSecretKey);
+        byte[] symmetricKey = Encryptor.decryptWithNotificationCiphersBytes(privateKey, encryptedSecretKey);
         if (symmetricKey == null) {
             return data;
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushNotificationDecryptor.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushNotificationDecryptor.java
@@ -102,7 +102,7 @@ class PushNotificationDecryptor {
         if (privateKey == null) {
             return data;
         }
-        byte[] symmetricKey = Encryptor.decryptWithNotificationCiphersBytes(privateKey, encryptedSecretKey);
+        byte[] symmetricKey = Encryptor.decryptWithRSABytes(privateKey, encryptedSecretKey);
         if (symmetricKey == null) {
             return data;
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -288,10 +288,8 @@ open class PushService {
             val keyStoreWrapper = KeyStoreWrapper.getInstance()
 
             var rsaPublicKey: String? = null
-            val name = SalesforceKeyGenerator.getUniqueId(PUSH_NOTIFICATION_KEY_NAME)
-            val sanitizedName = name.replace("[^A-Za-z0-9]".toRegex(), "")
-            if (sanitizedName.isNotEmpty()) {
-                rsaPublicKey = keyStoreWrapper.getRSAPublicString(sanitizedName)
+            if (pushNotificationKeyName.isNotEmpty()) {
+                rsaPublicKey = keyStoreWrapper.getRSAPublicString(pushNotificationKeyName)
             }
             return rsaPublicKey
         }
@@ -425,6 +423,10 @@ open class PushService {
         private const val FIELD_ID = "id"
         private const val NOT_ENABLED = "not_enabled"
         const val PUSH_NOTIFICATION_KEY_NAME = "PushNotificationKey"
+        val pushNotificationKeyName = SalesforceKeyGenerator
+            .getUniqueId(PUSH_NOTIFICATION_KEY_NAME)
+            .replace("[^A-Za-z0-9]".toRegex(), "")
+
         protected const val REGISTRATION_STATUS_SUCCEEDED = 0
         protected const val REGISTRATION_STATUS_FAILED = 1
         protected const val UNREGISTRATION_STATUS_SUCCEEDED = 2

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
@@ -79,6 +79,21 @@ public class KeyStoreWrapper {
     }
 
     /**
+     * Delete key if it exists
+     *
+     * @param name Name of the key to delete
+     */
+    public void deleteKey(String name) {
+        try {
+            if (keyStore.containsAlias(name)) {
+                keyStore.deleteEntry(name);
+            }
+        } catch (Exception e) {
+            SalesforceSDKLogger.e(TAG, "Could not delete key " + name, e);
+        }
+    }
+
+    /**
      * Generates an RSA keypair and returns the public key of length 2048.
      *
      * @param name Alias of the entry in which the generated key will appear in Android KeyStore.
@@ -220,7 +235,8 @@ public class KeyStoreWrapper {
                         name,
                         KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
                         .setKeySize(length)
-                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1);
+                        .setDigests(KeyProperties.DIGEST_SHA1, KeyProperties.DIGEST_SHA256)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1, KeyProperties.ENCRYPTION_PADDING_RSA_OAEP);
 
                 /*
                  * TODO: Remove this check once minVersion > 28.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
@@ -85,7 +85,7 @@ public class KeyStoreWrapper {
      */
     public void deleteKey(String name) {
         try {
-            if (keyStore.containsAlias(name)) {
+            if (!name.isEmpty() && keyStore.containsAlias(name)) {
                 keyStore.deleteEntry(name);
             }
         } catch (Exception e) {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManagerTest.kt
@@ -7,6 +7,8 @@ import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.app.SalesforceSDKUpgradeManager.UserManager
 import com.salesforce.androidsdk.config.AdminSettingsManager
 import com.salesforce.androidsdk.config.LegacyAdminSettingsManager
+import com.salesforce.androidsdk.push.PushService
+import com.salesforce.androidsdk.security.KeyStoreWrapper
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -134,6 +136,38 @@ class SalesforceSDKUpgradeManagerTest {
             mutableMapOf("custom-org3" to "value3", "custom-user31" to "value31"),
             adminSettingsMgr.getPrefs(user31)
         )
+    }
+
+    @Test
+    fun testUpgradeFromBefore111() {
+        // Set version to a version before 11.1.1
+        setVersion("11.1.0")
+
+        // Create public key for push notifications
+        val originalKey = KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)
+
+        // Upgrade to 11.1.1
+        upgradeMgr.upgrade()
+
+        // Public key stored should have changed
+        val currentKey = KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)
+
+        Assert.assertNotEquals("Key should have changed", originalKey, currentKey);
+    }
+
+    @Test
+    fun testUpgradeAfter111() {
+        // Create public key for push notifications
+        val originalKey = KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)
+
+        // Upgrade to 12.0.0
+        setVersion("12.0.0")
+        upgradeMgr.upgrade()
+
+        // Public key stored should have changed
+        val currentKey = KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)
+
+        Assert.assertEquals("Key should not have changed", originalKey, currentKey);
     }
 
     fun setVersion(version: String) {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManagerTest.kt
@@ -7,6 +7,7 @@ import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.app.SalesforceSDKUpgradeManager.UserManager
 import com.salesforce.androidsdk.config.AdminSettingsManager
 import com.salesforce.androidsdk.config.LegacyAdminSettingsManager
+import com.salesforce.androidsdk.push.PushMessaging
 import com.salesforce.androidsdk.push.PushService
 import com.salesforce.androidsdk.security.KeyStoreWrapper
 import org.junit.Assert
@@ -149,10 +150,8 @@ class SalesforceSDKUpgradeManagerTest {
         // Upgrade to 11.1.1
         upgradeMgr.upgrade()
 
-        // Public key stored should have changed
-        val currentKey = KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)
-
-        Assert.assertNotEquals("Key should have changed", originalKey, currentKey);
+        // Make sure re-registration is requested
+        Assert.assertTrue(PushMessaging.reRegistrationRequested)
     }
 
     @Test
@@ -164,10 +163,8 @@ class SalesforceSDKUpgradeManagerTest {
         setVersion("12.0.0")
         upgradeMgr.upgrade()
 
-        // Public key stored should have changed
-        val currentKey = KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)
-
-        Assert.assertEquals("Key should not have changed", originalKey, currentKey);
+        // Make sure re-registration is NOT requested
+        Assert.assertFalse(PushMessaging.reRegistrationRequested)
     }
 
     fun setVersion(version: String) {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/KeyStoreWrapperTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/KeyStoreWrapperTest.java
@@ -139,7 +139,7 @@ public class KeyStoreWrapperTest {
         final String encryptedData = Base64.encodeToString(encryptedBytes, Base64.NO_WRAP | Base64.NO_PADDING);
         Assert.assertNotSame("Encrypted data should not match original data", data, encryptedData);
         final byte[] decryptedBytes = Encryptor.decryptWithNotificationCiphersBytes(privateKey, encryptedData);
-        final String decryptedData = new String(Base64.decode(decryptedBytes, Base64.DEFAULT), StandardCharsets.UTF_8);
+        final String decryptedData = new String(decryptedBytes, StandardCharsets.UTF_8);
         Assert.assertEquals("Decrypted data should match original data", data, decryptedData);
     }
 }


### PR DESCRIPTION
- encrypt and decrypt method use new cipher but try old cipher in case of failure
- key generation code had to be tweaked (to support different digest and encryption padding)
- had issue with default provider so using AndroidKeyStoreBCWorkaround for new cipher
- Added test