### PR TITLE
Android 15 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
 
 aliases:
   # Docker image tags can be found here: https://circleci.com/developer/images/image/cimg/android
-  - &cimg cimg/android:2024.04.1-node
+  - &cimg cimg/android:2024.09.1-node
   # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
   - &default-api-level 34
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.5.0")
+        classpath("com.android.tools.build:gradle:8.6.1")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
         classpath("org.jacoco:org.jacoco.core:0.8.12")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.5.0")
+    implementation("com.android.tools.build:gradle:8.6.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.24")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/AccountEditor/AndroidManifest.xml
@@ -17,7 +17,7 @@
 		android:icon="@drawable/sf__icon">
 
         <!--  Main activity -->
-        <activity android:label="@string/app_name"
+        <activity
             android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
             android:configChanges="orientation|keyboardHidden"
             android:theme="@style/SalesforceSDK_SplashScreen"

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.accounteditor"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"
 		android:icon="@drawable/sf__icon"
-        android:enableOnBackInvokedCallback="@bool/isGraterThan33"
+        android:enableOnBackInvokedCallback="@bool/isGreaterThan33"
         tools:ignore="UnusedAttribute">
 
         <!--  Main activity -->

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="1"
     android:versionName="1.0"
 	android:installLocation="internalOnly">
@@ -15,11 +16,11 @@
         android:name="com.salesforce.androidsdk.phonegap.app.HybridApp"
         android:manageSpaceActivity="com.salesforce.androidsdk.ui.ManageSpaceActivity"
 		android:icon="@drawable/sf__icon"
-        android:enableOnBackInvokedCallback="@bool/isGraterThan33">
+        android:enableOnBackInvokedCallback="@bool/isGraterThan33"
+        tools:ignore="UnusedAttribute">
 
         <!--  Main activity -->
-        <activity android:label="@string/app_name"
-            android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
+        <activity android:name="com.salesforce.androidsdk.phonegap.ui.SalesforceDroidGapActivity"
             android:configChanges="orientation|keyboardHidden"
             android:theme="@style/SalesforceSDK_SplashScreen"
             android:exported="true">

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.mobilesyncexplorerhybrid"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values-v34/system_back.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values-v34/system_back.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="isGraterThan33">true</bool>
+    <bool name="isGreaterThan33">true</bool>
 </resources>

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values/system_back.xml
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/res/values/system_back.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="isGraterThan33">false</bool>
+    <bool name="isGreaterThan33">false</bool>
 </resources>

--- a/libs/SalesforceHybrid/res/values/themes.xml
+++ b/libs/SalesforceHybrid/res/values/themes.xml
@@ -2,5 +2,6 @@
 <resources>
     <style name="SalesforceSDK_SplashScreen" parent="Theme.SplashScreen.IconBackground">
         <item name="postSplashScreenTheme">@style/Theme.AppCompat.NoActionBar</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 </resources>

--- a/libs/SalesforceSDK/res/values/sf__styles.xml
+++ b/libs/SalesforceSDK/res/values/sf__styles.xml
@@ -190,6 +190,7 @@
         <item name="android:navigationBarColor">@color/sf__background_dark</item>
         <item name="sfNegativeButtonTextColor">@color/sf__secondary_color_dark</item>
         <item name="sfNegativeButtonBorderColor">@color/sf__secondary_color_dark</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 
     <style name="SalesforceSDK.ScreenLock.ErrorMessage">

--- a/libs/SalesforceSDK/res/values/sf__styles.xml
+++ b/libs/SalesforceSDK/res/values/sf__styles.xml
@@ -20,6 +20,7 @@
         <item name="android:navigationBarColor">@color/sf__background</item>
         <item name="sfNegativeButtonTextColor">@color/sf__primary_color</item>
         <item name="sfNegativeButtonBorderColor">@color/sf__border_color</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
     </style>
 
     <style name="SalesforceSDK.AccessibleNav">

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPManager.kt
@@ -119,7 +119,6 @@ internal class IDPManager(
                     spConfig,
                     codeChallenge
                 ) { result ->
-                    authCodeActivity.finish()
                     onResult(result)
                 }
             }
@@ -214,6 +213,7 @@ internal class IDPManager(
                 addCategory(Intent.CATEGORY_DEFAULT)
             }
             startActivity(activeFlow.context, launchIntent)
+            activeFlow.authCodeActivity?.finish()
         } else {
             activeFlow.onStatusUpdate(Status.ERROR_RECEIVED_FROM_SP)
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
@@ -51,6 +51,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.window.OnBackInvokedDispatcher;
 
+import androidx.activity.EdgeToEdge;
 import androidx.annotation.NonNull;
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
@@ -82,6 +83,8 @@ public class ScreenLockActivity extends FragmentActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+
         // Protect against screenshots.
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE);

--- a/native/NativeSampleApps/AppConfigurator/AndroidManifest.xml
+++ b/native/NativeSampleApps/AppConfigurator/AndroidManifest.xml
@@ -4,14 +4,13 @@
     android:versionName="1.0">
     
     <application
-        android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:enableOnBackInvokedCallback="true">
 
         <activity android:name="com.salesforce.samples.appconfigurator.ui.MainActivity"
-            android:label="@string/app_name"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -19,7 +18,6 @@
         </activity>
 
         <activity android:name="com.salesforce.samples.appconfigurator.ui.EnableProfileActivity"
-            android:label="@string/app_name"
             android:exported="false" />
 
   		<receiver android:name="com.salesforce.samples.appconfigurator.AppConfiguratorAdminReceiver"

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.appconfigurator"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.configuredapp"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -30,10 +30,10 @@ android {
     namespace = "com.salesforce.samples.restexplorer"
     testNamespace = "com.salesforce.samples.restexplorer.tests"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 


### PR DESCRIPTION
- Bumped compileSdk and targetSdk of sample apps to 35
- Fixed an issue related to new intent rules in Android 15 that broke IDP initiated IDP flow.  
- Enabled [Edge to Edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) UI for `ScreenLockActivity` and fixed the status bar icon color in dark mode.
- Opted out of Edge to Edge for most Mobile SDK activities (screenshot and more information below -- **please read**).
- Opted out of Edge to Edge for Hybrid Apps.

![IMG_0002](https://github.com/user-attachments/assets/692bf4b1-a305-4a58-b553-c622dd385504)

The left is what the login screen looks like by default with Edge to Edge if the App targets API 35.  The opt out flag is not advertised at all by Google, was introduced as **deprecated** and has code comments clearly stating this should only be used as a temporary solution.  The reason I chose to do this for MSDK 12.2 is because with our XML based UIs poses some issues.  For example, I can adjust the elements on the login screen to be in the correct place but the status bar above our blue url bar will remain transparent.  The API used to color is is _removed_ in API 35.  There are hacks to work around it like adding another UI element there but since customers expect to be able to theme that like they do today it complicates things significantly.  Considering how simple our screens are I think the best thing to do going forward is to rewrite them with Jetpack Compose in 13.0.  This would include Login, Server Picker, User Switcher, and Dev Info.  

I believe we will need to use the workaround for Hybrid apps until Cordova updates to support API 35.