### PR TITLE
Basic support for Foldable/Large screens.

### DIFF
--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -39,14 +39,12 @@
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK"
             android:launchMode="singleTop"
-            android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustNothing"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true" />
 
         <!-- Screen Lock Activity-->
         <activity android:name="com.salesforce.androidsdk.ui.ScreenLockActivity"
             android:exported="false"
-            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize|stateAlwaysVisible"
             android:theme="@style/SalesforceSDK.ScreenLock" />
 
@@ -60,14 +58,12 @@
         <activity android:name="com.salesforce.androidsdk.ui.ServerPickerActivity"
             android:excludeFromRecents="true"
             android:theme="@style/SalesforceSDK"
-            android:screenOrientation="portrait"
             android:exported="false" />
 
         <!-- Account switcher activity -->
         <activity android:name="com.salesforce.androidsdk.ui.AccountSwitcherActivity"
             android:excludeFromRecents="true"
             android:theme="@style/SalesforceSDK"
-            android:screenOrientation="portrait"
             android:exported="false" />
 
         <!-- IDP auth code activity -->

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -22,6 +22,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
+    implementation("androidx.window:window:1.2.0")
+    implementation("androidx.window:window-core:1.2.0")
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -62,6 +62,10 @@ import androidx.lifecycle.Lifecycle.Event.ON_STOP
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.window.core.layout.WindowHeightSizeClass
+import androidx.window.core.layout.WindowSizeClass
+import androidx.window.core.layout.WindowWidthSizeClass
+import androidx.window.layout.WindowMetricsCalculator
 import com.salesforce.androidsdk.BuildConfig.DEBUG
 import com.salesforce.androidsdk.R.string.account_type
 import com.salesforce.androidsdk.R.string.sf__dev_support_title
@@ -1367,6 +1371,21 @@ open class SalesforceSDKManager protected constructor(
              */
             activity.window.decorView.systemUiVisibility = SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR or SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
         }
+    }
+
+    /**
+     * Determines whether the device has a compact screen.
+     * Taken directly from https://developer.android.com/guide/topics/large-screens/large-screen-cookbook#kotlin
+     */
+    fun compactScreen(activity: Activity) : Boolean {
+        val metrics = WindowMetricsCalculator.getOrCreate().computeMaximumWindowMetrics(activity)
+        val width = metrics.bounds.width()
+        val height = metrics.bounds.height()
+        val density = activity.resources.displayMetrics.density
+        val windowSizeClass = WindowSizeClass.compute(width/density, height/density)
+
+        return windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT ||
+                windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT
     }
 
     @Suppress("unused")

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/AccountSwitcherActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/AccountSwitcherActivity.java
@@ -26,6 +26,7 @@
  */
 package com.salesforce.androidsdk.ui;
 
+import android.content.pm.ActivityInfo;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.AdapterView;
@@ -60,6 +61,12 @@ public class AccountSwitcherActivity extends AppCompatActivity {
 		// This makes the navigation bar visible on light themes.
 		SalesforceSDKManager.getInstance().setViewNavigationVisibility(this);
 		setContentView(R.layout.sf__account_switcher);
+
+		if (SalesforceSDKManager.getInstance().compactScreen(this)) {
+			setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+		} else {
+			setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
+		}
 	}
 
 	@Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -35,6 +35,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager.FEATURE_FACE
 import android.content.pm.PackageManager.FEATURE_IRIS
 import android.os.Build.VERSION.SDK_INT
@@ -233,6 +234,10 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
                 PRIORITY_DEFAULT
             ) { handleBackBehavior() }
         }
+
+        requestedOrientation = if (salesforceSDKManager.compactScreen(this))
+            ActivityInfo.SCREEN_ORIENTATION_PORTRAIT else
+            ActivityInfo.SCREEN_ORIENTATION_FULL_USER
     }
 
     override fun onDestroy() {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.ui;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
@@ -156,6 +157,12 @@ public class ServerPickerActivity extends AppCompatActivity implements
         final RadioGroup radioGroup = findViewById(getServerListGroupId());
         radioGroup.setOnCheckedChangeListener(this);
         urlEditDialog = new CustomServerUrlEditor();
+
+        if (SalesforceSDKManager.getInstance().compactScreen(this)) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        } else {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
+        }
 
         // TODO:  Remove this when min API > 33
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {


### PR DESCRIPTION
This makes the following no longer letterboxed:
- LoginActivity
- ServerPickerActivity
- AccountSwitcherActivity

ScreenLockActivity did not need the fix.  I did not check IDP activities.  