### PR TITLE
Fix protected functions not being open in classes recently converted to Kotlin.

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.kt
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.kt
@@ -306,7 +306,7 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
 
     /** The unauthenticated start page from the boot configuration */
     @Suppress("MemberVisibilityCanBePrivate")
-    protected val unauthenticatedStartPage
+    protected open val unauthenticatedStartPage
         get() = bootConfig?.unauthenticatedStartPage
 
     fun logout(callbackContext: CallbackContext?) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -596,7 +596,7 @@ open class SalesforceSDKManager protected constructor(
      * false otherwise
      */
     @Synchronized
-    internal fun setBrowserLoginEnabled(
+    fun setBrowserLoginEnabled(
         browserLoginEnabled: Boolean,
         shareBrowserSessionEnabled: Boolean
     ) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -230,7 +230,7 @@ open class SalesforceSDKManager protected constructor(
         }.also { field = it }
 
     /** The Salesforce SDK manager's login server manager */
-    val loginServerManager by lazy {
+    open val loginServerManager by lazy {
         LoginServerManager(appContext)
     }
 
@@ -316,8 +316,8 @@ open class SalesforceSDKManager protected constructor(
      * based on the value configured on the server
      */
     @set:Synchronized
-    var isBrowserLoginEnabled = false
-        private set
+    open var isBrowserLoginEnabled = false
+        protected set
 
     /** Optionally enables browser session sharing */
     var isShareBrowserSessionEnabled = false
@@ -379,8 +379,9 @@ open class SalesforceSDKManager protected constructor(
      * By default, the display name under
      * [android.content.pm.ApplicationInfo.labelRes] will be used.
      */
+    @Suppress("INAPPLICABLE_JVM_NAME")
     @get:JvmName("provideAppName")
-    var appName: String? = null
+    open var appName: String? = null
         get() = runCatching {
             if (field == null) {
                 val packageInfo = appContext.packageManager.getPackageInfo(
@@ -437,7 +438,7 @@ open class SalesforceSDKManager protected constructor(
      * BuildConfig.DEBUG unless another value is specified.
      * @return Boolean true enables developer support features; false otherwise
      */
-    fun isDevSupportEnabled() = isDevSupportEnabledOverride ?: isDebugBuild
+    open fun isDevSupportEnabled() = isDevSupportEnabledOverride ?: isDebugBuild
 
     /**
      * Sets if developer support features are enabled.
@@ -486,7 +487,7 @@ open class SalesforceSDKManager protected constructor(
     }
 
     /** Login options associated with the app */
-    val loginOptions: LoginOptions get() = getLoginOptions(null, null)
+    open val loginOptions: LoginOptions get() = getLoginOptions(null, null)
 
     /**
      * Sets the login options associated with the app.
@@ -494,7 +495,7 @@ open class SalesforceSDKManager protected constructor(
      * @param jwt The `jwt`
      * @param url The URL
      */
-    fun getLoginOptions(
+    open fun getLoginOptions(
         jwt: String?,
         url: String?
     ) = loginOptionsInternal?.apply {
@@ -530,10 +531,10 @@ open class SalesforceSDKManager protected constructor(
      * @return True if the Salesforce Mobile SDK should automatically logout when
      * the access token is revoked
      */
-    fun shouldLogoutWhenTokenRevoked() = true
+    open fun shouldLogoutWhenTokenRevoked() = true
 
     /** The Salesforce SDK manager's user account manager */
-    val userAccountManager: UserAccountManager by lazy {
+    open val userAccountManager: UserAccountManager by lazy {
         UserAccountManager.getInstance()
     }
 
@@ -546,7 +547,7 @@ open class SalesforceSDKManager protected constructor(
      * for this option.  This functionality will eventually be provided by the
      * backend.
      */
-    var shouldBlockSalesforceIntegrationUser = false
+    open var shouldBlockSalesforceIntegrationUser = false
 
     /**
      * Creates a NativeLoginManager instance that allows the app to use its
@@ -595,7 +596,7 @@ open class SalesforceSDKManager protected constructor(
      * false otherwise
      */
     @Synchronized
-    fun setBrowserLoginEnabled(
+    internal fun setBrowserLoginEnabled(
         browserLoginEnabled: Boolean,
         shareBrowserSessionEnabled: Boolean
     ) {
@@ -638,7 +639,7 @@ open class SalesforceSDKManager protected constructor(
 
     /** Returns the app display name used by the passcode dialog */
     @Suppress("unused")
-    val appDisplayString = DEFAULT_APP_DISPLAY_NAME
+    open val appDisplayString = DEFAULT_APP_DISPLAY_NAME
 
     /** Returns the name of the app as defined in AndroidManifest.xml */
     val applicationName
@@ -719,8 +720,7 @@ open class SalesforceSDKManager protected constructor(
     /**
      * Starts the login flow if user account has been removed.
      */
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected fun startLoginPage() {
+    protected open fun startLoginPage() {
 
         // Clear cookies
         CookieManager.getInstance().removeAllCookies(null)
@@ -870,7 +870,7 @@ open class SalesforceSDKManager protected constructor(
      * @param showLoginPage If true, displays the login page after removing the
      * account
      */
-    fun logout(
+    open fun logout(
         /* Note: Kotlin's @JvmOverloads annotations does not generate this overload */
         frontActivity: Activity?,
         showLoginPage: Boolean = true
@@ -889,7 +889,7 @@ open class SalesforceSDKManager protected constructor(
      * account
      */
     @JvmOverloads
-    fun logout(
+    open fun logout(
         account: Account? = null,
         frontActivity: Activity?,
         showLoginPage: Boolean = true
@@ -1386,7 +1386,7 @@ open class SalesforceSDKManager protected constructor(
      *
      * @param activity The activity used to set style attributes
      */
-    fun setViewNavigationVisibility(activity: Activity) {
+    open fun setViewNavigationVisibility(activity: Activity) {
         if (!isDarkTheme || activity.javaClass.name == loginActivityClass.name) {
             /*
              * This covers the case where OS dark theme is true, but app has
@@ -1400,7 +1400,7 @@ open class SalesforceSDKManager protected constructor(
      * Determines whether the device has a compact screen.
      * Taken directly from https://developer.android.com/guide/topics/large-screens/large-screen-cookbook#kotlin
      */
-    fun compactScreen(activity: Activity): Boolean {
+    open fun compactScreen(activity: Activity): Boolean {
         val metrics = WindowMetricsCalculator.getOrCreate().computeMaximumWindowMetrics(activity)
         val width = metrics.bounds.width()
         val height = metrics.bounds.height()
@@ -1413,7 +1413,7 @@ open class SalesforceSDKManager protected constructor(
 
     @Suppress("unused")
     @OnLifecycleEvent(ON_STOP)
-    protected fun onAppBackgrounded() {
+    protected open fun onAppBackgrounded() {
         screenLockManager?.onAppBackgrounded()
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppBackgrounded()
 
@@ -1425,7 +1425,7 @@ open class SalesforceSDKManager protected constructor(
 
     @Suppress("unused")
     @OnLifecycleEvent(ON_START)
-    protected fun onAppForegrounded() {
+    protected open fun onAppForegrounded() {
         screenLockManager?.onAppForegrounded()
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppForegrounded()
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -280,8 +280,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         super.finish()
     }
 
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected fun certAuthOrLogin() {
+    protected open fun certAuthOrLogin() {
         when {
             shouldUseCertBasedAuth() -> {
                 val alias = getRuntimeConfig(this).getString(ManagedAppCertAlias)
@@ -298,7 +297,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
             }
 
             else -> {
-                d(TAG, "User agent login flow being triggered")
+                d(TAG, "Web server or user agent login flow triggered")
                 webviewHelper?.loadLoginPage()
             }
         }
@@ -325,12 +324,10 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * @return True if certificate based authentication flow should be used and
      * false otherwise
      */
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected fun shouldUseCertBasedAuth(): Boolean =
+    protected open fun shouldUseCertBasedAuth(): Boolean =
         getRuntimeConfig(this).getBoolean(RequireCertAuth)
 
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected fun getOAuthWebviewHelper(
+    protected open fun getOAuthWebviewHelper(
         callback: OAuthWebviewHelperEvents,
         loginOptions: LoginOptions,
         webView: WebView,
@@ -366,8 +363,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * @return true if the fix was applied and false if the key code was not
      * handled
      */
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected fun fixBackButtonBehavior(keyCode: Int) =
+    protected open fun fixBackButtonBehavior(keyCode: Int) =
         when (keyCode) {
             KEYCODE_BACK -> {
                 handleBackBehavior()
@@ -450,8 +446,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * reload the login page.
      * @param v The view that was clicked
      */
-    @Suppress("MemberVisibilityCanBePrivate")
-    fun onClearCookiesClick(@Suppress("UNUSED_PARAMETER") v: View?) {
+    private fun onClearCookiesClick(@Suppress("UNUSED_PARAMETER") v: View?) {
         webviewHelper?.clearCookies()
         webviewHelper?.loadLoginPage()
     }
@@ -461,7 +456,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      *
      * @param v IDP login button
      */
-    fun onIDPLoginClick(@Suppress("UNUSED_PARAMETER") v: View?) {
+    open fun onIDPLoginClick(v: View?) {
         SalesforceSDKManager.getInstance().spManager?.kickOffSPInitiatedLoginFlow(
             this,
             SPStatusCallback()
@@ -472,8 +467,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * Called when the "reload" button is clicked to reloads the login page.
      * @param v The reload button
      */
-    @Suppress("MemberVisibilityCanBePrivate")
-    fun onReloadClick(@Suppress("UNUSED_PARAMETER") v: View?) {
+    private fun onReloadClick(@Suppress("UNUSED_PARAMETER") v: View?) {
         webviewHelper?.loadLoginPage()
     }
 
@@ -482,8 +476,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * activity.
      * @param v The pick server button
      */
-    @Suppress("MemberVisibilityCanBePrivate")
-    fun onPickServerClick(@Suppress("UNUSED_PARAMETER") v: View?) {
+    private fun onPickServerClick(@Suppress("UNUSED_PARAMETER") v: View?) {
         Intent(this, ServerPickerActivity::class.java).also { intent ->
             startActivityForResult(
                 intent,
@@ -554,7 +547,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         }
     }
 
-    fun presentBiometric() {
+    internal fun presentBiometric() {
         val biometricPrompt = biometricPrompt
         val biometricManager = BiometricManager.from(this)
         when (biometricManager.canAuthenticate(authenticators)) {
@@ -659,8 +652,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
                 .build()
         }
 
-    fun onBioAuthClick(@Suppress("UNUSED_PARAMETER") view: View?) =
-        presentBiometric()
+    open fun onBioAuthClick(view: View?) = presentBiometric()
 
     companion object {
         const val PICK_SERVER_REQUEST_CODE = 10

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -446,7 +446,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * reload the login page.
      * @param v The view that was clicked
      */
-    private fun onClearCookiesClick(@Suppress("UNUSED_PARAMETER") v: View?) {
+    open fun onClearCookiesClick(v: View?) {
         webviewHelper?.clearCookies()
         webviewHelper?.loadLoginPage()
     }
@@ -476,7 +476,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * activity.
      * @param v The pick server button
      */
-    private fun onPickServerClick(@Suppress("UNUSED_PARAMETER") v: View?) {
+    open fun onPickServerClick(v: View?) {
         Intent(this, ServerPickerActivity::class.java).also { intent ->
             startActivityForResult(
                 intent,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -494,8 +494,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
             }.getOrDefault(false)
         }
 
-    @Suppress("MemberVisibilityCanBePrivate")
-    protected val oAuthClientId: String
+    protected open val oAuthClientId: String
         get() = loginOptions.oauthClientId
 
     @Suppress("MemberVisibilityCanBePrivate")

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -275,7 +275,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
     var shouldReloadPage: Boolean = false
         private set
 
-    fun saveState(outState: Bundle) {
+    internal fun saveState(outState: Bundle) {
         val accountOptions = accountOptions
 
         webView?.saveState(outState)
@@ -288,10 +288,10 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         }
     }
 
-    fun clearCookies() =
+    open fun clearCookies() =
         CookieManager.getInstance().removeAllCookies(null)
 
-    fun clearView() =
+    internal fun clearView() =
         webView?.loadUrl("about:blank")
 
     /**
@@ -299,14 +299,14 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
      * needed.
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    protected fun makeWebViewClient() = AuthWebViewClient()
+    protected open fun makeWebViewClient() = AuthWebViewClient()
 
     /**
      * A factory method for the web Chrome client. This can be overridden as
      * needed
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    protected fun makeWebChromeClient() = WebChromeClient()
+    protected open fun makeWebChromeClient() = WebChromeClient()
 
     /**
      * A callback when the user facing part of the authentication flow completed
@@ -318,7 +318,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
      * @param errorDesc The error description
      * @param e The exception
      */
-    fun onAuthFlowError(
+    internal fun onAuthFlowError(
         error: String,
         errorDesc: String?,
         e: Throwable?
@@ -365,7 +365,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
-    protected fun showError(exception: Throwable) {
+    protected open fun showError(exception: Throwable) {
         makeText(
             context,
             context.getString(
@@ -380,7 +380,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
      * Reloads the authorization page in the web view.  Also, updates the window
      * title so it's easier to identify the login system.
      */
-    fun loadLoginPage() = loginOptions.let { loginOptions ->
+    internal fun loadLoginPage() = loginOptions.let { loginOptions ->
         when {
             isEmpty(loginOptions.jwt) -> {
                 loginOptions.loginUrl = this@OAuthWebviewHelper.loginUrl
@@ -499,7 +499,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         get() = loginOptions.oauthClientId
 
     @Suppress("MemberVisibilityCanBePrivate")
-    protected fun getAuthorizationUrl(
+    protected open fun getAuthorizationUrl(
         useWebServerAuthentication: Boolean,
         useHybridAuthentication: Boolean
     ): URI {
@@ -551,11 +551,11 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
      * See the OAuth docs for the complete list of valid values
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    protected val authorizationDisplayType
+    protected open val authorizationDisplayType
         get() = context.getString(oauth_display_type)
 
     /** Override to customize the login url */
-    protected val loginUrl: String?
+    protected open val loginUrl: String?
         get() = SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer?.url?.run {
             trim { it <= ' ' }
         }
@@ -565,7 +565,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
      * URL.  That redirect marks the end of the user facing portion of the
      * authentication flow.
      */
-    protected inner class AuthWebViewClient : WebViewClient() {
+    protected open inner class AuthWebViewClient : WebViewClient() {
 
         override fun onPageFinished(
             view: WebView,
@@ -716,14 +716,14 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
      * successfully. The last step is to call the identity service to get the
      * username.
      */
-    fun onAuthFlowComplete(tr: TokenEndpointResponse?, nativeLogin: Boolean = false) {
+    open fun onAuthFlowComplete(tr: TokenEndpointResponse?, nativeLogin: Boolean = false) {
         d(TAG, "token response -> $tr")
         CoroutineScope(IO).launch {
             FinishAuthTask().execute(tr, nativeLogin)
         }
     }
 
-    fun onWebServerFlowComplete(code: String?) =
+    internal fun onWebServerFlowComplete(code: String?) =
         CoroutineScope(IO).launch {
             doCodeExchangeEndpoint(code)
         }
@@ -1142,7 +1142,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         return salesforceHosts.map { host.endsWith(it) }.any() { it }
     }
 
-    protected fun addAccount(account: UserAccount?) {
+    private fun addAccount(account: UserAccount?) {
         val clientManager = ClientManager(
             context,
             SalesforceSDKManager.getInstance().accountType,
@@ -1237,7 +1237,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
      * The name to be shown for account in Settings -> Accounts & Sync
      * @return name to be shown for account in Settings -> Accounts & Sync
      */
-    protected fun buildAccountName(
+    protected open fun buildAccountName(
         username: String?,
         instanceServer: String?
     ) = String.format(

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/app/PublicOverrideTests.kt
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/app/PublicOverrideTests.kt
@@ -1,0 +1,22 @@
+package com.salesforce.androidsdk.phonegap.app
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class PublicOverrideTests {
+    @Test
+    fun overrideSalesforceDroidGapActivity() {
+        class Override : SalesforceDroidGapActivity() {
+            override val unauthenticatedStartPage: String
+                get() = ""
+        }
+
+        // Instantiate to ensure this compiles.
+        Override()
+    }
+}

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/app/PublicOverrideTests.kt
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/app/PublicOverrideTests.kt
@@ -2,6 +2,7 @@ package com.salesforce.androidsdk.phonegap.app
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
 import com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,7 +17,9 @@ class PublicOverrideTests {
                 get() = ""
         }
 
-        // Instantiate to ensure this compiles.
-        Override()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            // Instantiate to ensure this compiles.
+            Override()
+        }
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PublicOverridesTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PublicOverridesTest.kt
@@ -1,0 +1,108 @@
+@file:Suppress("DEPRECATION")
+
+package com.salesforce.androidsdk.app
+
+import android.accounts.Account
+import android.app.Activity
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.accounts.UserAccountManager
+import com.salesforce.androidsdk.auth.OAuth2
+import com.salesforce.androidsdk.config.LoginServerManager
+import com.salesforce.androidsdk.rest.ClientManager.LoginOptions
+import com.salesforce.androidsdk.ui.LoginActivity
+import com.salesforce.androidsdk.ui.OAuthWebviewHelper
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URI
+
+/*
+    Note: The code style in this class is bad on purpose.
+
+    The implementation of the overridden functions and properties does not matter, it is only there
+    for the sake of compilation.  What is important is the list of overrideable functions/properties
+    that the test ensures still exist, which is easier to read without multi-line declarations and
+    implementations.
+ */
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+internal class PublicOverridesTest {
+    private val context = InstrumentationRegistry.getInstrumentation().context
+    private val callback = object : OAuthWebviewHelper.OAuthWebviewHelperEvents {
+        override fun loadingLoginPage(loginUrl: String) {}
+        override fun onAccountAuthenticatorResult(authResult: Bundle) {}
+        override fun finish(userAccount: UserAccount?) {}
+    }
+    private val loginOptions = LoginOptions("", "", "", emptyArray<String>())
+
+    @Test
+    fun overrideOAuthWebviewHelper() {
+        class Override(context: Context, callback: OAuthWebviewHelperEvents, loginOptions: LoginOptions) : OAuthWebviewHelper(context, callback, loginOptions) {
+
+            override val authorizationDisplayType: String get() = ""
+            override val loginUrl: String get() = ""
+
+            // functions/properties below this are used by internal apps
+            override fun clearCookies() {}
+            override fun getAuthorizationUrl(useWebServerAuthentication: Boolean, useHybridAuthentication: Boolean): URI { return URI("") }
+            override fun buildAccountName(username: String?, instanceServer: String?): String { return "" }
+            override fun makeWebChromeClient(): WebChromeClient { return WebChromeClient() }
+            override fun makeWebViewClient(): AuthWebViewClient { return AuthWebViewClient() }
+            override fun onAuthFlowComplete(tr: OAuth2.TokenEndpointResponse?, nativeLogin: Boolean) { }
+            @Suppress("unused")
+            private inner class TestClient: AuthWebViewClient()
+        }
+
+        // Instantiate to ensure this compiles.
+        Override(context, callback, loginOptions)
+    }
+
+    @Test
+    fun overrideLoginActivity() {
+        class Override : LoginActivity() {
+            override fun certAuthOrLogin() { }
+            override fun shouldUseCertBasedAuth(): Boolean { return  true }
+            override fun getOAuthWebviewHelper(callback: OAuthWebviewHelper.OAuthWebviewHelperEvents, loginOptions: LoginOptions, webView: WebView, savedInstanceState: Bundle?): OAuthWebviewHelper { return OAuthWebviewHelper(this, callback, loginOptions, webView, savedInstanceState) }
+            override fun onIDPLoginClick(v: View?) { }
+            override fun onBioAuthClick(view: View?) { }
+        }
+
+        // Instantiate to ensure this compiles.
+        Override()
+    }
+
+    @Test
+    fun overrideSalesforceSDKManager() {
+        class Override(context: Context, mainActivity: Class<out Activity>) : SalesforceSDKManager(context, mainActivity) {
+            override fun shouldLogoutWhenTokenRevoked(): Boolean { return false }
+            override val appDisplayString: String get() = ""
+            override fun cleanUp(userAccount: UserAccount?) { }
+            override fun startLoginPage() { }
+            override fun getUserAgent(qualifier: String): String { return "" }
+            override fun compactScreen(activity: Activity): Boolean { return true }
+
+            // functions/properties below this are used by internal apps
+            override var isBrowserLoginEnabled = false
+            override val userAccountManager: UserAccountManager get() = super.userAccountManager
+            override fun isDevSupportEnabled(): Boolean { return false }
+            override val loginOptions: LoginOptions get() = super.loginOptions
+            override fun getLoginOptions(jwt: String?, url: String?): LoginOptions { return loginOptions }
+            override fun logout(frontActivity: Activity?, showLoginPage: Boolean) { }
+            override fun logout(account: Account?, frontActivity: Activity?, showLoginPage: Boolean) { }
+            override val loginServerManager: LoginServerManager get() = super.loginServerManager
+            override fun setViewNavigationVisibility(activity: Activity) { }
+            override fun onAppBackgrounded() { }
+            override fun onAppForegrounded() { }
+        }
+
+        // Instantiate to ensure this compiles.
+        Override()
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PublicOverridesTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PublicOverridesTest.kt
@@ -6,6 +6,7 @@ import android.accounts.Account
 import android.app.Activity
 import android.content.Context
 import android.os.Bundle
+import android.view.Menu
 import android.view.View
 import android.webkit.WebChromeClient
 import android.webkit.WebView
@@ -56,6 +57,7 @@ internal class PublicOverridesTest {
             override fun makeWebChromeClient(): WebChromeClient { return WebChromeClient() }
             override fun makeWebViewClient(): AuthWebViewClient { return AuthWebViewClient() }
             override fun onAuthFlowComplete(tr: OAuth2.TokenEndpointResponse?, nativeLogin: Boolean) { }
+            override val oAuthClientId: String get() = super.oAuthClientId
             @Suppress("unused")
             private inner class TestClient: AuthWebViewClient()
         }
@@ -67,11 +69,16 @@ internal class PublicOverridesTest {
     @Test
     fun overrideLoginActivity() {
         class Override : LoginActivity() {
-            override fun certAuthOrLogin() { }
             override fun shouldUseCertBasedAuth(): Boolean { return  true }
-            override fun getOAuthWebviewHelper(callback: OAuthWebviewHelper.OAuthWebviewHelperEvents, loginOptions: LoginOptions, webView: WebView, savedInstanceState: Bundle?): OAuthWebviewHelper { return OAuthWebviewHelper(this, callback, loginOptions, webView, savedInstanceState) }
             override fun onIDPLoginClick(v: View?) { }
             override fun onBioAuthClick(view: View?) { }
+
+            // functions/properties below this are used by internal apps
+            override fun fixBackButtonBehavior(keyCode: Int): Boolean { return false }
+            override fun certAuthOrLogin() { }
+            override fun getOAuthWebviewHelper(callback: OAuthWebviewHelper.OAuthWebviewHelperEvents, loginOptions: LoginOptions, webView: WebView, savedInstanceState: Bundle?): OAuthWebviewHelper { return OAuthWebviewHelper(this, callback, loginOptions, webView, savedInstanceState) }
+            override fun onPickServerClick(v: View?) { }
+            override fun onClearCookiesClick(v: View?) { }
         }
 
         InstrumentationRegistry.getInstrumentation().runOnMainSync {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PublicOverridesTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PublicOverridesTest.kt
@@ -74,8 +74,10 @@ internal class PublicOverridesTest {
             override fun onBioAuthClick(view: View?) { }
         }
 
-        // Instantiate to ensure this compiles.
-        Override()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            // Instantiate to ensure this compiles.
+            Override()
+        }
     }
 
     @Test


### PR DESCRIPTION
Classes covered:
- SalesforceSDKManager
- SalesforceDroidGapActivity
- LoginActivity
- OAuthWebviewHelper