### PR TITLE
@W-15061223: [Android] Add additional native login feature: forgot password

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -641,7 +641,7 @@ internal class NativeLoginManager(
     )
 
     /**
-     * Generates either the reCAPTCHA token parameter for non- enterprise
+     * Generates either the reCAPTCHA token parameter for non-enterprise
      * reCAPTCHA configurations or the reCAPTCHA event parameter for enterprise
      * reCAPTCHA configurations.
      * @param reCaptchaToken A reCAPTCHA token provided by the reCAPTCHA SDK

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -286,7 +286,7 @@ internal class NativeLoginManager(
                 username = trimmedUsername
             ).toJson()
         }.onFailure { e ->
-            SalesforceSDKLogger.e(TAG, "Cannot JSON encode OTP request body due to an encoding error with message '${e.message}'.", e)
+            SalesforceSDKLogger.e(TAG, "Cannot JSON encode start password reset request body due to an encoding error with message '${e.message}'.", e)
             return UnknownError
         }.getOrNull()
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -376,7 +376,7 @@ internal class NativeLoginManager(
     // endregion
     // region Salesforce Identity API Headless, Password-Less Login Via One-Time-Passcode
 
-    override suspend fun startPasswordLessAuthorization(
+    override suspend fun submitOtpRequest(
         username: String,
         reCaptchaToken: String,
         otpVerificationMethod: OtpVerificationMethod
@@ -395,7 +395,7 @@ internal class NativeLoginManager(
         )
         // Generate the start password-less login request body.
         val startPasswordLessLoginRequestBodyString = runCatching {
-            StartPasswordLessLoginRequestBody(
+            OtpRequestBody(
                 recaptcha = reCaptchaParameterGenerationResult.nonEnterpriseReCaptchaToken,
                 recaptchaevent = reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
                 username = trimmedUsername,
@@ -439,21 +439,7 @@ internal class NativeLoginManager(
         }
     }
 
-    @Deprecated(
-        "The replacement function provided in 12.1.0 uses a more consistent naming convention.",
-        ReplaceWith("submitStartPasswordLessAuthorizationRequest(username, reCaptchaToken, otpVerificationMethod)")
-    )
-    override suspend fun submitOtpRequest(
-        username: String,
-        reCaptchaToken: String,
-        otpVerificationMethod: OtpVerificationMethod
-    ): OtpRequestResult = startPasswordLessAuthorization(
-        username,
-        reCaptchaToken,
-        otpVerificationMethod
-    )
-
-    override suspend fun completePasswordLessAuthorization(
+    override suspend fun submitPasswordlessAuthorizationRequest(
         otp: String,
         otpIdentifier: String,
         otpVerificationMethod: OtpVerificationMethod
@@ -512,20 +498,6 @@ internal class NativeLoginManager(
         )
     }
 
-    @Deprecated(
-        "The replacement function provided in 12.1.0 uses a more consistent naming convention.",
-        ReplaceWith("submitCompletePasswordLessAuthorizationRequest(otp, otpIdentifier, otpVerificationMethod)")
-    )
-    override suspend fun submitPasswordlessAuthorizationRequest(
-        otp: String,
-        otpIdentifier: String,
-        otpVerificationMethod: OtpVerificationMethod
-    ) = completePasswordLessAuthorization(
-        otp,
-        otpIdentifier,
-        otpVerificationMethod
-    )
-
     /**
      * A data class for the start password reset request body.
      * @param recaptcha The reCAPTCHA token provided by the reCAPTCHA Android
@@ -578,7 +550,7 @@ internal class NativeLoginManager(
      * @param verificationMethod The OTP verification code's delivery method in
      * "email" or "sms"
      */
-    private data class StartPasswordLessLoginRequestBody(
+    private data class OtpRequestBody(
         val recaptcha: String?,
         val recaptchaevent: ReCaptchaEventRequestParameter?,
         val username: String,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -46,6 +46,7 @@ import com.salesforce.androidsdk.auth.OAuth2.CODE_VERIFIER
 import com.salesforce.androidsdk.auth.OAuth2.GRANT_TYPE
 import com.salesforce.androidsdk.auth.OAuth2.HYBRID_AUTH_CODE
 import com.salesforce.androidsdk.auth.OAuth2.OAUTH_AUTH_PATH
+import com.salesforce.androidsdk.auth.OAuth2.OAUTH_ENDPOINT_HEADLESS_FORGOT_PASSWORD
 import com.salesforce.androidsdk.auth.OAuth2.OAUTH_ENDPOINT_HEADLESS_INIT_PASSWORDLESS_LOGIN
 import com.salesforce.androidsdk.auth.OAuth2.OAUTH_TOKEN_PATH
 import com.salesforce.androidsdk.auth.OAuth2.REDIRECT_URI
@@ -123,13 +124,8 @@ internal class NativeLoginManager(
         val trimmedUsername = username.trim()
         val trimmedPassword = password.trim()
 
-        if (!isValidUsername(trimmedUsername)) {
-            return InvalidUsername
-        }
-
-        if (!isValidPassword(trimmedPassword)) {
-            return InvalidPassword
-        }
+        trimmedUsername.mapInvalidUsernameToResult()?.let { return it }
+        trimmedPassword.mapInvalidPasswordToResult()?.let { return it }
 
         val encodedCreds = generateColonConcatenatedBase64String(
             value1 = trimmedUsername,
@@ -270,108 +266,194 @@ internal class NativeLoginManager(
         return requestBodyString.toRequestBody(mediaType)
     }
 
-    // region Headless, Password-Less Login Via One-Time-Passcode
+    // region Salesforce Identity API Headless Forgot Password Flow
 
-    override suspend fun submitOtpRequest(
+    override suspend fun startPasswordReset(
+        username: String,
+        reCaptchaToken: String,
+    ): NativeLoginResult {
+
+        // Validate parameters.
+        val trimmedUsername = username.trim()
+        trimmedUsername.mapInvalidUsernameToResult()?.let { return it }
+        val reCaptchaParameterGenerationResult = generateReCaptchaParameters(reCaptchaToken)
+
+        // Generate the start password reset request body.
+        val startPasswordResetRequestBodyString = runCatching {
+            StartPasswordResetRequestBody(
+                recaptcha = reCaptchaParameterGenerationResult.nonEnterpriseReCaptchaToken,
+                recaptchaevent = reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
+                username = trimmedUsername
+            ).toJson()
+        }.onFailure { e ->
+            SalesforceSDKLogger.e(TAG, "Cannot JSON encode OTP request body due to an encoding error with message '${e.message}'.", e)
+            return UnknownError
+        }.getOrNull()
+
+        // Create the start password reset request.
+        val startPasswordResetRequest = RestRequest(
+            POST,
+            LOGIN,
+            "$loginUrl$OAUTH_ENDPOINT_HEADLESS_FORGOT_PASSWORD",
+            startPasswordResetRequestBodyString,
+            null
+        )
+
+        // Submit the start password reset request and fetch the response.
+        val startPasswordResetResponse = suspendedRestCall(startPasswordResetRequest) ?: return UnknownError
+
+        // React to the start password reset response.
+        return when (startPasswordResetResponse.isSuccess) {
+            true -> {
+                startPasswordResetResponse.consumeQuietly()
+                Success
+            }
+
+            else -> {
+                SalesforceSDKLogger.e(
+                    TAG,
+                    "Cannot start password reset as the Salesforce Identity API returned an unsuccessful HTTP status. '${startPasswordResetResponse.asString()}'"
+                )
+                UnknownError
+            }
+        }
+    }
+
+    override suspend fun completePasswordReset(
+        username: String,
+        otp: String,
+        newPassword: String
+    ): NativeLoginResult {
+
+        // Validate parameters.
+        val trimmedUsername = username.trim()
+        trimmedUsername.mapInvalidUsernameToResult()?.let { return it }
+        val trimmedNewPassword = newPassword.trim()
+        trimmedNewPassword.mapInvalidPasswordToResult()?.let { return it }
+        val trimmedOtp = otp.trim()
+
+        // Generate the complete password reset request body.
+        val completePasswordResetRequestBodyString = runCatching {
+            CompletePasswordResetRequestBody(
+                username = trimmedUsername,
+                otp = trimmedOtp,
+                newPassword = newPassword
+            ).toJson()
+        }.onFailure { e ->
+            SalesforceSDKLogger.e(TAG, "Cannot JSON encode complete password reset request body due to an encoding error with message '${e.message}'.", e)
+            return UnknownError
+        }.getOrNull()
+
+        // Create the complete password reset request.
+        val completePasswordResetRequest = RestRequest(
+            POST,
+            LOGIN,
+            "$loginUrl$OAUTH_ENDPOINT_HEADLESS_FORGOT_PASSWORD",
+            completePasswordResetRequestBodyString,
+            null
+        )
+
+        // Submit the complete password reset request and fetch the response.
+        val completePasswordResetResponse = suspendedRestCall(completePasswordResetRequest) ?: return UnknownError
+
+        // React to the complete password reset response.
+        return when (completePasswordResetResponse.isSuccess) {
+            true -> {
+                completePasswordResetResponse.consumeQuietly()
+                Success
+            }
+
+            else -> {
+                SalesforceSDKLogger.e(
+                    TAG,
+                    "Cannot complete password reset as the Salesforce Identity API returned an unsuccessful HTTP status. '${completePasswordResetResponse.asString()}'"
+                )
+                UnknownError
+            }
+        }
+    }
+
+    // endregion
+    // region Salesforce Identity API Headless, Password-Less Login Via One-Time-Passcode
+
+    override suspend fun startPasswordLessAuthorization(
         username: String,
         reCaptchaToken: String,
         otpVerificationMethod: OtpVerificationMethod
     ): OtpRequestResult {
 
         // Validate parameters.
-        if (!isValidUsername(username.trim())) {
-            return OtpRequestResult(InvalidUsername)
-        }
-        val reCaptchaSiteKeyId = when {
-            reCaptchaSiteKeyId == null -> {
-                SalesforceSDKLogger.e(TAG, "A reCAPTCHA site key wasn't and must be provided when using enterprise reCAPATCHA.")
-                return OtpRequestResult(UnknownError)
-            }
+        val trimmedUsername = username.trim()
+        trimmedUsername.mapInvalidUsernameToResult()?.let { return OtpRequestResult(it) }
+        val reCaptchaParameterGenerationResult = generateReCaptchaParameters(reCaptchaToken)
 
-            else -> reCaptchaSiteKeyId
-        }
-        val googleCloudProjectId = when {
-            googleCloudProjectId == null -> {
-                SalesforceSDKLogger.e(TAG, "A Google Cloud project id wasn't and must be provided when using enterprise reCAPATCHA.")
-                return OtpRequestResult(nativeLoginResult = UnknownError)
-            }
-
-            else -> googleCloudProjectId
-        }
-
-        /*
-         * Create the OTP request body with the provided parameters. Note: The
-         * `emailtemplate` parameter isn't supported here, but could be added in
-         * the future.
-         */
-        // Determine the reCAPTCHA parameter for non-enterprise reCAPTCHA
-        val reCaptchaParameter = when {
-            isReCaptchaEnterprise -> null
-            else -> reCaptchaToken
-        }
-        // Determine the reCAPTCHA "event" parameter for enterprise reCAPTCHA
-        val reCaptchaEventParameter = when {
-            isReCaptchaEnterprise -> OtpRequestBodyReCaptchaEvent(
-                token = reCaptchaToken,
-                siteKey = reCaptchaSiteKeyId,
-                projectId = googleCloudProjectId
-            )
-
-            else -> null
-        }
         // Determine the OTP verification method.
         val otpVerificationMethodString = otpVerificationMethod.identityApiAuthVerificationTypeHeaderValue
-        // Determine the OTP request headers.
-        val otpRequestHeaders = hashMapOf(
+        // Determine the start password-less login request headers.
+        val startPasswordLessLoginRequestHeaders = hashMapOf(
             CONTENT_TYPE_HEADER_NAME to CONTENT_TYPE_VALUE_APPLICATION_JSON,
         )
-        // Generate the OTP request body.
-        val requestBodyString = runCatching {
-            OtpRequestBody(
-                recaptcha = reCaptchaParameter,
-                recaptchaevent = reCaptchaEventParameter,
-                username = username,
+        // Generate the start password-less login request body.
+        val startPasswordLessLoginRequestBodyString = runCatching {
+            StartPasswordLessLoginRequestBody(
+                recaptcha = reCaptchaParameterGenerationResult.nonEnterpriseReCaptchaToken,
+                recaptchaevent = reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
+                username = trimmedUsername,
                 verificationMethod = otpVerificationMethodString
             ).toJson()
         }.onFailure { e ->
-            SalesforceSDKLogger.e(TAG, "Cannot JSON encode OTP request body due to an encoding error with message '${e.message}'.", e)
+            SalesforceSDKLogger.e(TAG, "Cannot JSON encode start password-less login request body due to an encoding error with message '${e.message}'.", e)
             return OtpRequestResult(nativeLoginResult = UnknownError)
         }.getOrNull()
 
-        // Create the OTP request.
-        val otpRequest = RestRequest(
+        // Create the start password-less login request.
+        val startPasswordLessLoginRequest = RestRequest(
             POST,
             LOGIN,
             "$loginUrl$OAUTH_ENDPOINT_HEADLESS_INIT_PASSWORDLESS_LOGIN",
-            requestBodyString,
-            otpRequestHeaders
+            startPasswordLessLoginRequestBodyString,
+            startPasswordLessLoginRequestHeaders
         )
 
-        // Submit the OTP request and fetch the OTP response.
-        val otpResponse = suspendedRestCall(otpRequest) ?: return OtpRequestResult(nativeLoginResult = UnknownError)
+        // Submit the start password-less login request and fetch the OTP response.
+        val startPasswordLessLoginResponse = suspendedRestCall(startPasswordLessLoginRequest) ?: return OtpRequestResult(nativeLoginResult = UnknownError)
 
-        // React to the OTP response.
-        return when (otpResponse.isSuccess) {
+        // React to the start password-less login response.
+        return when (startPasswordLessLoginResponse.isSuccess) {
             true -> {
                 runCatching {
-                    // Decode the OTP response to obtain the OTP identifier.
-                    otpResponse.consumeQuietly()
-                    OtpRequestResult(Success, otpResponse.asJSONObject().get("identifier").toString())
+                    // Decode the start password-less login response to obtain the OTP identifier.
+                    startPasswordLessLoginResponse.consumeQuietly()
+                    OtpRequestResult(Success, startPasswordLessLoginResponse.asJSONObject().get("identifier").toString())
                 }.getOrElse { e ->
-                    SalesforceSDKLogger.e(TAG, "Cannot JSON decode OTP response body due to a decoding error with message '${e.message}'.")
-                    otpResponse.consumeQuietly()
+                    SalesforceSDKLogger.e(TAG, "Cannot JSON decode start password-less login response body due to a decoding error with message '${e.message}'.")
+                    startPasswordLessLoginResponse.consumeQuietly()
                     OtpRequestResult(UnknownError)
                 }
             }
 
             else -> {
-                SalesforceSDKLogger.e(TAG, "OTP request failure.")
+                SalesforceSDKLogger.e(TAG, "Start password-less login request failure.")
                 OtpRequestResult(UnknownError)
             }
         }
     }
 
-    override suspend fun submitPasswordlessAuthorizationRequest(
+    @Deprecated(
+        "The replacement function provided in 12.1.0 uses a more consistent naming convention.",
+        ReplaceWith("submitStartPasswordLessAuthorizationRequest(username, reCaptchaToken, otpVerificationMethod)")
+    )
+    override suspend fun submitOtpRequest(
+        username: String,
+        reCaptchaToken: String,
+        otpVerificationMethod: OtpVerificationMethod
+    ): OtpRequestResult = startPasswordLessAuthorization(
+        username,
+        reCaptchaToken,
+        otpVerificationMethod
+    )
+
+    override suspend fun completePasswordLessAuthorization(
         otp: String,
         otpIdentifier: String,
         otpVerificationMethod: OtpVerificationMethod
@@ -430,23 +512,78 @@ internal class NativeLoginManager(
         )
     }
 
+    @Deprecated(
+        "The replacement function provided in 12.1.0 uses a more consistent naming convention.",
+        ReplaceWith("submitCompletePasswordLessAuthorizationRequest(otp, otpIdentifier, otpVerificationMethod)")
+    )
+    override suspend fun submitPasswordlessAuthorizationRequest(
+        otp: String,
+        otpIdentifier: String,
+        otpVerificationMethod: OtpVerificationMethod
+    ) = completePasswordLessAuthorization(
+        otp,
+        otpIdentifier,
+        otpVerificationMethod
+    )
+
     /**
-     * A data class for the OTP request body.
+     * A data class for the start password reset request body.
      * @param recaptcha The reCAPTCHA token provided by the reCAPTCHA Android
      * SDK.  This is not used with reCAPTCHA Enterprise
      * @param recaptchaevent The reCAPTCHA parameters for use with reCAPTCHA
      * Enterprise
-     * @param username The Salesforce username
+     * @param username A valid Salesforce username.  Note that email may be used
+     * for community users
+     */
+    private data class StartPasswordResetRequestBody(
+        val recaptcha: String?,
+        val recaptchaevent: ReCaptchaEventRequestParameter?,
+        val username: String
+    ) {
+        fun toJson() = JSONObject().apply {
+            put("recaptcha", recaptcha)
+            put("recaptchaevent", recaptchaevent?.toJson())
+            put("username", username)
+        }
+    }
+
+    /**
+     * A data class for the complete reset password OTP request body.
+     * @param username A valid Salesforce username.  Note that email may be used
+     * for community users
+     * @param otp The user-entered one-time-password previously delivered to the
+     * user by the Salesforce Identity API forgot password endpoint
+     * @param newPassword The user-entered new password
+     */
+    private data class CompletePasswordResetRequestBody(
+        val username: String,
+        val otp: String,
+        val newPassword: String
+    ) {
+        fun toJson() = JSONObject().apply {
+            put("username", username)
+            put("otp", otp)
+            put("newpassword", newPassword)
+        }
+    }
+
+    /**
+     * A data class for the start password-less login request body.
+     * @param recaptcha The reCAPTCHA token provided by the reCAPTCHA Android
+     * SDK.  This is not used with reCAPTCHA Enterprise
+     * @param recaptchaevent The reCAPTCHA parameters for use with reCAPTCHA
+     * Enterprise
+     * @param username A valid Salesforce username.  Note that email may be used
+     * for community users
      * @param verificationMethod The OTP verification code's delivery method in
      * "email" or "sms"
      */
-    private data class OtpRequestBody(
+    private data class StartPasswordLessLoginRequestBody(
         val recaptcha: String?,
-        val recaptchaevent: OtpRequestBodyReCaptchaEvent?,
+        val recaptchaevent: ReCaptchaEventRequestParameter?,
         val username: String,
         val verificationMethod: String
     ) {
-        // TODO: Inquire regarding modern JSON serialization in MSDK. ECJ20240317
         fun toJson() = JSONObject().apply {
             put("recaptcha", recaptcha)
             put("recaptchaevent", recaptchaevent?.toJson())
@@ -456,7 +593,8 @@ internal class NativeLoginManager(
     }
 
     /**
-     * A data class for the OTP request body's reCAPTCHA event parameter.
+     * A data class for the Salesforce Identity API request body reCAPTCHA event
+     * parameters.
      * @param token The reCAPTCHA token provided by the reCAPTCHA Android SDK.
      * This is used only with reCAPTCHA Enterprise
      * @param siteKey The Google Cloud project reCAPTCHA Key's "Id" as shown in
@@ -469,7 +607,7 @@ internal class NativeLoginManager(
      * @param projectId The Google Cloud project's "Id" as shown in Google Cloud
      * Console
      */
-    private data class OtpRequestBodyReCaptchaEvent(
+    private data class ReCaptchaEventRequestParameter(
         val token: String,
         val siteKey: String,
         val expectedAction: String = "login",
@@ -500,6 +638,70 @@ internal class NativeLoginManager(
     ) = encodeToString(
         "$value1:$value2".toByteArray(),
         URL_SAFE or NO_WRAP or NO_PADDING
+    )
+
+    /**
+     * Generates either the reCAPTCHA token parameter for non- enterprise
+     * reCAPTCHA configurations or the reCAPTCHA event parameter for enterprise
+     * reCAPTCHA configurations.
+     * @param reCaptchaToken A reCAPTCHA token provided by the reCAPTCHA SDK
+     * @return The reCAPTCHA parameter generation result with exactly one of the
+     * non-enterprise reCAPTCHA parameter, enterprise reCAPTCHA parameter or
+     * a native login result for generation failure
+     */
+    private fun generateReCaptchaParameters(
+        reCaptchaToken: String
+    ): ReCaptchaParameterGenerationResult {
+
+        // Validate state.
+        val reCaptchaSiteKeyId = when {
+            reCaptchaSiteKeyId == null -> {
+                SalesforceSDKLogger.e(TAG, "A reCAPTCHA site key wasn't and must be provided when using enterprise reCAPATCHA.")
+                return ReCaptchaParameterGenerationResult(result = UnknownError)
+            }
+
+            else -> reCaptchaSiteKeyId
+        }
+        val googleCloudProjectId = when {
+            googleCloudProjectId == null -> {
+                SalesforceSDKLogger.e(TAG, "A Google Cloud project id wasn't and must be provided when using enterprise reCAPATCHA.")
+                return ReCaptchaParameterGenerationResult(result = UnknownError)
+            }
+
+            else -> googleCloudProjectId
+        }
+
+        // Generate the Salesforce Identity API reCAPTCHA request parameters.
+        return ReCaptchaParameterGenerationResult(
+            nonEnterpriseReCaptchaToken = when {
+                isReCaptchaEnterprise -> null
+                else -> reCaptchaToken
+            },
+            enterpriseReCaptchaEvent = when {
+                isReCaptchaEnterprise -> ReCaptchaEventRequestParameter(
+                    token = reCaptchaToken,
+                    siteKey = reCaptchaSiteKeyId,
+                    projectId = googleCloudProjectId
+                )
+
+                else -> null
+            }
+        )
+    }
+
+    /**
+     * The result of generating Salesforce Identity API request reCAPTCHA
+     * parameters.
+     */
+    private data class ReCaptchaParameterGenerationResult(
+        /** The reCAPTCHA token parameter for non-enterprise reCAPTCHA */
+        val nonEnterpriseReCaptchaToken: String? = null,
+
+        /** The reCAPTCHA event parameter for enterprise reCAPTCHA */
+        val enterpriseReCaptchaEvent: ReCaptchaEventRequestParameter? = null,
+
+        /** The error native login result of the reCAPTCHA parameter generation or null for successful generation */
+        val result: NativeLoginResult? = null
     )
 
     /**
@@ -551,6 +753,32 @@ internal class NativeLoginManager(
             return InvalidCredentials
         }
     }
+
+
+    // endregion
+    // region Private String Parameter Validation
+
+    /**
+     * Validates this string is valid password.
+     * @return null for valid passwords - The invalid password login result
+     * otherwise.
+     */
+    private fun String.mapInvalidPasswordToResult() =
+        when {
+            !isValidPassword(trim()) -> InvalidPassword
+            else -> null
+        }
+
+    /**
+     * Validates this string is valid username.
+     * @return null for valid usernames - The invalid username login result
+     * otherwise.
+     */
+    private fun String.mapInvalidUsernameToResult() =
+        when {
+            !isValidUsername(trim()) -> InvalidUsername
+            else -> null
+        }
 
     // endregion
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -504,8 +504,7 @@ internal class NativeLoginManager(
      * SDK.  This is not used with reCAPTCHA Enterprise
      * @param recaptchaevent The reCAPTCHA parameters for use with reCAPTCHA
      * Enterprise
-     * @param username A valid Salesforce username.  Note that email may be used
-     * for community users
+     * @param username A valid Salesforce username or email
      */
     private data class StartPasswordResetRequestBody(
         val recaptcha: String?,
@@ -521,8 +520,7 @@ internal class NativeLoginManager(
 
     /**
      * A data class for the complete reset password OTP request body.
-     * @param username A valid Salesforce username.  Note that email may be used
-     * for community users
+     * @param username A valid Salesforce username or email
      * @param otp The user-entered one-time-password previously delivered to the
      * user by the Salesforce Identity API forgot password endpoint
      * @param newPassword The user-entered new password
@@ -545,8 +543,7 @@ internal class NativeLoginManager(
      * SDK.  This is not used with reCAPTCHA Enterprise
      * @param recaptchaevent The reCAPTCHA parameters for use with reCAPTCHA
      * Enterprise
-     * @param username A valid Salesforce username.  Note that email may be used
-     * for community users
+     * @param username A valid Salesforce username or email
      * @param verificationMethod The OTP verification code's delivery method in
      * "email" or "sms"
      */

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -141,6 +141,9 @@ public class OAuth2 {
     /** Endpoint path for Salesforce Identity API initialize headless, password-less login flow */
     protected static String OAUTH_ENDPOINT_HEADLESS_INIT_PASSWORDLESS_LOGIN = "/services/auth/headless/init/passwordless/login";
 
+    /** Endpoint path for Salesforce Identity API headless forgot password flow */
+    protected static String OAUTH_ENDPOINT_HEADLESS_FORGOT_PASSWORD = "/services/auth/headless/forgot_password";
+
     private static final String OAUTH_DISPLAY_PARAM = "?display=";
     protected static final String OAUTH_TOKEN_PATH = "/services/oauth2/token";
     private static final String OAUTH_REVOKE_PATH = "/services/oauth2/revoke?token=";

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
@@ -72,12 +72,55 @@ interface NativeLoginManager {
      */
     fun getFallbackWebAuthenticationIntent(): Intent
 
-    // region Headless, Password-Less Login Via One-Time-Passcode
+    // region Salesforce Identity API Headless Forgot Password Flow
 
     /**
-     * Submits a request for a one-time-passcode to the Salesforce headless
-     * password-less login flow. This fulfills step three of the headless
-     * password-less login flow.
+     * Submits a request to start a password reset to the Salesforce Identity
+     * API headless forgot password flow.  This fulfills step one of the
+     * headless forgot password flow.
+     *
+     * See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_forgot_password_flow.htm&type=5
+     *
+     * @param username A valid Salesforce username.  Note that email may be used
+     * for community users
+     * @param reCaptchaToken A reCAPTCHA token provided by the reCAPTCHA SDK
+     * @return A native login result indicating success or one of several
+     * possible failures, including both in-app and Salesforce Identity API
+     * results
+     */
+    suspend fun startPasswordReset(
+        username: String,
+        reCaptchaToken: String
+    ): NativeLoginResult
+
+    /**
+     * Submits a request to complete a password reset to the Salesforce Identity
+     * API headless forgot password flow. This fulfills step four of the
+     * headless forgot password flow.
+     *
+     * See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_forgot_password_flow.htm&type=5
+     *
+     * @param username A valid Salesforce username.  Note that email may be used
+     * for community users
+     * @param otp A user-entered one-time-password
+     * @param newPassword The user-entered new password
+     * @return A native login result indicating success or one of several
+     * possible failures, including both in-app and Salesforce Identity API
+     * results
+     */
+    suspend fun completePasswordReset(
+        username: String,
+        otp: String,
+        newPassword: String
+    ): NativeLoginResult
+
+    // endregion
+    // region Salesforce Identity API Headless, Password-Less Login Via One-Time-Passcode
+
+    /**
+     * Submits a request to start password-less login via one-time-passcode to
+     * the Salesforce Identity API headless, password-less login flow. This
+     * fulfills step three of the headless, password-less login flow.
      *
      * See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_passwordless_login_public_clients.htm&type=5
      *
@@ -88,6 +131,16 @@ interface NativeLoginManager {
      * @return An OTP request result with the overall login result and the OTP
      * identifier for successful OTP requests
      */
+    suspend fun startPasswordLessAuthorization(
+        username: String,
+        reCaptchaToken: String,
+        otpVerificationMethod: OtpVerificationMethod
+    ): OtpRequestResult
+
+    @Deprecated(
+        "Use the replacement function provided in 12.1.0 for more consistent naming conventions.",
+        ReplaceWith("startPasswordLessAuthorization(username, reCaptchaToken, otpVerificationMethod)")
+    )
     suspend fun submitOtpRequest(
         username: String,
         reCaptchaToken: String,
@@ -95,20 +148,32 @@ interface NativeLoginManager {
     ): OtpRequestResult
 
     /**
-     * Submits a request for a one-time-passcode to the Salesforce headless
-     * password-less login flow. This fulfills steps eight, eleven and thirteen
-     * of the headless password-less login flow.
+     * Submits a request to complete a password-less login to the Salesforce
+     * Identity API headless, password-less login flow. This fulfills steps
+     * eight, eleven and thirteen of the headless password-less login flow.
      *
      * See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_passwordless_login_public_clients.htm&type=5
      *
-     * @param otp A user-entered OTP
-     * @param otpIdentifier The OTP identifier issued by the Headless Identity
-     * API
-     * @param otpVerificationMethod The OTP verification method used to obtain
-     * the OTP identifier
-     * @return A login result indicating the outcome of the authorization and
-     * access token requests
+     * @param otp A user-entered one-time-password
+     * @param otpIdentifier The one-time-password identifier issued by the
+     * Salesforce Identity API headless, password login flow in the start
+     * password-less authorization method.
+     * @param otpVerificationMethod The one-time-password verification method
+     * used to obtain the OTP identifier
+     * @return A native login result indicating success or one of several
+     * possible failures, including both in-app and Salesforce Identity API
+     * results
      */
+    suspend fun completePasswordLessAuthorization(
+        otp: String,
+        otpIdentifier: String,
+        otpVerificationMethod: OtpVerificationMethod
+    ): NativeLoginResult
+
+    @Deprecated(
+        "Use the replacement function provided in 12.1.0 for more consistent naming conventions.",
+        ReplaceWith("completePasswordLessAuthorization(otp, otpIdentifier, otpVerificationMethod)")
+    )
     suspend fun submitPasswordlessAuthorizationRequest(
         otp: String,
         otpIdentifier: String,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
@@ -81,8 +81,7 @@ interface NativeLoginManager {
      *
      * See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_forgot_password_flow.htm&type=5
      *
-     * @param username A valid Salesforce username.  Note that email may be used
-     * for community users
+     * @param username A valid Salesforce username or email
      * @param reCaptchaToken A reCAPTCHA token provided by the reCAPTCHA SDK
      * @return A native login result indicating success or one of several
      * possible failures, including both in-app and Salesforce Identity API
@@ -100,8 +99,7 @@ interface NativeLoginManager {
      *
      * See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_forgot_password_flow.htm&type=5
      *
-     * @param username A valid Salesforce username.  Note that email may be used
-     * for community users
+     * @param username A valid Salesforce username or email
      * @param otp A user-entered one-time-password
      * @param newPassword The user-entered new password
      * @return A native login result indicating success or one of several
@@ -124,8 +122,7 @@ interface NativeLoginManager {
      *
      * See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_passwordless_login_public_clients.htm&type=5
      *
-     * @param username A valid Salesforce username.  Note that email may be used
-     * for community users
+     * @param username A valid Salesforce username or email
      * @param reCaptchaToken A reCAPTCHA token provided by the reCAPTCHA SDK
      * @param otpVerificationMethod: The delivery method for the OTP
      * @return An OTP request result with the overall login result and the OTP

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
@@ -131,16 +131,6 @@ interface NativeLoginManager {
      * @return An OTP request result with the overall login result and the OTP
      * identifier for successful OTP requests
      */
-    suspend fun startPasswordLessAuthorization(
-        username: String,
-        reCaptchaToken: String,
-        otpVerificationMethod: OtpVerificationMethod
-    ): OtpRequestResult
-
-    @Deprecated(
-        "Use the replacement function provided in 12.1.0 for more consistent naming conventions.",
-        ReplaceWith("startPasswordLessAuthorization(username, reCaptchaToken, otpVerificationMethod)")
-    )
     suspend fun submitOtpRequest(
         username: String,
         reCaptchaToken: String,
@@ -164,16 +154,6 @@ interface NativeLoginManager {
      * possible failures, including both in-app and Salesforce Identity API
      * results
      */
-    suspend fun completePasswordLessAuthorization(
-        otp: String,
-        otpIdentifier: String,
-        otpVerificationMethod: OtpVerificationMethod
-    ): NativeLoginResult
-
-    @Deprecated(
-        "Use the replacement function provided in 12.1.0 for more consistent naming conventions.",
-        ReplaceWith("completePasswordLessAuthorization(otp, otpIdentifier, otpVerificationMethod)")
-    )
     suspend fun submitPasswordlessAuthorizationRequest(
         otp: String,
         otpIdentifier: String,


### PR DESCRIPTION
🎸 _Ready For Review_ 🥁

Here MSDK acquires the headless forgot password flow from the Salesforce Identity API.

https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_forgot_password_flow.htm&type=5

This follows the style we used for login and password-less login in 12.0.  Most of the new code should look quite familiar with the subtle exception of some new utility methods to keep reused logic from becoming redundant.