### PR TITLE
Android 15 support 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.5.0")
+        classpath("com.android.tools.build:gradle:8.6.1")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
         classpath("org.jacoco:org.jacoco.core:0.8.12")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.5.0")
+    implementation("com.android.tools.build:gradle:8.6.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.24")
 }

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.accounteditor"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.mobilesyncexplorerhybrid"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/libs/SalesforceSDK/res/drawable/sf__fix_status_bar.xml
+++ b/libs/SalesforceSDK/res/drawable/sf__fix_status_bar.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@+id/sf__status_bar_background" android:height="100dp" >
+        <shape android:shape="rectangle">
+            <size android:height="100dp" android:width="100dp"/>
+            <solid android:color="@color/sf__primary_color"/>
+        </shape>
+    </item>
+
+    <item android:id="@+id/sf__nav_bar_background" android:height="100dp">
+        <shape android:shape="rectangle">
+            <size android:height="100dp" android:width="100dp"/>
+            <solid android:color="@android:color/transparent"/>
+        </shape>
+    </item>
+</layer-list>

--- a/libs/SalesforceSDK/res/layout/sf__dev_info.xml
+++ b/libs/SalesforceSDK/res/layout/sf__dev_info.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
+    android:id="@+id/sf__dev_menu_layout"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <ListView android:id="@+id/list" android:layout_width="match_parent"

--- a/libs/SalesforceSDK/res/layout/sf__server_picker.xml
+++ b/libs/SalesforceSDK/res/layout/sf__server_picker.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/sf__server_picker_layout"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
 	android:background="?android:colorBackground" >

--- a/libs/SalesforceSDK/res/values/sf__styles.xml
+++ b/libs/SalesforceSDK/res/values/sf__styles.xml
@@ -112,6 +112,7 @@
 
     <style name="SalesforceSDK_Dark.Login">
         <item name="android:navigationBarColor">@color/sf__background</item>
+        <item name="android:colorBackground">@color/sf__background</item>
     </style>
 
     <style name="SalesforceSDKActionBar" parent="@android:style/Widget.Material.ActionBar">
@@ -189,6 +190,7 @@
         <item name="android:navigationBarColor">@color/sf__background_dark</item>
         <item name="sfNegativeButtonTextColor">@color/sf__secondary_color_dark</item>
         <item name="sfNegativeButtonBorderColor">@color/sf__secondary_color_dark</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 
     <style name="SalesforceSDK.ScreenLock.ErrorMessage">

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/idp/IDPManager.kt
@@ -119,7 +119,6 @@ internal class IDPManager(
                     spConfig,
                     codeChallenge
                 ) { result ->
-                    authCodeActivity.finish()
                     onResult(result)
                 }
             }
@@ -214,6 +213,7 @@ internal class IDPManager(
                 addCategory(Intent.CATEGORY_DEFAULT)
             }
             startActivity(activeFlow.context, launchIntent)
+            activeFlow.authCodeActivity?.finish()
         } else {
             activeFlow.onStatusUpdate(Status.ERROR_RECEIVED_FROM_SP)
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/AccountSwitcherActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/AccountSwitcherActivity.java
@@ -26,6 +26,8 @@
  */
 package com.salesforce.androidsdk.ui;
 
+import static com.salesforce.androidsdk.ui.EdgeToEdgeUtilKt.fixEdgeToEdge;
+
 import android.content.pm.ActivityInfo;
 import android.os.Bundle;
 import android.view.View;
@@ -67,6 +69,8 @@ public class AccountSwitcherActivity extends AppCompatActivity {
 		} else {
 			setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
 		}
+
+		fixEdgeToEdge(this, findViewById(R.id.sf__account_select_layout));
 	}
 
 	@Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.java
@@ -26,6 +26,8 @@
  */
 package com.salesforce.androidsdk.ui;
 
+import static com.salesforce.androidsdk.ui.EdgeToEdgeUtilKt.fixEdgeToEdge;
+
 import android.os.Bundle;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
@@ -63,6 +65,8 @@ public class DevInfoActivity extends AppCompatActivity {
         String[] from = new String[] {NAME, VALUE};
         int[] to = new int[] { android.R.id.text1, android.R.id.text2};
         ((ListView) findViewById(R.id.list)).setAdapter(new SimpleAdapter(this, listData, android.R.layout.simple_list_item_2, from, to));
+
+        fixEdgeToEdge(this, findViewById(R.id.sf__dev_menu_layout));
     }
 
     private List<Map<String, String>> prepareListData(List<String> rawData) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/EdgeToEdgeUtil.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/EdgeToEdgeUtil.kt
@@ -1,0 +1,36 @@
+package com.salesforce.androidsdk.ui
+
+import android.graphics.drawable.LayerDrawable
+import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+import android.view.View
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import com.salesforce.androidsdk.R.drawable.sf__fix_status_bar
+import com.salesforce.androidsdk.R.id.sf__status_bar_background
+
+// TODO: Remove this in 13.0 after rewriting screens in compose.
+internal fun AppCompatActivity.fixEdgeToEdge(view: View) {
+    if (application.applicationInfo.targetSdkVersion > UPSIDE_DOWN_CAKE) {
+        enableEdgeToEdge()
+        ViewCompat.setOnApplyWindowInsetsListener(view) { listenerView, windowInsets ->
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+
+            // Fix screens being drawn behind status and navigation bars
+            listenerView.updatePadding(insets.left, insets.top, insets.right, insets.bottom)
+
+            // Fix transparent status bar not matching action bar
+            val background = ResourcesCompat.getDrawable(resources, sf__fix_status_bar, null)
+            val statusBarFiller = (background as LayerDrawable).findDrawableByLayerId(sf__status_bar_background)
+            statusBarFiller.setBounds(0, 0, insets.right, insets.bottom)
+            view.setBackgroundResource(sf__fix_status_bar)
+
+            WindowInsetsCompat.CONSUMED
+        }
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/EdgeToEdgeUtil.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/EdgeToEdgeUtil.kt
@@ -1,6 +1,5 @@
 package com.salesforce.androidsdk.ui
 
-import android.graphics.drawable.LayerDrawable
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.view.View
@@ -11,7 +10,6 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import com.salesforce.androidsdk.R.drawable.sf__fix_status_bar
-import com.salesforce.androidsdk.R.id.sf__status_bar_background
 
 // TODO: Remove this in 13.0 after rewriting screens in compose.
 internal fun AppCompatActivity.fixEdgeToEdge(view: View) {
@@ -26,10 +24,7 @@ internal fun AppCompatActivity.fixEdgeToEdge(view: View) {
             listenerView.updatePadding(insets.left, insets.top, insets.right, insets.bottom)
 
             // Fix transparent status bar not matching action bar
-            val background = ResourcesCompat.getDrawable(resources, sf__fix_status_bar, null)
-            val statusBarFiller = (background as LayerDrawable).findDrawableByLayerId(sf__status_bar_background)
-            statusBarFiller.setBounds(0, 0, insets.right, insets.bottom)
-            view.setBackgroundResource(sf__fix_status_bar)
+            view.background = ResourcesCompat.getDrawable(resources, sf__fix_status_bar, null)
 
             WindowInsetsCompat.CONSUMED
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/EdgeToEdgeUtil.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/EdgeToEdgeUtil.kt
@@ -1,6 +1,7 @@
 package com.salesforce.androidsdk.ui
 
 import android.graphics.drawable.LayerDrawable
+import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.view.View
 import androidx.activity.enableEdgeToEdge
@@ -14,7 +15,7 @@ import com.salesforce.androidsdk.R.id.sf__status_bar_background
 
 // TODO: Remove this in 13.0 after rewriting screens in compose.
 internal fun AppCompatActivity.fixEdgeToEdge(view: View) {
-    if (application.applicationInfo.targetSdkVersion > UPSIDE_DOWN_CAKE) {
+    if (application.applicationInfo.targetSdkVersion > UPSIDE_DOWN_CAKE && SDK_INT > UPSIDE_DOWN_CAKE) {
         enableEdgeToEdge()
         ViewCompat.setOnApplyWindowInsetsListener(view) { listenerView, windowInsets ->
             val insets = windowInsets.getInsets(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -78,6 +78,7 @@ import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getMainExecutor
 import androidx.core.content.ContextCompat.registerReceiver
+import com.salesforce.androidsdk.R.id.sf__auth_container_phone
 import com.salesforce.androidsdk.R.id.sf__bio_login_button
 import com.salesforce.androidsdk.R.id.sf__idp_login_button
 import com.salesforce.androidsdk.R.id.sf__menu_clear_cookies
@@ -229,6 +230,8 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         requestedOrientation = if (salesforceSDKManager.compactScreen(this))
             ActivityInfo.SCREEN_ORIENTATION_PORTRAIT else
             ActivityInfo.SCREEN_ORIENTATION_FULL_USER
+
+        fixEdgeToEdge(findViewById(sf__auth_container_phone))
     }
 
     override fun onDestroy() {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.java
@@ -26,6 +26,8 @@
  */
 package com.salesforce.androidsdk.ui;
 
+import static com.salesforce.androidsdk.ui.EdgeToEdgeUtilKt.fixEdgeToEdge;
+
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -53,6 +55,7 @@ public class ManageSpaceActivity extends AppCompatActivity {
 		manageSpaceDialog = buildManageSpaceDialog();
 		manageSpaceDialog.setCanceledOnTouchOutside(false);
 		manageSpaceDialog.show();
+		fixEdgeToEdge(this, findViewById(R.id.manage_space_layout));
 	}
 
 	@Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.java
@@ -51,6 +51,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.window.OnBackInvokedDispatcher;
 
+import androidx.activity.EdgeToEdge;
 import androidx.annotation.NonNull;
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
@@ -82,6 +83,8 @@ public class ScreenLockActivity extends FragmentActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+
         // Protect against screenshots.
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ServerPickerActivity.java
@@ -27,6 +27,7 @@
 package com.salesforce.androidsdk.ui;
 
 import static com.salesforce.androidsdk.security.BiometricAuthenticationManager.SHOW_BIOMETRIC;
+import static com.salesforce.androidsdk.ui.EdgeToEdgeUtilKt.fixEdgeToEdge;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -149,6 +150,8 @@ public class ServerPickerActivity extends AppCompatActivity implements
         } else {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
         }
+
+        fixEdgeToEdge(this, findViewById(R.id.sf__server_picker_layout));
     }
 
     @Override

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.appconfigurator"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -15,10 +15,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.configuredapp"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -30,10 +30,10 @@ android {
     namespace = "com.salesforce.samples.restexplorer"
     testNamespace = "com.salesforce.samples.restexplorer.tests"
 
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 34
+        targetSdk = 35
         minSdk = 26
     }
 


### PR DESCRIPTION
- Bumped compileSdk and targetSdk of sample apps to 35 and Gradle to 8.6.1 to match.
- Fixed an issue related to new intent rules in Android 15 that broke IDP initiated IDP flow.
- Enabled [Edge to Edge](https://developer.android.com/develop/ui/views/layout/edge-to-edge) UI for ScreenLockActivity and fixed the status bar icon color in dark mode.
- Conditionally (if app targets API 35+) enabled Edge to Edge for all other screens.  Fixed layouts taking the entire screen and showing behind status and navigation bars.  Fixed status and navigation bar colors for all screens.