### PR TITLE
Rename token_expired LogoutReason to refresh_token_expired.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -203,7 +203,7 @@ public class OAuth2 {
 
     public enum LogoutReason {
         CORRUPT_STATE,           // "Corrupted client state"
-        TOKEN_EXPIRED,           // "Refresh token expired"
+        REFRESH_TOKEN_EXPIRED,   // "Refresh token expired"
         SSDK_LOGOUT_POLICY,      // "SSDK initiated logout for policy violation"
         TIMEOUT,                 // "Timeout while waiting for server response"
         UNEXPECTED,              // "Unexpected error or crash"

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -463,7 +463,7 @@ public class ClientManager {
                         // authenticated endpoint.  However, there is no harm in attempting and the debug logs
                         // produced may help developers better understand the state of their app.
                         SalesforceSDKManager.getInstance()
-                                .logout(null, null, false, OAuth2.LogoutReason.TOKEN_EXPIRED);
+                                .logout(null, null, false, OAuth2.LogoutReason.REFRESH_TOKEN_EXPIRED);
                     }
 
                     // Broadcasts an intent that the access token has been revoked.


### PR DESCRIPTION
This LogoutReason basically does not matter since it will never make it back to the server but it should still match iOS.  