### PR TITLE
@W-14831222: [Android] NullPointerException: userAccount must not be null on app foreground with biometrics

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -36,6 +36,8 @@ import android.content.SharedPreferences.Editor;
 import android.os.Bundle;
 import android.text.TextUtils;
 
+import androidx.annotation.Nullable;
+
 import com.salesforce.androidsdk.app.Features;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.AuthenticatorService;
@@ -413,7 +415,7 @@ public class UserAccountManager {
 	 * @param account Account object.
 	 * @return UserAccount object.
 	 */
-	public UserAccount buildUserAccount(Account account) {
+	public @Nullable UserAccount buildUserAccount(Account account) {
 		if (account == null) {
 			return null;
 		}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/BiometricAuthenticationManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/BiometricAuthenticationManager.kt
@@ -49,13 +49,17 @@ internal class BiometricAuthenticationManager: AppLockManager(
         get() { return SalesforceSDKManager.getInstance().userAccountManager.currentUser }
 
     override fun shouldLock(): Boolean {
+        val userAccountManager = SalesforceSDKManager.getInstance().userAccountManager
+
         val elapsedTime = System.currentTimeMillis() - lastBackgroundTimestamp
-        val account = SalesforceSDKManager.getInstance().userAccountManager.currentAccount ?: return false
-        val userAccount = SalesforceSDKManager.getInstance().userAccountManager.buildUserAccount(account)
+        val account = userAccountManager.currentAccount ?: return false
+        val userAccount = userAccountManager.buildUserAccount(account) ?: return false
+
         val (enabled, timeout) = getPolicy(userAccount)
 
         return enabled && (elapsedTime > timeout)
     }
+
     override fun lock() {
         currentUser?.let {
             locked = true


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

  This guards for a reported null pointer crash in the biometric authentication manager.  Though, it does not solve for why an Android `Account` exists that a `UserAccount` cannot be derived from.  Potentially, more research would be needed in  `UserAccountManager.buildUserAccount(Account)` to identify the gap or to gather metrics related to the actual `Account` data at runtime.  The immediate goal is to reduce the impact of the observed crashes and improve the user experience. Here's a follow-up work item for that effort: [W-15381271: -MSDK Android- Android Account Is Sometimes Null In BiometricAuthenticationManager shouldLock
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001nRqC3YAK/view)