### PR TITLE
@W-15547113: [MSDK Android] Crash When Returning To Login View From Server Picker View

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -30,7 +30,6 @@ import static com.salesforce.androidsdk.security.BiometricAuthenticationManager.
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.drawable.Drawable;
@@ -299,9 +298,11 @@ public class ServerPickerActivity extends AppCompatActivity implements
 
     public void onAuthConfigFetched() {
         setResult(Activity.RESULT_OK, null);
-        Context ctx = SalesforceSDKManager.getInstance().getAppContext();
         Bundle options = SalesforceSDKManager.getInstance().getLoginOptions().asBundle();
-        Intent intent = new Intent(ctx, SalesforceSDKManager.getInstance().getWebviewLoginActivityClass());
+        Intent intent = new Intent(
+                this,
+                SalesforceSDKManager.getInstance().getWebviewLoginActivityClass()
+        );
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
@@ -320,7 +321,7 @@ public class ServerPickerActivity extends AppCompatActivity implements
          * The only other way to do this is with the NO_HISTORY flag on the custom tab, however
          * this will cause it to always reload on background -- breaking MFA.
          */
-        ctx.startActivity(intent);
+        startActivity(intent);
         finish();
     }
 }


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

  This resolves what looks like an easy-to-fix crash when returning to login from the server picker.  The crash is due to `startActivity` being called on a `Context` reference that isn't always an `Activity` instance.  Since the method is already `ServerPickerActivity`, calling `startActivity` on `this` seems like it'd do just what the exception is asking for.

  @brandonpage - Does this align with the comment in this method?

    