### PR TITLE
Using cordova.js from cordova-android 12.0.1

### DIFF
--- a/external/cordova/cordova.js
+++ b/external/cordova/cordova.js
@@ -19,7 +19,7 @@
  under the License.
 */
 ;(function() {
-var PLATFORM_VERSION_BUILD_LABEL = '11.0.0';
+var PLATFORM_VERSION_BUILD_LABEL = '12.0.1';
 // file: src/scripts/require.js
 var require;
 var define;


### PR DESCRIPTION
The cordova.js in the android repo is only used by our hybrid tests.
We have not updated the file since cordova-android 11.0.0 (now we are at cordova-android 12.0.1).
Fortunately, nothing changed in that file except the version number.