### PR TITLE
Make SalesforceSDKManager's ScreenLockManager getter public.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -147,6 +147,7 @@ import com.salesforce.androidsdk.auth.idp.IDPManager as DefaultIDPManager
 import com.salesforce.androidsdk.auth.idp.SPManager as DefaultSPManager
 import com.salesforce.androidsdk.auth.interfaces.NativeLoginManager as NativeLoginManagerInterface
 import com.salesforce.androidsdk.security.interfaces.BiometricAuthenticationManager as BiometricAuthenticationManagerInterface
+import com.salesforce.androidsdk.security.interfaces.ScreenLockManager as ScreenLockManagerInterface
 
 /**
  * This class serves as an interface to the various functions of the Salesforce
@@ -221,7 +222,7 @@ open class SalesforceSDKManager protected constructor(
     private val screenLockManagerLock = Any()
 
     /** The Salesforce SDK manager's screen lock manager */
-    var screenLockManager: ScreenLockManager? = null
+    var screenLockManager: ScreenLockManagerInterface? = null
         @JvmName("getScreenLockManager")
         get() = field ?: synchronized(screenLockManagerLock) {
             ScreenLockManager()
@@ -701,7 +702,7 @@ open class SalesforceSDKManager protected constructor(
             adminPermsManager?.resetAll()
             adminSettingsManager = null
             adminPermsManager = null
-            screenLockManager?.reset()
+            (screenLockManager as ScreenLockManager?)?.reset()
             screenLockManager = null
             biometricAuthenticationManager = null
         }
@@ -718,7 +719,7 @@ open class SalesforceSDKManager protected constructor(
         UserAccountManager.getInstance().clearCachedCurrentUser()
 
         userAccount?.let { userAccountResolved ->
-            screenLockManager?.cleanUp(userAccountResolved)
+            (screenLockManager as ScreenLockManager?)?.cleanUp(userAccountResolved)
             (biometricAuthenticationManager as BiometricAuthenticationManager)
                 .cleanUp(userAccountResolved)
         }
@@ -1461,7 +1462,7 @@ open class SalesforceSDKManager protected constructor(
     @Suppress("unused")
     @OnLifecycleEvent(ON_STOP)
     protected open fun onAppBackgrounded() {
-        screenLockManager?.onAppBackgrounded()
+        (screenLockManager as ScreenLockManager?)?.onAppBackgrounded()
 
         // Publish analytics one-time on app background, if enabled.
         if (SalesforceAnalyticsManager.analyticsPublishingType() == PublishOnAppBackground) {
@@ -1481,7 +1482,7 @@ open class SalesforceSDKManager protected constructor(
     @Suppress("unused")
     @OnLifecycleEvent(ON_START)
     protected open fun onAppForegrounded() {
-        screenLockManager?.onAppForegrounded()
+        (screenLockManager as ScreenLockManager?)?.onAppForegrounded()
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppForegrounded()
 
         // Review push-notifications registration for the current user, if enabled.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -221,7 +221,7 @@ open class SalesforceSDKManager protected constructor(
     private val screenLockManagerLock = Any()
 
     /** The Salesforce SDK manager's screen lock manager */
-    internal var screenLockManager: ScreenLockManager? = null
+    var screenLockManager: ScreenLockManager? = null
         @JvmName("getScreenLockManager")
         get() = field ?: synchronized(screenLockManagerLock) {
             ScreenLockManager()

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -110,6 +110,7 @@ import com.salesforce.androidsdk.security.BiometricAuthenticationManager
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Companion.isBiometricAuthenticationEnabled
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getRandom128ByteKey
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getSHA256Hash
+import com.salesforce.androidsdk.security.ScreenLockManager
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.PICK_SERVER_REQUEST_CODE
 import com.salesforce.androidsdk.ui.OAuthWebviewHelper.AccountOptions.Companion.fromBundle
 import com.salesforce.androidsdk.util.EventsObservable
@@ -1032,7 +1033,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
             if (id?.screenLockTimeout?.compareTo(0) == 1) {
                 SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_SCREEN_LOCK)
                 val timeoutInMills = (id?.screenLockTimeout ?: 0) * 1000 * 60
-                instance.screenLockManager?.storeMobilePolicy(
+                (instance.screenLockManager as ScreenLockManager?)?.storeMobilePolicy(
                     account,
                     id?.screenLock ?: false,
                     timeoutInMills
@@ -1042,9 +1043,8 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
             // Biometric authorization required by mobile policy
             if (id?.biometricAuth == true) {
                 SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH)
-                val bioAuthManager = instance.biometricAuthenticationManager as BiometricAuthenticationManager?
                 val timeoutInMills = (id?.biometricAuthTimeout ?: 0) * 60 * 1000
-                bioAuthManager?.storeMobilePolicy(
+                (instance.biometricAuthenticationManager as BiometricAuthenticationManager?)?.storeMobilePolicy(
                     account,
                     id?.biometricAuth ?: false,
                     timeoutInMills

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
@@ -233,7 +233,7 @@ public class ScreenLockActivity extends FragmentActivity {
     private void finishSuccess() {
         resetUI();
         sendAccessibilityEvent(getString(R.string.sf__screen_lock_auth_success));
-        ScreenLockManager screenLockManager = SalesforceSDKManager.getInstance().getScreenLockManager();
+        ScreenLockManager screenLockManager = (ScreenLockManager) SalesforceSDKManager.getInstance().getScreenLockManager();
         if (screenLockManager != null) {
             screenLockManager.onUnlock();
         }


### PR DESCRIPTION
I appears we simply missed this when we converted `SalesforceSDKManager` to Koltin in 12.0.