### PR TITLE
Convert Firebase Test Lab code coverage for CodeCov.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,10 @@ jobs:
               exit 1
             fi
           when: always
+      - run: 
+          name: Convert Code Coverage
+          command: ./gradlew libs:<< parameters.lib >>:convertCodeCoverage
+          when: always
       - when:
           condition: << parameters.pr >>
           steps:
@@ -192,7 +196,7 @@ jobs:
                 environment:
                   CURRENT_LIB: << parameters.lib >>
       - codecov/upload:
-          file: firebase/artifacts/sdcard/coverage.ec
+          file: libs/<< parameters.lib >>/build/reports/jacoco/convertedCodeCoverage/convertedCodeCoverage.xml
           flags: << parameters.lib >>
       - store_artifacts:
           path: firebase/
@@ -260,9 +264,6 @@ jobs:
               exit 1
             fi
           when: always
-      - codecov/upload:
-          file: firebase/artifacts/sdcard/coverage.ec
-          flags: RestExplorer
       - store_artifacts:
           path: firebase/
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ executors:
     docker:
       - image: *cimg
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3584m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
 
 jobs:
   pr-danger:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ executors:
     docker:
       - image: *cimg
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx3584m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
 
 jobs:
   pr-danger:
@@ -198,6 +198,7 @@ jobs:
       - codecov/upload:
           file: libs/<< parameters.lib >>/build/reports/jacoco/convertedCodeCoverage/convertedCodeCoverage.xml
           flags: << parameters.lib >>
+          validate: false
       - store_artifacts:
           path: firebase/
       - store_artifacts:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
         classpath("com.android.tools.build:gradle:8.5.0")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
+        classpath("org.jacoco:org.jacoco.core:0.8.12")
     }
 }
 

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `android-library`
     `kotlin-android`
     `publish-module`
+    jacoco
 }
 
 dependencies {
@@ -75,6 +76,25 @@ android {
         renderScript = true
         aidl = true
         buildConfig = true
+    }
+
+    val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {
+        group = "Coverage"
+        description = "Convert coverage.ec from Firebase Test Lab to XML that is usable by CodeCov."
+    }
+
+    convertCodeCoverage {
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        sourceDirectories.setFrom("${project.projectDir}/src/main/java")
+        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
+        val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
+        classDirectories.setFrom(javaTree, kotlinTree)
+        executionData.setFrom(fileTree("$rootDir/firebase/artifacts/sdcard") { setIncludes(arrayListOf("*.ec")) })
     }
 }
 

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `android-library`
     `kotlin-android`
     `publish-module`
+    jacoco
 }
 
 dependencies {
@@ -74,5 +75,24 @@ android {
         renderScript = true
         aidl = true
         buildConfig = true
+    }
+
+    val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {
+        group = "Coverage"
+        description = "Convert coverage.ec from Firebase Test Lab to XML that is usable by CodeCov."
+    }
+
+    convertCodeCoverage {
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        sourceDirectories.setFrom("${project.projectDir}/src/main/java")
+        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
+        val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
+        classDirectories.setFrom(javaTree, kotlinTree)
+        executionData.setFrom(fileTree("$rootDir/firebase/artifacts/sdcard") { setIncludes(arrayListOf("*.ec")) })
     }
 }

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `android-library`
     `kotlin-android`
     `publish-module`
+    jacoco
 }
 
 dependencies {
@@ -82,5 +83,24 @@ android {
 
     kotlin {
         jvmToolchain(17)
+    }
+
+    val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {
+        group = "Coverage"
+        description = "Convert coverage.ec from Firebase Test Lab to XML that is usable by CodeCov."
+    }
+
+    convertCodeCoverage {
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        sourceDirectories.setFrom("${project.projectDir}/src/main/java")
+        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
+        val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
+        classDirectories.setFrom(javaTree, kotlinTree)
+        executionData.setFrom(fileTree("$rootDir/firebase/artifacts/sdcard") { setIncludes(arrayListOf("*.ec")) })
     }
 }

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     `android-library`
     `kotlin-android`
     `publish-module`
+    jacoco
 }
 
 dependencies {
@@ -93,6 +94,25 @@ android {
         renderScript = true
         aidl = true
         buildConfig = true
+    }
+
+    val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {
+        group = "Coverage"
+        description = "Convert coverage.ec from Firebase Test Lab to XML that is usable by CodeCov."
+    }
+
+    convertCodeCoverage {
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        sourceDirectories.setFrom("${project.projectDir}/src/main/java")
+        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
+        val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
+        classDirectories.setFrom(javaTree, kotlinTree)
+        executionData.setFrom(fileTree("$rootDir/firebase/artifacts/sdcard") { setIncludes(arrayListOf("*.ec")) })
     }
 }
 

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `android-library`
     `kotlin-android`
     `publish-module`
+    jacoco
 }
 
 dependencies {
@@ -84,6 +85,25 @@ android {
         renderScript = true
         aidl = true
         buildConfig = true
+    }
+
+    val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {
+        group = "Coverage"
+        description = "Convert coverage.ec from Firebase Test Lab to XML that is usable by CodeCov."
+    }
+
+    convertCodeCoverage {
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        sourceDirectories.setFrom("${project.projectDir}/src/main/java")
+        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
+        val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
+        classDirectories.setFrom(javaTree, kotlinTree)
+        executionData.setFrom(fileTree("$rootDir/firebase/artifacts/sdcard") { setIncludes(arrayListOf("*.ec")) })
     }
 }
 

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `android-library`
     `kotlin-android`
     `publish-module`
+    jacoco
 }
 
 dependencies {
@@ -80,5 +81,24 @@ android {
         renderScript = true
         aidl = true
         buildConfig = true
+    }
+
+    val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {
+        group = "Coverage"
+        description = "Convert coverage.ec from Firebase Test Lab to XML that is usable by CodeCov."
+    }
+
+    convertCodeCoverage {
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        sourceDirectories.setFrom("${project.projectDir}/src/main/java")
+        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
+        val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
+        classDirectories.setFrom(javaTree, kotlinTree)
+        executionData.setFrom(fileTree("$rootDir/firebase/artifacts/sdcard") { setIncludes(arrayListOf("*.ec")) })
     }
 }


### PR DESCRIPTION
Apparently [CodeCov no longer supports .ec files](https://docs.codecov.com/docs/supported-report-formats), which is the only thing we can generate in Firebase Test Cloud.  So I wrote a gradle task to convert the unsupported format to XML CodeCov can process (and html we can read) with JoCoCo.