### PR TITLE
Using Single Access API to get front door URL

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -292,7 +292,9 @@ public class OAuth2 {
      * @param addlParams additional paramaters
      *
      * @return 'frontdoor'ed URL (or the original url if access token or instance url are null)
+     * @deprecated Use {@link com.salesforce.androidsdk.rest.RestRequest#getRequestForSingleAccess(String)} instead
      */
+    @Deprecated
     public static URI getFrontdoorUrl(URI url,
                                       String accessToken,
                                       String instanceURL,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
@@ -37,9 +37,7 @@ import com.salesforce.androidsdk.R
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.OAuth2.getAuthorizationUrl
-import com.salesforce.androidsdk.auth.OAuth2.getFrontdoorUrl
 import com.salesforce.androidsdk.config.BootConfig
-import com.salesforce.androidsdk.rest.ApiVersionStrings
 import com.salesforce.androidsdk.rest.ClientManager
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestRequest
@@ -48,6 +46,7 @@ import com.salesforce.androidsdk.util.UriFragmentParser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.net.URI
 
@@ -80,10 +79,13 @@ internal class IDPAuthCodeHelper private constructor(
     private fun generateAuthCode() {
         SalesforceSDKLogger.d(TAG, "Generating oauth code")
         CoroutineScope(Dispatchers.IO).launch {
-            getValidAccessToken()?.let {accessToken ->
-                makeFrontDoorRequest(accessToken, webView)
-            } ?: run {
-                onError("Failed to get an access token")
+            val restClient = buildRestClient() ?: return@launch onError("Failed to build rest client")
+            val authorizationUrlForSP = getAuthorizationPathForSP() ?: return@launch onError("Failed to get authorization url")
+            val frontdoorUrl = getFrontdoorUrl(restClient, authorizationUrlForSP) ?: return@launch onError("Failed to get front door url")
+
+            // Launch front door url in web view on the main thread
+            withContext(Dispatchers.Main) {
+                webView.loadUrl(frontdoorUrl)
             }
         }
     }
@@ -112,56 +114,42 @@ internal class IDPAuthCodeHelper private constructor(
     }
 
     /**
-     * Helper function to get a fresh access token
-     *
-     * @return the valid access token or null
+     * Compute relative path of authorization url for SP
+     * @return authorization relative path
      */
-    private fun getValidAccessToken(): String? {
-        SalesforceSDKLogger.d(TAG, "Obtaining valid access token")
-        buildRestClient()?.let {restClient ->
-            val restResponse = try {
-                restClient.sendSync(RestRequest.getCheapRequest(ApiVersionStrings.VERSION_NUMBER))
-            } catch (e: IOException) {
-                SalesforceSDKLogger.e(TAG, "Failed to obtain valid access token", e)
-                null
-            }
-
-            return if (restResponse == null || !restResponse.isSuccess) null else restClient.authToken
-        } ?: run {
-            SalesforceSDKLogger.e(TAG, "Cannot get valid access token - failed to build rest client")
-            return null
-        }
-    }
-
-    /**
-     * Kicks off the 'frontdoor' request in the supplied WebView instance.
-     *
-     * @param accessToken Valid access token.
-     * @param webView WebView instance.
-     */
-    fun makeFrontDoorRequest(accessToken: String, webView: WebView) {
-        SalesforceSDKLogger.d(TAG, "Making front door request")
+    fun getAuthorizationPathForSP(): String? {
+        SalesforceSDKLogger.d(TAG, "Getting authorization url")
         val context = SalesforceSDKManager.getInstance().appContext
         val useHybridAuthentication = SalesforceSDKManager.getInstance().useHybridAuthentication
-        val frontdoorUrl = getFrontdoorUrl(
-            getAuthorizationUrl(
-                true, // use web server flow
-                useHybridAuthentication,
-                URI(userAccount.loginServer),
-                spConfig.oauthClientId,
-                spConfig.oauthCallbackUrl,
-                spConfig.oauthScopes,
-                context.getString(R.string.oauth_display_type),
-                codeChallenge,
-                null
-            ),
-            accessToken,
-            userAccount.instanceServer,
+        val authorizationUri = getAuthorizationUrl(
+            true, // use web server flow
+            useHybridAuthentication,
+            URI(userAccount.loginServer),
+            spConfig.oauthClientId,
+            spConfig.oauthCallbackUrl,
+            spConfig.oauthScopes,
+            context.getString(R.string.oauth_display_type),
+            codeChallenge,
             null
         )
-        CoroutineScope(Dispatchers.Main).launch {
-            webView.loadUrl(frontdoorUrl.toString())
+        SalesforceSDKLogger.d(TAG, "Authorization url: $authorizationUri")
+
+        return authorizationUri?.let {
+            it.path + (it.query?.let { query -> "?$query" } ?: "")
+        } ?: null
+    }
+
+    fun getFrontdoorUrl(restClient:RestClient, redirectUri: String): String? {
+        SalesforceSDKLogger.d(TAG, "Getting front door url")
+        val singleAccessRequest = RestRequest.getRequestForSingleAccess(redirectUri)
+        val restResponse = try {
+            restClient.sendSync(singleAccessRequest)
+        } catch (e: IOException) {
+            SalesforceSDKLogger.e(TAG, "Failed to obtain valid front door url", e)
+            null
         }
+        SalesforceSDKLogger.d(TAG, "Single access response: $restResponse")
+        return if (restResponse == null || !restResponse.isSuccess) null else restResponse.asJSONObject().getString("frontdoor_uri")
     }
 
     private fun onError(error: String, exception: java.lang.Exception? = null) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPAuthCodeHelper.kt
@@ -132,7 +132,6 @@ internal class IDPAuthCodeHelper private constructor(
             codeChallenge,
             null
         )
-        SalesforceSDKLogger.d(TAG, "Authorization url: $authorizationUri")
 
         return authorizationUri?.let {
             it.path + (it.query?.let { query -> "?$query" } ?: "")
@@ -148,7 +147,6 @@ internal class IDPAuthCodeHelper private constructor(
             SalesforceSDKLogger.e(TAG, "Failed to obtain valid front door url", e)
             null
         }
-        SalesforceSDKLogger.d(TAG, "Single access response: $restResponse")
         return if (restResponse == null || !restResponse.isSuccess) null else restResponse.asJSONObject().getString("frontdoor_uri")
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -55,76 +55,76 @@ import okhttp3.Response;
  */
 public class RestClient {
 
-	// Keys in credentials map
-	private static final String USER_AGENT = "userAgent";
-	private static final String INSTANCE_URL = "instanceUrl";
-	private static final String LOGIN_URL = "loginUrl";
-	private static final String IDENTITY_URL = "identityUrl";
-	private static final String ORG_ID = "orgId";
-	private static final String USER_ID = "userId";
-	private static final String REFRESH_TOKEN = "refreshToken";
-	private static final String ACCESS_TOKEN = "accessToken";
-	private static final String COMMUNITY_ID = "communityId";
-	private static final String COMMUNITY_URL = "communityUrl";
-	private static final String TAG = "RestClient";
+    // Keys in credentials map
+    private static final String USER_AGENT = "userAgent";
+    private static final String INSTANCE_URL = "instanceUrl";
+    private static final String LOGIN_URL = "loginUrl";
+    private static final String IDENTITY_URL = "identityUrl";
+    private static final String ORG_ID = "orgId";
+    private static final String USER_ID = "userId";
+    private static final String REFRESH_TOKEN = "refreshToken";
+    private static final String ACCESS_TOKEN = "accessToken";
+    private static final String COMMUNITY_ID = "communityId";
+    private static final String COMMUNITY_URL = "communityUrl";
+    private static final String TAG = "RestClient";
 
-	private static final Map<String, OAuthRefreshInterceptor> OAUTH_REFRESH_INTERCEPTORS = new HashMap<>();
-	private static final Map<String, OkHttpClient.Builder> OK_CLIENT_BUILDERS = new HashMap<>();
+    private static final Map<String, OAuthRefreshInterceptor> OAUTH_REFRESH_INTERCEPTORS = new HashMap<>();
+    private static final Map<String, OkHttpClient.Builder> OK_CLIENT_BUILDERS = new HashMap<>();
     private static final Map<String, OkHttpClient> OK_CLIENTS = new HashMap<>();
 
-	private final ClientInfo clientInfo;
+    private final ClientInfo clientInfo;
     private final HttpAccess httpAccessor;
-	private final AuthTokenProvider authTokenProvider;
+    private final AuthTokenProvider authTokenProvider;
     private OAuthRefreshInterceptor oAuthRefreshInterceptor;
-	private OkHttpClient.Builder okHttpClientBuilder;
-	private OkHttpClient okHttpClient;
+    private OkHttpClient.Builder okHttpClientBuilder;
+    private OkHttpClient okHttpClient;
 
-	/**
-	 * AuthTokenProvider interface.
-	 * RestClient will call its authTokenProvider to refresh its authToken once it has expired. 
-	 */
-	public interface AuthTokenProvider {
-		String getInstanceUrl();
-		String getNewAuthToken();
-		String getRefreshToken();
-		long getLastRefreshTime();
-	}
-	
-	/**
-	 * AsyncRequestCallback interface.
-	 * Interface through which the result of an asynchronous request is handled.
-	 */
-	public interface AsyncRequestCallback {
+    /**
+     * AuthTokenProvider interface.
+     * RestClient will call its authTokenProvider to refresh its authToken once it has expired.
+     */
+    public interface AuthTokenProvider {
+        String getInstanceUrl();
+        String getNewAuthToken();
+        String getRefreshToken();
+        long getLastRefreshTime();
+    }
 
-		/**
-		 * NB: onSuccess runs on a network thread
-		 *     If you are making your call from an activity and need to make UI changes
-		 *     make sure to first consume the response and then call runOnUiThread
+    /**
+     * AsyncRequestCallback interface.
+     * Interface through which the result of an asynchronous request is handled.
+     */
+    public interface AsyncRequestCallback {
+
+        /**
+         * NB: onSuccess runs on a network thread
+         * If you are making your call from an activity and need to make UI changes
+         * make sure to first consume the response and then call runOnUiThread
 		 *
-		 *     result.consumeQuietly(); // consume before going back to main thread
-		 *     runOnUiThread(new Runnable() {
+         * result.consumeQuietly(); // consume before going back to main thread
+         * runOnUiThread(new Runnable() {
 		 *         @Override
 		 *         public void run() { ... }
 		 *     });
-		 * @param request
-		 * @param response
-		 */
-		void onSuccess(RestRequest request, RestResponse response);
+         * @param request
+         * @param response
+         */
+        void onSuccess(RestRequest request, RestResponse response);
 
-		/**
-		 * NB: onError runs on a network thread
-		 *     If you are making your call from an activity and need to make UI changes
-		 *     make sure to call runOnUiThread
+        /**
+         * NB: onError runs on a network thread
+         * If you are making your call from an activity and need to make UI changes
+         * make sure to call runOnUiThread
 		 *
-		 *     runOnUiThread(new Runnable() {
+         * runOnUiThread(new Runnable() {
 		 *         @Override
 		 *         public void run() { ... }
 		 *     });
-		 * @param exception
-		 */
-		void onError(Exception exception);
-	}
-	
+         * @param exception
+         */
+        void onError(Exception exception);
+    }
+
     /**
      * Constructs a RestClient with the given clientInfo, authToken, httpAccessor and authTokenProvider.
      * When it gets a 401 (not authorized) response from the server:
@@ -132,188 +132,188 @@ public class RestClient {
      * <li> If authTokenProvider is not null, it will ask the authTokenProvider for a new access token and retry the request a second time.</li>
      * <li> Otherwise it will return the 401 response.</li>
      * </ul>
-	 * @param clientInfo
+     * @param clientInfo
      * @param authToken
      * @param httpAccessor
      * @param authTokenProvider
-	 */
-	public RestClient(ClientInfo clientInfo, String authToken, HttpAccess httpAccessor, AuthTokenProvider authTokenProvider) {
-		this.clientInfo = clientInfo;
+     */
+    public RestClient(ClientInfo clientInfo, String authToken, HttpAccess httpAccessor, AuthTokenProvider authTokenProvider) {
+        this.clientInfo = clientInfo;
         this.httpAccessor = httpAccessor;
-		this.authTokenProvider = authTokenProvider;
-		setOAuthRefreshInterceptor(authToken);
-		setOkHttpClientBuilder();
-		setOkHttpClient(null);
-	}
-
-	/**
-	 * Remove cached OkHttpClient.Builder, OkHttpClient and OAuthRefreshInterceptor for the given user
-	 */
-	public synchronized static void clearCaches(UserAccount userAccount) {
-		String orgId = userAccount != null ? userAccount.getOrgId() : null;
-		String userId = userAccount != null ? userAccount.getUserId() : null;
-		String cacheKey = computeCacheKey(orgId, userId);
-		OAUTH_REFRESH_INTERCEPTORS.remove(cacheKey);
-		OK_CLIENT_BUILDERS.remove(cacheKey);
-		OkHttpClient client = OK_CLIENTS.remove(cacheKey);
-		if (client != null) {
-			client.dispatcher().cancelAll();
-		}
-	}
-
-	/**
-	 * Clear caches of org-id/user-id to OkHttpClient.Builder, OkHttpClient and OAuthRefreshInterceptor
-	 */
-	public synchronized static void clearCaches() {
-		OAUTH_REFRESH_INTERCEPTORS.clear();
-		OK_CLIENT_BUILDERS.clear();
-		OK_CLIENTS.clear();
+        this.authTokenProvider = authTokenProvider;
+        setOAuthRefreshInterceptor(authToken);
+        setOkHttpClientBuilder();
+        setOkHttpClient(null);
     }
 
-	private String getCacheKey() {
-		return computeCacheKey(clientInfo.orgId, clientInfo.userId);
-	}
+    /**
+     * Remove cached OkHttpClient.Builder, OkHttpClient and OAuthRefreshInterceptor for the given user
+     */
+    public synchronized static void clearCaches(UserAccount userAccount) {
+        String orgId = userAccount != null ? userAccount.getOrgId() : null;
+        String userId = userAccount != null ? userAccount.getUserId() : null;
+        String cacheKey = computeCacheKey(orgId, userId);
+        OAUTH_REFRESH_INTERCEPTORS.remove(cacheKey);
+        OK_CLIENT_BUILDERS.remove(cacheKey);
+        OkHttpClient client = OK_CLIENTS.remove(cacheKey);
+        if (client != null) {
+            client.dispatcher().cancelAll();
+        }
+    }
 
-	private static String computeCacheKey(String orgId, String userId) {
-		return orgId != null && userId != null ? orgId + "-" + userId : "unauthenticated";
-	}
+    /**
+     * Clear caches of org-id/user-id to OkHttpClient.Builder, OkHttpClient and OAuthRefreshInterceptor
+     */
+    public synchronized static void clearCaches() {
+        OAUTH_REFRESH_INTERCEPTORS.clear();
+        OK_CLIENT_BUILDERS.clear();
+        OK_CLIENTS.clear();
+    }
 
-	/**
-	 * Sets the OAuthRefreshInterceptor associated with this user account.
-	 */
+    private String getCacheKey() {
+        return computeCacheKey(clientInfo.orgId, clientInfo.userId);
+    }
+
+    private static String computeCacheKey(String orgId, String userId) {
+        return orgId != null && userId != null ? orgId + "-" + userId : "unauthenticated";
+    }
+
+    /**
+     * Sets the OAuthRefreshInterceptor associated with this user account.
+     */
     private synchronized void setOAuthRefreshInterceptor(String authToken) {
-		final String cacheKey = getCacheKey();
-		OAuthRefreshInterceptor oAuthRefreshInterceptor = OAUTH_REFRESH_INTERCEPTORS.get(cacheKey);
+        final String cacheKey = getCacheKey();
+        OAuthRefreshInterceptor oAuthRefreshInterceptor = OAUTH_REFRESH_INTERCEPTORS.get(cacheKey);
 
-		// If none cached, create new one
-		if (oAuthRefreshInterceptor == null) {
-			oAuthRefreshInterceptor = new OAuthRefreshInterceptor(clientInfo, authToken, authTokenProvider);
-			OAUTH_REFRESH_INTERCEPTORS.put(cacheKey, oAuthRefreshInterceptor);
-		}
-		this.oAuthRefreshInterceptor = oAuthRefreshInterceptor;
-	}
+        // If none cached, create new one
+        if (oAuthRefreshInterceptor == null) {
+            oAuthRefreshInterceptor = new OAuthRefreshInterceptor(clientInfo, authToken, authTokenProvider);
+            OAUTH_REFRESH_INTERCEPTORS.put(cacheKey, oAuthRefreshInterceptor);
+        }
+        this.oAuthRefreshInterceptor = oAuthRefreshInterceptor;
+    }
 
-	/**
-	 * Sets the OkHttpclient.Builder associated with this user account. The OkHttpclient.Builder
-	 * are cached in a map and reused as and when a user account
-	 * switch occurs, to prevent multiple threads being spawned unnecessarily.
-	 */
-	private synchronized void setOkHttpClientBuilder() {
-		final String cacheKey = getCacheKey();
-		OkHttpClient.Builder okHttpClientBuilder = OK_CLIENT_BUILDERS.get(cacheKey);
+    /**
+     * Sets the OkHttpclient.Builder associated with this user account. The OkHttpclient.Builder
+     * are cached in a map and reused as and when a user account
+     * switch occurs, to prevent multiple threads being spawned unnecessarily.
+     */
+    private synchronized void setOkHttpClientBuilder() {
+        final String cacheKey = getCacheKey();
+        OkHttpClient.Builder okHttpClientBuilder = OK_CLIENT_BUILDERS.get(cacheKey);
 
-		// If none cached, create new one
-		if (okHttpClientBuilder == null) {
-			okHttpClientBuilder = httpAccessor.createNewClientBuilder();
-			if (!cacheKey.equals("unauthenticated")) {
-				okHttpClientBuilder.addInterceptor(getOAuthRefreshInterceptor());
-			}
+        // If none cached, create new one
+        if (okHttpClientBuilder == null) {
+            okHttpClientBuilder = httpAccessor.createNewClientBuilder();
+            if (!cacheKey.equals("unauthenticated")) {
+                okHttpClientBuilder.addInterceptor(getOAuthRefreshInterceptor());
+            }
 
-			OK_CLIENT_BUILDERS.put(getCacheKey(), okHttpClientBuilder);
-		}
-		this.okHttpClientBuilder = okHttpClientBuilder;
-	}
+            OK_CLIENT_BUILDERS.put(getCacheKey(), okHttpClientBuilder);
+        }
+        this.okHttpClientBuilder = okHttpClientBuilder;
+    }
 
-	/**
-	 * Sets the OkHttpclient associated with this user account. The OkHttpclient
-	 * are cached in a map and reused as and when a user account
-	 * switch occurs, to prevent multiple threads being spawned unnecessarily.
-	 */
-	public synchronized void setOkHttpClient(OkHttpClient okHttpClient) {
-		final String cacheKey = getCacheKey();
+    /**
+     * Sets the OkHttpclient associated with this user account. The OkHttpclient
+     * are cached in a map and reused as and when a user account
+     * switch occurs, to prevent multiple threads being spawned unnecessarily.
+     */
+    public synchronized void setOkHttpClient(OkHttpClient okHttpClient) {
+        final String cacheKey = getCacheKey();
 
-		// If a valid client passed in, caches it.
-		if (okHttpClient != null) {
-			OK_CLIENTS.put(cacheKey, okHttpClient);
-		}
-		okHttpClient = OK_CLIENTS.get(cacheKey);
+        // If a valid client passed in, caches it.
+        if (okHttpClient != null) {
+            OK_CLIENTS.put(cacheKey, okHttpClient);
+        }
+        okHttpClient = OK_CLIENTS.get(cacheKey);
 
-		// If none cached, create new one
-		if (okHttpClient == null) {
-			okHttpClient = getOkHttpClientBuilder().build();
-			OK_CLIENTS.put(cacheKey, okHttpClient);
-		}
-		this.okHttpClient = okHttpClient;
-	}
+        // If none cached, create new one
+        if (okHttpClient == null) {
+            okHttpClient = getOkHttpClientBuilder().build();
+            OK_CLIENTS.put(cacheKey, okHttpClient);
+        }
+        this.okHttpClient = okHttpClient;
+    }
 
-	/**
-	 * Set the client info. Used by clients to implement Login As
-	 * @param clientInfo The new client info to set
-	 */
-	public void setClientInfo(final ClientInfo clientInfo) {
-		getOAuthRefreshInterceptor().setClientInfo(clientInfo);
-	}
+    /**
+     * Set the client info. Used by clients to implement Login As
+     * @param clientInfo The new client info to set
+     */
+    public void setClientInfo(final ClientInfo clientInfo) {
+        getOAuthRefreshInterceptor().setClientInfo(clientInfo);
+    }
 
-	/**
-	 * @return credentials as JSONObject
-	 */
-	public JSONObject getJSONCredentials() {
-		ClientInfo clientInfo = getClientInfo();
-		Map<String, String> data = new HashMap<>();
-		data.put(ACCESS_TOKEN, getAuthToken());
-		data.put(REFRESH_TOKEN, getRefreshToken());
-		data.put(USER_ID, clientInfo.userId);
-		data.put(ORG_ID, clientInfo.orgId);
-		data.put(LOGIN_URL, clientInfo.loginUrl.toString());
-		data.put(IDENTITY_URL, clientInfo.identityUrl.toString());
-		data.put(INSTANCE_URL, clientInfo.instanceUrl.toString());
-		data.put(USER_AGENT, SalesforceSDKManager.getInstance().getUserAgent());
-		data.put(COMMUNITY_ID, clientInfo.communityId);
-		data.put(COMMUNITY_URL, clientInfo.communityUrl);
-		return new JSONObject(data);
-	}
+    /**
+     * @return credentials as JSONObject
+     */
+    public JSONObject getJSONCredentials() {
+        ClientInfo clientInfo = getClientInfo();
+        Map<String, String> data = new HashMap<>();
+        data.put(ACCESS_TOKEN, getAuthToken());
+        data.put(REFRESH_TOKEN, getRefreshToken());
+        data.put(USER_ID, clientInfo.userId);
+        data.put(ORG_ID, clientInfo.orgId);
+        data.put(LOGIN_URL, clientInfo.loginUrl.toString());
+        data.put(IDENTITY_URL, clientInfo.identityUrl.toString());
+        data.put(INSTANCE_URL, clientInfo.instanceUrl.toString());
+        data.put(USER_AGENT, SalesforceSDKManager.getInstance().getUserAgent());
+        data.put(COMMUNITY_ID, clientInfo.communityId);
+        data.put(COMMUNITY_URL, clientInfo.communityUrl);
+        return new JSONObject(data);
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("RestClient: {\n")
-		  .append(this.oAuthRefreshInterceptor.clientInfo.toString())
-		  .append("   timeSinceLastRefresh: ").append(oAuthRefreshInterceptor.getElapsedTimeSinceLastRefresh()).append("\n")
-		  .append("}\n");
-		return sb.toString();
-	}
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("RestClient: {\n")
+                .append(this.oAuthRefreshInterceptor.clientInfo.toString())
+                .append("   timeSinceLastRefresh: ").append(oAuthRefreshInterceptor.getElapsedTimeSinceLastRefresh()).append("\n")
+                .append("}\n");
+        return sb.toString();
+    }
 
-	/**
-	 * @return The authToken for this RestClient.
-	 */
-	public synchronized String getAuthToken() {
-		return oAuthRefreshInterceptor.getAuthToken();
-	}
-	
-	/**
-	 * @return The refresh token, if available.
-	 */
-	public String getRefreshToken() {
-		return oAuthRefreshInterceptor.getRefreshToken();
-	}
-	
-	/**
-	 * @return The client info.
-	 */
-	public ClientInfo getClientInfo() {
-		return oAuthRefreshInterceptor.clientInfo;
-	}
+    /**
+     * @return The authToken for this RestClient.
+     */
+    public synchronized String getAuthToken() {
+        return oAuthRefreshInterceptor.getAuthToken();
+    }
 
-	/**
-	 * @return underlying OAuthRefreshInterceptor
-	 */
-	public OAuthRefreshInterceptor getOAuthRefreshInterceptor() {
-		return oAuthRefreshInterceptor;
-	}
+    /**
+     * @return The refresh token, if available.
+     */
+    public String getRefreshToken() {
+        return oAuthRefreshInterceptor.getRefreshToken();
+    }
 
-	/**
-	 * @return underlying OkHttpClient.Builder
-	 */
-	public OkHttpClient.Builder getOkHttpClientBuilder() {
-		return okHttpClientBuilder;
-	}
+    /**
+     * @return The client info.
+     */
+    public ClientInfo getClientInfo() {
+        return oAuthRefreshInterceptor.clientInfo;
+    }
 
-	/**
-	 * @return underlying OkHttpClient
-	 */
-	public OkHttpClient getOkHttpClient() {
-		return okHttpClient;
-	}
+    /**
+     * @return underlying OAuthRefreshInterceptor
+     */
+    public OAuthRefreshInterceptor getOAuthRefreshInterceptor() {
+        return oAuthRefreshInterceptor;
+    }
+
+    /**
+     * @return underlying OkHttpClient.Builder
+     */
+    public OkHttpClient.Builder getOkHttpClientBuilder() {
+        return okHttpClientBuilder;
+    }
+
+    /**
+     * @return underlying OkHttpClient
+     */
+    public OkHttpClient getOkHttpClient() {
+        return okHttpClient;
+    }
 
     /**
      * Helper to build okHttp Request from RestRequest
@@ -321,7 +321,7 @@ public class RestClient {
      * @return
      */
     public Request buildRequest(RestRequest restRequest) {
-        final Request.Builder builder =  new Request.Builder()
+        final Request.Builder builder = new Request.Builder()
                 .url(HttpUrl.get(oAuthRefreshInterceptor.clientInfo.resolveUrl(restRequest)))
                 .method(restRequest.getMethod().toString(), restRequest.getRequestBody());
 
@@ -335,43 +335,43 @@ public class RestClient {
         return builder.build();
     }
 
-	/**
-	 * Send the given restRequest and process the result asynchronously with the given callback.
-	 * Note: Intended to be used by code on the UI thread.
-	 * @param restRequest
-	 * @param callback
-	 * @return okHttp Call object (through which you can cancel the request or get the request back)
-	 */
+    /**
+     * Send the given restRequest and process the result asynchronously with the given callback.
+     * Note: Intended to be used by code on the UI thread.
+     * @param restRequest
+     * @param callback
+     * @return okHttp Call object (through which you can cancel the request or get the request back)
+     */
     public Call sendAsync(final RestRequest restRequest, final AsyncRequestCallback callback) {
-	    Request request = buildRequest(restRequest);
-		Call call = okHttpClient.newCall(request);
-		call.enqueue(new Callback() {
+        Request request = buildRequest(restRequest);
+        Call call = okHttpClient.newCall(request);
+        call.enqueue(new Callback() {
 
             @Override
-			public void onFailure(Call call, IOException e) {
-									 callback.onError(e);
-								 }
-
-			@Override
-			public void onResponse(Call call, Response response) throws IOException {
-			    callback.onSuccess(restRequest, new RestResponse(response));
+            public void onFailure(Call call, IOException e) {
+                callback.onError(e);
             }
-		});
-		return call;
-	}
 
-	/**
-	 * Send the given restRequest synchronously and return a RestResponse
-	 * Note: Cannot be used by code on the UI thread (use sendAsync instead).
-	 * @param restRequest
-	 * @return
-	 * @throws IOException 
-	 */
-	public RestResponse sendSync(RestRequest restRequest) throws IOException {
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                callback.onSuccess(restRequest, new RestResponse(response));
+            }
+        });
+        return call;
+    }
+
+    /**
+     * Send the given restRequest synchronously and return a RestResponse
+     * Note: Cannot be used by code on the UI thread (use sendAsync instead).
+     * @param restRequest
+     * @return
+     * @throws IOException
+     */
+    public RestResponse sendSync(RestRequest restRequest) throws IOException {
         Request request = buildRequest(restRequest);
         Response response = okHttpClient.newCall(request).execute();
         return new RestResponse(response);
-	}
+    }
 
     /**
      * Send the given restRequest synchronously and return a RestResponse
@@ -393,84 +393,84 @@ public class RestClient {
         return new RestResponse(response);
     }
 
-	/**
-	 * All immutable information for an authenticated client (e.g. username, org ID, etc.).
-	 */
-	public static class ClientInfo {
+    /**
+     * All immutable information for an authenticated client (e.g. username, org ID, etc.).
+     */
+    public static class ClientInfo {
 
-		public final URI instanceUrl;
-		public final URI loginUrl;
-		public final URI identityUrl;
-		public final String accountName;
-		public final String username;
-		public final String userId;
-		public final String orgId;
-		public final String communityId;
-		public final String communityUrl;
-		public final String firstName;
-		public final String lastName;
-		public final String displayName;
-		public final String email;
-		public final String photoUrl;
-		public final String thumbnailUrl;
-		public final String lightningDomain;
-		public final String lightningSid;
-		public final String vfDomain;
-		public final String vfSid;
-		public final String contentDomain;
-		public final String contentSid;
-		public final String csrfToken;
-		public final Map<String, String> additionalOauthValues;
+        public final URI instanceUrl;
+        public final URI loginUrl;
+        public final URI identityUrl;
+        public final String accountName;
+        public final String username;
+        public final String userId;
+        public final String orgId;
+        public final String communityId;
+        public final String communityUrl;
+        public final String firstName;
+        public final String lastName;
+        public final String displayName;
+        public final String email;
+        public final String photoUrl;
+        public final String thumbnailUrl;
+        public final String lightningDomain;
+        public final String lightningSid;
+        public final String vfDomain;
+        public final String vfSid;
+        public final String contentDomain;
+        public final String contentSid;
+        public final String csrfToken;
+        public final Map<String, String> additionalOauthValues;
 
-		/**
-		 * Parameterized constructor.
-		 *
-		 * @param instanceUrl Instance URL.
-		 * @param loginUrl Login URL.
-		 * @param identityUrl Identity URL.
-		 * @param accountName Account name.
-		 * @param username User name.
-		 * @param userId User ID.
-		 * @param orgId Org ID.
-		 * @param communityId Community ID.
-		 * @param communityUrl Community URL.
-         * @param firstName First Name.
-         * @param lastName LastName.
-		 * @param displayName DisplayName.
-         * @param email Email.
-         * @param photoUrl Photo URL.
-         * @param thumbnailUrl Thumbnail URL.
+        /**
+         * Parameterized constructor.
+         *
+         * @param instanceUrl           Instance URL.
+         * @param loginUrl              Login URL.
+         * @param identityUrl           Identity URL.
+         * @param accountName           Account name.
+         * @param username              User name.
+         * @param userId                User ID.
+         * @param orgId                 Org ID.
+         * @param communityId           Community ID.
+         * @param communityUrl          Community URL.
+         * @param firstName             First Name.
+         * @param lastName              LastName.
+         * @param displayName           DisplayName.
+         * @param email                 Email.
+         * @param photoUrl              Photo URL.
+         * @param thumbnailUrl          Thumbnail URL.
          * @param additionalOauthValues Additional OAuth values.
-		 * @param lightningDomain Lightning domain.
-		 * @param lightningSid Lightning SID.
-		 * @param vfDomain VF domain.
-		 * @param vfSid VF SID.
-		 * @param contentDomain Content domain.
-		 * @param contentSid Content SID.
-		 * @param csrfToken CSRF token.
-		 */
-		public ClientInfo(URI instanceUrl, URI loginUrl,
-				URI identityUrl, String accountName, String username,
-				String userId, String orgId, String communityId, String communityUrl,
-				String firstName, String lastName, String displayName, String email,
-				String photoUrl, String thumbnailUrl, Map<String, String> additionalOauthValues,
-				String lightningDomain, String lightningSid, String vfDomain, String vfSid,
-				String contentDomain, String contentSid, String csrfToken) {
-			this.instanceUrl = instanceUrl;
-			this.loginUrl = loginUrl;
-			this.identityUrl = identityUrl;
-			this.accountName = accountName;
-			this.username = username;
-			this.userId = userId;
-			this.orgId = orgId;
-			this.communityId = communityId;
-			this.communityUrl = communityUrl;
-			this.firstName = firstName;
-			this.lastName = lastName;
-			this.displayName = displayName;
-			this.email = email;
-			this.photoUrl = photoUrl;
-			this.thumbnailUrl = thumbnailUrl;
+         * @param lightningDomain       Lightning domain.
+         * @param lightningSid          Lightning SID.
+         * @param vfDomain              VF domain.
+         * @param vfSid                 VF SID.
+         * @param contentDomain         Content domain.
+         * @param contentSid            Content SID.
+         * @param csrfToken             CSRF token.
+         */
+        public ClientInfo(URI instanceUrl, URI loginUrl,
+                          URI identityUrl, String accountName, String username,
+                          String userId, String orgId, String communityId, String communityUrl,
+                          String firstName, String lastName, String displayName, String email,
+                          String photoUrl, String thumbnailUrl, Map<String, String> additionalOauthValues,
+                          String lightningDomain, String lightningSid, String vfDomain, String vfSid,
+                          String contentDomain, String contentSid, String csrfToken) {
+            this.instanceUrl = instanceUrl;
+            this.loginUrl = loginUrl;
+            this.identityUrl = identityUrl;
+            this.accountName = accountName;
+            this.username = username;
+            this.userId = userId;
+            this.orgId = orgId;
+            this.communityId = communityId;
+            this.communityUrl = communityUrl;
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.displayName = displayName;
+            this.email = email;
+            this.photoUrl = photoUrl;
+            this.thumbnailUrl = thumbnailUrl;
             this.additionalOauthValues = additionalOauthValues;
             this.lightningDomain = lightningDomain;
             this.lightningSid = lightningSid;
@@ -479,7 +479,7 @@ public class RestClient {
             this.contentDomain = contentDomain;
             this.contentSid = contentSid;
             this.csrfToken = csrfToken;
-		}
+        }
 
         /**
          * @return unique id built from user id and org id
@@ -488,131 +488,131 @@ public class RestClient {
             return this.userId + this.orgId;
         }
 
-		@Override
-		public String toString() {
-			StringBuilder sb = new StringBuilder();
-			sb.append("  ClientInfo: {\n")
-			  .append("     loginUrl: ").append(loginUrl.toString()).append("\n")
-			  .append("     identityUrl: ").append(identityUrl.toString()).append("\n")
-			  .append("     instanceUrl: ").append(instanceUrl.toString()).append("\n")
-			  .append("     accountName: ").append(accountName).append("\n")
-			  .append("     username: ").append(username).append("\n")
-			  .append("     userId: ").append(userId).append("\n")
-			  .append("     orgId: ").append(orgId).append("\n")
-			  .append("     communityId: ").append(communityId).append("\n")
-			  .append("     communityUrl: ").append(communityUrl).append("\n")
-              .append("     firstName: ").append(firstName).append("\n")
-              .append("     lastName: ").append(lastName).append("\n")
-			  .append("     displayName: ").append(displayName).append("\n")
-              .append("     email: ").append(email).append("\n")
-              .append("     photoUrl: ").append(photoUrl).append("\n")
-              .append("     thumbnailUrl: ").append(thumbnailUrl).append("\n")
-			  .append("     lightningDomain: ").append(lightningDomain).append("\n")
-			  .append("     lightningSid: ").append(lightningSid).append("\n")
-			  .append("     vfDomain: ").append(vfDomain).append("\n")
-			  .append("     vfSid: ").append(vfSid).append("\n")
-			  .append("     contentDomain: ").append(contentDomain).append("\n")
-			  .append("     contentSid: ").append(contentSid).append("\n")
-			  .append("     csrfToken: ").append(csrfToken).append("\n")
-			  .append("     additionalOauthValues: ").append(additionalOauthValues).append("\n")
-			  .append("  }\n");
-			return sb.toString();
-		}
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("  ClientInfo: {\n")
+                    .append("     loginUrl: ").append(loginUrl.toString()).append("\n")
+                    .append("     identityUrl: ").append(identityUrl.toString()).append("\n")
+                    .append("     instanceUrl: ").append(instanceUrl.toString()).append("\n")
+                    .append("     accountName: ").append(accountName).append("\n")
+                    .append("     username: ").append(username).append("\n")
+                    .append("     userId: ").append(userId).append("\n")
+                    .append("     orgId: ").append(orgId).append("\n")
+                    .append("     communityId: ").append(communityId).append("\n")
+                    .append("     communityUrl: ").append(communityUrl).append("\n")
+                    .append("     firstName: ").append(firstName).append("\n")
+                    .append("     lastName: ").append(lastName).append("\n")
+                    .append("     displayName: ").append(displayName).append("\n")
+                    .append("     email: ").append(email).append("\n")
+                    .append("     photoUrl: ").append(photoUrl).append("\n")
+                    .append("     thumbnailUrl: ").append(thumbnailUrl).append("\n")
+                    .append("     lightningDomain: ").append(lightningDomain).append("\n")
+                    .append("     lightningSid: ").append(lightningSid).append("\n")
+                    .append("     vfDomain: ").append(vfDomain).append("\n")
+                    .append("     vfSid: ").append(vfSid).append("\n")
+                    .append("     contentDomain: ").append(contentDomain).append("\n")
+                    .append("     contentSid: ").append(contentSid).append("\n")
+                    .append("     csrfToken: ").append(csrfToken).append("\n")
+                    .append("     additionalOauthValues: ").append(additionalOauthValues).append("\n")
+                    .append("  }\n");
+            return sb.toString();
+        }
 
-		/**
-		 * Returns a string representation of the instance URL. If this is a
-		 * community user, the community URL will be returned. If not, the
-		 * instance URL will be returned.
-		 *
-		 * @return Instance URL.
-		 */
-		public String getInstanceUrlAsString() {
-			if (communityUrl != null && !"".equals(communityUrl.trim())) {
-				return communityUrl;
-			}
-			return instanceUrl.toString();
-		}
+        /**
+         * Returns a string representation of the instance URL. If this is a
+         * community user, the community URL will be returned. If not, the
+         * instance URL will be returned.
+         *
+         * @return Instance URL.
+         */
+        public String getInstanceUrlAsString() {
+            if (communityUrl != null && !"".equals(communityUrl.trim())) {
+                return communityUrl;
+            }
+            return instanceUrl.toString();
+        }
 
-		/**
-		 * Returns a URI representation of the instance URL. If this is a
-		 * community user, the community URL will be returned. If not, the
-		 * instance URL will be returned.
-		 *
-		 * @return Instance URL.
-		 */
-		public URI getInstanceUrl() {
-			if (communityUrl != null && !communityUrl.trim().isEmpty()) {
-				URI uri = null;
-				try {
-					uri = new URI(communityUrl);
-				} catch (URISyntaxException e) {
+        /**
+         * Returns a URI representation of the instance URL. If this is a
+         * community user, the community URL will be returned. If not, the
+         * instance URL will be returned.
+         *
+         * @return Instance URL.
+         */
+        public URI getInstanceUrl() {
+            if (communityUrl != null && !communityUrl.trim().isEmpty()) {
+                URI uri = null;
+                try {
+                    uri = new URI(communityUrl);
+                } catch (URISyntaxException e) {
                     SalesforceSDKLogger.e(TAG, "Exception thrown while parsing URL: " + communityUrl, e);
-				}
-				return uri;
-			}
-			return instanceUrl;
-		}
+                }
+                return uri;
+            }
+            return instanceUrl;
+        }
 
-		/**
-		 * Resolves the given {@link RestRequest} to its URL.
-		 * @param request The Rest request to resolve.
-		 * @return The URI associated with the Rest request.
-		 */
-		public URI resolveUrl(RestRequest request) {
-			return resolveUrl(request.getPath(), request.getEndpoint());
-		}
+        /**
+         * Resolves the given {@link RestRequest} to its URL.
+         * @param request The Rest request to resolve.
+         * @return The URI associated with the Rest request.
+         */
+        public URI resolveUrl(RestRequest request) {
+            return resolveUrl(request.getPath(), request.getEndpoint());
+        }
 
-		/**
-		 * Resolves the given path against the community URL or the instance
-		 * URL, depending on whether the user is a community user or not.
-		 *
-		 * @param path Path.
-		 * @return Resolved URL.
-		 */
-		public URI resolveUrl(String path) {
-			return resolveUrl(path, RestRequest.RestEndpoint.INSTANCE);
-		}
+        /**
+         * Resolves the given path against the community URL or the instance
+         * URL, depending on whether the user is a community user or not.
+         *
+         * @param path Path.
+         * @return Resolved URL.
+         */
+        public URI resolveUrl(String path) {
+            return resolveUrl(path, RestRequest.RestEndpoint.INSTANCE);
+        }
 
-		/**
-		 * Resolves the given path against the community URL, login URL, or instance
-		 * URL.  If the user is a community user, the community URL will be used.  Otherwise,
-		 * the URL will be built from the
-		 * {@link RestRequest.RestEndpoint} parameter.
-		 * @param path Path
-		 * @param endpoint The Rest endpoint of the URL.
-		 * @return Resolved URL.
-		 */
-		public URI resolveUrl(String path, RestRequest.RestEndpoint endpoint) {
-			String resolvedPathStr = path;
+        /**
+         * Resolves the given path against the community URL, login URL, or instance
+         * URL.  If the user is a community user, the community URL will be used.  Otherwise,
+         * the URL will be built from the
+         * {@link RestRequest.RestEndpoint} parameter.
+         * @param path     Path
+         * @param endpoint The Rest endpoint of the URL.
+         * @return Resolved URL.
+         */
+        public URI resolveUrl(String path, RestRequest.RestEndpoint endpoint) {
+            String resolvedPathStr = path;
 
-			// Resolve URL only for a relative URL.
-			if (!path.matches("[hH][tT][tT][pP][sS]?://.*")) {
-				final StringBuilder resolvedUrlBuilder = new StringBuilder();
-				if (communityUrl != null && !communityUrl.trim().isEmpty()) {
-					resolvedUrlBuilder.append(communityUrl);
-				} else if (endpoint == RestRequest.RestEndpoint.INSTANCE) {
-					resolvedUrlBuilder.append(instanceUrl.toString());
-				} else if (endpoint == RestRequest.RestEndpoint.LOGIN) {
-					resolvedUrlBuilder.append(loginUrl.toString());
-				}
-				if (!resolvedUrlBuilder.toString().endsWith("/")) {
-					resolvedUrlBuilder.append("/");
-				}
-				if (path.startsWith("/")) {
-					path = path.substring(1);
-				}
-				resolvedUrlBuilder.append(path);
-				resolvedPathStr = resolvedUrlBuilder.toString();
-			}
-			URI uri = null;
-			try {
-				uri = new URI(resolvedPathStr);
-			} catch (URISyntaxException e) {
+            // Resolve URL only for a relative URL.
+            if (!path.matches("[hH][tT][tT][pP][sS]?://.*")) {
+                final StringBuilder resolvedUrlBuilder = new StringBuilder();
+                if (communityUrl != null && !communityUrl.trim().isEmpty()) {
+                    resolvedUrlBuilder.append(communityUrl);
+                } else if (endpoint == RestRequest.RestEndpoint.INSTANCE) {
+                    resolvedUrlBuilder.append(instanceUrl.toString());
+                } else if (endpoint == RestRequest.RestEndpoint.LOGIN) {
+                    resolvedUrlBuilder.append(loginUrl.toString());
+                }
+                if (!resolvedUrlBuilder.toString().endsWith("/")) {
+                    resolvedUrlBuilder.append("/");
+                }
+                if (path.startsWith("/")) {
+                    path = path.substring(1);
+                }
+                resolvedUrlBuilder.append(path);
+                resolvedPathStr = resolvedUrlBuilder.toString();
+            }
+            URI uri = null;
+            try {
+                uri = new URI(resolvedPathStr);
+            } catch (URISyntaxException e) {
                 SalesforceSDKLogger.e(TAG, "Exception thrown while parsing URL: " + resolvedPathStr, e);
-			}
-			return uri;
-		}
-	}
+            }
+            return uri;
+        }
+    }
 
     /**
      * Use a unauthenticated client info when do not need authentication support (e.g.
@@ -627,8 +627,8 @@ public class RestClient {
             super(null, null, null, null, null,
                     null, null, null, null, null,
                     null, null, null, null, null,
-					null, null, null, null,
-					null, null, null, null);
+                    null, null, null, null,
+                    null, null, null, null);
         }
 
         @Override
@@ -646,8 +646,7 @@ public class RestClient {
             URI uri = null;
             try {
                 uri = new URI(path);
-            }
-            catch (URISyntaxException e) {
+            } catch (URISyntaxException e) {
                 SalesforceSDKLogger.e(TAG, "Exception thrown while parsing URL: " + path, e);
             }
             return uri;
@@ -681,29 +680,29 @@ public class RestClient {
             this.authTokenProvider = authTokenProvider;
         }
 
-		private boolean shouldRefresh(Response response) throws IOException {
-			int responseCode = response.code();
+        private boolean shouldRefresh(Response response) throws IOException {
+            int responseCode = response.code();
 
-			// most calls return 401 if oauth access token is not valid
-			boolean isNotAuthorized = responseCode == HttpURLConnection.HTTP_UNAUTHORIZED;
+            // most calls return 401 if oauth access token is not valid
+            boolean isNotAuthorized = responseCode == HttpURLConnection.HTTP_UNAUTHORIZED;
 
-			// service/oauth2 calls return 403 with Bad_OAuth_Token response if oauth access is not valid
-			boolean hasBadOAuthToken = responseCode == HttpURLConnection.HTTP_FORBIDDEN
-					&& response.request().url().encodedPath().startsWith(RestRequest.SERVICES_OAUTH2)
-					&& (response.body() != null && response.body().string().equals("Bad_OAuth_Token"));
+            // service/oauth2 calls return 403 with Bad_OAuth_Token response if oauth access is not valid
+            boolean hasBadOAuthToken = responseCode == HttpURLConnection.HTTP_FORBIDDEN
+                    && response.request().url().encodedPath().startsWith(RestRequest.SERVICES_OAUTH2)
+                    && (response.body() != null && response.body().string().equals("Bad_OAuth_Token"));
 
-			if (isNotAuthorized || hasBadOAuthToken) {
-				SalesforceSDKLogger.d(TAG, "response request url: " + response.request().url());
-				SalesforceSDKLogger.d(TAG, "response code: " + response.code());
+            if (isNotAuthorized || hasBadOAuthToken) {
+                SalesforceSDKLogger.d(TAG, "response request url: " + response.request().url());
+                SalesforceSDKLogger.d(TAG, "response code: " + response.code());
 
-				// Is biometric enabled and locked ?
-				BiometricAuthenticationManager bioAuthManager =
-						(BiometricAuthenticationManager) SalesforceSDKManager.getInstance().getBiometricAuthenticationManager();
-				return bioAuthManager == null || bioAuthManager.shouldAllowRefresh();
-			} else {
-				return false;
-			}
-		}
+                // Is biometric enabled and locked?
+                BiometricAuthenticationManager bioAuthManager =
+                        (BiometricAuthenticationManager) SalesforceSDKManager.getInstance().getBiometricAuthenticationManager();
+                return bioAuthManager == null || bioAuthManager.shouldAllowRefresh();
+            } else {
+                return false;
+            }
+        }
 
         @Override
         public Response intercept(Chain chain) throws IOException {
@@ -711,70 +710,70 @@ public class RestClient {
             request = buildAuthenticatedRequest(request);
             Response response = chain.proceed(request);
 
-			/*
-			 * Standard access token expiry returns 401 as the error code.
-			 */
+            /*
+             * Standard access token expiry returns 401 as the error code.
+             */
             if (shouldRefresh(response)) {
-				SalesforceSDKLogger.d(TAG, "shouldRefresh() returned true");
+                SalesforceSDKLogger.d(TAG, "shouldRefresh() returned true");
 
-				final URI curInstanceUrl = clientInfo.getInstanceUrl();
-				if (curInstanceUrl != null) {
-					final HttpUrl currentInstanceUrl = HttpUrl.get(curInstanceUrl);
-					if (currentInstanceUrl != null) {
+                final URI curInstanceUrl = clientInfo.getInstanceUrl();
+                if (curInstanceUrl != null) {
+                    final HttpUrl currentInstanceUrl = HttpUrl.get(curInstanceUrl);
+                    if (currentInstanceUrl != null) {
 
-						// Checks if the host of the request is the same as instance URL.
-						boolean isHostInstanceUrl = currentInstanceUrl.host().equals(request.url().host());
-						refreshAccessToken();
-						if (getAuthToken() != null) {
-							request = buildAuthenticatedRequest(request);
+                        // Checks if the host of the request is the same as instance URL.
+                        boolean isHostInstanceUrl = currentInstanceUrl.host().equals(request.url().host());
+                        refreshAccessToken();
+                        if (getAuthToken() != null) {
+                            request = buildAuthenticatedRequest(request);
 
-							/*
-							 * During instance migration, the instance URL could change. Hence, the host
-							 * needs to be adjusted to replace the old instance URL with the new instance
-							 * URL before replaying this request. However, this adjustment should be applied
-							 * only if the host of the request was the old instance URL. This avoids
-							 * accidental manipulation of the host for requests where the caller has
-							 * passed in their own fully formed host URL that is not instance URL.
-							 *
-							 * We also need to cover the case where the host changes during refresh
-							 * because the replayed request will fail.
-							 */
-							final URI refreshInstanceUrl = clientInfo.getInstanceUrl();
-							boolean refreshUpdatedUrl = refreshInstanceUrl != null &&
-									!refreshInstanceUrl.getHost().equals(request.url().host());
-							if (isHostInstanceUrl && refreshUpdatedUrl) {
-								final HttpUrl updatedInstanceUrl = HttpUrl.get(refreshInstanceUrl);
-								if (updatedInstanceUrl != null) {
-									request = adjustHostInRequest(request, updatedInstanceUrl.host());
-								}
-							}
-							response.close();
-							response = chain.proceed(request);
-						}
-					}
-				}
+                            /*
+                             * During instance migration, the instance URL could change. Hence, the host
+                             * needs to be adjusted to replace the old instance URL with the new instance
+                             * URL before replaying this request. However, this adjustment should be applied
+                             * only if the host of the request was the old instance URL. This avoids
+                             * accidental manipulation of the host for requests where the caller has
+                             * passed in their own fully formed host URL that is not instance URL.
+                             *
+                             * We also need to cover the case where the host changes during refresh
+                             * because the replayed request will fail.
+                             */
+                            final URI refreshInstanceUrl = clientInfo.getInstanceUrl();
+                            boolean refreshUpdatedUrl = refreshInstanceUrl != null &&
+                                    !refreshInstanceUrl.getHost().equals(request.url().host());
+                            if (isHostInstanceUrl && refreshUpdatedUrl) {
+                                final HttpUrl updatedInstanceUrl = HttpUrl.get(refreshInstanceUrl);
+                                if (updatedInstanceUrl != null) {
+                                    request = adjustHostInRequest(request, updatedInstanceUrl.host());
+                                }
+                            }
+                            response.close();
+                            response = chain.proceed(request);
+                        }
+                    }
+                }
             }
             return response;
         }
 
-		/**
-		 * Build new request which has the new host. This is essential in case of instance migration
-		 *
-		 * @param request
-		 * @param host the host segment of the url to be placed
-		 * @return
-		 */
-		private Request adjustHostInRequest(Request request, final String host) {
-			HttpUrl.Builder urlBuilder = request.url().newBuilder();
+        /**
+         * Build new request which has the new host. This is essential in case of instance migration
+         *
+         * @param request
+         * @param host    the host segment of the url to be placed
+         * @return
+         */
+        private Request adjustHostInRequest(Request request, final String host) {
+            HttpUrl.Builder urlBuilder = request.url().newBuilder();
 
-			// Only replace the host
-			urlBuilder.host(host);
-			Request.Builder builder = request.newBuilder();
-			builder.url(urlBuilder.build());
-			return builder.build();
-		}
+            // Only replace the host
+            urlBuilder.host(host);
+            Request.Builder builder = request.newBuilder();
+            builder.url(urlBuilder.build());
+            return builder.build();
+        }
 
-		/**
+        /**
          * Build new request which has authentication header
          * @param request
          * @return
@@ -834,14 +833,14 @@ public class RestClient {
         /**
          * Swaps the existing access token for a new one.
          */
-		public void refreshAccessToken() throws IOException {
+        public void refreshAccessToken() throws IOException {
 
             // If we haven't retried already and we have an accessTokenProvider
             // Then let's try to get a new authToken
             if (authTokenProvider != null) {
                 final String newAuthToken = authTokenProvider.getNewAuthToken();
 
-				if (newAuthToken == null || authTokenProvider.getInstanceUrl() == null) {
+                if (newAuthToken == null || authTokenProvider.getInstanceUrl() == null) {
                     throw new RefreshTokenRevokedException("Could not refresh token");
                 }
 
@@ -861,9 +860,9 @@ public class RestClient {
                                 clientInfo.communityUrl, clientInfo.firstName, clientInfo.lastName,
                                 clientInfo.displayName, clientInfo.email, clientInfo.photoUrl,
                                 clientInfo.thumbnailUrl, clientInfo.additionalOauthValues,
-								clientInfo.lightningDomain, clientInfo.lightningSid,
-								clientInfo.vfDomain, clientInfo.vfSid,
-								clientInfo.contentDomain, clientInfo.contentSid, clientInfo.csrfToken);
+                                clientInfo.lightningDomain, clientInfo.lightningSid,
+                                clientInfo.vfDomain, clientInfo.vfSid,
+                                clientInfo.contentDomain, clientInfo.contentSid, clientInfo.csrfToken);
                     } catch (URISyntaxException ex) {
                         SalesforceSDKLogger.w(TAG, "Invalid server URL", ex);
                     }
@@ -876,19 +875,19 @@ public class RestClient {
         }
     }
 
-	/**
-	 * Exception thrown when refresh token was found to be revoked
-	 */
-	public static class RefreshTokenRevokedException extends IOException {
+    /**
+     * Exception thrown when refresh token was found to be revoked
+     */
+    public static class RefreshTokenRevokedException extends IOException {
 
-		private static final long serialVersionUID = 2L;
+        private static final long serialVersionUID = 2L;
 
-		RefreshTokenRevokedException(String msg) {
-			super(msg);
-		}
+        RefreshTokenRevokedException(String msg) {
+            super(msg);
+        }
 
-		public RefreshTokenRevokedException(String msg, Throwable cause) {
-			super(msg, cause);
-		}
-	}
+        public RefreshTokenRevokedException(String msg, Throwable cause) {
+            super(msg, cause);
+        }
+    }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -693,6 +693,9 @@ public class RestClient {
 					&& (response.body() != null && response.body().string().equals("Bad_OAuth_Token"));
 
 			if (isNotAuthorized || hasBadOAuthToken) {
+				SalesforceSDKLogger.d(TAG, "response request url: " + response.request().url());
+				SalesforceSDKLogger.d(TAG, "response code: " + response.code());
+
 				// Is biometric enabled and locked ?
 				BiometricAuthenticationManager bioAuthManager =
 						(BiometricAuthenticationManager) SalesforceSDKManager.getInstance().getBiometricAuthenticationManager();
@@ -712,6 +715,7 @@ public class RestClient {
 			 * Standard access token expiry returns 401 as the error code.
 			 */
             if (shouldRefresh(response)) {
+				SalesforceSDKLogger.d(TAG, "shouldRefresh() returned true");
 
 				final URI curInstanceUrl = clientInfo.getInstanceUrl();
 				if (curInstanceUrl != null) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -698,7 +698,7 @@ public class RestClient {
 						(BiometricAuthenticationManager) SalesforceSDKManager.getInstance().getBiometricAuthenticationManager();
 				return bioAuthManager == null || bioAuthManager.shouldAllowRefresh();
 			} else {
-				return true;
+				return false;
 			}
 		}
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -62,6 +62,7 @@ import okhttp3.RequestBody;
  * <ul>
  * <li> userinfo</li>
  * <li> tokeninfo</li>
+ * <li> singleaccess</li>
  * <li> versions</li>
  * <li> resources</li>
  * <li> describeGlobal</li>
@@ -118,6 +119,7 @@ public class RestRequest {
     public static final String HALT_ON_ERROR = "haltOnError";
     public static final String RICH_INPUT = "richInput";
     public static final String SERVICES_DATA = "/services/data/";
+	public static final String SERVICES_OAUTH2 = "/services/oauth2/";
     public static final String REFERENCE_ID = "referenceId";
     public static final String TYPE = "type";
     public static final String ATTRIBUTES = "attributes";
@@ -159,8 +161,9 @@ public class RestRequest {
 
 	enum RestAction {
 
-		USERINFO("/services/oauth2/userinfo"),
-		TOKENINFO("/services/oauth2/introspect"),
+		USERINFO(SERVICES_OAUTH2 + "userinfo"),
+		TOKENINFO(SERVICES_OAUTH2 + "introspect"),
+		SINGLEACCESS(SERVICES_OAUTH2 + "singleaccess"),
 		VERSIONS(SERVICES_DATA),
 		RESOURCES(SERVICES_DATA + "%s/"),
 		DESCRIBE_GLOBAL(SERVICES_DATA + "%s/sobjects/"),
@@ -368,6 +371,20 @@ public class RestRequest {
 	 */
 	public static RestRequest getRequestForUserInfo() {
 		return new RestRequest(RestMethod.GET, RestEndpoint.LOGIN, RestAction.USERINFO.getPath(), (RequestBody) null, null);
+	}
+
+	/**
+	 * Request to generate URL to bridge into UI sessions
+	 * @param redirectUri A relative path that points to where the user is redirected when their new session begins.
+	 * @return RestRequest object that requests single access URL.
+	 * @see <a href="https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm">https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm</a></a>
+	 */
+	public static RestRequest getRequestForSingleAccess(String redirectUri) {
+		RequestBody requestBody = RequestBody.create(
+				"redirect_uri=" + redirectUri,
+				MediaType.parse("application/x-www-form-urlencoded")
+		);
+		return new RestRequest(RestMethod.POST, RestEndpoint.INSTANCE, RestAction.SINGLEACCESS.getPath(), requestBody, null);
 	}
 
 	/**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -95,15 +95,15 @@ import okhttp3.RequestBody;
  */
 public class RestRequest {
 
-	/**
-	 * application/json media type
-	 */
-	public static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json; charset=utf-8");
+    /**
+     * application/json media type
+     */
+    public static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json; charset=utf-8");
 
-	/**
-	 * utf_8 charset
-	 */
-	public static final String UTF_8 = StandardCharsets.UTF_8.name();
+    /**
+     * utf_8 charset
+     */
+    public static final String UTF_8 = StandardCharsets.UTF_8.name();
 
     /**
      * Misc keys appearing in requests
@@ -119,14 +119,14 @@ public class RestRequest {
     public static final String HALT_ON_ERROR = "haltOnError";
     public static final String RICH_INPUT = "richInput";
     public static final String SERVICES_DATA = "/services/data/";
-	public static final String SERVICES_OAUTH2 = "/services/oauth2/";
+    public static final String SERVICES_OAUTH2 = "/services/oauth2/";
     public static final String REFERENCE_ID = "referenceId";
     public static final String TYPE = "type";
     public static final String ATTRIBUTES = "attributes";
     public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
     public static final String SFORCE_QUERY_OPTIONS = "Sforce-Query-Options";
     public static final String BATCH_SIZE_OPTION = "batchSize";
-	public static final int MIN_BATCH_SIZE = 200;
+    public static final int MIN_BATCH_SIZE = 200;
     public static final int MAX_BATCH_SIZE = 2000;
     public static final int DEFAULT_BATCH_SIZE = 2000;
     public static final int MAX_COLLECTION_RETRIEVE_SIZE = 2000;
@@ -136,85 +136,85 @@ public class RestRequest {
      */
     public static final DateFormat HTTP_DATE_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
 
-	static {
+    static {
         HTTP_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("GMT"));
     }
 
-	/**
-	 * Salesforce timestamp format.
-	 */
-	public static final DateFormat ISO8601_DATE_FORMAT = new SimpleDateFormat ("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
+    /**
+     * Salesforce timestamp format.
+     */
+    public static final DateFormat ISO8601_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US);
 
     /**
-	 * Enumeration for all HTTP methods.
-	 */
-	public enum RestMethod {
-		GET, POST, PUT, DELETE, HEAD, PATCH
-	}
+     * Enumeration for all HTTP methods.
+     */
+    public enum RestMethod {
+        GET, POST, PUT, DELETE, HEAD, PATCH
+    }
 
     /**
      * Enumeration for all REST API endpoints.
      */
-	public enum RestEndpoint {
-		LOGIN, INSTANCE
-	}
+    public enum RestEndpoint {
+        LOGIN, INSTANCE
+    }
 
-	enum RestAction {
+    enum RestAction {
 
-		USERINFO(SERVICES_OAUTH2 + "userinfo"),
-		TOKENINFO(SERVICES_OAUTH2 + "introspect"),
-		SINGLEACCESS(SERVICES_OAUTH2 + "singleaccess"),
-		VERSIONS(SERVICES_DATA),
-		RESOURCES(SERVICES_DATA + "%s/"),
-		DESCRIBE_GLOBAL(SERVICES_DATA + "%s/sobjects/"),
-		METADATA(SERVICES_DATA + "%s/sobjects/%s/"),
-		DESCRIBE(SERVICES_DATA + "%s/sobjects/%s/describe/"),
-		CREATE(SERVICES_DATA + "%s/sobjects/%s"),
-		RETRIEVE(SERVICES_DATA + "%s/sobjects/%s/%s"),
-		UPSERT(SERVICES_DATA + "%s/sobjects/%s/%s/%s"),
-		UPDATE(SERVICES_DATA + "%s/sobjects/%s/%s"),
-		DELETE(SERVICES_DATA + "%s/sobjects/%s/%s"),
-		QUERY(SERVICES_DATA + "%s/query"),
-		QUERY_ALL(SERVICES_DATA + "%s/queryAll"),
-		SEARCH(SERVICES_DATA + "%s/search"),
-		SEARCH_SCOPE_AND_ORDER(SERVICES_DATA + "%s/search/scopeOrder"),
-		SEARCH_RESULT_LAYOUT(SERVICES_DATA + "%s/search/layout"),
+        USERINFO(SERVICES_OAUTH2 + "userinfo"),
+        TOKENINFO(SERVICES_OAUTH2 + "introspect"),
+        SINGLEACCESS(SERVICES_OAUTH2 + "singleaccess"),
+        VERSIONS(SERVICES_DATA),
+        RESOURCES(SERVICES_DATA + "%s/"),
+        DESCRIBE_GLOBAL(SERVICES_DATA + "%s/sobjects/"),
+        METADATA(SERVICES_DATA + "%s/sobjects/%s/"),
+        DESCRIBE(SERVICES_DATA + "%s/sobjects/%s/describe/"),
+        CREATE(SERVICES_DATA + "%s/sobjects/%s"),
+        RETRIEVE(SERVICES_DATA + "%s/sobjects/%s/%s"),
+        UPSERT(SERVICES_DATA + "%s/sobjects/%s/%s/%s"),
+        UPDATE(SERVICES_DATA + "%s/sobjects/%s/%s"),
+        DELETE(SERVICES_DATA + "%s/sobjects/%s/%s"),
+        QUERY(SERVICES_DATA + "%s/query"),
+        QUERY_ALL(SERVICES_DATA + "%s/queryAll"),
+        SEARCH(SERVICES_DATA + "%s/search"),
+        SEARCH_SCOPE_AND_ORDER(SERVICES_DATA + "%s/search/scopeOrder"),
+        SEARCH_RESULT_LAYOUT(SERVICES_DATA + "%s/search/layout"),
         OBJECT_LAYOUT(SERVICES_DATA + "%s/ui-api/layout/%s"),
-		COMPOSITE(SERVICES_DATA + "%s/composite"),
+        COMPOSITE(SERVICES_DATA + "%s/composite"),
         BATCH(SERVICES_DATA + "%s/composite/batch"),
         SOBJECT_TREE(SERVICES_DATA + "%s/composite/tree/%s"),
-		SOBJECT_COLLECTION(SERVICES_DATA + "%s/composite/sobjects"),
-		SOBJECT_COLLECTION_RETRIEVE(SERVICES_DATA + "%s/composite/sobjects/%s"),
-		SOBJECT_COLLECTION_UPSERT(SERVICES_DATA + "%s/composite/sobjects/%s/%s"),
+        SOBJECT_COLLECTION(SERVICES_DATA + "%s/composite/sobjects"),
+        SOBJECT_COLLECTION_RETRIEVE(SERVICES_DATA + "%s/composite/sobjects/%s"),
+        SOBJECT_COLLECTION_UPSERT(SERVICES_DATA + "%s/composite/sobjects/%s/%s"),
         NOTIFICATIONS_STATUS(SERVICES_DATA + "%s/connect/notifications/status"),
-		NOTIFICATIONS(SERVICES_DATA + "%s/connect/notifications/%s"),
-		PRIMING_RECORDS(SERVICES_DATA + "%s/connect/briefcase/priming-records"),
-		LIMITS(SERVICES_DATA + "%s/limits");
+        NOTIFICATIONS(SERVICES_DATA + "%s/connect/notifications/%s"),
+        PRIMING_RECORDS(SERVICES_DATA + "%s/connect/briefcase/priming-records"),
+        LIMITS(SERVICES_DATA + "%s/limits");
 
-		private final String pathTemplate;
+        private final String pathTemplate;
 
-		RestAction(String uriTemplate) {
-			this.pathTemplate = uriTemplate;
-		}
-		
-		public String getPath(Object... args) {
-			return String.format(pathTemplate, args);
-		}
-	}
+        RestAction(String uriTemplate) {
+            this.pathTemplate = uriTemplate;
+        }
 
-	private final RestMethod method;
-	private final RestEndpoint endpoint;
-	private final String path;
-	private final RequestBody requestBody;
-	private final Map<String, String> additionalHttpHeaders;
-	private final JSONObject requestBodyAsJson; // needed for composite and batch requests
-	private static final String TAG = "RestRequest";
+        public String getPath(Object... args) {
+            return String.format(pathTemplate, args);
+        }
+    }
+
+    private final RestMethod method;
+    private final RestEndpoint endpoint;
+    private final String path;
+    private final RequestBody requestBody;
+    private final Map<String, String> additionalHttpHeaders;
+    private final JSONObject requestBodyAsJson; // needed for composite and batch requests
+    private static final String TAG = "RestRequest";
 
     /**
      * Generic constructor for arbitrary requests without a body.
      *
-     * @param method				HTTP method used in the request (GET/POST/DELETE etc).
-     * @param path					URI path. This is automatically resolved against the user's current instance host.
+     * @param method HTTP method used in the request (GET/POST/DELETE etc).
+     * @param path   URI path. This is automatically resolved against the user's current instance host.
      */
     public RestRequest(RestMethod method, String path) {
         this(method, path, (RequestBody) null, null);
@@ -223,8 +223,8 @@ public class RestRequest {
     /**
      * Generic constructor for arbitrary requests without a body.
      *
-     * @param method				HTTP method used for the request (GET/POST/DELETE etc).
-     * @param path					URI path. This will automatically be resolved against the user's current instance host.
+     * @param method                HTTP method used for the request (GET/POST/DELETE etc).
+     * @param path                  URI path. This will automatically be resolved against the user's current instance host.
      * @param additionalHttpHeaders Additional headers.
      *
      */
@@ -232,27 +232,27 @@ public class RestRequest {
         this(method, path, (RequestBody) null, additionalHttpHeaders);
     }
 
-	/**
-	 * Generic constructor for arbitrary requests.
-	 * 
-	 * @param method				HTTP method used for the request (GET/POST/DELETE etc).
-	 * @param path					URI path. This will automatically be resolved against the user's current instance host.
-	 * @param requestBody			Request body, if one exists. Can be null.
+    /**
+     * Generic constructor for arbitrary requests.
      *
-     * Note: Do not use this constructor if requestBody is not null and you want to build a batch or composite request.
-	 */
-	public RestRequest(RestMethod method, String path, RequestBody requestBody) {
+     * @param method      HTTP method used for the request (GET/POST/DELETE etc).
+     * @param path        URI path. This will automatically be resolved against the user's current instance host.
+     * @param requestBody Request body, if one exists. Can be null.
+     *
+     *                    Note: Do not use this constructor if requestBody is not null and you want to build a batch or composite request.
+     */
+    public RestRequest(RestMethod method, String path, RequestBody requestBody) {
         this(method, path, requestBody, null);
-	}
+    }
 
     /**
      * Generic constructor for arbitrary requests.
      *
-     * @param method				 HTTP method used for the request (GET/POST/DELETE etc).
-     * @param path					 URI path. This will automatically be resolved against the user's current instance host.
-     * @param requestBodyAsJson		 Request body as JSON, if one exists. Can be null.
+     * @param method            HTTP method used for the request (GET/POST/DELETE etc).
+     * @param path              URI path. This will automatically be resolved against the user's current instance host.
+     * @param requestBodyAsJson Request body as JSON, if one exists. Can be null.
      *
-     * Note: Use this constructor if requestBody is not null and you want to build a batch or composite request.
+     *                          Note: Use this constructor if requestBody is not null and you want to build a batch or composite request.
      */
     public RestRequest(RestMethod method, String path, JSONObject requestBodyAsJson) {
         this(method, path, requestBodyAsJson, null);
@@ -261,26 +261,26 @@ public class RestRequest {
     /**
      * Generic constructor for arbitrary requests.
      *
-     * @param method				 HTTP method used for the request (GET/POST/DELETE etc).
-     * @param path					 URI path. This will automatically be resolved against the user's current instance host.
-     * @param requestBody			 Request body, if one exists. Can be null.
-     * @param additionalHttpHeaders  Additional headers.
+     * @param method                HTTP method used for the request (GET/POST/DELETE etc).
+     * @param path                  URI path. This will automatically be resolved against the user's current instance host.
+     * @param requestBody           Request body, if one exists. Can be null.
+     * @param additionalHttpHeaders Additional headers.
      *
-     * Note: Do not use this constructor if requestBody is not null and you want to build a batch or composite request.
+     *                              Note: Do not use this constructor if requestBody is not null and you want to build a batch or composite request.
      */
     public RestRequest(RestMethod method, String path, RequestBody requestBody, Map<String, String> additionalHttpHeaders) {
-    	this(method, RestEndpoint.INSTANCE, path, requestBody, additionalHttpHeaders);
+        this(method, RestEndpoint.INSTANCE, path, requestBody, additionalHttpHeaders);
     }
 
     /**
      * Generic constructor for arbitrary requests.
      *
-     * @param method				HTTP method used for the request (GET/POST/DELETE etc).
-     * @param path				    URI path. This will automatically be resolved against the user's current instance host.
+     * @param method                HTTP method used for the request (GET/POST/DELETE etc).
+     * @param path                  URI path. This will automatically be resolved against the user's current instance host.
      * @param requestBodyAsJson     Request body as JSON, if one exists. Can be null.
      * @param additionalHttpHeaders Additional headers.
      *
-     * Note: Use this constructor if requestBody is not null and you want to build a batch or composite request.
+     *                              Note: Use this constructor if requestBody is not null and you want to build a batch or composite request.
      */
     public RestRequest(RestMethod method, String path, JSONObject requestBodyAsJson, Map<String, String> additionalHttpHeaders) {
         this(method, RestEndpoint.INSTANCE, path, requestBodyAsJson, additionalHttpHeaders);
@@ -289,12 +289,12 @@ public class RestRequest {
     /**
      * Generic constructor for arbitrary requests.
      *
-     * @param method				HTTP method used for the request (GET/POST/DELETE etc).
-     * @param endpoint				The endpoint associated with the request.
-     * @param path					URI path. This will be resolved against the user's current
-     * 								Rest endpoint, as specified by the endpoint parameter.
-     * @param requestBody			Request body, if one exists. Can be null.
-     * @param additionalHttpHeaders	Additional headers.
+     * @param method                HTTP method used for the request (GET/POST/DELETE etc).
+     * @param endpoint              The endpoint associated with the request.
+     * @param path                  URI path. This will be resolved against the user's current
+     *                              Rest endpoint, as specified by the endpoint parameter.
+     * @param requestBody           Request body, if one exists. Can be null.
+     * @param additionalHttpHeaders Additional headers.
      */
     public RestRequest(RestMethod method, RestEndpoint endpoint, String path, RequestBody requestBody, Map<String, String> additionalHttpHeaders) {
         this.method = method;
@@ -308,12 +308,12 @@ public class RestRequest {
     /**
      * Generic constructor for arbitrary requests.
      *
-     * @param method				HTTP method used for the request (GET/POST/DELETE etc).
-     * @param endpoint				The endpoint associated with the request.
-     * @param path					URI path. This will be resolved against the user's current
-     * 								Rest endpoint, as specified by the endpoint parameter.
-     * @param requestBodyAsJson		Request body as JSON, if one exists. Can be null.
-     * @param additionalHttpHeaders	Additional headers.
+     * @param method                HTTP method used for the request (GET/POST/DELETE etc).
+     * @param endpoint              The endpoint associated with the request.
+     * @param path                  URI path. This will be resolved against the user's current
+     *                              Rest endpoint, as specified by the endpoint parameter.
+     * @param requestBodyAsJson     Request body as JSON, if one exists. Can be null.
+     * @param additionalHttpHeaders Additional headers.
      */
     public RestRequest(RestMethod method, RestEndpoint endpoint, String path, JSONObject requestBodyAsJson, Map<String, String> additionalHttpHeaders) {
         this.method = method;
@@ -325,171 +325,174 @@ public class RestRequest {
     }
 
     /**
-	 * @return  HTTP method of the request.
-	 */
-	public RestMethod getMethod() {
-		return method;
-	}
-
-	/**
-	 * @return The endpoint of the request.
-	 */
-	public RestEndpoint getEndpoint() { return endpoint; }
-
-	/**
-	 * @return  Path of the request.
-	 */
-	public String getPath() {
-		return path;
-	}
-
-	/**
-	 * @return  Request body.
-	 */
-	public RequestBody getRequestBody() {
-		return requestBody;
-	}
+     * @return HTTP method of the request.
+     */
+    public RestMethod getMethod() {
+        return method;
+    }
 
     /**
-     * @return  Request body as JSON.
+     * @return The endpoint of the request.
+     */
+    public RestEndpoint getEndpoint() {
+        return endpoint;
+    }
+
+    /**
+     * @return Path of the request.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * @return Request body.
+     */
+    public RequestBody getRequestBody() {
+        return requestBody;
+    }
+
+    /**
+     * @return Request body as JSON.
      */
     public JSONObject getRequestBodyAsJson() {
         return requestBodyAsJson;
     }
 
     /**
-	 * @return  Additional HTTP headers.
-	 */
-	public Map<String, String> getAdditionalHttpHeaders() {
-		return additionalHttpHeaders;
-	}
+     * @return Additional HTTP headers.
+     */
+    public Map<String, String> getAdditionalHttpHeaders() {
+        return additionalHttpHeaders;
+    }
 
-	/**
-	 * Request to get information about the user making the request.
-	 * @return RestRequest object that requests user info.
-	 * @see <a href="https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm">https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm</a></a>
-	 */
-	public static RestRequest getRequestForUserInfo() {
-		return new RestRequest(RestMethod.GET, RestEndpoint.LOGIN, RestAction.USERINFO.getPath(), (RequestBody) null, null);
-	}
+    /**
+     * Request to get information about the user making the request.
+     * @return RestRequest object that requests user info.
+     * @see <a href="https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm">https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm</a></a>
+     */
+    public static RestRequest getRequestForUserInfo() {
+        return new RestRequest(RestMethod.GET, RestEndpoint.LOGIN, RestAction.USERINFO.getPath(), (RequestBody) null, null);
+    }
 
-	/**
-	 * Request to generate URL to bridge into UI sessions (a front door URL)
-	 * Applications should use that API instead of building front door URLs directly
-	 * @param redirectUri A relative path that points to where the user is redirected when their new session begins.
-	 * @return RestRequest object that requests single access URL.
-	 * @see <a href="https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm">https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm</a></a>
-	 */
-	public static RestRequest getRequestForSingleAccess(String redirectUri) throws UnsupportedEncodingException {
-		RequestBody requestBody = RequestBody.create(
-				"redirect_uri=" + URLEncoder.encode(redirectUri, UTF_8),
-				MediaType.parse("application/x-www-form-urlencoded")
-		);
-		return new RestRequest(RestMethod.POST, RestEndpoint.INSTANCE, RestAction.SINGLEACCESS.getPath(), requestBody, null);
-	}
+    /**
+     * Request to generate URL to bridge into UI sessions (a front door URL)
+     * Applications should use that API instead of building front door URLs directly
+     *
+     * @param redirectUri A relative path that points to where the user is redirected when their new session begins.
+     * @return RestRequest object that requests single access URL.
+     * @see <a href="https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm">https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm</a>
+     */
+    public static RestRequest getRequestForSingleAccess(String redirectUri) throws UnsupportedEncodingException {
+        RequestBody requestBody = RequestBody.create(
+                "redirect_uri=" + URLEncoder.encode(redirectUri, UTF_8),
+                MediaType.parse("application/x-www-form-urlencoded")
+        );
+        return new RestRequest(RestMethod.POST, RestEndpoint.INSTANCE, RestAction.SINGLEACCESS.getPath(), requestBody, null);
+    }
 
-	/**
-	 * Request to get summary information about each Salesforce.com version currently available.
-	 * 
-	 * @return  RestRequest object that requests the list of versions.
+    /**
+     * Request to get summary information about each Salesforce.com version currently available.
+     *
+     * @return RestRequest object that requests the list of versions.
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_versions.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_versions.htm</a>
      */
     public static RestRequest getRequestForVersions() {
         return new RestRequest(RestMethod.GET, RestAction.VERSIONS.getPath());
     }
-	
-	/**
-	 * Request to list available resources for the specified API version, including resource name and URI.
-	 *
-	 * @param apiVersion    Salesforce API version.
-     * @return              RestRequest object that requests resources for the given API version.
+
+    /**
+     * Request to list available resources for the specified API version, including resource name and URI.
+     *
+     * @param apiVersion Salesforce API version.
+     * @return RestRequest object that requests resources for the given API version.
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_discoveryresource.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_discoveryresource.htm</a>
-	 */
-	public static RestRequest getRequestForResources(String apiVersion) {
-		return new RestRequest(RestMethod.GET, RestAction.RESOURCES.getPath(apiVersion));
-	}
+     */
+    public static RestRequest getRequestForResources(String apiVersion) {
+        return new RestRequest(RestMethod.GET, RestAction.RESOURCES.getPath(apiVersion));
+    }
 
-	/**
-	 * Request to list the available objects and their metadata for your organization's data.
-	 *
-     * @param apiVersion    Salesforce API version.
-     * @return              RestRequest object that requests objects and metadata for the given API version.
+    /**
+     * Request to list the available objects and their metadata for your organization's data.
+     *
+     * @param apiVersion Salesforce API version.
+     * @return RestRequest object that requests objects and metadata for the given API version.
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_describeGlobal.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_describeGlobal.htm</a>
-	 */
-	public static RestRequest getRequestForDescribeGlobal(String apiVersion) {
-		return new RestRequest(RestMethod.GET, RestAction.DESCRIBE_GLOBAL.getPath(apiVersion));
-	}
+     */
+    public static RestRequest getRequestForDescribeGlobal(String apiVersion) {
+        return new RestRequest(RestMethod.GET, RestAction.DESCRIBE_GLOBAL.getPath(apiVersion));
+    }
 
-	/**
-	 * Request to describe the individual metadata for the specified object.
-	 *
-     * @param apiVersion    Salesforce API version.
-     * @param objectType    Type of object for which the caller is requesting object metadata.
-     * @return              RestRequest object that requests an object's metadata for the given API version.
-	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_basic_info.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_basic_info.htm</a>
-	 */
-	public static RestRequest getRequestForMetadata(String apiVersion, String objectType) {
+    /**
+     * Request to describe the individual metadata for the specified object.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param objectType Type of object for which the caller is requesting object metadata.
+     * @return RestRequest object that requests an object's metadata for the given API version.
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_basic_info.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_basic_info.htm</a>
+     */
+    public static RestRequest getRequestForMetadata(String apiVersion, String objectType) {
         return new RestRequest(RestMethod.GET, RestAction.METADATA.getPath(apiVersion, objectType));
-	}
+    }
 
-	/**
-	 * Request to completely describe the individual metadata at all levels for the specified object.
-	 *
+    /**
+     * Request to completely describe the individual metadata at all levels for the specified object.
+     *
      * @param apiVersion Salesforce API version.
      * @param objectType Type of object for which the caller is requesting the metadata description.
      * @return RestRequest object that requests an object's metadata description for the given API version.
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_describe.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_describe.htm</a>
-	 */
-	public static RestRequest getRequestForDescribe(String apiVersion, String objectType) {
+     */
+    public static RestRequest getRequestForDescribe(String apiVersion, String objectType) {
         return new RestRequest(RestMethod.GET, RestAction.DESCRIBE.getPath(apiVersion, objectType));
-	}
-	
-	/**
-	 * Request to create a record. 
-	 *
-     * @param apiVersion    Salesforce API version.
-     * @param objectType    Type of record to be created.
-     * @param fields        Map of the new record's fields and their values. Can be null.
-     * @return              RestRequest object that requests creation of a record.
-	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm</a>
-	 */
-	public static RestRequest getRequestForCreate(String apiVersion, String objectType, Map<String, Object> fields) {
-		return new RestRequest(RestMethod.POST, RestAction.CREATE.getPath(apiVersion, objectType), fields == null ? null : new JSONObject(fields));
-	}
+    }
 
-	/**
-	 * Request to retrieve a record by object ID.
-	 *
-     * @param apiVersion    Salesforce API version.
-     * @param objectType    Type of the requested record.
-     * @param objectId      Salesforce ID of the requested record.
-     * @param fieldList     List of requested field names.
-     * @return              RestRequest object that requests a record.
-	 * @throws UnsupportedEncodingException
+    /**
+     * Request to create a record.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param objectType Type of record to be created.
+     * @param fields     Map of the new record's fields and their values. Can be null.
+     * @return RestRequest object that requests creation of a record.
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm</a>
-	 */
-	public static RestRequest getRequestForRetrieve(String apiVersion, String objectType, String objectId, List<String> fieldList) throws UnsupportedEncodingException {
-		StringBuilder path = new StringBuilder(RestAction.RETRIEVE.getPath(apiVersion, objectType, objectId));
-		if (fieldList != null && fieldList.size() > 0) { 
-			path.append("?fields=");
-			path.append(URLEncoder.encode(TextUtils.join(",", fieldList), UTF_8));
-		}
-		return new RestRequest(RestMethod.GET, path.toString());
-	}
+     */
+    public static RestRequest getRequestForCreate(String apiVersion, String objectType, Map<String, Object> fields) {
+        return new RestRequest(RestMethod.POST, RestAction.CREATE.getPath(apiVersion, objectType), fields == null ? null : new JSONObject(fields));
+    }
 
-	/**
-	 * Request to update a record. 
-	 *
-     * @param apiVersion    Salesforce API version.
-     * @param objectType    Type of the record.
-     * @param objectId      Salesforce ID of the record.
-     * @param fields        Map of the fields to be updated and their new values.
-     * @return              RestRequest object that requests a record update.
-	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm</a>
-	 */
-	public static RestRequest getRequestForUpdate(String apiVersion, String objectType, String objectId, Map<String, Object> fields) {
+    /**
+     * Request to retrieve a record by object ID.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param objectType Type of the requested record.
+     * @param objectId   Salesforce ID of the requested record.
+     * @param fieldList  List of requested field names.
+     * @return RestRequest object that requests a record.
+     * @throws UnsupportedEncodingException
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm</a>
+     */
+    public static RestRequest getRequestForRetrieve(String apiVersion, String objectType, String objectId, List<String> fieldList) throws UnsupportedEncodingException {
+        StringBuilder path = new StringBuilder(RestAction.RETRIEVE.getPath(apiVersion, objectType, objectId));
+        if (fieldList != null && fieldList.size() > 0) {
+            path.append("?fields=");
+            path.append(URLEncoder.encode(TextUtils.join(",", fieldList), UTF_8));
+        }
+        return new RestRequest(RestMethod.GET, path.toString());
+    }
+
+    /**
+     * Request to update a record.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param objectType Type of the record.
+     * @param objectId   Salesforce ID of the record.
+     * @param fields     Map of the fields to be updated and their new values.
+     * @return RestRequest object that requests a record update.
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm</a>
+     */
+    public static RestRequest getRequestForUpdate(String apiVersion, String objectType, String objectId, Map<String, Object> fields) {
         return getRequestForUpdate(apiVersion, objectType, objectId, fields, null);
-	}
+    }
 
     /**
      * Request to update a record.
@@ -499,26 +502,26 @@ public class RestRequest {
      * @param objectId              Salesforce ID of the record.
      * @param fields                Map of the fields to be updated and their new values. Can be null.
      * @param ifUnmodifiedSinceDate Fulfill the request only if the record has not been modified since the given date.
-     * @return                      RestRequest object that requests a record update.
+     * @return RestRequest object that requests a record update.
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm</a>
      */
     public static RestRequest getRequestForUpdate(String apiVersion, String objectType, String objectId, Map<String, Object> fields, Date ifUnmodifiedSinceDate) {
         Map<String, String> additionalHttpHeaders = prepareConditionalHeader(IF_UNMODIFIED_SINCE, ifUnmodifiedSinceDate);
         return new RestRequest(RestMethod.PATCH, RestAction.UPDATE.getPath(apiVersion, objectType, objectId), fields == null ? null : new JSONObject(fields), additionalHttpHeaders);
     }
-	
-	/**
-	 * Request to upsert (update or insert) a record. 
-	 *
-     * @param apiVersion        Salesforce API version.
-     * @param objectType        Type of the record.
-     * @param externalIdField   Name of ID field in source data.
-     * @param externalId        ID of source data record. Can be an empty string.
-     * @param fields            Map of the fields to be upserted and their new values. Can be null.
-     * @return                  RestRequest object that requests a record upsert.
-	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_upsert.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_upsert.htm</a>
-	 */
-	public static RestRequest getRequestForUpsert(String apiVersion, String objectType, String externalIdField, String externalId, Map<String, Object> fields) {
+
+    /**
+     * Request to upsert (update or insert) a record.
+     *
+     * @param apiVersion      Salesforce API version.
+     * @param objectType      Type of the record.
+     * @param externalIdField Name of ID field in source data.
+     * @param externalId      ID of source data record. Can be an empty string.
+     * @param fields          Map of the fields to be upserted and their new values. Can be null.
+     * @return RestRequest object that requests a record upsert.
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_upsert.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_upsert.htm</a>
+     */
+    public static RestRequest getRequestForUpsert(String apiVersion, String objectType, String externalIdField, String externalId, Map<String, Object> fields) {
         return new RestRequest(
                 externalId == null ? RestMethod.POST : RestMethod.PATCH,
                 RestAction.UPSERT.getPath(
@@ -528,174 +531,174 @@ public class RestRequest {
                         externalId == null ? "" : externalId),
                 fields == null ? null : new JSONObject(fields));
     }
-	
-	/**
-	 * Request to delete a record. 
-	 *
-     * @param apiVersion    Salesforce API version.
-     * @param objectType    Type of the record.
-	 * @param objectId      Salesforce ID of the record.
-     * @return              RestRequest object that requests a record deletion.
+
+    /**
+     * Request to delete a record.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param objectType Type of the record.
+     * @param objectId   Salesforce ID of the record.
+     * @return RestRequest object that requests a record deletion.
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm</a>
-	 */
-	public static RestRequest getRequestForDelete(String apiVersion, String objectType, String objectId) {
+     */
+    public static RestRequest getRequestForDelete(String apiVersion, String objectType, String objectId) {
         return new RestRequest(RestMethod.DELETE, RestAction.DELETE.getPath(apiVersion, objectType, objectId));
-	}
+    }
 
     /**
-	 * Request to execute the specified SOSL search. 
-	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param q             SOSL search string.
-     * @return              RestRequest object that requests a SOSL search.
-	 * @throws UnsupportedEncodingException
+     * Request to execute the specified SOSL search.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param q          SOSL search string.
+     * @return RestRequest object that requests a SOSL search.
+     * @throws UnsupportedEncodingException
      * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search.htm</a>
-	 */
-	public static RestRequest getRequestForSearch(String apiVersion, String q) throws UnsupportedEncodingException {
-		StringBuilder path = new StringBuilder(RestAction.SEARCH.getPath(apiVersion));
-		path.append("?q=");
-		path.append(URLEncoder.encode(q, UTF_8));
-		return new RestRequest(RestMethod.GET, path.toString());
-	}
-
-	/**
-	 * Request to execute the specified SOQL query.
-	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param q             SOQL query string.
-	 * @return              RestRequest object that requests a SOQL query.
-	 * @throws UnsupportedEncodingException
-	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm</a>
-	 */
-	public static RestRequest getRequestForQuery(String apiVersion, String q) throws UnsupportedEncodingException {
-		return getRequestForQuery(apiVersion, q, DEFAULT_BATCH_SIZE);
-	}
-
-	/**
-	 * Request to execute the specified SOQL query.
-	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param q             SOQL query string.
-	 * @param batchSize     Batch size: number between 200 and 2000 (default).
-	 * @return              RestRequest object that requests a SOQL query.
-	 * @throws UnsupportedEncodingException
-	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm</a>
-	 */
-	public static RestRequest getRequestForQuery(String apiVersion, String q, int batchSize) throws UnsupportedEncodingException {
-		StringBuilder path = new StringBuilder(RestAction.QUERY.getPath(apiVersion));
-		path.append("?q=");
-		path.append(URLEncoder.encode(q, UTF_8));
-		batchSize = Math.max(Math.min(batchSize, MAX_BATCH_SIZE), MIN_BATCH_SIZE);
-		Map<String, String> headers = null;
-		if (batchSize != DEFAULT_BATCH_SIZE) {
-			headers = new HashMap<>();
-			headers.put(SFORCE_QUERY_OPTIONS, BATCH_SIZE_OPTION + "=" + batchSize);
-		}
-		return new RestRequest(RestMethod.GET, path.toString(), headers);
-	}
-
-	/**
-	 * Request to execute the specified SOQL query which includes deleted records because of a merge or delete in the result set.
-	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param q             SOQL query string.
-	 * @return              RestRequest object that requests a SOQL query that includes deleted records.
-	 * @throws UnsupportedEncodingException
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_queryall.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_queryall.htm</a>
-	 */
-	public static RestRequest getRequestForQueryAll(String apiVersion, String q) throws UnsupportedEncodingException {
-		StringBuilder path = new StringBuilder(RestAction.QUERY_ALL.getPath(apiVersion));
-		path.append("?q=");
-		path.append(URLEncoder.encode(q, UTF_8));
-		return new RestRequest(RestMethod.GET, path.toString());
-	}
-
-	/**
-	 * Request to get search scope and order.
-	 *
-	 * @param apiVersion    Salesforce API version.
-     * @return              RestRequest object that requests the search scope and order for the given API version.
-	 * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_scope_order.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_scope_order.htm</a>
-	 */
-	public static RestRequest getRequestForSearchScopeAndOrder(String apiVersion) {
-        return new RestRequest(RestMethod.GET, new StringBuilder(RestAction.SEARCH_SCOPE_AND_ORDER.getPath(apiVersion)).toString());
-	}	
-	
-	/**
-	 * Request to get search result layouts
-	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param objectList    List of objects whose search result layouts are being requested.
-     * @return              RestRequest object that requests the search result layout for the given list of objects.
-	 * @throws UnsupportedEncodingException
-     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_layouts.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_layouts.htm</a>
-	 */
-	public static RestRequest getRequestForSearchResultLayout(String apiVersion, List<String> objectList) throws UnsupportedEncodingException {
-		StringBuilder path = new StringBuilder(RestAction.SEARCH_RESULT_LAYOUT.getPath(apiVersion));
-		path.append("?q=");
-		path.append(URLEncoder.encode(TextUtils.join(",", objectList).toString(), UTF_8));
-		return new RestRequest(RestMethod.GET, path.toString());
-	}
-
-	/**
-	 * Request to get object layout data.
-	 *
-	 * @param apiVersion Salesforce API version.
-	 * @param objectAPIName Object API name.
-	 * @param formFactor Form factor. Could be "Large", "Medium" or "Small". Default value is "Large".
-	 * @param layoutType Layout type. Could be "Compact" or "Full". Default value is "Full".
-	 * @param mode Mode. Could be "Create", "Edit" or "View". Default value is "View".
-	 * @param recordTypeId Record type ID. Default will be used if not supplied.
-	 * @return RestRequest object that requests the object layout for the given parameters.
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm">https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm</a>
-	 */
-	public static RestRequest getRequestForObjectLayout(String apiVersion, String objectAPIName,
-														String formFactor, String layoutType,
-														String mode, String recordTypeId) {
-		final StringBuilder path = new StringBuilder(RestAction.OBJECT_LAYOUT.getPath(apiVersion, objectAPIName));
-		path.append("?");
-		if (!TextUtils.isEmpty(formFactor)) {
-			path.append("formFactor=");
-			path.append(formFactor);
-			path.append("&");
-		}
-		if (!TextUtils.isEmpty(layoutType)) {
-			path.append("layoutType=");
-			path.append(layoutType);
-			path.append("&");
-		}
-		if (!TextUtils.isEmpty(mode)) {
-			path.append("mode=");
-			path.append(mode);
-			path.append("&");
-		}
-		if (!TextUtils.isEmpty(recordTypeId)) {
-			path.append("recordTypeId=");
-			path.append(recordTypeId);
-		}
-		if (path.charAt(path.length() - 1) == '?' || path.charAt(path.length() - 1) == '&') {
-			path.deleteCharAt(path.length() - 1);
-		}
-		return new RestRequest(RestMethod.GET, path.toString());
-	}
+     */
+    public static RestRequest getRequestForSearch(String apiVersion, String q) throws UnsupportedEncodingException {
+        StringBuilder path = new StringBuilder(RestAction.SEARCH.getPath(apiVersion));
+        path.append("?q=");
+        path.append(URLEncoder.encode(q, UTF_8));
+        return new RestRequest(RestMethod.GET, path.toString());
+    }
 
     /**
-	 * Composite request
-	 *
-     * @param apiVersion        Salesforce API version.
-     * @param allOrNone         Indicates whether the request will accept partially complete results.
-	 * @param refIdToRequests   Linked map of reference IDs to RestRequest objects. The requests will be played in order in which they were added.
+     * Request to execute the specified SOQL query.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param q          SOQL query string.
+     * @return RestRequest object that requests a SOQL query.
+     * @throws UnsupportedEncodingException
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm</a>
+     */
+    public static RestRequest getRequestForQuery(String apiVersion, String q) throws UnsupportedEncodingException {
+        return getRequestForQuery(apiVersion, q, DEFAULT_BATCH_SIZE);
+    }
+
+    /**
+     * Request to execute the specified SOQL query.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param q          SOQL query string.
+     * @param batchSize  Batch size: number between 200 and 2000 (default).
+     * @return RestRequest object that requests a SOQL query.
+     * @throws UnsupportedEncodingException
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_query.htm</a>
+     */
+    public static RestRequest getRequestForQuery(String apiVersion, String q, int batchSize) throws UnsupportedEncodingException {
+        StringBuilder path = new StringBuilder(RestAction.QUERY.getPath(apiVersion));
+        path.append("?q=");
+        path.append(URLEncoder.encode(q, UTF_8));
+        batchSize = Math.max(Math.min(batchSize, MAX_BATCH_SIZE), MIN_BATCH_SIZE);
+        Map<String, String> headers = null;
+        if (batchSize != DEFAULT_BATCH_SIZE) {
+            headers = new HashMap<>();
+            headers.put(SFORCE_QUERY_OPTIONS, BATCH_SIZE_OPTION + "=" + batchSize);
+        }
+        return new RestRequest(RestMethod.GET, path.toString(), headers);
+    }
+
+    /**
+     * Request to execute the specified SOQL query which includes deleted records because of a merge or delete in the result set.
+     *
+     * @param apiVersion Salesforce API version.
+     * @param q          SOQL query string.
+     * @return RestRequest object that requests a SOQL query that includes deleted records.
+     * @throws UnsupportedEncodingException
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_queryall.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_queryall.htm</a>
+     */
+    public static RestRequest getRequestForQueryAll(String apiVersion, String q) throws UnsupportedEncodingException {
+        StringBuilder path = new StringBuilder(RestAction.QUERY_ALL.getPath(apiVersion));
+        path.append("?q=");
+        path.append(URLEncoder.encode(q, UTF_8));
+        return new RestRequest(RestMethod.GET, path.toString());
+    }
+
+    /**
+     * Request to get search scope and order.
+     *
+     * @param apiVersion Salesforce API version.
+     * @return RestRequest object that requests the search scope and order for the given API version.
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_scope_order.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_scope_order.htm</a>
+     */
+    public static RestRequest getRequestForSearchScopeAndOrder(String apiVersion) {
+        return new RestRequest(RestMethod.GET, new StringBuilder(RestAction.SEARCH_SCOPE_AND_ORDER.getPath(apiVersion)).toString());
+    }
+
+    /**
+     * Request to get search result layouts
+     *
+     * @param apiVersion Salesforce API version.
+     * @param objectList List of objects whose search result layouts are being requested.
+     * @return RestRequest object that requests the search result layout for the given list of objects.
+     * @throws UnsupportedEncodingException
+     * @see <a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_layouts.htm">http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_search_layouts.htm</a>
+     */
+    public static RestRequest getRequestForSearchResultLayout(String apiVersion, List<String> objectList) throws UnsupportedEncodingException {
+        StringBuilder path = new StringBuilder(RestAction.SEARCH_RESULT_LAYOUT.getPath(apiVersion));
+        path.append("?q=");
+        path.append(URLEncoder.encode(TextUtils.join(",", objectList).toString(), UTF_8));
+        return new RestRequest(RestMethod.GET, path.toString());
+    }
+
+    /**
+     * Request to get object layout data.
+     *
+     * @param apiVersion    Salesforce API version.
+     * @param objectAPIName Object API name.
+     * @param formFactor    Form factor. Could be "Large", "Medium" or "Small". Default value is "Large".
+     * @param layoutType    Layout type. Could be "Compact" or "Full". Default value is "Full".
+     * @param mode          Mode. Could be "Create", "Edit" or "View". Default value is "View".
+     * @param recordTypeId  Record type ID. Default will be used if not supplied.
+     * @return RestRequest object that requests the object layout for the given parameters.
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm">https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm</a>
+     */
+    public static RestRequest getRequestForObjectLayout(String apiVersion, String objectAPIName,
+                                                        String formFactor, String layoutType,
+                                                        String mode, String recordTypeId) {
+        final StringBuilder path = new StringBuilder(RestAction.OBJECT_LAYOUT.getPath(apiVersion, objectAPIName));
+        path.append("?");
+        if (!TextUtils.isEmpty(formFactor)) {
+            path.append("formFactor=");
+            path.append(formFactor);
+            path.append("&");
+        }
+        if (!TextUtils.isEmpty(layoutType)) {
+            path.append("layoutType=");
+            path.append(layoutType);
+            path.append("&");
+        }
+        if (!TextUtils.isEmpty(mode)) {
+            path.append("mode=");
+            path.append(mode);
+            path.append("&");
+        }
+        if (!TextUtils.isEmpty(recordTypeId)) {
+            path.append("recordTypeId=");
+            path.append(recordTypeId);
+        }
+        if (path.charAt(path.length() - 1) == '?' || path.charAt(path.length() - 1) == '&') {
+            path.deleteCharAt(path.length() - 1);
+        }
+        return new RestRequest(RestMethod.GET, path.toString());
+    }
+
+    /**
+     * Composite request
+     *
+     * @param apiVersion      Salesforce API version.
+     * @param allOrNone       Indicates whether the request will accept partially complete results.
+     * @param refIdToRequests Linked map of reference IDs to RestRequest objects. The requests will be played in order in which they were added.
      * @return RestRequest object that requests execution of the given composite request.
      * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_composite.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_composite.htm</a>
-	 */
-	public static CompositeRequest getCompositeRequest(String apiVersion, boolean allOrNone, LinkedHashMap<String, RestRequest> refIdToRequests) throws JSONException {
-		CompositeRequestBuilder builder = new CompositeRequestBuilder();
-        for (Map.Entry<String,RestRequest> entry : refIdToRequests.entrySet()) {
-			builder.addRequest(entry.getKey(), entry.getValue());
-		}
-		builder.setAllOrNone(allOrNone);
+     */
+    public static CompositeRequest getCompositeRequest(String apiVersion, boolean allOrNone, LinkedHashMap<String, RestRequest> refIdToRequests) throws JSONException {
+        CompositeRequestBuilder builder = new CompositeRequestBuilder();
+        for (Map.Entry<String, RestRequest> entry : refIdToRequests.entrySet()) {
+            builder.addRequest(entry.getKey(), entry.getValue());
+        }
+        builder.setAllOrNone(allOrNone);
         return builder.build(apiVersion);
-	}
+    }
 
     @Override
     public String toString() {
@@ -711,23 +714,24 @@ public class RestRequest {
         requestJson.put(METHOD, getMethod().toString());
         requestJson.put(URL, getPath());
         requestJson.put(BODY, getRequestBodyAsJson());
-        if (getAdditionalHttpHeaders() != null) requestJson.put(HTTP_HEADERS, new JSONObject(getAdditionalHttpHeaders()));
+        if (getAdditionalHttpHeaders() != null)
+            requestJson.put(HTTP_HEADERS, new JSONObject(getAdditionalHttpHeaders()));
         return requestJson;
     }
 
     /**
      * Batch request
-     * @param apiVersion    Salesforce API version.
-     * @param haltOnError   Indicates whether to stop processing the batch if an error occurs.
-     * @param requests      List of RestRequest objects.
-     * @return              RestRequest object that requests execution of the given batch of requests.
+     * @param apiVersion  Salesforce API version.
+     * @param haltOnError Indicates whether to stop processing the batch if an error occurs.
+     * @param requests    List of RestRequest objects.
+     * @return RestRequest object that requests execution of the given batch of requests.
      * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_batch.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_batch.htm</a>
      */
     public static BatchRequest getBatchRequest(String apiVersion, boolean haltOnError, List<RestRequest> requests) throws JSONException {
-    	BatchRequestBuilder builder = new BatchRequestBuilder();
+        BatchRequestBuilder builder = new BatchRequestBuilder();
         for (RestRequest request : requests) {
-			builder.addRequest(request);
-		}
+            builder.addRequest(request);
+        }
         builder.setHaltOnError(haltOnError);
         return builder.build(apiVersion);
     }
@@ -735,10 +739,10 @@ public class RestRequest {
     /**
      * Request to create one or more sObject trees with root records of the specified type.
      *
-     * @param apiVersion    Salesforce API version.
-     * @param objectType    Type of object requested.
-     * @param objectTrees   List of {link #SObjectTree} objects.
-     * @return              RestRequest object that requests creation of one or more sObject trees.
+     * @param apiVersion  Salesforce API version.
+     * @param objectType  Type of object requested.
+     * @param objectTrees List of {link #SObjectTree} objects.
+     * @return RestRequest object that requests creation of one or more sObject trees.
      * @throws JSONException
      * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobject_tree.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobject_tree.htm</a>
      */
@@ -754,9 +758,9 @@ public class RestRequest {
     /**
      * Request to get status of notifications for the user.
      *
-     * @param apiVersion   Salesforce API version.
+     * @param apiVersion Salesforce API version.
 	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_status.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_status.htm</a>
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_status.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_status.htm</a>
      */
     public static RestRequest getRequestForNotificationsStatus(String apiVersion) {
         return new RestRequest(RestMethod.GET, RestAction.NOTIFICATIONS_STATUS.getPath(apiVersion));
@@ -765,10 +769,10 @@ public class RestRequest {
     /**
      * Request to get a notification.
      *
-     * @param apiVersion      Salesforce API version.
-     * @param notificationId  ID of notification.
+     * @param apiVersion     Salesforce API version.
+     * @param notificationId ID of notification.
 	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm</a>
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm</a>
      */
     public static RestRequest getRequestForNotification(String apiVersion, String notificationId) {
         return new RestRequest(RestMethod.GET, RestAction.NOTIFICATIONS.getPath(apiVersion, notificationId));
@@ -777,14 +781,14 @@ public class RestRequest {
     /**
      * Request for updating a notification.
      *
-     * @param apiVersion      Salesforce API version.
-     * @param notificationId  ID of notification.
-     * @param read            Marks notification as read (true) or unread (false). If null, field won't be updated.
-     *                        Required if `seen` not provided.
-     * @param seen            Marks notification as seen (true) or unseen (false). If null, field won't be updated.
-     *                        Required if `read` not provided.
+     * @param apiVersion     Salesforce API version.
+     * @param notificationId ID of notification.
+     * @param read           Marks notification as read (true) or unread (false). If null, field won't be updated.
+     *                       Required if `seen` not provided.
+     * @param seen           Marks notification as seen (true) or unseen (false). If null, field won't be updated.
+     *                       Required if `read` not provided.
 	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm</a>
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resource_notifications_specific.htm</a>
      */
     public static RestRequest getRequestForNotificationUpdate(String apiVersion, String notificationId, Boolean read, Boolean seen) {
         final Map<String, Object> parameters = new HashMap<>();
@@ -801,12 +805,12 @@ public class RestRequest {
     /**
      * Request for getting notifications.
      *
-     * @param apiVersion   Salesforce API version.
-     * @param size         Number of notifications to get.
-     * @param before       Get notifications occurring before the provided date. Shouldn't be used with `after`.
-     * @param after        Get notifications occurring after the provided date. Shouldn't be used with `before`.
+     * @param apiVersion Salesforce API version.
+     * @param size       Number of notifications to get.
+     * @param before     Get notifications occurring before the provided date. Shouldn't be used with `after`.
+     * @param after      Get notifications occurring after the provided date. Shouldn't be used with `before`.
 	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_list.htm>https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_list.htm</a>
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_list.htm>https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_notifications_list.htm</a>
      */
     public static RestRequest getRequestForNotifications(String apiVersion, Integer size, Date before, Date after) {
         final Map<String, String> parameters = new HashMap<>();
@@ -830,13 +834,13 @@ public class RestRequest {
     /**
      * Request for updating notifications.
      *
-     * @param apiVersion       Salesforce API version.
-     * @param notificationIds  IDs of notifications to get. Shouldn't be used with `before`.
-     * @param before           Get notifications before the provided date. Shouldn't be used with `notificationIds`.
-     * @param read             Marks notifications as read (true) or unread (false). If null, field won't be updated.
-     *                         Required if `seen` not provided.
-     * @param seen             Marks notifications as seen (true) or unseen (false). If null, field won't be updated.
-     *                         Required if `read` not provided.
+     * @param apiVersion      Salesforce API version.
+     * @param notificationIds IDs of notifications to get. Shouldn't be used with `before`.
+     * @param before          Get notifications before the provided date. Shouldn't be used with `notificationIds`.
+     * @param read            Marks notifications as read (true) or unread (false). If null, field won't be updated.
+     *                        Required if `seen` not provided.
+     * @param seen            Marks notifications as seen (true) or unseen (false). If null, field won't be updated.
+     *                        Required if `read` not provided.
      */
     public static RestRequest getRequestForNotificationsUpdate(String apiVersion, List<String> notificationIds, Date before, Boolean read, Boolean seen) {
         final Map<String, Object> parameters = new HashMap<>();
@@ -856,139 +860,139 @@ public class RestRequest {
         return new RestRequest(RestMethod.PATCH, path, new JSONObject(parameters));
     }
 
-	/**
-	 * Request for getting list of record related to offline briefcase
+    /**
+     * Request for getting list of record related to offline briefcase
+     *
+     * @param apiVersion       Salesforce API version.
+     * @param relayToken       Relay token (to get next page of results) - or null
+     * @param changedAfterTime To only get ids of records that changed after given time - or null
 	 *
-	 * @param apiVersion       Salesforce API version.
-	 * @param relayToken       Relay token (to get next page of results) - or null
-	 * @param changedAfterTime To only get ids of records that changed after given time - or null
-	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_briefcase_priming_records.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_briefcase_priming_records.htm</a>
-	 */
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_briefcase_priming_records.htm">https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_briefcase_priming_records.htm</a>
+     */
     public static RestRequest getRequestForPrimingRecords(String apiVersion, String relayToken, Long changedAfterTime) throws UnsupportedEncodingException {
-    	StringBuilder path = new StringBuilder(RestAction.PRIMING_RECORDS.getPath(apiVersion));
-    	if (relayToken != null) {
-    		path.append("?relayToken=");
-    		path.append(URLEncoder.encode(relayToken, UTF_8));
-		}
-    	if (changedAfterTime != null) {
-    		path.append(relayToken != null ? "&" : "?");
-    		path.append("changedAfterTimestamp=");
-    		path.append(URLEncoder.encode(PrimingRecordsResponse.TIMESTAMP_FORMAT.format(new Date(changedAfterTime)), UTF_8));
-		}
-		return new RestRequest(RestMethod.GET, path.toString());
-	}
+        StringBuilder path = new StringBuilder(RestAction.PRIMING_RECORDS.getPath(apiVersion));
+        if (relayToken != null) {
+            path.append("?relayToken=");
+            path.append(URLEncoder.encode(relayToken, UTF_8));
+        }
+        if (changedAfterTime != null) {
+            path.append(relayToken != null ? "&" : "?");
+            path.append("changedAfterTimestamp=");
+            path.append(URLEncoder.encode(PrimingRecordsResponse.TIMESTAMP_FORMAT.format(new Date(changedAfterTime)), UTF_8));
+        }
+        return new RestRequest(RestMethod.GET, path.toString());
+    }
 
-	/**
-	 * Request for creating multiple records with fewer round trips
+    /**
+     * Request for creating multiple records with fewer round trips
+     *
+     * @param apiVersion Salesforce API version.
+     * @param allOrNone  Indicates whether to roll back the entire request when the creation of any object fails (true) or to continue with the independent creation of other objects in the request.
+     * @param records    A list of sObjects.
 	 *
-	 * @param apiVersion Salesforce API version.
-	 * @param allOrNone  Indicates whether to roll back the entire request when the creation of any object fails (true) or to continue with the independent creation of other objects in the request.
-	 * @param records    A list of sObjects.
-	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_create.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_create.htm</a>
-	 */
-	public static RestRequest getRequestForCollectionCreate(String apiVersion, boolean allOrNone, JSONArray records) throws JSONException {
-		JSONObject requestBodyAsJson = new JSONObject();
-		requestBodyAsJson.put(ALL_OR_NONE, allOrNone);
-		requestBodyAsJson.put(RECORDS, records);
-		return new RestRequest(RestMethod.POST, RestAction.SOBJECT_COLLECTION.getPath(apiVersion), requestBodyAsJson);
-	}
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_create.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_create.htm</a>
+     */
+    public static RestRequest getRequestForCollectionCreate(String apiVersion, boolean allOrNone, JSONArray records) throws JSONException {
+        JSONObject requestBodyAsJson = new JSONObject();
+        requestBodyAsJson.put(ALL_OR_NONE, allOrNone);
+        requestBodyAsJson.put(RECORDS, records);
+        return new RestRequest(RestMethod.POST, RestAction.SOBJECT_COLLECTION.getPath(apiVersion), requestBodyAsJson);
+    }
 
-	/**
-	 * Request for retrieving multiple records with fewer round trips
+    /**
+     * Request for retrieving multiple records with fewer round trips
+     *
+     * @param apiVersion Salesforce API version.
+     * @param objectType Type of the requested record.
+     * @param objectIds  List of Salesforce IDs of the requested records.
+     * @param fieldList  List of requested field names.
 	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param objectType    Type of the requested record.
-	 * @param objectIds     List of Salesforce IDs of the requested records.
-	 * @param fieldList     List of requested field names.
-	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_retrieve.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_retrieve.htm</a>
-	 */
-	public static RestRequest getRequestForCollectionRetrieve(String apiVersion, String objectType, List<String> objectIds, List<String> fieldList)
-		throws UnsupportedEncodingException, JSONException {
-		StringBuilder path = new StringBuilder(RestAction.SOBJECT_COLLECTION_RETRIEVE.getPath(apiVersion, objectType));
-		// Using a post body which is allowed by the end point and allows more ids to be sent up (2000 instead of ~800)
-		JSONObject body = new JSONObject();
-		body.put("ids", new JSONArray(objectIds));
-		body.put("fields", new JSONArray(fieldList));
-		return new RestRequest(RestMethod.POST, path.toString(), body);
-	}
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_retrieve.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_retrieve.htm</a>
+     */
+    public static RestRequest getRequestForCollectionRetrieve(String apiVersion, String objectType, List<String> objectIds, List<String> fieldList)
+            throws UnsupportedEncodingException, JSONException {
+        StringBuilder path = new StringBuilder(RestAction.SOBJECT_COLLECTION_RETRIEVE.getPath(apiVersion, objectType));
+        // Using a post body which is allowed by the end point and allows more ids to be sent up (2000 instead of ~800)
+        JSONObject body = new JSONObject();
+        body.put("ids", new JSONArray(objectIds));
+        body.put("fields", new JSONArray(fieldList));
+        return new RestRequest(RestMethod.POST, path.toString(), body);
+    }
 
-	/**
-	 * Request for updating multiple records with fewer round trips
+    /**
+     * Request for updating multiple records with fewer round trips
+     *
+     * @param apiVersion Salesforce API version.
+     * @param allOrNone  Indicates whether to roll back the entire request when the update of any object fails (true) or to continue with the independent update of other objects in the request.
+     * @param records    A list of sObjects.
 	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param allOrNone     Indicates whether to roll back the entire request when the update of any object fails (true) or to continue with the independent update of other objects in the request.
-	 * @param records       A list of sObjects.
-	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_update.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_update.htm</a>
-	 */
-	public static RestRequest getRequestForCollectionUpdate(String apiVersion, boolean allOrNone, JSONArray records) throws JSONException {
-		JSONObject requestBodyAsJson = new JSONObject();
-		requestBodyAsJson.put(ALL_OR_NONE, allOrNone);
-		requestBodyAsJson.put(RECORDS, records);
-		return new RestRequest(RestMethod.PATCH, RestAction.SOBJECT_COLLECTION.getPath(apiVersion), requestBodyAsJson);
-	}
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_update.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_update.htm</a>
+     */
+    public static RestRequest getRequestForCollectionUpdate(String apiVersion, boolean allOrNone, JSONArray records) throws JSONException {
+        JSONObject requestBodyAsJson = new JSONObject();
+        requestBodyAsJson.put(ALL_OR_NONE, allOrNone);
+        requestBodyAsJson.put(RECORDS, records);
+        return new RestRequest(RestMethod.PATCH, RestAction.SOBJECT_COLLECTION.getPath(apiVersion), requestBodyAsJson);
+    }
 
-	/**
-	 * Request for upserting multiple records with fewer round trips
+    /**
+     * Request for upserting multiple records with fewer round trips
+     *
+     * @param apiVersion      Salesforce API version.
+     * @param allOrNone       Indicates whether to roll back the entire request when the upsert of any object fails (true) or to continue with the independent upsert of other objects in the request.
+     * @param objectType      Type of the requested record.
+     * @param externalIdField Name of ID field in source data.
+     * @param records         A list of sObjects.
 	 *
-	 * @param apiVersion        Salesforce API version.
-	 * @param allOrNone         Indicates whether to roll back the entire request when the upsert of any object fails (true) or to continue with the independent upsert of other objects in the request.
-	 * @param objectType        Type of the requested record.
-	 * @param externalIdField   Name of ID field in source data.
-	 * @param records           A list of sObjects.
-	 *
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_upsert.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_upsert.htm</a>
-	 */
-	public static RestRequest getRequestForCollectionUpsert(String apiVersion, boolean allOrNone, String objectType, String externalIdField, JSONArray records) throws JSONException {
-		JSONObject requestBodyAsJson = new JSONObject();
-		requestBodyAsJson.put(ALL_OR_NONE, allOrNone);
-		requestBodyAsJson.put(RECORDS, records);
-		return new RestRequest(RestMethod.PATCH, RestAction.SOBJECT_COLLECTION_UPSERT.getPath(apiVersion, objectType, externalIdField), requestBodyAsJson);
-	}
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_upsert.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_upsert.htm</a>
+     */
+    public static RestRequest getRequestForCollectionUpsert(String apiVersion, boolean allOrNone, String objectType, String externalIdField, JSONArray records) throws JSONException {
+        JSONObject requestBodyAsJson = new JSONObject();
+        requestBodyAsJson.put(ALL_OR_NONE, allOrNone);
+        requestBodyAsJson.put(RECORDS, records);
+        return new RestRequest(RestMethod.PATCH, RestAction.SOBJECT_COLLECTION_UPSERT.getPath(apiVersion, objectType, externalIdField), requestBodyAsJson);
+    }
 
-	/**
-	 * Request for deleting multiple records with fewer round trips
-	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @param allOrNone     Indicates whether to roll back the entire request when the delete of any object fails (true) or to continue with the independent delete of other objects in the request.
-	 * @param objectIds     List of Salesforce IDs of the records to delete.
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_delete.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_delete.htm</a>
-	 */
-	public static RestRequest getRequestForCollectionDelete(String apiVersion, boolean allOrNone, List<String> objectIds) throws UnsupportedEncodingException {
-		StringBuilder path = new StringBuilder(RestAction.SOBJECT_COLLECTION.getPath(apiVersion));
-		path.append("?allOrNone=" + allOrNone + "&ids=");
-		path.append(URLEncoder.encode(TextUtils.join(",", objectIds), UTF_8));
-		return new RestRequest(RestMethod.DELETE, path.toString());
-	}
+    /**
+     * Request for deleting multiple records with fewer round trips
+     *
+     * @param apiVersion Salesforce API version.
+     * @param allOrNone  Indicates whether to roll back the entire request when the delete of any object fails (true) or to continue with the independent delete of other objects in the request.
+     * @param objectIds  List of Salesforce IDs of the records to delete.
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_delete.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_delete.htm</a>
+     */
+    public static RestRequest getRequestForCollectionDelete(String apiVersion, boolean allOrNone, List<String> objectIds) throws UnsupportedEncodingException {
+        StringBuilder path = new StringBuilder(RestAction.SOBJECT_COLLECTION.getPath(apiVersion));
+        path.append("?allOrNone=" + allOrNone + "&ids=");
+        path.append(URLEncoder.encode(TextUtils.join(",", objectIds), UTF_8));
+        return new RestRequest(RestMethod.DELETE, path.toString());
+    }
 
-	/**
-	 * Request for getting information about limits in your org
-	 *
-	 * @param apiVersion    Salesforce API version.
-	 * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm</a>
-	 */
-	public static RestRequest getRequestForLimits(String apiVersion) {
-		StringBuilder path = new StringBuilder(RestAction.LIMITS.getPath(apiVersion));
-		return new RestRequest(RestMethod.GET, path.toString());
-	}
+    /**
+     * Request for getting information about limits in your org
+     *
+     * @param apiVersion Salesforce API version.
+     * @see <a href="https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm">https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm</a>
+     */
+    public static RestRequest getRequestForLimits(String apiVersion) {
+        StringBuilder path = new StringBuilder(RestAction.LIMITS.getPath(apiVersion));
+        return new RestRequest(RestMethod.GET, path.toString());
+    }
 
-	/**
-	 * Cheap request to re-hydrate access token
-	 * @param apiVersion
-	 * @return a rest request
-	 */
-	public static RestRequest getCheapRequest(String apiVersion) {
-		return getRequestForResources(apiVersion);
-	}
+    /**
+     * Cheap request to re-hydrate access token
+     * @param apiVersion
+     * @return a rest request
+     */
+    public static RestRequest getCheapRequest(String apiVersion) {
+        return getRequestForResources(apiVersion);
+    }
 
     /**
      * Helper method for creating conditional HTTP header.
      *
      * @param headerName Name of header.
-     * @param date Date of header. If null, this method returns null.
+     * @param date       Date of header. If null, this method returns null.
      * @return Map of header name and date, or null if no date is provided.
      */
     private static Map<String, String> prepareConditionalHeader(String headerName, Date date) {
@@ -1001,7 +1005,7 @@ public class RestRequest {
         }
     }
 
-	/**
+    /**
      * Helper class for getRequestForSObjectTree.
      */
     public static class SObjectTree {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -379,9 +379,9 @@ public class RestRequest {
 	 * @return RestRequest object that requests single access URL.
 	 * @see <a href="https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm">https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm</a></a>
 	 */
-	public static RestRequest getRequestForSingleAccess(String redirectUri) {
+	public static RestRequest getRequestForSingleAccess(String redirectUri) throws UnsupportedEncodingException {
 		RequestBody requestBody = RequestBody.create(
-				"redirect_uri=" + redirectUri,
+				"redirect_uri=" + URLEncoder.encode(redirectUri, UTF_8),
 				MediaType.parse("application/x-www-form-urlencoded")
 		);
 		return new RestRequest(RestMethod.POST, RestEndpoint.INSTANCE, RestAction.SINGLEACCESS.getPath(), requestBody, null);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -374,7 +374,8 @@ public class RestRequest {
 	}
 
 	/**
-	 * Request to generate URL to bridge into UI sessions
+	 * Request to generate URL to bridge into UI sessions (a front door URL)
+	 * Applications should use that API instead of building front door URLs directly
 	 * @param redirectUri A relative path that points to where the user is redirected when their new session begins.
 	 * @return RestRequest object that requests single access URL.
 	 * @see <a href="https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm">https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm</a></a>

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientTest.java
@@ -335,6 +335,17 @@ public class RestClientTest {
     }
 
     /**
+     * Testing a get single access call to the server - check response
+     * @throws Exception
+     */
+    @Test
+    public void testGetSingleAccess() throws Exception {
+        RestResponse response = restClient.sendSync(RestRequest.getRequestForSingleAccess("abc/def"));
+        checkResponse(response, HttpURLConnection.HTTP_OK, false);
+        checkKeys(response.asJSONObject(), "frontdoor_uri");
+    }
+
+    /**
      * Testing a get versions call to the server - check response
      * @throws Exception
      */
@@ -757,7 +768,7 @@ public class RestClientTest {
      * @throws Exception
      */
     @Test
-    public void testRestClientUnauthenticatedlientInfo() throws Exception {
+    public void testRestClientUnauthenticatedClientInfo() throws Exception {
         RestClient unauthenticatedRestClient = new RestClient(new RestClient.UnauthenticatedClientInfo(), null, HttpAccess.DEFAULT, null);
         RestRequest request = new RestRequest(RestMethod.GET, "https://na1.salesforce.com/services/data");
         RestResponse response = unauthenticatedRestClient.sendSync(request);
@@ -774,7 +785,7 @@ public class RestClientTest {
      * @throws Exception
      */
     @Test
-    public void testRestClientUnauthenticatedlientInfoAsync() throws Exception {
+    public void testRestClientUnauthenticatedClientInfoAsync() throws Exception {
         RestClient unauthenticatedRestClient = new RestClient(new RestClient.UnauthenticatedClientInfo(), null, HttpAccess.DEFAULT, null);
         RestRequest request = new RestRequest(RestMethod.GET, "https://na1.salesforce.com/services/data");
         RestResponse response = sendAsync(unauthenticatedRestClient, request);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
@@ -49,6 +49,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okio.Buffer;
 
 @RunWith(AndroidJUnit4.class)
@@ -102,6 +104,23 @@ public class RestRequestTest {
 		Assert.assertEquals("Wrong path", "/services/oauth2/userinfo", request.getPath());
 		Assert.assertEquals("Wrong endpoint", RestRequest.RestEndpoint.LOGIN, request.getEndpoint());
 		Assert.assertNull("Wrong request entity", request.getRequestBody());
+		Assert.assertNull("Wrong additional headers", request.getAdditionalHttpHeaders());
+	}
+
+	/**
+	 * Test for getRequestForSingleAcess
+	 */
+	@Test
+	public void testGetRequestForSingleAccess() throws IOException {
+		RestRequest request = RestRequest.getRequestForSingleAccess("abc/def");
+		RequestBody expectedRequestBody = RequestBody.create(
+				"redirect_uri=abc/def",
+				MediaType.parse("application/x-www-form-urlencoded")
+		);
+		Assert.assertEquals("Wrong method", RestMethod.POST, request.getMethod());
+		Assert.assertEquals("Wrong path", "/services/oauth2/singleaccess", request.getPath());
+		Assert.assertEquals("Wrong endpoint", RestRequest.RestEndpoint.INSTANCE, request.getEndpoint());
+		Assert.assertEquals("Wrong request body", bodyToString(expectedRequestBody), bodyToString(request.getRequestBody()));
 		Assert.assertNull("Wrong additional headers", request.getAdditionalHttpHeaders());
 	}
 
@@ -695,5 +714,11 @@ public class RestRequestTest {
 		final Buffer buffer = new Buffer();
 		request.getRequestBody().writeTo(buffer);
 		return buffer.readUtf8();
-	}	
+	}
+
+	private static String bodyToString(RequestBody requestBody) throws IOException {
+		Buffer buffer = new Buffer();
+		requestBody.writeTo(buffer);
+		return buffer.readUtf8();
+	}
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestRequestTest.java
@@ -114,7 +114,7 @@ public class RestRequestTest {
 	public void testGetRequestForSingleAccess() throws IOException {
 		RestRequest request = RestRequest.getRequestForSingleAccess("abc/def");
 		RequestBody expectedRequestBody = RequestBody.create(
-				"redirect_uri=abc/def",
+				"redirect_uri=abc%2Fdef",
 				MediaType.parse("application/x-www-form-urlencoded")
 		);
 		Assert.assertEquals("Wrong method", RestMethod.POST, request.getMethod());


### PR DESCRIPTION
- Added `RestRequest.getRequestForSingleAccess` (with new tests in `RestClientTest` and `RestRequestTest`) which calls `/services/oauth2/singleaccess` to generate a frontdoor URL to bridge into UI sessions.
- Added `shouldRefresh` method in `RestClient.OAuthRefreshInterceptor`: it now refreshes when getting either a 401 or a 403 with reason `Bad_OAuth_Token` while going to `/services/oauth2` (as long as the biometric is not enabled and locked).
- Using `getRequestForSingleAccess` in `IDPAuthCodeHelper` instead of building 
a frontdoor URL directly - tested the IDP/SP flows manually (including the case where the access token has expired).

NB: Left `SalesforceDroidGapActivity.getFronDoorUrl` - we will address it in a separate PR by using the cookies returned by the hybrid authentication flow instead of going through front door.