### PR TITLE
Add new color key for Android 15 status bar.

### DIFF
--- a/libs/SalesforceSDK/res/drawable/sf__fix_status_bar.xml
+++ b/libs/SalesforceSDK/res/drawable/sf__fix_status_bar.xml
@@ -3,7 +3,7 @@
     <item android:id="@+id/sf__status_bar_background" android:height="100dp" >
         <shape android:shape="rectangle">
             <size android:height="100dp" android:width="100dp"/>
-            <solid android:color="@color/sf__primary_color"/>
+            <solid android:color="@color/sf__api_35_status_bar_color"/>
         </shape>
     </item>
 

--- a/libs/SalesforceSDK/res/values/sf__colors.xml
+++ b/libs/SalesforceSDK/res/values/sf__colors.xml
@@ -18,4 +18,7 @@
     <color name="sf__hint_color_dark">#42D5B0B0</color>
     <color name="sf__accessibility_nav_color">#3e3e3c</color> <!-- SLDS grey 11 -->
     <color name="sf__subtext_color">#706E6B</color> <!-- SLDS grey 9 -->
+
+    <!-- TODO: Remove in 13.0 -->
+    <color name="sf__api_35_status_bar_color">#0070D2</color>
 </resources>


### PR DESCRIPTION
`sf__api_35_status_bar_color` defaults to Salesforce blue but can be overridden by the app (without affecting any other UI elements):

![Screenshot 2024-10-09 at 2 50 36 PM](https://github.com/user-attachments/assets/81c93b80-4a8b-47fc-ad9c-3b8fda8335e6)
