### PR TITLE
@W-14893505: [ASA Program] [#SA-01][Android] App Enables Dangerous File Access via setAllowFileAccessFromFileURLs

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -197,7 +197,6 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
             useWideViewPort = true
             layoutAlgorithm = LayoutAlgorithm.NORMAL
             javaScriptEnabled = true
-            allowFileAccessFromFileURLs = true
             javaScriptCanOpenWindowsAutomatically = true
             databaseEnabled = true
             domStorageEnabled = true


### PR DESCRIPTION
🎸 _Ready For Review!_ 🥁

  This removes file URL access from the login web view to comply with the security goal of this work item.  This was discussed among the team today and there doesn't seem to be a known reason for why this is enabled.  The login use cases I tried today all seem to function just as well without this option.  If anyone has login edge cases that might have been affected, do let me know and I'll investigate.  

  Thanks!