### PR TITLE
Setting cookies on hybrid remote webview instead of loading page through front door

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.kt
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.kt
@@ -26,10 +26,15 @@
  */
 package com.salesforce.androidsdk.phonegap.ui
 
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import android.view.KeyEvent
 import android.webkit.URLUtil.isHttpsUrl
 import androidx.lifecycle.lifecycleScope
+import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.HttpAccess.NoNetworkException
 import com.salesforce.androidsdk.config.BootConfig
@@ -41,6 +46,7 @@ import com.salesforce.androidsdk.config.LoginServerManager.SANDBOX_LOGIN_URL
 import com.salesforce.androidsdk.phonegap.app.SalesforceHybridSDKManager
 import com.salesforce.androidsdk.phonegap.ui.SalesforceWebViewClientHelper.getAppHomeUrl
 import com.salesforce.androidsdk.phonegap.ui.SalesforceWebViewClientHelper.hasCachedAppHome
+import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger.d
 import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger.i
 import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger.w
 import com.salesforce.androidsdk.rest.ApiVersionStrings.VERSION_NUMBER
@@ -56,7 +62,7 @@ import com.salesforce.androidsdk.util.AuthConfigUtil.MyDomainAuthConfig
 import com.salesforce.androidsdk.util.AuthConfigUtil.getMyDomainAuthConfig
 import com.salesforce.androidsdk.util.EventsObservable
 import com.salesforce.androidsdk.util.EventsObservable.EventType.GapWebViewCreateComplete
-import com.salesforce.androidsdk.util.SalesforceSDKLogger
+import com.salesforce.androidsdk.util.SalesforceSDKLogger.e
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Default
 import kotlinx.coroutines.launch
@@ -67,6 +73,7 @@ import org.apache.cordova.CordovaActivity
 import org.apache.cordova.CordovaWebView
 import org.apache.cordova.CordovaWebViewEngine
 import org.apache.cordova.CordovaWebViewImpl.createEngine
+
 
 /**
  * Class that defines the main activity for a PhoneGap-based application.
@@ -99,6 +106,12 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
     /** Indicates if the web app is loaded */
     private var webAppLoaded = false
 
+    /** Broadcast receiver notified when access token is refreshed */
+    private var tokenRefreshReceiver: TokenRefreshReceiver? = null
+
+    /** Manager for cookies in web view */
+    private val salesforceCookieManager: SalesforceWebViewCookieManager = SalesforceWebViewCookieManager()
+
     /**
      * Called when the activity is first created.
      */
@@ -118,6 +131,9 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
             setupGlobalStoreFromDefaultConfig()
             setupGlobalSyncsFromDefaultConfig()
         }
+
+        // Set up token refresh receiver
+        tokenRefreshReceiver = TokenRefreshReceiver()
 
         // Create the delegate
         delegate?.onCreate()
@@ -145,13 +161,20 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
     public override fun onResume() {
         super.onResume()
 
+        // Register the BroadcastReceiver with the intent filter
+        val filter = IntentFilter().apply {
+            addAction(ClientManager.ACCESS_TOKEN_REFRESH_INTENT)
+            addAction(ClientManager.INSTANCE_URL_UPDATE_INTENT)
+        }
+        registerReceiver(tokenRefreshReceiver, filter, RECEIVER_NOT_EXPORTED)
+
         // Fetch authentication configuration if required
         lifecycleScope.launch {
             doAuthConfig()
         }
 
-        delegate?.onResume(false)
 
+        delegate?.onResume(false)
         // Will call this.onResume(RestClient client) with a null client
     }
 
@@ -165,13 +188,17 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
 
         when (this.restClient) {
             // When not logged in
-            null -> when {
-                !webAppLoaded -> onResumeNotLoggedIn()
-                else -> i(TAG, "onResume - unauthenticated web app already loaded")
+            null -> {
+                when {
+                    !webAppLoaded -> onResumeNotLoggedIn()
+                    else -> i(TAG, "onResume - unauthenticated web app already loaded")
+                }
             }
 
             // Logged in
-            else ->
+            else -> {
+                salesforceCookieManager.setCookies(UserAccountManager.getInstance().currentUser)
+
                 when {
                     // Web app never loaded
                     !webAppLoaded -> onResumeLoggedInNotLoaded()
@@ -179,6 +206,7 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
                     // Web app already loaded
                     else -> i(TAG, "onResume - already logged in/web app already loaded")
                 }
+            }
         }
     }
 
@@ -222,10 +250,7 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
                         else -> {
                             w(TAG, "onResumeNotLoggedIn - should not authenticate/remote start page - loading web app")
                             unauthenticatedStartPage?.let { unauthenticatedStartPage ->
-                                loadRemoteStartPage(
-                                    unauthenticatedStartPage,
-                                    false
-                                )
+                                loadRemoteStartPage(unauthenticatedStartPage)
                             }
                         }
                     }
@@ -262,7 +287,7 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
                 SalesforceSDKManager.getInstance().hasNetwork() -> {
                     i(TAG, "onResumeLoggedInNotLoaded - remote start page/online - loading web app")
                     bootConfig?.startPage?.let { startPage ->
-                        loadRemoteStartPage(startPage, true)
+                        loadRemoteStartPage(startPage)
                     }
                 }
 
@@ -285,6 +310,10 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
 
     public override fun onPause() {
         super.onPause()
+
+        // Unregister the BroadcastReceiver to avoid leaks
+        unregisterReceiver(tokenRefreshReceiver);
+
         delegate?.onPause()
     }
 
@@ -397,13 +426,12 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
 
     /**
      * If an action causes a redirect to the login page, this method will be
-     * called. It causes the session to be refreshed and reloads the URL through
-     * the front door.
+     * called. It causes the session to be refreshed and reloads the URL.
      *
      * @param url The page to load once the session has been refreshed
      */
-    fun refresh(url: String?) {
-        i(TAG, "refresh called")
+    fun refresh(url: String) {
+        i(TAG, "refresh called url:$url")
 
         /*
          * If client is null at this point, authentication hasn't been performed
@@ -412,10 +440,19 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
          * cases involving hitting the back button when authentication is in
          * progress
          */
+
+        d(TAG, "refresh - 1")
+
         if (restClient == null) {
             clientManager?.getRestClient(this) { recreate() }
+            d(TAG, "refresh - 2")
             return
         }
+
+        webAppLoaded = false /* to force a reload */
+
+        d(TAG, "refresh - 3")
+
 
         restClient?.sendAsync(
             getCheapRequest(VERSION_NUMBER), object : AsyncRequestCallback {
@@ -425,25 +462,26 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
                     response: RestResponse
                 ) {
                     i(TAG, "refresh callback - refresh succeeded")
+                    // Get a fresh RestClient / set cookies and reload web view if needed
+                    onResume(null)
 
-                    runOnUiThread {
-                        /*
-                         * The client instance being used here needs to be
-                         * refreshed, to ensure we use the new access token.
-                         * However, if the refresh token was revoked when the
-                         * app was in the background we need to catch that
-                         * exception and trigger a proper logout to reset the
-                         * state of this class
-                        */
-                        runCatching {
-                            restClient = clientManager?.peekRestClient()
-                            val frontDoorUrl = getFrontDoorUrl(url, isAbsoluteUrl(url))
-                            loadUrl(frontDoorUrl)
-                        }.onFailure {
-                            i(TAG, "User has been logged out.")
-                            logout(null)
-                        }
-                    }
+//                    runOnUiThread {
+//                        /*
+//                         * The client instance being used here needs to be
+//                         * refreshed, to ensure we use the new access token.
+//                         * However, if the refresh token was revoked when the
+//                         * app was in the background we need to catch that
+//                         * exception and trigger a proper logout to reset the
+//                         * state of this class
+//                        */
+//                        runCatching {
+//                            restClient = clientManager?.peekRestClient()
+//                            loadRemoteStartPage(url)
+//                        }.onFailure {
+//                            i(TAG, "User has been logged out.")
+//                            logout(null)
+//                        }
+//                    }
                 }
 
                 override fun onError(exception: Exception) {
@@ -477,69 +515,31 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
     @Suppress("unused")
     fun loadRemoteStartPage() =
         bootConfig?.startPage?.let { startPage ->
-            loadRemoteStartPage(startPage, true)
+            loadRemoteStartPage(startPage)
         }
 
     /**
      * Load the remote start page.
      * @param startPageUrl The start page to load
-     * @param loadThroughFrontDoor Whether or not to load through front-door
      */
     private fun loadRemoteStartPage(
-        startPageUrl: String,
-        loadThroughFrontDoor: Boolean
+        startPageUrl: String
     ) {
         assert(bootConfig?.isLocal != true)
 
-        var url = startPageUrl
-        if (loadThroughFrontDoor) {
-            url = getFrontDoorUrl(url, isAbsoluteUrl(url)) ?: return
+        val clientInfo = restClient?.clientInfo
+        val url = when {
+            isAbsoluteUrl(startPageUrl) && clientInfo != null -> {
+                startPageUrl
+            }
+            else -> {
+                clientInfo?.resolveUrl(startPageUrl).toString()
+            }
         }
 
         i(TAG, "loadRemoteStartPage called - loading!")
-
         loadUrl(url)
         webAppLoaded = true
-    }
-
-    /**
-     * Returns the front-doored URL of a URL passed in.
-     *
-     * @param providedUrl URL to be front-doored
-     * @param isAbsoluteUrl True if the URL should be used as is; false
-     * otherwise
-     * @return The front-doored URL
-     */
-    fun getFrontDoorUrl(
-        providedUrl: String?,
-        isAbsoluteUrl: Boolean
-    ): String? {
-
-        /*
-         * Use the absolute URL in some cases and the relative URL in some other
-         * cases because of differences between instance URL and community URL.
-         * Community URL can be custom and the logic of determining which URL to
-         * use is in the 'resolveUrl' method in 'ClientInfo'
-         */
-        val restClient = restClient ?: return null
-        return "${restClient.clientInfo.instanceUrlAsString}/secur/frontdoor.jsp?".toHttpUrlOrNull()
-            ?.newBuilder()
-            ?.addQueryParameter(
-                name = "sid",
-                value = restClient.authToken
-            )
-            ?.addQueryParameter(
-                name = "retURL",
-                value = when {
-                    isAbsoluteUrl -> providedUrl
-                    else -> restClient.clientInfo.resolveUrl(providedUrl).toString()
-                }
-            )
-            ?.addQueryParameter(
-                name = "display",
-                value = "touch"
-            )
-            ?.build().toString()
     }
 
     /**
@@ -601,12 +601,29 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
                     authConfig = getMyDomainAuthConfig(loginServer)
                 }
             }.onFailure { e ->
-                SalesforceSDKLogger.e(TAG, "Exception occurred while fetching authentication configuration", e)
+                e(TAG, "Exception occurred while fetching authentication configuration", e)
             }
         }
     }
 
+    inner class TokenRefreshReceiver : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent) {
+            // Check if the broadcast is for the right intent
+            if (intent.action == ClientManager.ACCESS_TOKEN_REFRESH_INTENT
+                || intent.action == ClientManager.INSTANCE_URL_UPDATE_INTENT) {
+                d(TAG, "TokenRefreshReceiver onReceive - calling onResume")
+                // Get a fresh RestClient / set cookies and reload web view if needed
+                onResume(null)
+            }
+        }
+    }
+
+
     companion object {
         private const val TAG = "SfDroidGapActivity"
     }
+
 }
+
+
+

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.kt
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.kt
@@ -430,7 +430,7 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
      *
      * @param url The page to load once the session has been refreshed
      */
-    fun reload(url: String) {
+    fun refresh(url: String) {
         i(TAG, "reload called url:$url")
 
         /*
@@ -519,6 +519,52 @@ open class SalesforceDroidGapActivity : CordovaActivity(), SalesforceActivityInt
         i(TAG, "loadRemoteStartPage called - loading! - $url")
         loadUrl(url)
         webAppLoaded = true
+    }
+
+    /**
+     * Returns the front-doored URL of a URL passed in.
+     *
+     * @param providedUrl URL to be front-doored
+     * @param isAbsoluteUrl True if the URL should be used as is; false
+     * otherwise
+     * @return The front-doored URL
+     *
+     * @Deprecated we are no longer using front door to setup the session in the web view
+     *             instead we get the session from the login/refresh oauth flow
+     *             and sets them in CookieManager using SalesforceWebViewCookieManager
+     *             This method will be remove in Mobile SDK 13.0
+     */
+    @Deprecated("Deprecated - to be removed in 13.0")
+    fun getFrontDoorUrl(
+        providedUrl: String?,
+        isAbsoluteUrl: Boolean
+    ): String? {
+
+        /*
+         * Use the absolute URL in some cases and the relative URL in some other
+         * cases because of differences between instance URL and community URL.
+         * Community URL can be custom and the logic of determining which URL to
+         * use is in the 'resolveUrl' method in 'ClientInfo'
+         */
+        val restClient = restClient ?: return null
+        return "${restClient.clientInfo.instanceUrlAsString}/secur/frontdoor.jsp?".toHttpUrlOrNull()
+            ?.newBuilder()
+            ?.addQueryParameter(
+                name = "sid",
+                value = restClient.authToken
+            )
+            ?.addQueryParameter(
+                name = "retURL",
+                value = when {
+                    isAbsoluteUrl -> providedUrl
+                    else -> restClient.clientInfo.resolveUrl(providedUrl).toString()
+                }
+            )
+            ?.addQueryParameter(
+                name = "display",
+                value = "touch"
+            )
+            ?.build().toString()
     }
 
     /**

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
@@ -51,7 +51,7 @@ import java.util.Map;
  */
 public class SalesforceWebViewClientHelper {
 
-	private static final String TAG = "SalesforceWebViewClientHelper";
+    private static final String TAG = "SalesforceWebViewClientHelper";
     private static final String SFDC_WEB_VIEW_CLIENT_SETTINGS = "sfdc_gapviewclient";
     private static final String APP_HOME_URL_PROP_KEY =  "app_home_url";
     private static final String HYBRID_SESSION_REDIRECT = "/services/identity/mobileauthredirect";
@@ -74,13 +74,13 @@ public class SalesforceWebViewClientHelper {
      * @return              True if url loading should be overridden, false otherwise.
      */
     public static boolean shouldOverrideUrlLoading(Context ctx,
-    		WebView view, String url) {
-    	final String startURL = SalesforceWebViewClientHelper.isLoginRedirect(ctx, url);
+                                                   WebView view, String url) {
+        final String startURL = SalesforceWebViewClientHelper.isLoginRedirect(ctx, url);
         if (startURL != null && ctx instanceof SalesforceDroidGapActivity) {
-            ((SalesforceDroidGapActivity) ctx).refresh(startURL);
-        	return true;
+            ((SalesforceDroidGapActivity) ctx).reload(startURL);
+            return true;
         } else {
-        	return false;
+            return false;
         }
     }
 
@@ -103,7 +103,7 @@ public class SalesforceWebViewClientHelper {
             EventsObservable.get().notifyEvent(EventType.GapWebViewPageFinished, url);
             return true;
         } else {
-        	return false;
+            return false;
         }
     }
 
@@ -120,8 +120,8 @@ public class SalesforceWebViewClientHelper {
      * @return      true if there is a cached version of the app's home page
      */
     public static boolean hasCachedAppHome(Context ctx) {
-    	String cachedAppHomeUrl = getAppHomeUrl(ctx);
-    	return cachedAppHomeUrl != null && (new File(cachedAppHomeUrl)).exists();
+        String cachedAppHomeUrl = getAppHomeUrl(ctx);
+        return cachedAppHomeUrl != null && (new File(cachedAppHomeUrl)).exists();
     }
 
     private static boolean isReservedUrl(String url) {
@@ -164,15 +164,15 @@ public class SalesforceWebViewClientHelper {
                 }
                 final List<String> ssoUrls = authConfig.getSsoUrls();
                 if (ssoUrls != null && ssoUrls.size() > 0) {
-                   for (String ssoUrl : ssoUrls) {
-                       int paramsIndex = ssoUrl.indexOf(QUESTION_MARK);
-                       if (paramsIndex != -1) {
-                           ssoUrl = ssoUrl.substring(0, paramsIndex);
-                       }
-                       if (url.contains(ssoUrl)) {
-                           return true;
-                       }
-                   }
+                    for (String ssoUrl : ssoUrls) {
+                        int paramsIndex = ssoUrl.indexOf(QUESTION_MARK);
+                        if (paramsIndex != -1) {
+                            ssoUrl = ssoUrl.substring(0, paramsIndex);
+                        }
+                        if (url.contains(ssoUrl)) {
+                            return true;
+                        }
+                    }
                 }
             }
         }

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewClientHelper.java
@@ -77,7 +77,7 @@ public class SalesforceWebViewClientHelper {
                                                    WebView view, String url) {
         final String startURL = SalesforceWebViewClientHelper.isLoginRedirect(ctx, url);
         if (startURL != null && ctx instanceof SalesforceDroidGapActivity) {
-            ((SalesforceDroidGapActivity) ctx).reload(startURL);
+            ((SalesforceDroidGapActivity) ctx).refresh(startURL);
             return true;
         } else {
             return false;

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewCookieManager.kt
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewCookieManager.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.phonegap.ui
+
+import android.net.Uri
+import android.os.SystemClock
+import android.webkit.CookieManager
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger.d
+import com.salesforce.androidsdk.phonegap.util.SalesforceHybridLogger.w
+import java.net.URI
+
+class SalesforceWebViewCookieManager {
+    private val cookieManager = CookieManager.getInstance()
+
+    fun setCookies(userAccount: UserAccount) {
+        d(TAG, "setCookies for userAccount:${userAccount.toJson()}")
+
+        val instanceUrl = userAccount.instanceServer
+        val lightningDomain = userAccount.lightningDomain
+        val lightningSid = userAccount.lightningSid
+        val contentDomain = userAccount.contentDomain
+        val contentSid = userAccount.contentSid
+        val accessToken = userAccount.authToken
+        val vfDomain = userAccount.vfDomain
+        val vfSid = userAccount.vfSid
+        val clientSrc = userAccount.cookieClientSrc
+        val sidClient = userAccount.cookieSidClient
+        val sidCookieName = userAccount.sidCookieName
+        val csrfToken = userAccount.csrfToken
+        val orgId = userAccount.orgId
+        val communityUrl = userAccount.communityUrl
+        val mainDomain = getDomainFromUrl(instanceUrl)
+
+        // Setup domain for community to avoid dupe cookies
+        // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
+        val setDomain = !communityUrl.isNullOrBlank()
+
+        // Main domain cookies
+        setCookieValue("sid for main", mainDomain, setDomain, sidCookieName, accessToken)
+        setCookieValue(CLIENT_SRC, mainDomain, setDomain, CLIENT_SRC, clientSrc)
+        setCookieValue(SID_CLIENT, mainDomain, setDomain, SID_CLIENT, sidClient)
+        setCookieValue(ORG_ID, mainDomain, setDomain, ORG_ID, orgId)
+        setCookieValue(csrfTokenCookieName, mainDomain, setDomain, csrfTokenCookieName, csrfToken)
+
+        // Lightning domain cookies
+        setCookieValue("sid for lightning", lightningDomain, setDomain, sidCookieName, lightningSid)
+        setCookieValue(csrfTokenCookieName, lightningDomain, setDomain, csrfTokenCookieName, csrfToken)
+
+        // Content domain cookies
+        setCookieValue("sid for content", contentDomain, setDomain, sidCookieName, contentSid)
+
+        // Vf domain cookies
+        setCookieValue("sid for vf", vfDomain, setDomain, sidCookieName, vfSid)
+        setCookieValue(CLIENT_SRC, vfDomain, setDomain, CLIENT_SRC, clientSrc)
+        setCookieValue(SID_CLIENT, vfDomain, setDomain, SID_CLIENT, sidClient)
+        setCookieValue(ORG_ID, vfDomain, setDomain, ORG_ID, orgId)
+
+        syncCookies()
+    }
+
+    private fun setCookieValue(
+        cookieType: String, domain: String?, setDomain: Boolean, name: String?, value: String?
+    ) {
+        if (!domain.isNullOrBlank() && !name.isNullOrBlank() && !value.isNullOrBlank()) {
+            val url = getHttpsUrlFromDomain(domain)
+
+            val builder = StringBuilder()
+            builder.append("$name=$value")
+
+            if (setDomain) {
+                builder.append("$DOMAIN_PREFIX$domain")
+            }
+
+            // Set 'SameSite=None' param.
+            // NB will NOT work on old versions of chrome
+            // (https://www.chromium.org/updates/same-site/incompatible-clients/).
+            builder.append(PATH)
+            // We need to set secure param when setting SameSite=None
+            builder.append(SECURE)
+            builder.append(SAME_SITE)
+            cookieManager.setCookie(url, builder.toString())
+
+            d(TAG, "setCookieValue - Set $cookieType in domain:$domain with value:$value")
+        } else {
+            w(TAG, "setCookieValue - Unable to set $cookieType in domain:$domain")
+        }
+    }
+
+    /** Syncs the cookies for webview  */
+    private fun syncCookies() {
+        cookieManager.flush()
+        // Give enough time to yield
+        SystemClock.sleep(SLEEP_TIME_SYNC)
+    }
+
+    companion object {
+        const val CLIENT_SRC = "clientSrc"
+        const val SID_CLIENT = "sid_Client"
+        const val ORG_ID = "oid"
+        private const val PATH = "; path=/"
+        private const val SECURE = "; secure"
+        private const val SAME_SITE = "; SameSite=None"
+        private const val DOMAIN_PREFIX = "; domain="
+        const val SLEEP_TIME_SYNC: Long = 15
+        private const val TAG = "SalesforceWebViewCookieManager"
+        private const val csrfTokenCookieName = "eikoocnekotMob"
+    }
+
+    private fun getHttpsUrlFromDomain(domain: String): String {
+        // Prepend with https:// if it doesn't have a protocol
+        var url = domain
+        if (domain != null && !domain.contains("://")) {
+            val builder = Uri.Builder()
+            url = builder.scheme("https").authority(domain).build().toString()
+        }
+        return url
+    }
+
+    private fun getDomainFromUrl(url: String): String {
+        val uri = URI(url)
+        return uri.host
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -57,8 +57,8 @@ public abstract class SalesforceActivity extends AppCompatActivity implements Sa
 
     @Override
     public void onPause() {
-		super.onPause();
-		delegate.onPause();
+        super.onPause();
+        delegate.onPause();
     }
 
     @Override


### PR DESCRIPTION
### New class: `SalesforceWebviewCookieManager`
- based on SApp's `BridgeCookieManager`
- Gets SIDs from the `UserAccount` and sets them in the `CookieManager`

### Modified `SalesforceDroidGapActivity`
- it no longer uses front-door to load remote app
- it calls `SalesforceWebviewCookieManager`'s `setCookies` method when receiving a refresh broadcast
- cleaned up the `reload` logic (previously called `refresh` but that name was a bit confusing)

### Manual testing
Created two apps on Mobile SDK cs4.com test org
- `apex/AccountEditor` which is the AccountEditor uploaded as hybrid remote app: it uses Mobile SDK Cordova plugins to do network operations
- `apex/AccountList` which is a true Visual Force app that shows a list of accounts and allow navigation to their detail screen

#### Testing steps with `apex/AccountEditor`
- login to hybrid remote app pointing to `apex/AccountEditor`
- do some operations (that talk to the server)
- from a browser in setup -> session management, kill the oauth2 parent session
- go back to application, do some operations
- check the log, it shows that a refresh took place but it was completely transparent to the user

#### Testing steps with `apex/AccountList`
- login to hybrid remote app pointing to `apex/AccountList`
- click on some account, it navigates to the account detail page
- from a browser in setup -> session management, kill the oauth2 parent session
- go back to application, navigate again to an account detail page
- check the log, it shows that a refresh followed by setCookies took place but they were completely transparent to the user

NB: the user experience is better than before, previously when a redirect to login took place, we would intercept, refresh and then reload the start page - now we are actually loading the page you are trying to get to

![HybridFlows](https://github.com/user-attachments/assets/e4bb2154-ceee-4b75-97be-c72326b81ba1)
