### PR TITLE
Fix advanced auth login issue after switching servers and other issues.

### DIFF
--- a/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
@@ -46,7 +46,7 @@
         <!--
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:exported="true">
 
             <intent-filter>

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
@@ -47,7 +47,7 @@
         <!--
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:exported="true">
 
             <intent-filter>

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -38,7 +38,7 @@
         <!-- Login activity -->
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize"
             android:exported="true" />
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -253,13 +253,18 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         // If the intent is a callback from Chrome, process it and do nothing else
         if (isChromeCallback(intent)) {
             completeAuthFlow(intent)
-            webviewHelper?.clearView()
             return
         }
 
-        // Reload the login page for every new intent to ensure the correct login server is selected
-        webviewHelper?.run {
-            loadLoginPage()
+        /*
+         * It is important to not reload if we have a custom tab displayed because that also generates
+         * a new code verifier which will break PKCE.
+         */
+        if (!SalesforceSDKManager.getInstance().isBrowserLoginEnabled) {
+            // Reload the login page to ensure the correct login server is displayed in the webview.
+            webviewHelper?.run {
+                loadLoginPage()
+            }
         }
     }
 
@@ -431,7 +436,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * Callbacks from the OAuth web view helper
      */
     override fun loadingLoginPage(loginUrl: String) {
-        supportActionBar?.title = loginUrl
+        this@LoginActivity.runOnUiThread { supportActionBar?.title = loginUrl }
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -292,8 +292,8 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
     open fun clearCookies() =
         CookieManager.getInstance().removeAllCookies(null)
 
-    internal fun clearView() =
-        webView?.loadUrl("about:blank")
+    private fun clearView() =
+        activity?.runOnUiThread { webView?.loadUrl("about:blank") }
 
     /**
      * A factory method for the web view client. This can be overridden as
@@ -367,14 +367,16 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
 
     @Suppress("MemberVisibilityCanBePrivate")
     protected open fun showError(exception: Throwable) {
-        makeText(
-            context,
-            context.getString(
-                sf__generic_error,
-                exception.toString()
-            ),
-            LENGTH_LONG
-        ).show()
+        activity?.runOnUiThread {
+            makeText(
+                context,
+                context.getString(
+                    sf__generic_error,
+                    exception.toString()
+                ),
+                LENGTH_LONG
+            ).show()
+        }
     }
 
     /**
@@ -478,6 +480,8 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
                 activity,
                 parse(uri.toString())
             )
+            // Making the webview blank gives custom tab login a cleaner appearance.
+            clearView()
         }.onFailure { throwable ->
             e(TAG, "Unable to launch Advanced Authentication, Chrome browser not installed.", throwable)
             makeText(context, "To log in, install Chrome.", LENGTH_LONG).show()

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -303,8 +303,6 @@ public class ServerPickerActivity extends AppCompatActivity implements
                 this,
                 SalesforceSDKManager.getInstance().getWebviewLoginActivityClass()
         );
-        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         BiometricAuthenticationManager bioAuthManager =
                 SalesforceSDKManager.getInstance().getBiometricAuthenticationManager();

--- a/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
+++ b/native/NativeSampleApps/ConfiguredApp/AndroidManifest.xml
@@ -39,7 +39,7 @@
 		<!--
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:exported="true">
 
             <intent-filter>

--- a/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
@@ -44,7 +44,7 @@
         -->
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
 			android:exported="true">
 
             <intent-filter>


### PR DESCRIPTION
Issues covered here:
- Failed PKCE Login due to the code verifier being replaced mid flow.  
  - Fixed by now allowing the webview to reload in LoginActivity `onNewIntent` while we are using advanced auth.
- If you switch servers the LoginActivity can appear again instead of the app after a successful login.
  - Partly fixed by the above restriction of reloading the webview (which checks the well known config and launches the login view again when it is done).
  - Partly fixed by switching the LoginActivity from `SingleTop` to `SingleTask`.  I really didn't want to do this because it is **technically a breaking chance** for consuming apps, but the LoginActivity randomly restarts after finish.  I think this is an Android bug we can't work around.  
- Advanced Auth login using the custom domain webview button (requires opt-in pattern) was broken.
  - Somehow for this flow it was possible for a few methods (`loadingLoginPage` and `showError`) to no longer be running on the correct thread so I ensured they run on main. 
- I also cleaned up the presentation of Advanced Auth a little by blanking out the webview when we launch a custom tab.  This means if the user backs our of the custom tab they see a blank screen instead of the webview still loaded with the _previous_ login server.  They will also see this blank screen briefly as we finish PKCE.