### PR TITLE
Fix push deregister error.

### DIFF
--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -5,6 +5,7 @@
 	android:versionCode="87"
 	android:versionName="12.2.0.dev">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -5,7 +5,6 @@
 	android:versionCode="87"
 	android:versionName="12.2.0.dev">
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -160,10 +160,9 @@ object PushMessaging {
                 FirebaseInstallations.getInstance(firebaseApp).delete()
                 firebaseApp.delete()
             }
+
             unregisterSFDCPush(context, account)
         }
-
-        unregisterSFDCPush(context, account)
     }
 
     /**
@@ -470,14 +469,7 @@ object PushMessaging {
         account: UserAccount?,
         action: PushNotificationsRegistrationAction,
     ) {
-        if (account == null) {
-            enqueuePushNotificationsRegistrationWork(
-                userAccount = null,
-                action = action,
-                pushNotificationsRegistrationType = ReRegistrationOnAppForeground,
-                delayDays = null
-            )
-        } else if (isRegistered(context, account)) {
+        if (account == null || isRegistered(context, account)) {
             enqueuePushNotificationsRegistrationWork(
                 userAccount = account,
                 action = action,


### PR DESCRIPTION
In #2545 I made a change to delay push deregister until the device had network connection so that the operation would succeed (eventually) even if the user chose to logout while offline.  At the time of testing this worked correctly in all cases but since a change has been made that causes an error on deregister (likely the recent bugfix #2607, which retained the tokens after logout).  The error doesn't actually cause the unregister operation to fail and is invisible to the end user, but an internal team ran into issues with automated testing because of it.  