### PR TITLE
Fix server picker issues with native login fallback to web based auth.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -199,7 +199,7 @@ open class SalesforceSDKManager protected constructor(
      */
     private var showDeveloperSupportBroadcastIntentReceiver: BroadcastReceiver? = null
 
-    internal val webviewLoginActivityClass: Class<out Activity> = loginActivity ?: LoginActivity::class.java
+    val webviewLoginActivityClass: Class<out Activity> = loginActivity ?: LoginActivity::class.java
 
     /**
      * The class of the activity used to perform the login process and create

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -301,7 +301,7 @@ public class ServerPickerActivity extends AppCompatActivity implements
         setResult(Activity.RESULT_OK, null);
         Context ctx = SalesforceSDKManager.getInstance().getAppContext();
         Bundle options = SalesforceSDKManager.getInstance().getLoginOptions().asBundle();
-        Intent intent = new Intent(ctx, SalesforceSDKManager.getInstance().getLoginActivityClass());
+        Intent intent = new Intent(ctx, SalesforceSDKManager.getInstance().getWebviewLoginActivityClass());
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 


### PR DESCRIPTION
Because of the new `CLEAR_TOP` flag we should explicitly use the Webview Login Activity Class when switching servers to avoid accidentally dismissing the webview activity.

I was tempted to convert `ServerPickerActivity` to Kotlin instead of making `webviewLoginActivityClass` public as it isn't much work.  However, customers can extend `ServerPickerActivity` and since a lot of it is Java public or protected we would need to carefully consider the external interface before and after.  I think it makes more sense to evaluate what the interface should be (which has not been done for may years), make deprecations if necessary and convert it in 13.0.  