### PR TITLE
Fix auth config fetch.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1831,6 +1831,8 @@ open class SalesforceSDKManager protected constructor(
                         browserLoginEnabled = false,
                         shareBrowserSessionEnabled = false
                     )
+
+                    return@withTimeout
                 }
 
                 getMyDomainAuthConfig(loginServer).let { authConfig ->


### PR DESCRIPTION
Yesterday on an [iOS PR](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3741) I proudly proclaimed that we didn't need the same fix on Android because it was implemented years ago.  Which _was_ true.  However, in linking the Android code as proof I noticed that it had been broken slightly by a Kotlin conversion; this PR rectifies that.  