### PR TITLE
@W-16814802: [iOS] Add Deep Link From External QR Code Reader To iOS Native Swift Template QR Code Login (Parity For Android)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -215,18 +215,6 @@ open class SalesforceSDKManager protected constructor(
      */
     val loginActivityClass: Class<out Activity> = nativeLoginActivity ?: webviewLoginActivityClass
 
-    /**
-     * For Salesforce Identity API UI Bridge support, the overriding front door bridge URL to
-     * use in place of the default initial login URL
-     */
-    var frontDoorBridgeUrl: String? = null
-
-    /**
-     * For Salesforce Identity API UI Bridge support, the overriding front door bridge URL's
-     * optional web server flow code verifier
-     */
-    var frontDoorBridgeCodeVerifier: String? = null
-
     /** The class for the account switcher activity */
     var accountSwitcherActivityClass = AccountSwitcherActivity::class.java
 
@@ -270,10 +258,6 @@ open class SalesforceSDKManager protected constructor(
         set(value) {
             field = value
         }
-
-    /** Indicates if login via QR Code and UI bridge API is enabled */
-    @set:Synchronized
-    open var isQrCodeLoginEnabled = false
 
     /** Indicates if logout is in progress */
     var isLoggingOut = false
@@ -962,9 +946,6 @@ open class SalesforceSDKManager protected constructor(
         )
 
         val accountToLogout = account ?: clientMgr.account
-
-        frontDoorBridgeUrl = null
-        frontDoorBridgeCodeVerifier = null
 
         isLoggingOut = true
         val mgr = AccountManager.get(appContext)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -727,7 +727,7 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
      * [LoginActivity.loginWithFrontdoorBridgeUrl].
      *
      * @param qrCodeLoginUrl The QR code login URL
-     * @return Boolean true if a log in attempt is possible using the provided QR code log in URL,
+     * @return Boolean true if a log in attempt is possible using the provided QR code login URL,
      * false otherwise
      */
     fun loginWithFrontdoorBridgeUrlFromQrCode(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -152,14 +152,13 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
          * frontdoor bridge URL.
          */
         val isUsingFrontDoorBridge = isFrontdoorBridgeUrlIntent(intent) || isQrCodeLoginUrlIntent(intent)
-        val uiBridgeApiParameters = when (isQrCodeLoginUrlIntent(intent)) {
-            true -> uiBridgeApiParametersFromQrCodeLoginUrl(intent.data?.toString())
-            else -> intent.getStringExtra(EXTRA_KEY_FRONTDOOR_BRIDGE_URL)?.let { frontdoorBridgeUrl ->
-                UiBridgeApiParameters(
-                    frontdoorBridgeUrl,
-                    intent.getStringExtra(EXTRA_KEY_PKCE_CODE_VERIFIER)
-                )
-            }
+        val uiBridgeApiParameters = if (isQrCodeLoginUrlIntent(intent)) {
+            uiBridgeApiParametersFromQrCodeLoginUrl(intent.data?.toString())
+        } else intent.getStringExtra(EXTRA_KEY_FRONTDOOR_BRIDGE_URL)?.let { frontdoorBridgeUrl ->
+            UiBridgeApiParameters(
+                frontdoorBridgeUrl,
+                intent.getStringExtra(EXTRA_KEY_PKCE_CODE_VERIFIER)
+            )
         }
 
         accountAuthenticatorResponse = intent.getParcelableExtra<AccountAuthenticatorResponse?>(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -146,16 +146,21 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         val salesforceSDKManager = SalesforceSDKManager.getInstance()
 
         /*
-         * For Salesforce Identity API UI Bridge support, the overriding front door bridge URL to
-         * use in place of the default initial login URL plus the optional web server flow code
-         * verifier accompanying the front door bridge URL
+         * For Salesforce Identity API UI Bridge support, the overriding
+         * frontdoor bridge URL to use in place of the default initial login URL
+         * plus the optional web server flow code verifier accompanying the
+         * frontdoor bridge URL.
          */
-        val frontDoorBridgeUrl = salesforceSDKManager.frontDoorBridgeUrl
-        val frontDoorBridgeCodeVerifier = salesforceSDKManager.frontDoorBridgeCodeVerifier
-        val isUsingFrontDoorBridge = frontDoorBridgeUrl != null
-        // Reset the the Salesforce SDK manager's UI bridge support.
-        salesforceSDKManager.frontDoorBridgeUrl = null
-        salesforceSDKManager.frontDoorBridgeCodeVerifier = null
+        val isUsingFrontDoorBridge = isFrontdoorBridgeUrlIntent(intent) || isQrCodeLoginUrlIntent(intent)
+        val uiBridgeApiParameters = when (isQrCodeLoginUrlIntent(intent)) {
+            true -> uiBridgeApiParametersFromQrCodeLoginUrl(intent.data?.toString())
+            else -> intent.getStringExtra(EXTRA_KEY_FRONTDOOR_BRIDGE_URL)?.let { frontdoorBridgeUrl ->
+                UiBridgeApiParameters(
+                    frontdoorBridgeUrl,
+                    intent.getStringExtra(EXTRA_KEY_PKCE_CODE_VERIFIER)
+                )
+            }
+        }
 
         accountAuthenticatorResponse = intent.getParcelableExtra<AccountAuthenticatorResponse?>(
             KEY_ACCOUNT_AUTHENTICATOR_RESPONSE
@@ -233,11 +238,10 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         )
 
         // Prompt user with the default login page or log in via other configurations such as using a Salesforce Identity API UI Bridge front door URL.
-        @Suppress("KotlinConstantConditions") // Note: This is a cosmetic suppress until the Android Studio inspector can smart cast the front door bridge URL as the compiler does.
         when {
-            isUsingFrontDoorBridge && frontDoorBridgeUrl != null -> loginWithFrontdoorBridgeUrl(
-                frontDoorBridgeUrl,
-                frontDoorBridgeCodeVerifier
+            isUsingFrontDoorBridge && uiBridgeApiParameters?.frontdoorBridgeUrl != null -> loginWithFrontdoorBridgeUrl(
+                uiBridgeApiParameters.frontdoorBridgeUrl,
+                uiBridgeApiParameters.pkceCodeVerifier
             )
 
             else -> certAuthOrLogin()
@@ -799,15 +803,26 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         var qrCodeLoginUrlJsonPkceCodeVerifierKey = "pkce_code_verifier"
 
         /**
-         * When QR code log in is enabled, determines if the provided intent has QR code login
-         * parameters.
+         * Determines if the provided intent has QR code login parameters.
          * @param intent The intent to determine QR code login enablement for
-         * @return Boolean true if the intent has QR code login parameters or false otherwise
+         * @return Boolean true if the intent has QR code login parameters or
+         * false otherwise
          */
-        fun isQrCodeLoginIntent(
+        fun isQrCodeLoginUrlIntent(
             intent: Intent
-        ) = SalesforceSDKManager.getInstance().isQrCodeLoginEnabled
-                && intent.data?.path?.contains(qrCodeLoginUrlPath) == true
+        ) = intent.data?.path?.contains(qrCodeLoginUrlPath) == true
+
+        /**
+         * Determines if the provided intent has front door bridge URL
+         * parameters.
+         * @param intent The intent to determine front door bridge URL
+         * enablement for
+         * @return Boolean true if the intent has front door bridge URL
+         * parameters or false otherwise
+         */
+        private fun isFrontdoorBridgeUrlIntent(
+            intent: Intent
+        ) = intent.hasExtra(EXTRA_KEY_FRONTDOOR_BRIDGE_URL)
 
         /**
          * Parses Salesforce Identity API UI Bridge parameters from the provided login QR code login
@@ -838,6 +853,12 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
 
         // endregion
         // region QR Code Login Via Salesforce Identity API UI Bridge Private Implementation
+
+        /** Extras key for the Salesforce Identity API UI Bridge front door URL */
+        const val EXTRA_KEY_FRONTDOOR_BRIDGE_URL = "frontdoor_bridge_url"
+
+        /** Extras key for the Salesforce Identity API UI PKCE code verifier */
+        const val EXTRA_KEY_PKCE_CODE_VERIFIER = "pkce_code_verifier"
 
         /**
          * For QR code login URLs, a regular expression to extract the Salesforce Identity API UI

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt
@@ -330,7 +330,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         val instance = SalesforceSDKManager.getInstance()
 
         // Reset state from previous log in attempt.
-        // - Salesforce Identity UI Bridge API log in, such as QR code log in.
+        // - Salesforce Identity UI Bridge API log in, such as QR code login.
         resetFrontDoorBridgeUrl()
 
         e(TAG, "$error: $errorDesc", e)
@@ -527,7 +527,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
     ): URI {
 
         // Reset log in state,
-        // - Salesforce Identity UI Bridge API log in, such as QR code log in.
+        // - Salesforce Identity UI Bridge API log in, such as QR code login.
         resetFrontDoorBridgeUrl()
 
         val loginOptions = loginOptions
@@ -754,7 +754,7 @@ open class OAuthWebviewHelper : KeyChainAliasCallback {
         CoroutineScope(IO).launch {
 
             // Reset log in state,
-            // - Salesforce Identity UI Bridge API log in, such as QR code log in.
+            // - Salesforce Identity UI Bridge API log in, such as QR code login.
             resetFrontDoorBridgeUrl()
 
             FinishAuthTask().execute(tr, nativeLogin)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -38,12 +38,21 @@ public abstract class SalesforceActivity extends AppCompatActivity implements Sa
 
 	private final SalesforceActivityDelegate delegate;
 
-	/**
-	 * An option to build the REST client automatically on activity resume, which has the side
-	 * effect of displaying the default login activity when no user is logged in.
-	 */
-	@Deprecated
-	protected boolean buildRestClientOnResume = true;
+    /**
+     * Determines if the Salesforce Mobile SDK (MSDK) REST Client is built when this activity
+     * resumes. This defaults to true.
+     * <p>
+     * The default is beneficial so apps using this activity as their main activity will create the
+     * MSDK networking client and start MSDK's default LoginActivity when no user is authenticated.
+     * This provides a lower-code path to implementing an app which automatically authenticates a
+     * user with Salesforce web login.
+     * <p>
+     * Whenever needed, an app may disable this feature.  Disabling this feature gives the app
+     * more control over when and which activities the are presented to the user when this activity
+     * is resumed.  However, that does require the app start MSDK's LoginActivity when required and
+     * with valid parameters for the app's authentication needs.
+     */
+    protected boolean isBuildRestClientOnResumeEnabled = true;
 
 	public SalesforceActivity() {
 		super();
@@ -59,7 +68,7 @@ public abstract class SalesforceActivity extends AppCompatActivity implements Sa
 	@Override
 	public void onResume() {
 		super.onResume();
-		delegate.onResume(buildRestClientOnResume);
+		delegate.onResume(isBuildRestClientOnResumeEnabled);
 	}
 
     @Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -38,6 +38,13 @@ public abstract class SalesforceActivity extends AppCompatActivity implements Sa
 
 	private final SalesforceActivityDelegate delegate;
 
+	/**
+	 * An option to build the REST client automatically on activity resume, which has the side
+	 * effect of displaying the default login activity when no user is logged in.
+	 */
+	@Deprecated
+	protected boolean buildRestClientOnResume = true;
+
 	public SalesforceActivity() {
 		super();
 		this.delegate = new SalesforceActivityDelegate(this);
@@ -52,7 +59,7 @@ public abstract class SalesforceActivity extends AppCompatActivity implements Sa
 	@Override
 	public void onResume() {
 		super.onResume();
-		delegate.onResume(true);
+		delegate.onResume(buildRestClientOnResume);
 	}
 
     @Override

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivity.java
@@ -48,8 +48,8 @@ public abstract class SalesforceActivity extends AppCompatActivity implements Sa
      * user with Salesforce web login.
      * <p>
      * Whenever needed, an app may disable this feature.  Disabling this feature gives the app
-     * more control over when and which activities the are presented to the user when this activity
-     * is resumed.  However, that does require the app start MSDK's LoginActivity when required and
+     * more control over when and which activities are presented to the user when this activity is
+	 * resumed.  However, that does require the app start MSDK's LoginActivity when required and
      * with valid parameters for the app's authentication needs.
      */
     protected boolean isBuildRestClientOnResumeEnabled = true;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
@@ -27,6 +27,8 @@
 package com.salesforce.androidsdk.ui;
 
 
+import androidx.annotation.Nullable;
+
 import com.salesforce.androidsdk.rest.RestClient;
 
 /**
@@ -40,7 +42,7 @@ public interface SalesforceActivityInterface {
      *
      * @param client RestClient instance.
      */
-    void onResume(RestClient client);
+    void onResume(@Nullable RestClient client);
 
     /**
      * Performs actions on logout complete.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/SalesforceActivityInterface.java
@@ -27,8 +27,6 @@
 package com.salesforce.androidsdk.ui;
 
 
-import androidx.annotation.Nullable;
-
 import com.salesforce.androidsdk.rest.RestClient;
 
 /**
@@ -42,7 +40,7 @@ public interface SalesforceActivityInterface {
      *
      * @param client RestClient instance.
      */
-    void onResume(@Nullable RestClient client);
+    void onResume(RestClient client);
 
     /**
      * Performs actions on logout complete.


### PR DESCRIPTION
🎸 _*Ready For Review!*_ 🥁

  When preparing the documentation for QR code log in on iOS, I noticed Android's implementation was more probably more different than required.  So, this brings a large portion of the documentation for the two in line.

  Also, Android still had one more bug where the deep link intent to main activity could be triggered again when returning to the activity.   That is fixed now.