### PR TITLE
Add Logout Reason to Revoke API call.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -41,6 +41,7 @@ import androidx.annotation.Nullable;
 import com.salesforce.androidsdk.app.Features;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.AuthenticatorService;
+import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager;
 import com.salesforce.androidsdk.security.ScreenLockManager;
@@ -385,6 +386,17 @@ public class UserAccountManager {
 	}
 
 	/**
+	 * Logs the current user out.
+	 *
+	 * @param frontActivity Front activity.
+	 * @param showLoginPage True - if the login page should be shown, False - otherwise.
+	 * @param reason The reason for the logout.
+	 */
+	public void signoutCurrentUser(Activity frontActivity, boolean showLoginPage, OAuth2.LogoutReason reason) {
+		SalesforceSDKManager.getInstance().logout(null, frontActivity, showLoginPage, reason);
+	}
+
+	/**
 	 * Logs the specified user out. If the user specified is not the current
 	 * user, push notification un-registration will not take place.
 	 *
@@ -407,6 +419,20 @@ public class UserAccountManager {
 	public void signoutUser(UserAccount userAccount, Activity frontActivity, boolean showLoginPage) {
 		final Account account = buildAccount(userAccount);
 		SalesforceSDKManager.getInstance().logout(account, frontActivity, showLoginPage);
+	}
+
+	/**
+	 * Logs the specified user out. If the user specified is not the current
+	 * user, push notification un-registration will not take place.
+	 *
+	 * @param userAccount User account.
+	 * @param frontActivity Front activity.
+	 * @param showLoginPage True - if the login page should be shown, False - otherwise.
+	 * @param reason The reason for the logout.
+	 */
+	public void signoutUser(UserAccount userAccount, Activity frontActivity, boolean showLoginPage, OAuth2.LogoutReason reason) {
+		final Account account = buildAccount(userAccount);
+		SalesforceSDKManager.getInstance().logout(account, frontActivity, showLoginPage, reason);
 	}
 
 	/**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -86,6 +86,7 @@ import com.salesforce.androidsdk.auth.AuthenticatorService.KEY_INSTANCE_URL
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.auth.HttpAccess.DEFAULT
 import com.salesforce.androidsdk.auth.NativeLoginManager
+import com.salesforce.androidsdk.auth.OAuth2.LogoutReason
 import com.salesforce.androidsdk.auth.OAuth2.revokeRefreshToken
 import com.salesforce.androidsdk.auth.idp.SPConfig
 import com.salesforce.androidsdk.auth.idp.interfaces.IDPManager
@@ -817,7 +818,8 @@ open class SalesforceSDKManager protected constructor(
         loginServer: String?,
         account: Account?,
         frontActivity: Activity?,
-        isLastAccount: Boolean
+        isLastAccount: Boolean,
+        logoutReason: LogoutReason,
     ) {
         val intentFilter = IntentFilter(UNREGISTERED_ATTEMPT_COMPLETE_EVENT)
 
@@ -839,7 +841,8 @@ open class SalesforceSDKManager protected constructor(
                         refreshToken,
                         loginServer,
                         account,
-                        frontActivity
+                        frontActivity,
+                        logoutReason,
                     )
                 }
             }
@@ -871,9 +874,10 @@ open class SalesforceSDKManager protected constructor(
      * account
      */
     open fun logout(
-        /* Note: Kotlin's @JvmOverloads annotations does not generate this overload */
+        /* Note: Kotlin's @JvmOverloads annotations does not correctly
+           generate this overload due to a JVM naming conflict.         */
         frontActivity: Activity?,
-        showLoginPage: Boolean = true
+        showLoginPage: Boolean = true,
     ) {
         logout(null, frontActivity, showLoginPage)
     }
@@ -892,7 +896,34 @@ open class SalesforceSDKManager protected constructor(
     open fun logout(
         account: Account? = null,
         frontActivity: Activity?,
-        showLoginPage: Boolean = true
+        showLoginPage: Boolean = true,
+    ) {
+        logout(account, frontActivity, showLoginPage)
+    }
+
+    // Note the below overload exists because @JvmOverloads generates non-overrideable
+    // signatures for all but the overload with all params. see:
+    // https://youtrack.jetbrains.com/issue/KT-33240/Generated-overloads-for-JvmOverloads-on-open-methods-should-be-final
+    //
+    // I highly doubt any apps are overriding the above function but it is technically breaking and shouldn't be
+    // combined until Mobile SDK 13.0.  TODO: remove above method and move @JvmOverloads to below overload -- or remove open.
+
+    /**
+     * Destroys the stored authentication credentials (removes the account)
+     * and, if requested, restarts the app.
+     *
+     * @param account The user account to logout. Defaults to the current user
+     * account
+     * @param frontActivity The front activity
+     * @param showLoginPage If true, displays the login page after removing the
+     * account
+     * @param reason The reason for the logout.
+     */
+    open fun logout(
+        account: Account? = null,
+        frontActivity: Activity?,
+        showLoginPage: Boolean = true,
+        reason: LogoutReason = LogoutReason.UNKNOWN,
     ) {
         createAndStoreEvent("userLogout", null, TAG, null)
         val clientMgr = ClientManager(
@@ -941,7 +972,8 @@ open class SalesforceSDKManager protected constructor(
                 loginServer,
                 accountToLogout,
                 frontActivity,
-                numAccounts == 1
+                isLastAccount = (numAccounts == 1),
+                reason,
             )
         } else {
             removeAccount(
@@ -950,7 +982,8 @@ open class SalesforceSDKManager protected constructor(
                 refreshToken,
                 loginServer,
                 accountToLogout,
-                frontActivity
+                frontActivity,
+                reason,
             )
         }
     }
@@ -972,7 +1005,8 @@ open class SalesforceSDKManager protected constructor(
         refreshToken: String?,
         loginServer: String?,
         account: Account?,
-        frontActivity: Activity?
+        frontActivity: Activity?,
+        logoutReason: LogoutReason,
     ) {
         cleanUp(
             frontActivity,
@@ -990,7 +1024,8 @@ open class SalesforceSDKManager protected constructor(
                     revokeRefreshToken(
                         DEFAULT,
                         URI(loginServer),
-                        refreshToken
+                        refreshToken,
+                        logoutReason,
                     )
                 }.onFailure { e ->
                     w(TAG, "Revoking token failed", e)
@@ -1181,7 +1216,7 @@ open class SalesforceSDKManager protected constructor(
 
         "Logout" to object : DevActionHandler {
             override fun onSelected() {
-                logout(frontActivity = frontActivity)
+                logout(frontActivity = frontActivity, reason = LogoutReason.USER_LOGOUT)
             }
         },
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -211,7 +211,7 @@ public class OAuth2 {
         @NonNull
         @Override
         public String toString() {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ROOT);
         }
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -29,6 +29,8 @@ package com.salesforce.androidsdk.auth;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
@@ -149,7 +151,7 @@ public class OAuth2 {
 
     private static final String OAUTH_DISPLAY_PARAM = "?display=";
     protected static final String OAUTH_TOKEN_PATH = "/services/oauth2/token";
-    private static final String OAUTH_REVOKE_PATH = "/services/oauth2/revoke?token=";
+    private static final String OAUTH_REVOKE_PATH = "/services/oauth2/revoke?token=%s&revoke_reason=%s";
     private static final String LIGHTNING_DOMAIN = "lightning_domain";
     private static final String LIGHTNING_SID = "lightning_sid";
     private static final String VF_DOMAIN = "visualforce_domain";
@@ -193,6 +195,24 @@ public class OAuth2 {
         TimeZone tz = TimeZone.getTimeZone("UTC");
         TIMESTAMP_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         TIMESTAMP_FORMAT.setTimeZone(tz);
+    }
+
+    public enum LogoutReason {
+        CORRUPT_STATE,           // "Corrupted client state"
+        TOKEN_EXPIRED,           // "Refresh token expired"
+        SSDK_LOGOUT_POLICY,      // "SSDK initiated logout for policy violation"
+        TIMEOUT,                 // "Timeout while waiting for server response"
+        UNEXPECTED,              // "Unexpected error or crash"
+        UNEXPECTED_RESPONSE,     // "Unexpected response from server"
+        UNKNOWN,                 // "Unknown"
+        USER_LOGOUT,             // "User initiated logout"
+        REFRESH_TOKEN_ROTATED;   // "Refresh token rotated"
+
+        @NonNull
+        @Override
+        public String toString() {
+            return this.name().toLowerCase();
+        }
     }
 
     /**
@@ -375,12 +395,24 @@ public class OAuth2 {
      * @param httpAccessor HttpAccess instance.
      * @param loginServer Login server.
      * @param refreshToken Refresh token.
+     *
+     * @deprecated Will be removed in 13.0.  Use {@link #revokeRefreshToken(HttpAccess, URI, String, LogoutReason)} instead.
      */
     public static void revokeRefreshToken(HttpAccess httpAccessor, URI loginServer, String refreshToken) {
-        final StringBuilder sb = new StringBuilder(loginServer.toString());
-        sb.append(OAUTH_REVOKE_PATH);
-        sb.append(Uri.encode(refreshToken));
-        final Request request = new Request.Builder().url(sb.toString()).get().build();
+        revokeRefreshToken(httpAccessor, loginServer, refreshToken, LogoutReason.UNKNOWN);
+    }
+
+    /**
+     * Revokes the existing refresh token.
+     *
+     * @param httpAccessor HttpAccess instance.
+     * @param loginServer Login server.
+     * @param refreshToken Refresh token.
+     * @param reason The reason the refresh token is being revoked.
+     */
+    public static void revokeRefreshToken(HttpAccess httpAccessor, URI loginServer, String refreshToken, LogoutReason reason) {
+        final String requestPath = String.format(OAUTH_REVOKE_PATH, refreshToken, reason.toString());
+        final Request request = new Request.Builder().url(loginServer.toString() + requestPath).get().build();
         try {
             httpAccessor.getOkHttpClient().newCall(request).execute();
         } catch (IOException e) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -606,6 +606,9 @@ public class ClientManager {
                         	if (Looper.myLooper() == null) {
                                 Looper.prepare();
                         	}
+                            // Note: As of writing (2024) this call will never succeed because revoke API is an
+                            // authenticated endpoint.  However, there is no harm in attempting and the debug logs
+                            // produced may help developers better understand the state of their app.
                             SalesforceSDKManager.getInstance()
                                     .logout(null, null, false, OAuth2.LogoutReason.TOKEN_EXPIRED);
                         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -606,7 +606,8 @@ public class ClientManager {
                         	if (Looper.myLooper() == null) {
                                 Looper.prepare();
                         	}
-                            SalesforceSDKManager.getInstance().logout(null, false);
+                            SalesforceSDKManager.getInstance()
+                                    .logout(null, null, false, OAuth2.LogoutReason.TOKEN_EXPIRED);
                         }
 
                         // Broadcasts an intent that the access token has been revoked.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
@@ -34,6 +34,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.auth.OAuth2;
 
 /**
  * Displays an activity that gives the user the option to clear app data
@@ -75,7 +76,8 @@ public class ManageSpaceActivity extends AppCompatActivity {
 
         	@Override
         	public void onClick(DialogInterface dialog, int which) {
-        		SalesforceSDKManager.getInstance().logout(ManageSpaceActivity.this, false);
+        		SalesforceSDKManager.getInstance()
+						.logout(null, ManageSpaceActivity.this, false, OAuth2.LogoutReason.USER_LOGOUT);
         	}
         }).setNegativeButton(getString(R.string.sf__manage_space_logout_no),
         new DialogInterface.OnClickListener() {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
@@ -72,20 +72,8 @@ public class ManageSpaceActivity extends AppCompatActivity {
         return new AlertDialog.Builder(this)
         .setMessage(R.string.sf__manage_space_confirmation)
         .setPositiveButton(getString(R.string.sf__manage_space_logout_yes),
-        new DialogInterface.OnClickListener() {
-
-        	@Override
-        	public void onClick(DialogInterface dialog, int which) {
-        		SalesforceSDKManager.getInstance()
-						.logout(null, ManageSpaceActivity.this, false, OAuth2.LogoutReason.USER_LOGOUT);
-        	}
-        }).setNegativeButton(getString(R.string.sf__manage_space_logout_no),
-        new DialogInterface.OnClickListener() {
-
-        	@Override
-        	public void onClick(DialogInterface dialog, int which) {
-        		finish();
-        	}
-        }).create();
+                (dialog, which) -> SalesforceSDKManager.getInstance()
+                        .logout(null, ManageSpaceActivity.this, false, OAuth2.LogoutReason.USER_LOGOUT))
+						.setNegativeButton(getString(R.string.sf__manage_space_logout_no), (dialog, which) -> finish()).create();
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -90,6 +90,7 @@ import com.salesforce.androidsdk.app.Features.FEATURE_BIOMETRIC_AUTH
 import com.salesforce.androidsdk.app.Features.FEATURE_SCREEN_LOCK
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.HttpAccess.DEFAULT
+import com.salesforce.androidsdk.auth.OAuth2
 import com.salesforce.androidsdk.auth.OAuth2.IdServiceResponse
 import com.salesforce.androidsdk.auth.OAuth2.OAuthFailedException
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse
@@ -989,7 +990,8 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
                                 revokeRefreshToken(
                                     DEFAULT,
                                     uri,
-                                    duplicateUserAccount.refreshToken
+                                    duplicateUserAccount.refreshToken,
+                                    OAuth2.LogoutReason.REFRESH_TOKEN_ROTATED,
                                 )
                             }
                         }
@@ -1010,8 +1012,9 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
                                     LENGTH_LONG
                                 ).show()
                             }
+                            // This is an unexpected logout(s) because we only support one Bio Auth user.
                             instance.userAccountManager.signoutUser(
-                                existingUser, activity, false
+                                existingUser, activity, false, OAuth2.LogoutReason.UNEXPECTED
                             )
                         }
                     })

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityDelegate.java
@@ -35,6 +35,7 @@ import static androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED;
 
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.util.EventsObservable;
@@ -93,7 +94,8 @@ public class SalesforceActivityDelegate {
                 @Override
                 public void authenticatedRestClient(RestClient client) {
                     if (client == null) {
-                        SalesforceSDKManager.getInstance().logout(activity);
+                        SalesforceSDKManager.getInstance()
+                                .logout(null, activity, true, OAuth2.LogoutReason.CORRUPT_STATE);
                         return;
                     }
                     ((SalesforceActivityInterface) activity).onResume(client);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
@@ -62,6 +62,7 @@ import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.security.ScreenLockManager;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
@@ -256,7 +257,7 @@ public class ScreenLockActivity extends FragmentActivity {
                 SharedPreferences accountPrefs = ctx.getSharedPreferences(MOBILE_POLICY_PREF
                         + account.getUserLevelFilenameSuffix(), Context.MODE_PRIVATE);
                 if (accountPrefs.getBoolean(SCREEN_LOCK, false)) {
-                    manager.signoutUser(account, null);
+                    manager.signoutUser(account, null, true, OAuth2.LogoutReason.USER_LOGOUT);
                 }
             }
         }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
@@ -53,6 +53,7 @@ import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.salesforce.androidsdk.TestForceApp;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.rest.ClientManager;
 import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
 import com.salesforce.androidsdk.rest.ClientManagerTest;
@@ -216,7 +217,7 @@ public class UserAccountManagerTest {
     	createTestAccount();
     	users = userAccMgr.getAuthenticatedUsers();
         Assert.assertEquals("There should be 1 authenticated user", 1, users.size());
-    	userAccMgr.signoutCurrentUser(null);
+    	userAccMgr.signoutCurrentUser(null, true, OAuth2.LogoutReason.USER_LOGOUT);
     	eq.waitForEvent(EventType.LogoutComplete, 30000);
     	users = userAccMgr.getAuthenticatedUsers();
         Assert.assertNull("There should be no authenticated users", users);
@@ -244,7 +245,7 @@ public class UserAccountManagerTest {
                 communityId(null).communityUrl(null).firstName(null).lastName(null).displayName(null).
                 email(null).photoUrl(null).thumbnailUrl(null).additionalOauthValues(null).
                 language(TEST_LANGUAGE).locale(TEST_LOCALE).build();
-		userAccMgr.signoutUser(userAcc, null, false);
+		userAccMgr.signoutUser(userAcc, null, false, OAuth2.LogoutReason.USER_LOGOUT);
     	eq.waitForEvent(EventType.LogoutComplete, 30000);
     	users = userAccMgr.getAuthenticatedUsers();
         Assert.assertEquals("There should be 1 authenticated user", 1, users.size());

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
@@ -39,7 +39,8 @@ class NativeLoginManagerTest {
 
     @After
     fun tearDown() {
-        SalesforceSDKManager.getInstance().userAccountManager.signoutCurrentUser(null)
+        SalesforceSDKManager.getInstance().userAccountManager
+            .signoutCurrentUser(null, true, OAuth2.LogoutReason.USER_LOGOUT)
     }
 
     @Test
@@ -67,7 +68,8 @@ class NativeLoginManagerTest {
         addUserAccount()
         Assert.assertTrue("Should show back button when there is a logged in user.", mgr.shouldShowBackButton)
 
-        SalesforceSDKManager.getInstance().userAccountManager.signoutCurrentUser(null)
+        SalesforceSDKManager.getInstance().userAccountManager
+            .signoutCurrentUser(null, true, OAuth2.LogoutReason.USER_LOGOUT)
         Assert.assertFalse("Should not show back button with no users logged in.", mgr.shouldShowBackButton)
     }
 

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/LogoutDialogFragment.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/LogoutDialogFragment.java
@@ -34,6 +34,7 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.auth.OAuth2;
 
 /**
  * A simple dialog fragment to provide options at logout.
@@ -52,7 +53,8 @@ public class LogoutDialogFragment extends DialogFragment {
 		return new AlertDialog.Builder(getActivity())
 				.setTitle(R.string.logout_title)
 				.setPositiveButton(R.string.logout_yes,
-						(dialog, which) -> SalesforceSDKManager.getInstance().logout(getActivity()))
+						(dialog, which) -> SalesforceSDKManager.getInstance()
+								.logout(null, getActivity(), true, OAuth2.LogoutReason.USER_LOGOUT))
 				.setNegativeButton(R.string.logout_cancel, null)
 				.create();
 	}


### PR DESCRIPTION
I have elected not to add support for passing the logout reason from hybrid or React Native apps because the audience for this change is internal apps and none of them use those libraries anymore.