### PR TITLE
Update Maven Central publish script to use token instead of user credentials.

### DIFF
--- a/publish/publish-root.gradle
+++ b/publish/publish-root.gradle
@@ -1,5 +1,5 @@
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
+ext["ossrhToken"] = ''
+ext["ossrhTokenPassword"] = ''
 ext["sonatypeStagingProfileId"] = ''
 ext["signing.keyId"] = ''
 ext["signing.password"] = ''
@@ -11,8 +11,8 @@ if (secretPropsFile.exists()) {
     new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
     p.each { name, value -> ext[name] = value }
 } else {
-    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["ossrhToken"] = System.getenv('OSSRH_TOKEN')
+    ext["ossrhTokenPassword"] = System.getenv('OSSRH_TOKEN_PASSWORD')
     ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
     ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
@@ -23,8 +23,8 @@ nexusPublishing {
     repositories {
         sonatype {
             stagingProfileId = sonatypeStagingProfileId
-            username = ossrhUsername
-            password = ossrhPassword
+            username = ossrhToken
+            password = ossrhTokenPassword
         }
     }
 }


### PR DESCRIPTION
The changes here aren't strictly necessary (just variable renaming) but they make the new inputs more clear. 

Maven Central has switched from allowing publishing with user credentials to a token only so we need to update our process.  I will update he doc to reflect this and the new variable names.