### PR TITLE
@W-15993541/W-15993636: [Android] Publish AILTN logs on background/Register push notifications on foreground

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublishingWorker.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublishingWorker.kt
@@ -27,14 +27,17 @@
 package com.salesforce.androidsdk.analytics
 
 import android.content.Context
+import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
 import androidx.work.ListenableWorker.Result.success
-import androidx.work.PeriodicWorkRequest.Builder
+import androidx.work.NetworkType.CONNECTED
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager.getInstance
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.salesforce.androidsdk.accounts.UserAccountManager
-import com.salesforce.androidsdk.analytics.AnalyticsPublishingWorker.Companion.reEnqueueAnalyticsPublishPeriodicWorkRequest
+import com.salesforce.androidsdk.analytics.AnalyticsPublishingWorker.Companion.enqueueAnalyticsPublishWorkRequest
 import java.util.concurrent.TimeUnit.HOURS
 
 /**
@@ -42,11 +45,17 @@ import java.util.concurrent.TimeUnit.HOURS
  * This class is intended to be instantiated by the background tasks work
  * manager.
  *
- * Use [reEnqueueAnalyticsPublishPeriodicWorkRequest] to enqueue a analytics
- * publish periodic work request.  Previous requests will be cancelled.
+ * [enqueueAnalyticsPublishWorkRequest] is used internally by the Salesforce
+ * Mobile SDK to enqueue analytics publish work requests to match the current
+ * analytics publishing configuration. Only one request may be active at a time.
+ * Only the Salesforce Mobile SDK should call this method as it is not intended
+ * for public use.
  *
  * @param context The Android context provided by the work manager
  * @param workerParams The worker parameters provided by the work manager
+ * @see [SalesforceAnalyticsManager.setPublishOnceTimeOnAppBackgroundEnabled]
+ * @see [SalesforceAnalyticsManager.setPublishPeriodicallyOnFrequencyEnabled]
+ * @see [SalesforceAnalyticsManager.setPublishPeriodicallyFrequencyHours]
  * @see <a href='https://developer.android.com/guide/background'>Android
  * Background Tasks</a>
  */
@@ -73,36 +82,67 @@ internal class AnalyticsPublishingWorker(
 
     companion object {
 
-        private const val publishAnalyticsPeriodicWorkName = "SalesforceAnalyticsPublishingPeriodicWork"
+        /**
+         * The Android background tasks name of the publish analytics work
+         * request.
+         * Note: This name is also used for one-time work, yet maintains this
+         * value for backwards compatibility and to ensure both periodic and one
+         * time work are mutually exclusive.
+         */
+        private const val PUBLISH_ANALYTICS_WORK_NAME = "SalesforceAnalyticsPublishingPeriodicWork"
 
         /**
-         * Enqueues a persistent background tasks periodic work request to
-         * publish stored analytics for the current user at the provided
-         * interval.
+         * Enqueues a persistent background tasks work request to publish stored
+         * analytics for the current user.
          *
          * If a work request is already queued, it will be cancelled before
          * the replacement is enqueued.
          *
+         * The publish hours interval parameter determines between background
+         * periodic publishing and one-time publishing.  Note, background
+         * periodic publishing starts or resumes the host app and may incur
+         * licensing costs if authorization token refresh is required.
+         *
+         * Only the Salesforce Mobile SDK should call this method as it is not
+         * intended for public use.
+         *
          * @param context The Android context
-         * @param publishHoursInterval The interval at which to publish in hours
+         * @param periodicBackgroundPublishingHoursInterval The interval for
+         * periodic background publishing in hours or null to publish one time
+         * only
          * @return UUID The worker's unique id, which may be used for
          * cancellation
          */
-        fun reEnqueueAnalyticsPublishPeriodicWorkRequest(
+        fun enqueueAnalyticsPublishWorkRequest(
             context: Context,
-            publishHoursInterval: Long
-        ) = Builder(
-            AnalyticsPublishingWorker::class.java,
-            publishHoursInterval,
-            HOURS
-        ).build().also { publishAnalyticsPeriodicWorkRequest ->
-            runCatching {
-                getInstance(context)
-            }.getOrNull()?.enqueueUniquePeriodicWork(
-                publishAnalyticsPeriodicWorkName,
-                CANCEL_AND_REENQUEUE,
-                publishAnalyticsPeriodicWorkRequest
-            )
-        }.id
+            periodicBackgroundPublishingHoursInterval: Long? = null
+        ) = when (periodicBackgroundPublishingHoursInterval) {
+
+            null -> OneTimeWorkRequest.Builder(
+                AnalyticsPublishingWorker::class.java
+            ).setConstraints(
+                Constraints.Builder().setRequiredNetworkType(CONNECTED).build()
+            ).build().also { publishAnalyticsOneTimeWorkRequest ->
+                runCatching {
+                    getInstance(context)
+                }.getOrNull()?.enqueue(publishAnalyticsOneTimeWorkRequest)
+            }.id
+
+            else -> PeriodicWorkRequest.Builder(
+                AnalyticsPublishingWorker::class.java,
+                periodicBackgroundPublishingHoursInterval,
+                HOURS
+            ).setConstraints(
+                Constraints.Builder().setRequiredNetworkType(CONNECTED).build()
+            ).build().also { publishAnalyticsPeriodicWorkRequest ->
+                runCatching {
+                    getInstance(context)
+                }.getOrNull()?.enqueueUniquePeriodicWork(
+                    PUBLISH_ANALYTICS_WORK_NAME,
+                    CANCEL_AND_REENQUEUE,
+                    publishAnalyticsPeriodicWorkRequest
+                )
+            }.id
+        }
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/SalesforceAnalyticsManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/SalesforceAnalyticsManager.java
@@ -188,7 +188,10 @@ public class SalesforceAnalyticsManager {
      *
      * @param periodicBackgroundPublishingHoursInterval The interval for
      *                                                  periodic background
-     *                                                  publishing in hours
+     *                                                  publishing in hours. It
+     *                                                  is recommended to keep
+     *                                                  this value under seven
+     *                                                  days
      * @see #setPublishPeriodicallyOnFrequencyEnabled(boolean)
      */
     public static synchronized void setPublishPeriodicallyFrequencyHours(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/SalesforceAnalyticsManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/SalesforceAnalyticsManager.java
@@ -70,8 +70,10 @@ public class SalesforceAnalyticsManager {
     private static final String UNAUTH_INSTANCE_KEY = "_no_user";
 
     private static Map<String, SalesforceAnalyticsManager> INSTANCES;
-    private static boolean sPublishHandlerActive;
-    private static int sPublishFrequencyInHours = DEFAULT_PUBLISH_FREQUENCY_IN_HOURS;
+    private static boolean isPublishWorkRequestEnqueued;
+    private static boolean isPublishOneTimeOnAppBackgroundEnabled = true;
+    private static boolean isPublishPeriodicallyOnFrequencyEnabled = false;
+    private static int publishPeriodicallyFrequencyHours = DEFAULT_PUBLISH_FREQUENCY_IN_HOURS;
     private static int sEventPublishBatchSize = DEFAULT_BATCH_SIZE;
 
     private final AnalyticsManager analyticsManager;
@@ -102,7 +104,7 @@ public class SalesforceAnalyticsManager {
     /**
      * Returns the instance of this class associated with this user and community.
      *
-     * @param account User account.
+     * @param account     User account.
      * @param communityId Community ID.
      * @return Instance of this class.
      */
@@ -131,9 +133,9 @@ public class SalesforceAnalyticsManager {
         }
 
         // Adds a handler for publishing if not already active.
-        if (!sPublishHandlerActive) {
-            recreateAnalyticsPublishPeriodicWorkRequest();
-            sPublishHandlerActive = true;
+        if (!isPublishWorkRequestEnqueued) {
+            recreateAnalyticsPeriodicBackgroundPublishingWorkRequest();
+            isPublishWorkRequestEnqueued = true;
         }
         return instance;
     }
@@ -157,7 +159,7 @@ public class SalesforceAnalyticsManager {
     /**
      * Resets the instance of this class associated with this user and community.
      *
-     * @param account User account.
+     * @param account     User account.
      * @param communityId Community ID.
      */
     public static synchronized void reset(UserAccount account, String communityId) {
@@ -182,13 +184,77 @@ public class SalesforceAnalyticsManager {
     }
 
     /**
-     * Sets the publish frequency, in hours.
+     * Sets the interval for periodic background publishing in hours.
      *
-     * @param publishFrequencyInHours Publish frequency, in hours.
+     * @param periodicBackgroundPublishingHoursInterval The interval for
+     *                                                  periodic background
+     *                                                  publishing in hours
+     * @see #setPublishPeriodicallyOnFrequencyEnabled(boolean)
      */
-    public static synchronized void setPublishFrequencyInHours(int publishFrequencyInHours) {
-        sPublishFrequencyInHours = publishFrequencyInHours;
-        recreateAnalyticsPublishPeriodicWorkRequest();
+    public static synchronized void setPublishPeriodicallyFrequencyHours(
+            int periodicBackgroundPublishingHoursInterval
+    ) {
+        SalesforceAnalyticsManager.publishPeriodicallyFrequencyHours = periodicBackgroundPublishingHoursInterval;
+        setPublishPeriodicallyOnFrequencyEnabled(true);
+    }
+
+    /**
+     * Sets the interval for periodic background publishing in hours.
+     *
+     * @deprecated Planned for removal 13.0.
+     * Use {@link #setPublishPeriodicallyFrequencyHours(int)} )}.
+     */
+    @Deprecated()
+    public static synchronized void setPublishFrequencyInHours(
+            int periodicBackgroundPublishingHoursInterval
+    ) {
+        setPublishPeriodicallyFrequencyHours(periodicBackgroundPublishingHoursInterval);
+    }
+
+    /**
+     * Specifies if analytics publishing should occur one time when the app is
+     * sent to the background.
+     */
+    public static boolean isPublishOnceTimeOnAppBackgroundEnabled() {
+        return isPublishOneTimeOnAppBackgroundEnabled;
+    }
+
+    /**
+     * Specifies if analytics publishing should occur one time when the app is
+     * sent to the background.
+     * <p/>
+     * This is mutually exclusive with
+     * [setPublishPeriodicallyOnFrequencyEnabled]
+     *
+     * @param value True to enable.  False to disable
+     */
+    public static void setPublishOnceTimeOnAppBackgroundEnabled(boolean value) {
+        isPublishOneTimeOnAppBackgroundEnabled = value;
+    }
+
+    /**
+     * Specifies if analytics publishing should occur periodically as an
+     * Android Background Task according to the frequency.
+     *
+     * @noinspection unused
+     * @see #setPublishPeriodicallyFrequencyHours
+     */
+    public static boolean isPublishPeriodicallyOnFrequencyEnabled() {
+        return isPublishPeriodicallyOnFrequencyEnabled;
+    }
+
+    /**
+     * Specifies if analytics publishing should occur periodically as an
+     * Android Background Task according to the frequency.
+     * <p>
+     * This is mutually exclusive with
+     * [setPublishOnceTimeOnAppBackgroundEnabled]
+     *
+     * @param value True to enable.  False to disable
+     * @see #setPublishPeriodicallyFrequencyHours
+     */
+    public static void setPublishPeriodicallyOnFrequencyEnabled(boolean value) {
+        isPublishPeriodicallyOnFrequencyEnabled = value;
     }
 
     /**
@@ -209,9 +275,23 @@ public class SalesforceAnalyticsManager {
      * Returns the publish frequency currently set, in hours.
      *
      * @return Publish frequency, in hours.
+     * @noinspection unused
      */
+    public static int getPublishPeriodicallyFrequencyHours() {
+        return publishPeriodicallyFrequencyHours;
+    }
+
+    /**
+     * Returns the publish frequency currently set, in hours.
+     *
+     * @return Publish frequency, in hours.
+     * @noinspection unused
+     * @deprecated Planned for removal 13.0.
+     * Use {@link #getPublishPeriodicallyFrequencyHours()} )}.
+     */
+    @Deprecated
     public static int getPublishFrequencyInHours() {
-        return sPublishFrequencyInHours;
+        return getPublishPeriodicallyFrequencyHours();
     }
 
     /**
@@ -295,6 +375,7 @@ public class SalesforceAnalyticsManager {
         if (events == null) {
             return;
         }
+
         final Set<String> eventsIds = new HashSet<>();
         boolean success = true;
         final Set<Map.Entry<Class<? extends Transform>, Class<? extends AnalyticsPublisher>>> remoteKeySet = remotes.entrySet();
@@ -474,10 +555,10 @@ public class SalesforceAnalyticsManager {
         e.commit();
     }
 
-    private static void recreateAnalyticsPublishPeriodicWorkRequest() {
-        AnalyticsPublishingWorker.Companion.reEnqueueAnalyticsPublishPeriodicWorkRequest(
+    private static void recreateAnalyticsPeriodicBackgroundPublishingWorkRequest() {
+        AnalyticsPublishingWorker.Companion.enqueueAnalyticsPublishWorkRequest(
                 SalesforceSDKManager.getInstance().getAppContext(),
-                sPublishFrequencyInHours
+                (long) publishPeriodicallyFrequencyHours
         );
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -74,6 +74,7 @@ import com.salesforce.androidsdk.R.style.SalesforceSDK_AlertDialog_Dark
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.accounts.UserAccountManager.USER_SWITCH_TYPE_LOGOUT
+import com.salesforce.androidsdk.analytics.AnalyticsPublishingWorker.Companion.enqueueAnalyticsPublishWorkRequest
 import com.salesforce.androidsdk.analytics.EventBuilderHelper.createAndStoreEvent
 import com.salesforce.androidsdk.analytics.SalesforceAnalyticsManager
 import com.salesforce.androidsdk.analytics.security.Encryptor
@@ -1451,6 +1452,14 @@ open class SalesforceSDKManager protected constructor(
     @OnLifecycleEvent(ON_STOP)
     protected open fun onAppBackgrounded() {
         screenLockManager?.onAppBackgrounded()
+
+        // Publish analytics one-time on app background, if enabled.
+        if (SalesforceAnalyticsManager.isPublishOnceTimeOnAppBackgroundEnabled()) {
+            enqueueAnalyticsPublishWorkRequest(
+                getInstance().appContext
+            )
+        }
+
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppBackgrounded()
 
         // Hide the Salesforce Mobile SDK "Show Developer Support" notification

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -106,9 +106,11 @@ import com.salesforce.androidsdk.developer.support.notifications.local.ShowDevel
 import com.salesforce.androidsdk.push.PushMessaging
 import com.salesforce.androidsdk.push.PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT
 import com.salesforce.androidsdk.push.PushMessaging.isRegistered
+import com.salesforce.androidsdk.push.PushMessaging.register
 import com.salesforce.androidsdk.push.PushMessaging.unregister
 import com.salesforce.androidsdk.push.PushNotificationInterface
 import com.salesforce.androidsdk.push.PushService
+import com.salesforce.androidsdk.push.PushService.Companion.isPushNotificationsRegistrationOneTimeOnAppForegroundEnabled
 import com.salesforce.androidsdk.rest.ClientManager
 import com.salesforce.androidsdk.rest.ClientManager.LoginOptions
 import com.salesforce.androidsdk.rest.RestClient
@@ -1473,6 +1475,18 @@ open class SalesforceSDKManager protected constructor(
     protected open fun onAppForegrounded() {
         screenLockManager?.onAppForegrounded()
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppForegrounded()
+
+        // Review push-notifications registration for the current user, if enabled.
+        /* TODO: W-15993636: Review that push notifications registration is performed when switching users. ECJ20240629 */
+        userAccountManager.currentUser?.let { userAccount ->
+            if (isPushNotificationsRegistrationOneTimeOnAppForegroundEnabled) {
+                register(
+                    context = appContext,
+                    account = userAccount,
+                    recreateKey = false
+                )
+            }
+        }
 
         // Display the Salesforce Mobile SDK "Show Developer Support" notification
         if (userAccountManager.currentAccount != null && authenticatedActivityForDeveloperSupport != null) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -901,7 +901,12 @@ open class SalesforceSDKManager protected constructor(
         frontActivity: Activity?,
         showLoginPage: Boolean = true,
     ) {
-        logout(account, frontActivity, showLoginPage)
+        logout(
+            account = account,
+            frontActivity = frontActivity,
+            showLoginPage = showLoginPage,
+            reason = LogoutReason.UNKNOWN
+        )
     }
 
     // Note the below overload exists because @JvmOverloads generates non-overrideable
@@ -1477,7 +1482,6 @@ open class SalesforceSDKManager protected constructor(
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppForegrounded()
 
         // Review push-notifications registration for the current user, if enabled.
-        /* TODO: W-15993636: Review that push notifications registration is performed when switching users. ECJ20240629 */
         userAccountManager.currentUser?.let { userAccount ->
             if (isPushNotificationsRegistrationOneTimeOnAppForegroundEnabled) {
                 register(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -160,11 +160,9 @@ object PushMessaging {
                 firebaseApp.delete()
             }
             unregisterSFDCPush(context, account)
-        } else {
-
-            // TODO: W-15993636: This is currently running twice with the call several lines above. ECJ20240629
-            unregisterSFDCPush(context, account)
         }
+
+        unregisterSFDCPush(context, account)
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -85,7 +85,7 @@ object PushMessaging {
      */
     @JvmStatic
     fun register(context: Context, account: UserAccount?) {
-        register(context = context, account = account, recreateKey = false);
+        register(context = context, account = account, recreateKey = false)
     }
 
     /**
@@ -160,9 +160,11 @@ object PushMessaging {
                 firebaseApp.delete()
             }
             unregisterSFDCPush(context, account)
-        }
+        } else {
 
-        unregisterSFDCPush(context, account)
+            // TODO: W-15993636: This is currently running twice with the call several lines above. ECJ20240629
+            unregisterSFDCPush(context, account)
+        }
     }
 
     /**
@@ -184,7 +186,6 @@ object PushMessaging {
             val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0))
             } else {
-                @Suppress("DEPRECATION")
                 context.packageManager.getPackageInfo(context.packageName, 0)
             }
             appName = context.getString(packageInfo.applicationInfo.labelRes)
@@ -472,15 +473,15 @@ object PushMessaging {
     ) {
         if (account == null) {
             enqueuePushNotificationsRegistrationWork(
-                null,
-                action,
-                null
+                userAccount = null,
+                action = action,
+                delayDays = null
             )
         } else if (isRegistered(context, account)) {
             enqueuePushNotificationsRegistrationWork(
-                account,
-                action,
-                null
+                userAccount = account,
+                action = action,
+                delayDays = null
             )
         }
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk.push
 
 import android.content.Intent
-import android.util.Log
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy.UPDATE
@@ -213,8 +212,7 @@ open class PushService {
         status: Int,
         userAccount: UserAccount?
     ) {
-        // TODO: W-15993636: Remove this diagnostic. ECJ20240629
-        Log.i("PushService", "onPushNotificationRegistrationStatus: '$status', '${userAccount?.accountName}'.")
+        // Intentionally Blank.
     }
 
     private fun registerSFDCPushNotification(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -47,7 +47,6 @@ import com.salesforce.androidsdk.push.PushMessaging.setRegistrationId
 import com.salesforce.androidsdk.push.PushMessaging.setRegistrationInfo
 import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction
 import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction.Deregister
-import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction.Register
 import com.salesforce.androidsdk.rest.ApiVersionStrings
 import com.salesforce.androidsdk.rest.ClientManager.AccMgrAuthTokenProvider
 import com.salesforce.androidsdk.rest.RestClient
@@ -125,20 +124,6 @@ open class PushService {
                 throwable
             )
         }
-
-        /*
-         * Although each user account should be registered with the SFDC API
-         * for push notifications on login and Firebase push notifications
-         * registration, enqueue an additional SFDC API push notifications
-         * registration for all users six days from now.  This may provide
-         * an additional level of registration verification, though the
-         * actual requirements may need more definition in the future.
-         */
-        enqueuePushNotificationsRegistrationWork(
-            userAccount = null,
-            action = Register,
-            delayMilliseconds = MILLISECONDS_IN_SIX_DAYS
-        )
     }
 
     private fun onUnregistered(account: UserAccount) {
@@ -412,9 +397,6 @@ open class PushService {
 
     companion object {
         private const val TAG = "PushService"
-
-        // Retry time constants.
-        private const val MILLISECONDS_IN_SIX_DAYS = 518400000L
 
         // Salesforce push notification constants.
         private const val MOBILE_PUSH_SERVICE_DEVICE = "MobilePushServiceDevice"

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
@@ -32,7 +32,6 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
-import com.salesforce.androidsdk.analytics.SalesforceAnalyticsManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.ui.LoginActivity;
 
@@ -64,12 +63,8 @@ public class RestExplorerApp extends Application {
          * Replace 'com.salesforce.samples.salesforceandroididptemplateapp' with the package name
          * of the IDP app meant to be used.
          */
-		SalesforceSDKManager.getInstance().setIDPAppPackageName("com.salesforce.samples.salesforceandroididptemplateapp");
+         SalesforceSDKManager.getInstance().setIDPAppPackageName("com.salesforce.samples.salesforceandroididptemplateapp");
 
-		// TODO: Remove this diagnostic. ECJ20240626
-		SalesforceAnalyticsManager.setPublishOnceTimeOnAppBackgroundEnabled(false);
-		SalesforceAnalyticsManager.setPublishPeriodicallyOnFrequencyEnabled(true);
-		SalesforceAnalyticsManager.setPublishPeriodicallyFrequencyHours(1);
 		/*
 		 * Un-comment the line below to enable push notifications in this app.
 		 * Replace 'pnInterface' with your implementation of 'PushNotificationInterface'.

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
@@ -66,6 +66,7 @@ public class RestExplorerApp extends Application {
          */
 		SalesforceSDKManager.getInstance().setIDPAppPackageName("com.salesforce.samples.salesforceandroididptemplateapp");
 
+		// TODO: Remove this diagnostic. ECJ20240626
 		SalesforceAnalyticsManager.setPublishOnceTimeOnAppBackgroundEnabled(false);
 		SalesforceAnalyticsManager.setPublishPeriodicallyOnFrequencyEnabled(true);
 		SalesforceAnalyticsManager.setPublishPeriodicallyFrequencyHours(1);

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/RestExplorerApp.java
@@ -32,6 +32,7 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import com.salesforce.androidsdk.analytics.SalesforceAnalyticsManager;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.ui.LoginActivity;
 
@@ -63,8 +64,11 @@ public class RestExplorerApp extends Application {
          * Replace 'com.salesforce.samples.salesforceandroididptemplateapp' with the package name
          * of the IDP app meant to be used.
          */
-         SalesforceSDKManager.getInstance().setIDPAppPackageName("com.salesforce.samples.salesforceandroididptemplateapp");
+		SalesforceSDKManager.getInstance().setIDPAppPackageName("com.salesforce.samples.salesforceandroididptemplateapp");
 
+		SalesforceAnalyticsManager.setPublishOnceTimeOnAppBackgroundEnabled(false);
+		SalesforceAnalyticsManager.setPublishPeriodicallyOnFrequencyEnabled(true);
+		SalesforceAnalyticsManager.setPublishPeriodicallyFrequencyHours(1);
 		/*
 		 * Un-comment the line below to enable push notifications in this app.
 		 * Replace 'pnInterface' with your implementation of 'PushNotificationInterface'.


### PR DESCRIPTION
🎸 _Ready For Review!_ 🥁

Note: This also includes [W-15993636](https://gus.lightning.force.com/a07EE00001uKF3pYAG) since the two topics look so similar in the code and test well together.

This changes MSDK to avoid resuming the app for background tasks that could incur additional authorization refresh events.  The default behavior is now to perform those tasks when the app resumes or pauses (foreground or background).  Configuration options are provided so app can opt-in to the old behavior, if desired.

I was able to test the apps to verify the new AILTN publishing in each configuration.  Also, I was able to test push notifications registration according to each configuration.