### PR TITLE
Android 15 Support - Part 1

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -58,7 +58,7 @@ import android.webkit.WebView
 import android.widget.Button
 import android.widget.Toast.LENGTH_SHORT
 import android.widget.Toast.makeText
-import android.window.OnBackInvokedDispatcher.PRIORITY_DEFAULT
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
@@ -129,19 +129,12 @@ import com.salesforce.androidsdk.R.menu.sf__login as sf__login_menu
  * OAuth web view helper class.
  */
 open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
-
     private var wasBackgrounded = false
-
     private var webviewHelper: OAuthWebviewHelper? = null
-
     private var authConfigReceiver: AuthConfigReceiver? = null
-
     private var receiverRegistered = false
-
     private var accountAuthenticatorResponse: AccountAuthenticatorResponse? = null
-
     private var accountAuthenticatorResult: Bundle? = null
-
     private var biometricAuthenticationButton: Button? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -227,11 +220,10 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
             receiverRegistered = true
         }
 
-        // TODO:  Remove this when min API > 33
-        if (SDK_INT >= TIRAMISU) {
-            onBackInvokedDispatcher.registerOnBackInvokedCallback(
-                PRIORITY_DEFAULT
-            ) { handleBackBehavior() }
+        // Take control of the back logic if the device is locked.
+        // TODO:  Remove SDK_INT check when min API > 33
+        if (SDK_INT >= TIRAMISU && biometricAuthenticationManager?.locked == true) {
+            onBackPressedDispatcher.addCallback { handleBackBehavior() }
         }
 
         requestedOrientation = if (salesforceSDKManager.compactScreen(this))
@@ -244,6 +236,8 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
             unregisterReceiver(authConfigReceiver)
             receiverRegistered = false
         }
+
+        handleBackBehavior()
         super.onDestroy()
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -487,7 +487,17 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
             e(TAG, "Unable to launch Advanced Authentication, Chrome browser not installed.", throwable)
             makeText(context, "To log in, install Chrome.", LENGTH_LONG).show()
             callback.finish(null)
-            context.startActivity(Intent(activity, ServerPickerActivity::class.java))
+
+            /*
+             * Launch server picker again to prevent this error from happening in an infinite loop.  It is impossible to
+             * break out of this loop without uninstalling the app.
+             *
+             * Clear top to prevent multiple server pickers form being on the stack if the user hits back multiple times
+             * before selecting a different server.
+             */
+            val serverPickerIntent = Intent(activity, ServerPickerActivity::class.java)
+            serverPickerIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            context.startActivity(serverPickerIntent)
         }
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -487,6 +487,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
             e(TAG, "Unable to launch Advanced Authentication, Chrome browser not installed.", throwable)
             makeText(context, "To log in, install Chrome.", LENGTH_LONG).show()
             callback.finish(null)
+            context.startActivity(Intent(activity, ServerPickerActivity::class.java))
         }
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -28,12 +28,10 @@ package com.salesforce.androidsdk.ui;
 
 import static com.salesforce.androidsdk.security.BiometricAuthenticationManager.SHOW_BIOMETRIC;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -41,7 +39,6 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.RadioGroup;
 import android.widget.ScrollView;
-import android.window.OnBackInvokedDispatcher;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -81,16 +78,6 @@ public class ServerPickerActivity extends AppCompatActivity implements
         urlEditDialog = new CustomServerUrlEditor();
     }
 
-    /**
-     * Sets the return value of the activity. Selection is stored in the
-     * shared prefs file, AuthActivity pulls from the file or a default value.
-     */
-    @SuppressLint("MissingSuperCall")
-    @Override
-    public void onBackPressed() {
-        reconfigureAuthorization();
-    }
-
     @Override
     public void onCheckedChanged(RadioGroup group, int checkedId) {
     	if (group != null) {
@@ -105,18 +92,16 @@ public class ServerPickerActivity extends AppCompatActivity implements
     	}
     }
 
-    @Override
-    public boolean onNavigateUp() {
-        onBackPressed();
-        return true;
-    }
-
     /**
      * Called when the 'Reset' button is clicked. Clears custom URLs.
      *
      * @param v View that was clicked.
+     *
+     * @deprecated Unused.  Will be modified or removed in 13.0.
      */
+    @Deprecated
     public void onResetClick(View v) {
+        // TODO: in 13.0 we should drop the parameter and move the contents of clearCustomUrlSetting here.
         clearCustomUrlSetting();
     }
 
@@ -164,14 +149,6 @@ public class ServerPickerActivity extends AppCompatActivity implements
         } else {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
         }
-
-        // TODO:  Remove this when min API > 33
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
-                    OnBackInvokedDispatcher.PRIORITY_DEFAULT,
-                    this::onBackPressed
-            );
-        }
     }
 
     @Override
@@ -185,6 +162,7 @@ public class ServerPickerActivity extends AppCompatActivity implements
         final RadioGroup radioGroup = findViewById(getServerListGroupId());
         radioGroup.setOnCheckedChangeListener(null);
         urlEditDialog = null;
+        reconfigureAuthorization();
         super.onDestroy();
     }
 

--- a/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
+++ b/native/NativeSampleApps/RestExplorer/AndroidManifest.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	android:versionCode="1"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:versionCode="1"
 	android:versionName="1.0"
 	android:installLocation="internalOnly">
 
 	<application android:icon="@drawable/sf__icon"
 	    android:label="@string/app_name"
 		android:name=".RestExplorerApp"
-		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity">
+		android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"
+		android:enableOnBackInvokedCallback="true"
+        tools:targetApi="tiramisu">
 
 		<!-- Launcher screen -->
 		<activity android:name=".ExplorerActivity"
-		    android:label="@string/app_name"
 			android:theme="@style/SalesforceSDK_Fullscreen"
 			android:exported="true">
 


### PR DESCRIPTION
This PR covers supporting Android 15 devices **prior to apps updating to API 35**.  I will follow up with a Part 2 that fixes issues and makes necessary improvements for apps targeting API 35.

Changes:
- Fixed endless advanced auth loop is no browser exits.
   - This isn't specific to Android 15 pre se, but a user is significantly more likely to run into this scenario in the new [Private Space](https://source.android.com/docs/security/features/private-space) profile.
-  Update [Predictive System Back](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture) behavior.  
   - "Predictable" for the OS really means that the app doesn't control it anymore.  I have basically moved all of necessary cleanup work to `onDestroy` so that it happens no matter what.
   - The only difference in behavior (besides the fancy new animations ✨) is pressing/gesturing back while locked (Passcode or Bio Auth) now does nothing instead of closing the app.  

All aspects of the SDK seem to work fine in Private Spaces and I have found no indication we have Android for Work logic that needs to be updated take this into account.  ~~The only thing left to test here is IDP within a Private Space, which I am setting up now.~~  Edit:  Working!


I tested [Support for 16 KB page size](https://developer.android.com/guide/practices/page-sizes) with somewhat confusing results on an emulator.  My concern was SQLCipher, but it was updated to support 16 KB page size in the version we are currently using (4.6.1).  Login an sync worked fine but it crashed with an error that didn't make much sense not long after.  I will test again on a physical Pixel 8 Pro after I upgrade it to Android 15.  However, this is still an experimental feature and I don't think we necessarily need to support it now.