### PR TITLE
Run CodeCov on all test runs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,8 +191,8 @@ jobs:
                 when: always
                 environment:
                   CURRENT_LIB: << parameters.lib >>
-            - codecov/upload:
-                file: firebase/artifacts/sdcard/coverage.ec
+      - codecov/upload:
+          file: firebase/artifacts/sdcard/coverage.ec
       - store_artifacts:
           path: firebase/
       - store_artifacts:

--- a/native/NativeSampleApps/test/RestExplorerTest/AndroidManifest.xml
+++ b/native/NativeSampleApps/test/RestExplorerTest/AndroidManifest.xml
@@ -2,4 +2,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
This is needed so that PR's have a baseline in `dev` to compare against. 