### PR TITLE
ReactNativeMap.isNull throws if the provided key is not in the map

### DIFF
--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
@@ -203,7 +203,7 @@ public class SalesforceNetReactBridge extends ReactContextBaseJavaModule {
 
         // Parse args
         RestRequest.RestMethod method = RestRequest.RestMethod.valueOf(args.getString(METHOD_KEY));
-        String endPoint = args.isNull(END_POINT_KEY) ? "" : args.getString(END_POINT_KEY);
+        String endPoint = !args.hasKey(END_POINT_KEY) || args.isNull(END_POINT_KEY) ? "" : args.getString(END_POINT_KEY);
         String path = args.getString(PATH_KEY);
         ReadableMap queryParams = args.getMap(QUERY_PARAMS_KEY);
         ReadableMap headerParams = args.getMap(HEADER_PARAMS_KEY);

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SmartStoreReactBridge.java
@@ -115,8 +115,8 @@ public class SmartStoreReactBridge extends ReactContextBaseJavaModule {
         // Run remove
         try {
             final SmartStore smartStore = getSmartStore(args);
-            ReadableArray arraySoupEntryIds = (args.isNull(ENTRY_IDS) ? null : args.getArray(ENTRY_IDS));
-            ReadableMap mapQuerySpec = (args.isNull(QUERY_SPEC) ? null : args.getMap(QUERY_SPEC));
+            ReadableArray arraySoupEntryIds = (!args.hasKey(ENTRY_IDS) || args.isNull(ENTRY_IDS) ? null : args.getArray(ENTRY_IDS));
+            ReadableMap mapQuerySpec = (!args.hasKey(QUERY_SPEC) || args.isNull(QUERY_SPEC) ? null : args.getMap(QUERY_SPEC));
             if (arraySoupEntryIds != null) {
                 List ids = ReactBridgeHelper.toJavaList(arraySoupEntryIds);
                 Long[] soupEntryIds = new Long[ids.size()];


### PR DESCRIPTION
It was not always like that - but that change of behavior means some of the bridge method might not work if an optional argument is not provided. I noticed the issue because testRemoveFromSoup started failing.