### PR TITLE
@W-16797266: [TRUST] Ensure all WorkManager Jobs have an associated tag or unique name

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublishingWorker.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AnalyticsPublishingWorker.kt
@@ -29,6 +29,7 @@ package com.salesforce.androidsdk.analytics
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
+import androidx.work.ExistingWorkPolicy.REPLACE
 import androidx.work.ListenableWorker.Result.success
 import androidx.work.NetworkType.CONNECTED
 import androidx.work.OneTimeWorkRequest
@@ -127,7 +128,11 @@ internal class AnalyticsPublishingWorker(
             ).build().also { publishAnalyticsOneTimeWorkRequest ->
                 runCatching {
                     getInstance(context)
-                }.getOrNull()?.enqueue(publishAnalyticsOneTimeWorkRequest)
+                }.getOrNull()?.enqueueUniqueWork(
+                    PUBLISH_ANALYTICS_WORK_NAME,
+                    REPLACE,
+                    publishAnalyticsOneTimeWorkRequest
+                )
             }.id
 
             PublishPeriodically -> PeriodicWorkRequest.Builder(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -49,7 +49,6 @@ import com.salesforce.androidsdk.push.PushMessaging.getRegistrationId
 import com.salesforce.androidsdk.push.PushMessaging.setRegistrationId
 import com.salesforce.androidsdk.push.PushMessaging.setRegistrationInfo
 import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction
-import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction.Deregister
 import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction.Register
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegisterPeriodically
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationDisabled
@@ -449,6 +448,12 @@ open class PushService {
 
         /**
          * The Android background tasks name of the push notifications
+         * unregistration work request
+         */
+        private const val PUSH_NOTIFICATIONS_UNREGISTRATION_WORK_NAME = "SalesforcePushNotificationsUnregistrationWork"
+
+        /**
+         * The Android background tasks name of the push notifications
          * registration work request
          */
         private const val PUSH_NOTIFICATIONS_REGISTRATION_WORK_NAME = "SalesforcePushNotificationsRegistrationWork"
@@ -520,7 +525,11 @@ open class PushService {
                     .setInputData(workData)
                     .setConstraints(constraints)
                     .build().also {  workRequest ->
-                        workManager.enqueue(workRequest)
+                        workManager.enqueueUniqueWork(
+                            PUSH_NOTIFICATIONS_UNREGISTRATION_WORK_NAME,
+                            REPLACE,
+                            workRequest
+                        )
                     }
 
                 // Send broadcast now to finish logout if we are offline.


### PR DESCRIPTION
🤘🏻 _*Ready For Review!*_ 🎸

  This simple Trust update ensures the Android Background Tasks library will not be used to create duplicate work.