### PR TITLE
IdServiceResponse now pulls same fields than iOS

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -109,7 +109,6 @@ public class OAuth2 {
     private static final String PHOTOS = "photos";
     private static final String PICTURE = "picture";
     private static final String THUMBNAIL = "thumbnail";
-
     private static final String AUTHORIZATION_CODE = "authorization_code";
     private static final String HYBRID_AUTH_CODE = "hybrid_auth_code";
     private static final String CODE = "code";
@@ -146,6 +145,32 @@ public class OAuth2 {
     private static final String FORWARD_SLASH = "/";
     private static final String SINGLE_SPACE = " ";
     private static final String TAG = "OAuth2";
+    private static final String ID_URL = "id";
+    private static final String ASSERTED_USER = "asserted_user";
+    private static final String USER_ID = "user_id";
+    private static final String ORG_ID = "organization_id";
+    private static final String NICKNAME = "nick_name";
+    private static final String URLS = "urls";
+    private static final String ENTERPRISE_SOAP_URL = "enterprise";
+    private static final String METADATA_SOAP_URL = "metadata";
+    private static final String PARTNER_SOAP_URL = "partner";
+    private static final String REST_URL = "rest";
+    private static final String REST_SOBJECTS_URL = "sobjects";
+    private static final String REST_SEARCH_URL = "search";
+    private static final String REST_QUERY_URL = "query";
+    private static final String REST_RECENT_URL = "recent";
+    private static final String PROFILE_URL = "profile";
+    private static final String CHATTER_FEEDS_URL = "feeds";
+    private static final String CHATTER_GROUPS_URL = "groups";
+    private static final String CHATTER_USERS_URL = "users";
+    private static final String CHATTER_FEED_ITEMS_URL = "feed_items";
+    private static final String IS_ACTIVE = "active";
+    private static final String USER_TYPE = "user_type";
+    private static final String LANGUAGE = "language";
+    private static final String LOCALE = "locale";
+    private static final String UTC_OFFSET = "utcOffset";
+    private static final String MOBILE_APP_PIN_LENGTH = "pin_length";
+    private static final String LAST_MODIFIED_DATE = "last_modified_date";
 
     /**
      * Builds the URL to the authorization web page for this login server.
@@ -497,6 +522,35 @@ public class OAuth2 {
         public JSONObject customAttributes;
         public JSONObject customPermissions;
 
+        public String idUrl;
+        public boolean assertedUser;
+        public String userId;
+        public String orgId;
+        public String nickname;
+        public String photos;
+        public String urls;
+        public String enterpriseSoapUrl;
+        public String metadataSoapUr;
+        public String partnerSoapUrl;
+        public String restUrl;
+        public String restSObjectsUrl;
+        public String restSearchUrl;
+        public String restQueryUrl;
+        public String restRecentUrl;
+        public String profileUrl;
+        public String chatterFeedsUrl;
+        public String chatterGroupsUrl;
+        public String chatterUsersUrl;
+        public String chatterFeedItemsUrl;
+        public boolean isActive;
+        public String userType;
+        public String language;
+        public String locale;
+        public int utcOffset;
+        public boolean mobilePolicyConfigured;
+        public String mobileAppPinLength;
+        public String lastModifiedDate;
+
         /**
          * Parameterized constructor built from identity service response.
          *
@@ -515,6 +569,37 @@ public class OAuth2 {
                     pictureUrl = photos.getString(PICTURE);
                     thumbnailUrl = photos.getString(THUMBNAIL);
                 }
+
+                idUrl = parsedResponse.getString(ID_URL);
+                assertedUser = parsedResponse.optBoolean(ASSERTED_USER);
+                userId = parsedResponse.getString(USER_ID);
+                orgId = parsedResponse.getString(ORG_ID);
+                nickname = parsedResponse.getString(NICKNAME);
+                final JSONObject urls = parsedResponse.getJSONObject(URLS);
+                if (urls != null) {
+                    enterpriseSoapUrl = urls.getString(ENTERPRISE_SOAP_URL);
+                    metadataSoapUr = urls.getString(METADATA_SOAP_URL);
+                    partnerSoapUrl = urls.getString(PARTNER_SOAP_URL);
+                    restUrl = urls.getString(REST_URL);
+                    restSObjectsUrl = urls.getString(REST_SOBJECTS_URL);
+                    restSearchUrl = urls.getString(REST_SEARCH_URL);
+                    restQueryUrl = urls.getString(REST_QUERY_URL);
+                    restRecentUrl = urls.getString(REST_RECENT_URL);
+                    profileUrl = urls.getString(PROFILE_URL);
+                    chatterFeedsUrl = urls.getString(CHATTER_FEEDS_URL);
+                    chatterGroupsUrl = urls.getString(CHATTER_GROUPS_URL);
+                    chatterUsersUrl = urls.getString(CHATTER_USERS_URL);
+                    chatterFeedItemsUrl = urls.getString(CHATTER_FEED_ITEMS_URL);
+                }
+                isActive = parsedResponse.optBoolean(IS_ACTIVE);
+                userType = parsedResponse.getString(USER_TYPE);
+                language = parsedResponse.getString(LANGUAGE);
+                locale = parsedResponse.getString(LOCALE);
+                utcOffset = parsedResponse.optInt(UTC_OFFSET, -1);
+                mobilePolicyConfigured = parsedResponse.has(MOBILE_POLICY);
+                mobileAppPinLength = parsedResponse.getString(MOBILE_APP_PIN_LENGTH);
+                lastModifiedDate = parsedResponse.getString(LAST_MODIFIED_DATE);
+
                 customAttributes = parsedResponse.optJSONObject(CUSTOM_ATTRIBUTES);
                 customPermissions = parsedResponse.optJSONObject(CUSTOM_PERMISSIONS);
 
@@ -531,7 +616,7 @@ public class OAuth2 {
                 }
 
 
-                if (parsedResponse.has(MOBILE_POLICY)) {
+                if (mobilePolicyConfigured) {
                     JSONObject mobilePolicyObject = parsedResponse.getJSONObject(MOBILE_POLICY);
                     screenLock = mobilePolicyObject.has(SCREEN_LOCK_TIMEOUT);
                     screenLockTimeout = mobilePolicyObject.getInt(SCREEN_LOCK_TIMEOUT);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java
@@ -41,6 +41,8 @@ import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
 import com.salesforce.androidsdk.util.test.TestCredentials;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,8 +53,10 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 import okhttp3.HttpUrl;
 import okhttp3.Request;
@@ -366,6 +370,108 @@ public class OAuth2Test {
         Assert.assertEquals("Wrong username returned", TestCredentials.USERNAME, id.username);
         Assert.assertEquals("Wrong screenLockTimeout returned", -1, id.screenLockTimeout);
 	}
+
+    @Test
+    public void testParseIdentityServiceResponse() throws JSONException {
+        String responseJson = """
+            {
+              "id": "https://login.salesforce.com/id/00DB0000000ToZ3MAK/005B0000005V71XIAS",
+              "asserted_user": true,
+              "user_id": "005B0000005V71XIAS",
+              "organization_id": "00DB0000000ToZ3MAK",
+              "username": "wmathurin@gs0.mobilesdk.com",
+              "nick_name": "wmathurin",
+              "display_name": "Wolfgang Mathurin",
+              "email": "wmathurin@salesforce.com",
+              "email_verified": true,
+              "first_name": "Wolfgang",
+              "last_name": "Mathurin",
+              "timezone": "America/Los_Angeles",
+              "photos": {
+                "picture": "https://mobilesdk.file.force.com/profilephoto/729B00000002yij/F",
+                "thumbnail": "https://mobilesdk.file.force.com/profilephoto/729B00000002yij/T"
+              },
+              "addr_street": null,
+              "addr_city": null,
+              "addr_state": null,
+              "addr_country": null,
+              "addr_zip": null,
+              "mobile_phone": null,
+              "mobile_phone_verified": false,
+              "is_lightning_login_user": false,
+              "status": {
+                "created_date": null,
+                "body": null
+              },
+              "urls": {
+                "enterprise": "https://mobilesdk.my.salesforce.com/services/Soap/c/{version}/00DB0000000ToZ3",
+                "metadata": "https://mobilesdk.my.salesforce.com/services/Soap/m/{version}/00DB0000000ToZ3",
+                "partner": "https://mobilesdk.my.salesforce.com/services/Soap/u/{version}/00DB0000000ToZ3",
+                "rest": "https://mobilesdk.my.salesforce.com/services/data/v{version}/",
+                "sobjects": "https://mobilesdk.my.salesforce.com/services/data/v{version}/sobjects/",
+                "search": "https://mobilesdk.my.salesforce.com/services/data/v{version}/search/",
+                "query": "https://mobilesdk.my.salesforce.com/services/data/v{version}/query/",
+                "recent": "https://mobilesdk.my.salesforce.com/services/data/v{version}/recent/",
+                "tooling_soap": "https://mobilesdk.my.salesforce.com/services/Soap/T/{version}/00DB0000000ToZ3",
+                "tooling_rest": "https://mobilesdk.my.salesforce.com/services/data/v{version}/tooling/",
+                "profile": "https://mobilesdk.my.salesforce.com/005B0000005V71XIAS",
+                "feeds": "https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/feeds",
+                "groups": "https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/groups",
+                "users": "https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/users",
+                "feed_items": "https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/feed-items",
+                "feed_elements": "https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/feed-elements",
+                "custom_domain": "https://mobilesdk.my.salesforce.com"
+              },
+              "active": true,
+              "user_type": "STANDARD",
+              "language": "en_US",
+              "locale": "en_US",
+              "utcOffset": -28800000,
+              "last_modified_date": "2019-08-27T00:26:52Z",
+              "is_app_installed": true
+            }
+            """;
+        IdServiceResponse id = new IdServiceResponse(new JSONObject(responseJson));
+        Assert.assertEquals("https://login.salesforce.com/id/00DB0000000ToZ3MAK/005B0000005V71XIAS", id.idUrl);
+        Assert.assertEquals(true, id.assertedUser);
+        Assert.assertEquals("005B0000005V71XIAS", id.userId);
+        Assert.assertEquals("00DB0000000ToZ3MAK", id.orgId);
+        Assert.assertEquals("wmathurin@gs0.mobilesdk.com", id.username);
+        Assert.assertEquals("wmathurin", id.nickname);
+        Assert.assertEquals("Wolfgang Mathurin", id.displayName);
+        Assert.assertEquals("Wolfgang", id.firstName);
+        Assert.assertEquals("Mathurin", id.lastName);
+        Assert.assertEquals("wmathurin@salesforce.com", id.email);
+        Assert.assertEquals("https://mobilesdk.file.force.com/profilephoto/729B00000002yij/F", id.pictureUrl);
+        Assert.assertEquals("https://mobilesdk.file.force.com/profilephoto/729B00000002yij/T", id.thumbnailUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/Soap/c/{version}/00DB0000000ToZ3", id.enterpriseSoapUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/Soap/m/{version}/00DB0000000ToZ3", id.metadataSoapUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/Soap/u/{version}/00DB0000000ToZ3", id.partnerSoapUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/", id.restUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/sobjects/", id.restSObjectsUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/search/", id.restSearchUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/query/", id.restQueryUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/recent/", id.restRecentUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/005B0000005V71XIAS", id.profileUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/feeds", id.chatterFeedsUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/groups", id.chatterGroupsUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/feed-items", id.chatterFeedItemsUrl);
+        Assert.assertEquals("https://mobilesdk.my.salesforce.com/services/data/v{version}/chatter/users", id.chatterUsersUrl);
+        Assert.assertEquals(true, id.isActive);
+        Assert.assertEquals("STANDARD", id.userType);
+        Assert.assertEquals("en_US", id.language);
+        Assert.assertEquals("en_US", id.locale);
+        Assert.assertEquals(-28800000, id.utcOffset);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+        calendar.setTime(id.lastModifiedDate);
+        Assert.assertEquals(2019, calendar.get(Calendar.YEAR));
+        Assert.assertEquals(8, calendar.get(Calendar.MONTH)+1);
+        Assert.assertEquals(27, calendar.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(0, calendar.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(26, calendar.get(Calendar.MINUTE));
+        Assert.assertEquals(52, calendar.get(Calendar.SECOND));
+    }
 
     /**
      * Testing getOpenIDToken.


### PR DESCRIPTION
Matching the [fields pulled on iOS](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/dev/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.h).
NB: There are a few more not pulled on either platform.