### PR TITLE
@W-15548296: [MSDK Android] NetworkOnMainThreadException In App Created From Hybrid Local Template

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -564,6 +564,7 @@ open class SalesforceSDKManager protected constructor(
      * license
      * @return The Native Login Manager.
      */
+    @Suppress("unused")
     fun useNativeLogin(
         consumerKey: String,
         callbackUrl: String,
@@ -1399,12 +1400,12 @@ open class SalesforceSDKManager protected constructor(
      * Determines whether the device has a compact screen.
      * Taken directly from https://developer.android.com/guide/topics/large-screens/large-screen-cookbook#kotlin
      */
-    fun compactScreen(activity: Activity) : Boolean {
+    fun compactScreen(activity: Activity): Boolean {
         val metrics = WindowMetricsCalculator.getOrCreate().computeMaximumWindowMetrics(activity)
         val width = metrics.bounds.width()
         val height = metrics.bounds.height()
         val density = activity.resources.displayMetrics.density
-        val windowSizeClass = WindowSizeClass.compute(width/density, height/density)
+        val windowSizeClass = WindowSizeClass.compute(width / density, height / density)
 
         return windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.COMPACT ||
                 windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT
@@ -1443,6 +1444,7 @@ open class SalesforceSDKManager protected constructor(
          * TODO: Remove the suppress lint annotation once the Android context is no longer retained.
          */
         @JvmField
+        @SuppressLint("StaticFieldLeak")
         protected var INSTANCE: SalesforceSDKManager? = null
 
         /** The current version of this SDK */
@@ -1749,8 +1751,7 @@ open class SalesforceSDKManager protected constructor(
             withTimeout(5000L) {
                 val loginServer = loginServerManager.selectedLoginServer?.url?.trim { it <= ' ' } ?: return@withTimeout
 
-                if (loginServer == PRODUCTION_LOGIN_URL || loginServer == SANDBOX_LOGIN_URL || !isHttpsUrl(loginServer) || loginServer.toHttpUrlOrNull() == null
-                ) {
+                if (loginServer == PRODUCTION_LOGIN_URL || loginServer == SANDBOX_LOGIN_URL || !isHttpsUrl(loginServer) || loginServer.toHttpUrlOrNull() == null) {
                     setBrowserLoginEnabled(
                         browserLoginEnabled = false,
                         shareBrowserSessionEnabled = false


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

  This resolves a network on main thread exception that I discovered in the hybrid template apps.

  This is interesting in that the call to `getMyDomainAuthConfig` is happening in a different location than it does in `SalesforceSDKManager.fetchAuthenticationConfiguration` with very subtly different logic.  The key difference is that the hybrid app doesn't call `setBrowserLoginEnabled` when the authorization config is obtained.  @brandonpage - Any chance you know why that is? It looks intentional downstream in `isSamlLoginRedirect`.

  Perhaps in the future the switch around `setBrowserLoginEnabled` could be added to the `SalesforceSdkManager` version so redundancy is reduced.  

