### PR TITLE
Remove shouldReloadPage

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -259,9 +259,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
 
         // Reload the login page for every new intent to ensure the correct login server is selected
         webviewHelper?.run {
-            if (shouldReloadPage) {
-                loadLoginPage()
-            }
+            loadLoginPage()
         }
     }
 
@@ -347,15 +345,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
 
     override fun onResume() {
         super.onResume()
-        if (wasBackgrounded) {
-            webviewHelper?.run {
-                if (shouldReloadPage) {
-                    clearView()
-                    loadLoginPage()
-                }
-            }
-            wasBackgrounded = false
-        }
+        wasBackgrounded = false
     }
 
     public override fun onSaveInstanceState(bundle: Bundle) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -185,14 +185,12 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         loginOptions: LoginOptions,
         webView: WebView,
         savedInstanceState: Bundle?,
-        shouldReloadPage: Boolean = true
     ) {
         this.activity = activity
         this.callback = callback
         this.context = webView.context
         this.webView = webView
         this.loginOptions = loginOptions
-        this.shouldReloadPage = shouldReloadPage
 
         webView.apply {
             webView.settings.apply {
@@ -240,7 +238,6 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         this.loginOptions = loginOptions
         this.webView = null
         this.activity = null
-        this.shouldReloadPage = true
     }
 
     private val callback: OAuthWebviewHelperEvents
@@ -258,16 +255,6 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
     private var key: PrivateKey? = null
 
     private var certChain: Array<X509Certificate>? = null
-
-    /**
-     * Indicates whether the login page should be reloaded when the app is
-     * backgrounded and foregrounded. By default, this is set to 'true' in the
-     * SDK in order to support various supported OAuth flows. Subclasses may
-     * override this for cases where they need to display the page as-is, such
-     * as TBID or social login pages where a code is typed in.
-     */
-    var shouldReloadPage: Boolean
-        private set
 
     fun saveState(outState: Bundle) {
         val accountOptions = accountOptions
@@ -464,15 +451,6 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         val customTabBrowser = SalesforceSDKManager.getInstance().customTabBrowser
         if (doesBrowserExist(customTabBrowser)) {
             customTabsIntent.intent.setPackage(customTabBrowser)
-        }
-
-        /*
-         * Prevent Chrome custom tab from staying in the activity history stack.
-         * This flag ensures that the Chrome custom tab is dismissed once the
-         * login process is complete
-         */
-        if (shouldReloadPage) {
-            customTabsIntent.intent.setFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
         }
 
         runCatching {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -146,9 +146,13 @@ import java.util.function.Consumer
  *
  * @Deprecated This class will no longer be public starting in Mobile SDK 13.0.  It
  * is no longer necessary to extend or change LoginActivity's instance of this class
- * to support multi-factory authentication.  If there are other uses cases please
+ * to support multi-factor authentication.  If there are other uses cases please
  * inform the team via Github or our Trailblazer community.  
  */
+@Deprecated(
+    "This class will no longer be public starting in Mobile SDK 13.0.",
+    level = DeprecationLevel.WARNING,
+)
 open class OAuthWebviewHelper : KeyChainAliasCallback {
 
     private var codeVerifier: String? = null
@@ -190,6 +194,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         loginOptions: LoginOptions,
         webView: WebView,
         savedInstanceState: Bundle?,
+        shouldReloadPage: Boolean = false,
     ) {
         this.activity = activity
         this.callback = callback
@@ -260,6 +265,15 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
     private var key: PrivateKey? = null
 
     private var certChain: Array<X509Certificate>? = null
+
+    /**
+     * This value is no longer needed to support Multi-Factor Authentication via
+     * standard or advanced authentication flows.
+     *
+     * @Deprecated This value is no longer used.
+     */
+    var shouldReloadPage: Boolean = false
+        private set
 
     fun saveState(outState: Bundle) {
         val accountOptions = accountOptions

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -389,7 +389,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
                     if (!instance.isShareBrowserSessionEnabled) {
                         uri = URI("$uri$PROMPT_LOGIN")
                     }
-                    loadLoginPageInChrome(uri)
+                    loadLoginPageInCustomTab(uri)
                 }
 
                 else -> webView?.loadUrl(uri.toString())
@@ -399,7 +399,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         }
     }
 
-    private fun loadLoginPageInChrome(uri: URI) {
+    private fun loadLoginPageInCustomTab(uri: URI) {
         val activity = activity ?: return
 
         val customTabsIntent = CustomTabsIntent.Builder().apply {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -143,6 +143,11 @@ import java.util.function.Consumer
  * c) Navigate to the authentication completion URL and token fetch
  * d) Call the id service to obtain additional info about the user
  * e) Create a local account and return an authentication result bundle
+ *
+ * @Deprecated This class will no longer be public starting in Mobile SDK 13.0.  It
+ * is no longer necessary to extend or change LoginActivity's instance of this class
+ * to support multi-factory authentication.  If there are other uses cases please
+ * inform the team via Github or our Trailblazer community.  
  */
 open class OAuthWebviewHelper : KeyChainAliasCallback {
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -303,7 +303,7 @@ public class ServerPickerActivity extends AppCompatActivity implements
         Bundle options = SalesforceSDKManager.getInstance().getLoginOptions().asBundle();
         Intent intent = new Intent(ctx, SalesforceSDKManager.getInstance().getLoginActivityClass());
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         BiometricAuthenticationManager bioAuthManager =
                 SalesforceSDKManager.getInstance().getBiometricAuthenticationManager();
@@ -313,8 +313,9 @@ public class ServerPickerActivity extends AppCompatActivity implements
         intent.putExtras(options);
 
         /*
-         * The activity needs to be created (instead of just reloading the webview)
-         * to support the transition from custom tab to standard webview login.
+         * The activity needs to be recreated (instead of just reloading the webview)
+         * to support the transition from custom tab to standard webview login.  If we do this
+         * with the CLEAR_TOP flag we ensure unnecessary Custom Tabs are destroyed.
          *
          * The only other way to do this is with the NO_HISTORY flag on the custom tab, however
          * this will cause it to always reload on background -- breaking MFA.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -26,8 +26,11 @@
  */
 package com.salesforce.androidsdk.ui;
 
+import static com.salesforce.androidsdk.security.BiometricAuthenticationManager.SHOW_BIOMETRIC;
+
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.drawable.Drawable;
@@ -50,6 +53,7 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.config.LoginServerManager;
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer;
 import com.salesforce.androidsdk.config.RuntimeConfig;
+import com.salesforce.androidsdk.security.interfaces.BiometricAuthenticationManager;
 
 import java.util.List;
 
@@ -64,8 +68,6 @@ import kotlin.Unit;
  */
 public class ServerPickerActivity extends AppCompatActivity implements
         android.widget.RadioGroup.OnCheckedChangeListener {
-
-    public static final String CHANGE_SERVER_INTENT = "com.salesforce.SERVER_CHANGED";
     private static final String SERVER_DIALOG_NAME = "custom_server_dialog";
 
     private CustomServerUrlEditor urlEditDialog;
@@ -297,11 +299,27 @@ public class ServerPickerActivity extends AppCompatActivity implements
 
     public void onAuthConfigFetched() {
         setResult(Activity.RESULT_OK, null);
-        final Intent changeServerIntent = new Intent(CHANGE_SERVER_INTENT);
-        // Android 14 requires non-exported receiver to be invoked with explicit intents
-        // See https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents
-        changeServerIntent.setPackage(getPackageName());
-        sendBroadcast(changeServerIntent);
+        Context ctx = SalesforceSDKManager.getInstance().getAppContext();
+        Bundle options = SalesforceSDKManager.getInstance().getLoginOptions().asBundle();
+        Intent intent = new Intent(ctx, SalesforceSDKManager.getInstance().getLoginActivityClass());
+        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+
+        BiometricAuthenticationManager bioAuthManager =
+                SalesforceSDKManager.getInstance().getBiometricAuthenticationManager();
+        if (bioAuthManager != null && bioAuthManager.isLocked()) {
+            options.putBoolean(SHOW_BIOMETRIC, true);
+        }
+        intent.putExtras(options);
+
+        /*
+         * The activity needs to be created (instead of just reloading the webview)
+         * to support the transition from custom tab to standard webview login.
+         *
+         * The only other way to do this is with the NO_HISTORY flag on the custom tab, however
+         * this will cause it to always reload on background -- breaking MFA.
+         */
+        ctx.startActivity(intent);
         finish();
     }
 }


### PR DESCRIPTION
This singular variable has always controlled too many distinct scenarios:
- If the webview or custom tab should reload when the app returns from the background.
- If the webview or custom tab should reload when we transition from the ServerPicker to LoginActivity.
- If `Intent.FLAG_ACTIVITY_NO_HISTORY` should be set on the custom tab activity.

This leads to bad scenarios like: you need to _not_ reload on background for MFA so you sacrifice the correct server being loaded from the picker when you switch.  <- That sucks.

**I believe all of these scenarios only have one real correct choice and it is to **not reload** ever, unless the server changes.  If a reload is needed for some extreme case we cannot foresee the manual option remains.**

[This is the PR that originally added shouldReloadPage](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2033), which set it to true by default.  This was done to make it possible to transition between webview and custom tab, however that also requires the no history flag which breaks MFA.  To work around this I have decided to **relaunch** the LoginActivity instead of reloading the webview (which feels a little bad) to support this transition.  This is necessary since there is no way to programmatically close a custom tab 🙄.  The only time we need to reload the webview is after we fetch the auth config because we don't know if login should be in a custom tab or not until then.  

P.S: An added benefit is this removes a reason for apps to subclass `LoginActivity` and override the default `OAuthWebviewHelper`.