### PR TITLE
Support for JWT-based access token

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewCookieManager.kt
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewCookieManager.kt
@@ -45,7 +45,7 @@ class SalesforceWebViewCookieManager {
         val lightningSid = userAccount.lightningSid
         val contentDomain = userAccount.contentDomain
         val contentSid = userAccount.contentSid
-        val accessToken = userAccount.authToken
+        val mainSid = if (userAccount.tokenFormat == "jwt") userAccount.parentSid else userAccount.authToken
         val vfDomain = userAccount.vfDomain
         val vfSid = userAccount.vfSid
         val clientSrc = userAccount.cookieClientSrc
@@ -61,7 +61,7 @@ class SalesforceWebViewCookieManager {
         val setDomain = !communityUrl.isNullOrBlank()
 
         // Main domain cookies
-        setCookieValue("sid for main", mainDomain, setDomain, sidCookieName, accessToken)
+        setCookieValue("sid for main", mainDomain, setDomain, sidCookieName, mainSid)
         setCookieValue(CLIENT_SRC, mainDomain, setDomain, CLIENT_SRC, clientSrc)
         setCookieValue(SID_CLIENT, mainDomain, setDomain, SID_CLIENT, sidClient)
         setCookieValue(ORG_ID, mainDomain, setDomain, ORG_ID, orgId)

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     `kotlin-android`
     `publish-module`
     jacoco
+    kotlin("plugin.serialization") version "2.0.21"
 }
 
 dependencies {
@@ -23,6 +24,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     implementation("androidx.window:window:1.3.0")
     implementation("androidx.window:window-core:1.3.0")
     androidTestImplementation("androidx.test:runner:1.6.0")

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -91,6 +91,8 @@ public class UserAccount {
 	public static final String COOKIE_SID_CLIENT = "cookie-sid_Client";
 	public static final String SID_COOKIE_NAME = "sidCookieName";
 	public static final String CLIENT_ID = "clientId";
+	public static final String PARENT_SID = "parentSid";
+	public static final String TOKEN_FORMAT = "tokenFormat";
 ;
 	private static final String TAG = "UserAccount";
 	private static final String FORWARD_SLASH = "/";
@@ -131,6 +133,8 @@ public class UserAccount {
 	private String cookieSidClient;
 	private String sidCookieName;
 	private String clientId;
+	private String parentSid;
+	private String tokenFormat;
 	private Map<String, String> additionalOauthValues;
 
 	/**
@@ -167,6 +171,8 @@ public class UserAccount {
 	 * @param cookieSidClient cookie sid client
 	 * @param sidCookieName sid cookie name
 	 * @param clientId oauth client id
+	 * @param parentSid parent sid
+	 * @param tokenFormat token format
 	 */
 	UserAccount(String authToken, String refreshToken,
 				String loginServer, String idUrl, String instanceServer,
@@ -177,7 +183,7 @@ public class UserAccount {
 				String lightningDomain, String lightningSid, String vfDomain, String vfSid,
 				String  contentDomain, String contentSid, String csrfToken, Boolean nativeLogin,
 				String language, String locale, String cookieClientSrc, String cookieSidClient,
-				String sidCookieName, String clientId) {
+				String sidCookieName, String clientId, String parentSid, String tokenFormat) {
 		this.authToken = authToken;
 		this.refreshToken = refreshToken;
 		this.loginServer = loginServer;
@@ -210,6 +216,8 @@ public class UserAccount {
 		this.cookieSidClient = cookieSidClient;
 		this.sidCookieName = sidCookieName;
 		this.clientId = clientId;
+		this.parentSid = parentSid;
+		this.tokenFormat = tokenFormat;
 		SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_USER_AUTH);
 	}
 
@@ -255,6 +263,8 @@ public class UserAccount {
 			cookieSidClient = object.optString(COOKIE_SID_CLIENT, null);
 			sidCookieName = object.optString(SID_COOKIE_NAME, null);
 			clientId = object.optString(CLIENT_ID, null);
+			parentSid = object.optString(PARENT_SID, null);
+			tokenFormat = object.optString(TOKEN_FORMAT, null);
 			additionalOauthValues = MapUtil.addJSONObjectToMap(object, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -306,6 +316,8 @@ public class UserAccount {
 			cookieSidClient = bundle.getString(COOKIE_SID_CLIENT);
 			sidCookieName = bundle.getString(SID_COOKIE_NAME);
 			clientId = bundle.getString(CLIENT_ID);
+			parentSid = bundle.getString(PARENT_SID);
+			tokenFormat = bundle.getString(TOKEN_FORMAT);
 			additionalOauthValues = MapUtil.addBundleToMap(bundle, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -599,6 +611,23 @@ public class UserAccount {
 		return clientId;
 	}
 
+	/**
+	 * Returns the parent sid.
+	 *
+	 * @return parent sid.
+	 */
+	public String getParentSid() {
+		return parentSid;
+	}
+
+	/**
+	 * Returns the token format.
+	 *
+	 * @return token format.
+	 */
+	public String getTokenFormat() {
+		return tokenFormat;
+	}
 
 	/**
 	 * Returns the additional OAuth values for this user.
@@ -866,6 +895,8 @@ public class UserAccount {
 			object.put(COOKIE_CLIENT_SRC, cookieClientSrc);
 			object.put(COOKIE_SID_CLIENT, cookieSidClient);
 			object.put(SID_COOKIE_NAME, sidCookieName);
+			object.put(PARENT_SID, parentSid);
+			object.put(TOKEN_FORMAT, tokenFormat);
 			object = MapUtil.addMapToJSONObject(additionalOauthValues, additionalOauthKeys, object);
 		} catch (JSONException e) {
 			SalesforceSDKLogger.e(TAG, "Unable to convert to JSON", e);
@@ -921,6 +952,8 @@ public class UserAccount {
 		object.putString(COOKIE_SID_CLIENT, cookieSidClient);
 		object.putString(SID_COOKIE_NAME, sidCookieName);
 		object.putString(CLIENT_ID, clientId);
+		object.putString(PARENT_SID, parentSid);
+		object.putString(TOKEN_FORMAT, tokenFormat);
 		object = MapUtil.addMapToBundle(additionalOauthValues, additionalOauthKeys, object);
 		return object;
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
@@ -64,6 +64,8 @@ class UserAccountBuilder private constructor() {
     private var cookieSidClient: String? = null
     private var sidCookieName: String? = null
     private var clientId: String? = null
+    private var parentSid: String? = null
+    private var tokenFormat: String? = null
     private var additionalOauthValues: Map<String, String>? = null
     private var allowUnset = true
 
@@ -96,6 +98,8 @@ class UserAccountBuilder private constructor() {
             .cookieClientSrc(tr.cookieClientSrc)
             .cookieSidClient(tr.cookieSidClient)
             .sidCookieName(tr.sidCookieName)
+            .parentSid(tr.parentSid)
+            .tokenFormat(tr.tokenFormat)
     }
 
     /**
@@ -158,6 +162,8 @@ class UserAccountBuilder private constructor() {
             .cookieSidClient(userAccount.cookieSidClient)
             .sidCookieName(userAccount.sidCookieName)
             .clientId(userAccount.clientId)
+            .parentSid(userAccount.parentSid)
+            .tokenFormat(userAccount.tokenFormat)
     }
 
     /**
@@ -475,6 +481,26 @@ class UserAccountBuilder private constructor() {
     }
 
     /**
+     * Sets parent sid
+     *
+     * @param parentSid parent sid
+     * @return Instance of this class.
+     */
+    fun parentSid(parentSid: String?): UserAccountBuilder {
+        return if (!allowUnset && parentSid == null) this else apply { this.parentSid = parentSid }
+    }
+
+    /**
+     * Sets token format
+     *
+     * @param tokenFormat token format
+     * @return Instance of this class.
+     */
+    fun tokenFormat(tokenFormat: String?): UserAccountBuilder {
+        return if (!allowUnset && tokenFormat == null) this else apply { this.tokenFormat = tokenFormat }
+    }
+
+    /**
      * Sets oauth client id
      *
      * @param clientId sid cookie name.
@@ -518,7 +544,8 @@ class UserAccountBuilder private constructor() {
             userId, username, accountName, communityId, communityUrl, firstName, lastName,
             displayName, email, photoUrl, thumbnailUrl, additionalOauthValues, lightningDomain,
             lightningSid, vfDomain, vfSid, contentDomain, contentSid, csrfToken, nativeLogin,
-            language, locale, cookieClientSrc, cookieSidClient, sidCookieName, clientId
+            language, locale, cookieClientSrc, cookieSidClient, sidCookieName, clientId,
+            parentSid, tokenFormat
         )
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -84,6 +84,8 @@ public class AuthenticatorService extends Service {
     public static final String KEY_COOKIE_CLIENT_SRC = "cookie-clientSrc";
     public static final String KEY_COOKIE_SID_CLIENT = "cookie-sid_Client";
     public static final String KEY_SID_COOKIE_NAME = "sidCookieName";
+    public static final String KEY_PARENT_SID = "parentSid";
+    public static final String KEY_TOKEN_FORMAT = "tokenFormat";
 
     private static final String TAG = "AuthenticatorService";
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/JwtAccessToken.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/JwtAccessToken.kt
@@ -1,0 +1,63 @@
+package com.salesforce.androidsdk.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.util.Base64
+
+@Serializable
+data class JwtHeader(
+    @SerialName("alg") val algorithn: String? = null,
+    @SerialName("typ") val type: String? = null,
+    @SerialName("kid") val keyId: String? = null,
+    @SerialName("tty") val tokenType: String? = null,
+    @SerialName("tnk") val tenantKey: String? = null,
+    @SerialName("ver") val version: String? = null,
+)
+
+@Serializable
+data class JwtPayload(
+    @SerialName("aud") val audience: List<String>? = null,
+    @SerialName("exp") val expirationTime: Int? = null,
+    @SerialName("iss") val issuer: String? = null,
+    @SerialName("nbf") val notBeforeTime: Int? = null,
+    @SerialName("sub") val subject: String? = null,
+    @SerialName("scp") val scopes: String? = null,
+    @SerialName("client_id") val clientId: String? = null,
+)
+
+/**
+ * Data class for decoding JWT-based access token
+ */
+data class JwtAccessToken(
+    val rawJwt: String,             // Captures the raw JWT string
+    val header: JwtHeader,
+    val payload: JwtPayload
+) {
+    // Secondary constructor to parse the JWT string and initialize properties
+    constructor(jwt: String) : this(
+        rawJwt = jwt,
+        header = parseJwtHeader(jwt),
+        payload = parseJwtPayload(jwt)
+    )
+
+    companion object {
+        private val json = Json { ignoreUnknownKeys = true }  // Ignore unknown keys
+
+        private fun parseJwtHeader(jwt: String): JwtHeader {
+            val parts = jwt.split(".")
+            require(parts.size >= 2) { "Invalid JWT format" }
+
+            val headerJson = String(Base64.getUrlDecoder().decode(parts[0]))
+            return json.decodeFromString(headerJson)
+        }
+
+        private fun parseJwtPayload(jwt: String): JwtPayload {
+            val parts = jwt.split(".")
+            require(parts.size >= 2) { "Invalid JWT format" }
+
+            val payloadJson = String(Base64.getUrlDecoder().decode(parts[1]))
+            return json.decodeFromString(payloadJson)
+        }
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -28,6 +28,7 @@ package com.salesforce.androidsdk.auth;
 
 import android.net.Uri;
 import android.text.TextUtils;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
@@ -193,6 +194,8 @@ public class OAuth2 {
     private static final String COOKIE_CLIENT_SRC = "cookie-clientSrc";
     private static final String COOKIE_SID_CLIENT = "cookie-sid_Client";
     private static final String SID_COOKIE_NAME = "sidCookieName";
+    private static final String PARENT_SID = "parent_sid";
+    private static final String TOKEN_FORMAT = "token_format";
 
     public static final DateFormat TIMESTAMP_FORMAT;
     static {
@@ -775,6 +778,8 @@ public class OAuth2 {
         public String cookieClientSrc;
         public String cookieSidClient;
         public String sidCookieName;
+        public String parentSid;
+        public String tokenFormat;
 
         /**
          * Parameterized constructor built during login flow.
@@ -812,6 +817,8 @@ public class OAuth2 {
                 cookieClientSrc = callbackUrlParams.get(COOKIE_CLIENT_SRC);
                 cookieSidClient = callbackUrlParams.get(COOKIE_SID_CLIENT);
                 sidCookieName = callbackUrlParams.get(SID_COOKIE_NAME);
+                parentSid = callbackUrlParams.get(PARENT_SID);
+                tokenFormat = callbackUrlParams.get(TOKEN_FORMAT);
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);
@@ -838,6 +845,7 @@ public class OAuth2 {
         public TokenEndpointResponse(Response response) {
             try {
                 final JSONObject parsedResponse = (new RestResponse(response)).asJSONObject();
+                Log.d(TAG, "parsedResponse-->" + parsedResponse);
                 authToken = parsedResponse.getString(ACCESS_TOKEN);
                 instanceUrl = parsedResponse.getString(INSTANCE_URL);
                 idUrl  = parsedResponse.getString(ID);
@@ -873,6 +881,8 @@ public class OAuth2 {
                 cookieClientSrc = parsedResponse.optString(COOKIE_CLIENT_SRC);
                 cookieSidClient = parsedResponse.optString(COOKIE_SID_CLIENT);
                 sidCookieName = parsedResponse.optString(SID_COOKIE_NAME);
+                parentSid = parsedResponse.optString(PARENT_SID);
+                tokenFormat = parsedResponse.optString(TOKEN_FORMAT);
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -93,6 +93,8 @@ public class UserAccountTest {
     public static final String TEST_COOKIE_SID_CLIENT = "cookie-sid-client-value";
     public static final String TEST_SID_COOKIE_NAME = "sid-cookie-name";
     public static final String TEST_CLIENT_ID = "test-client-id";
+    public static final String TEST_PARENT_SID = "test-parent-sid";
+    public static final String TEST_TOKEN_FORMAT = "test-token-format";
 
     // other user
     public static final String TEST_ORG_ID_2 = "test_org_id_2";
@@ -351,6 +353,8 @@ public class UserAccountTest {
         object.put(UserAccount.COOKIE_CLIENT_SRC, TEST_COOKIE_CLIENT_SRC);
         object.put(UserAccount.COOKIE_SID_CLIENT, TEST_COOKIE_SID_CLIENT);
         object.put(UserAccount.SID_COOKIE_NAME, TEST_SID_COOKIE_NAME);
+        object.put(UserAccount.PARENT_SID, TEST_PARENT_SID);
+        object.put(UserAccount.TOKEN_FORMAT, TEST_TOKEN_FORMAT);
         object = MapUtil.addMapToJSONObject(createAdditionalOauthValues(), createAdditionalOauthKeys(), object);
         return object;
     }
@@ -393,6 +397,8 @@ public class UserAccountTest {
         object.putString(UserAccount.COOKIE_SID_CLIENT, TEST_COOKIE_SID_CLIENT);
         object.putString(UserAccount.SID_COOKIE_NAME, TEST_SID_COOKIE_NAME);
         object.putString(UserAccount.CLIENT_ID, TEST_CLIENT_ID);
+        object.putString(UserAccount.PARENT_SID, TEST_PARENT_SID);
+        object.putString(UserAccount.TOKEN_FORMAT, TEST_TOKEN_FORMAT);
         object = MapUtil.addMapToBundle(createAdditionalOauthValues(), createAdditionalOauthKeys(), object);
         return object;
     }
@@ -433,6 +439,8 @@ public class UserAccountTest {
                 .cookieSidClient(TEST_COOKIE_SID_CLIENT)
                 .sidCookieName(TEST_SID_COOKIE_NAME)
                 .clientId(TEST_CLIENT_ID)
+                .parentSid(TEST_PARENT_SID)
+                .tokenFormat(TEST_TOKEN_FORMAT)
                 .additionalOauthValues(createAdditionalOauthValues())
                 .build();
     }
@@ -484,6 +492,9 @@ public class UserAccountTest {
         Assert.assertEquals("Cookie client src should match", TEST_COOKIE_CLIENT_SRC, account.getCookieClientSrc());
         Assert.assertEquals("Cookie sid client should match", TEST_COOKIE_SID_CLIENT, account.getCookieSidClient());
         Assert.assertEquals("Sid cookie name should match", TEST_SID_COOKIE_NAME, account.getSidCookieName());
+        Assert.assertEquals("Parent sid should match", TEST_PARENT_SID, account.getParentSid());
+        Assert.assertEquals("Token format should match", TEST_TOKEN_FORMAT, account.getTokenFormat());
+
         Assert.assertEquals("Additional OAuth values should match", createAdditionalOauthValues(), account.getAdditionalOauthValues());
     }
 
@@ -521,6 +532,8 @@ public class UserAccountTest {
         Assert.assertEquals("Cookie client src should match", TEST_COOKIE_CLIENT_SRC, account.getCookieClientSrc());
         Assert.assertEquals("Cookie sid client should match", TEST_COOKIE_SID_CLIENT, account.getCookieSidClient());
         Assert.assertEquals("Sid cookie name should match", TEST_SID_COOKIE_NAME, account.getSidCookieName());
+        Assert.assertEquals("Parent sid should match", TEST_PARENT_SID, account.getParentSid());
+        Assert.assertEquals("Token format should match", TEST_TOKEN_FORMAT, account.getTokenFormat());
         Assert.assertEquals("Additional OAuth values should match", createAdditionalOauthValues(), account.getAdditionalOauthValues());
     }
 
@@ -554,6 +567,8 @@ public class UserAccountTest {
         params.put("cookie-clientSrc", TEST_COOKIE_CLIENT_SRC);
         params.put("cookie-sid_Client", TEST_COOKIE_SID_CLIENT);
         params.put("sidCookieName", TEST_SID_COOKIE_NAME);
+        params.put("parent_sid", TEST_PARENT_SID);
+        params.put("token_format", TEST_TOKEN_FORMAT);
 
         return new OAuth2.TokenEndpointResponse(params, createAdditionalOauthKeys());
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/JwtAccessTokenTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/JwtAccessTokenTest.java
@@ -1,0 +1,55 @@
+package com.salesforce.androidsdk.auth;
+
+import static java.util.Collections.singletonList;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JwtAccessTokenTest {
+
+    private static final String TEST_RAW_JWT = "eyJ0bmsiOiJjb3JlL2ZhbGNvbnRlc3QxLWNvcmU0c2RiNi8wMERTRzAwMDAwOUZZVmQyQU8iLCJ2ZXIiOiIxLjAiLCJraWQiOiJDT1JFX0FUSldULjAwRFNHMDAwMDA5RllWZC4xNzI1NTc5NDIwMTI1IiwidHR5Ijoic2ZkYy1jb3JlLXRva2VuIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzY3AiOiJyZWZyZXNoX3Rva2VuIHdlYiBhcGkiLCJhdWQiOlsiaHR0cHM6Ly9tb2JpbGVzZGthdHNkYjYudGVzdDEubXkucGMtcm5kLnNhbGVzZm9yY2UuY29tIl0sInN1YiI6InVpZDowMDVTRzAwMDAwOGVpQWJZQUkiLCJuYmYiOjE3MzAzODY2MjAsIm10eSI6Im9hdXRoIiwic2ZpIjoiYTZjZjk1MjY2NjYzM2Q4ZDUxMDUzNjkzNDcwZDczYzVhOTY4ZTA4NmQ1OGQ2NzlmYTVjMzY1ZmNhMGZiZjhkYyIsInJvbGVzIjpbXSwiaXNzIjoiaHR0cHM6Ly9tb2JpbGVzZGthdHNkYjYudGVzdDEubXkucGMtcm5kLnNhbGVzZm9yY2UuY29tIiwiaHNjIjpmYWxzZSwiZXhwIjoxNzMwMzg2Njk1LCJpYXQiOjE3MzAzODY2MzUsImNsaWVudF9pZCI6IjNNVkc5LkFnd3RvSXZFUlNkOGk4bGVQcnFmczdDYXpSeDJsbGJMOHViTm9HNlIzSHNZb21RRlJwYmF5YU1INEh0ekgzemowTkRFbUMwUElvaHcwUGYifQ.R8RDUDlRD-6LIzV2epi8y7m1_zWBwfvmTAhUiGOjg1fDWGxsX48hSi95WITHtZ-D-gDQEjVl1GBGKsIe7jEBdGkhoFhbUuYFEnd15bcYlmLBIpmRdSbSvImusaeGVBx2hLhv4Icl7md_BuNoiz6BpuV-T_0a0QxRkpo97sGN1MghO6m9ItzXY9ldR7m5_pOORy3eZ1q4JZ1aj49pphom_O_ZQAeWYX7Gp9dZjhxlLFYgk0XrarC689LOhfSAyBhJO-OvtgKrvUY1XiWEaZR3A2FAk-AK1ZrNenKB_76JGEppuODCpRyqiUUlLmFkzcx897KeTQGoC_QDrdn0y4speA";
+
+    @Test
+    public void testDecodeValidJwtAndParseHeader() {
+        JwtAccessToken decodedJwt = new JwtAccessToken(TEST_RAW_JWT);
+        Assert.assertNotNull(decodedJwt);
+        JwtHeader jwtHeader = decodedJwt.getHeader();
+        Assert.assertNotNull(jwtHeader);
+
+        Assert.assertEquals("RS256", jwtHeader.getAlgorithn());
+        Assert.assertEquals("JWT", jwtHeader.getType());
+        Assert.assertEquals("CORE_ATJWT.00DSG000009FYVd.1725579420125", jwtHeader.getKeyId());
+        Assert.assertEquals("sfdc-core-token", jwtHeader.getTokenType());
+        Assert.assertEquals("core/falcontest1-core4sdb6/00DSG000009FYVd2AO", jwtHeader.getTenantKey());
+        Assert.assertEquals("1.0", decodedJwt.getHeader().getVersion());
+    }
+
+    @Test
+    public void testDecodeValidJwtAndParsePayload() {
+        JwtAccessToken decodedJwt = new JwtAccessToken(TEST_RAW_JWT);
+        Assert.assertNotNull(decodedJwt);
+        JwtPayload jwtPayload = decodedJwt.getPayload();
+        Assert.assertNotNull(jwtPayload);
+
+        Assert.assertEquals(singletonList("https://mobilesdkatsdb6.test1.my.pc-rnd.salesforce.com"), jwtPayload.getAudience());
+        Assert.assertEquals(1730386695, (int) jwtPayload.getExpirationTime());
+        Assert.assertEquals("https://mobilesdkatsdb6.test1.my.pc-rnd.salesforce.com", jwtPayload.getIssuer());
+        Assert.assertEquals(1730386620, (int) jwtPayload.getNotBeforeTime());
+        Assert.assertEquals("uid:005SG000008eiAbYAI", jwtPayload.getSubject());
+        Assert.assertEquals("refresh_token web api", jwtPayload.getScopes());
+        Assert.assertEquals("3MVG9.AgwtoIvERSd8i8lePrqfs7CazRx2llbL8ubNoG6R3HsYomQFRpbayaMH4HtzH3zj0NDEmC0PIohw0Pf", jwtPayload.getClientId());
+    }
+
+
+    @Test
+    public void testInvalidJwt() {
+        String invalidRawJwt = "invalid-jwt-string";
+
+        try {
+            new JwtAccessToken(invalidRawJwt);
+            Assert.fail("Expected illegal argument exception");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals("Wrong exception thrown", "Invalid JWT format", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Overview
Connected app / external client app can be configured to issue JWT-based access token (for more information see [here](https://help.salesforce.com/s/articleView?id=sf.connected_app_enable_jwt.htm&type=5)).

The mobile application does not need to know if it is using a JWT-based access token or an opaque token **in most cases**.
Login and refresh will just work as before.

However, front door URL cannot be built directly using the JWT-based access token. Instead the [single access API](https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm&type=5) should be called to generate front door URL.

We already made changes in the Mobile SDK to be JWT-based access token ready:
- We introduced a REST wrapper for single access API and leveraged it in the IDP-SP flow (see https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2610)
- We moved away from front-door and hydrated the web view session in hybrid remote apps using the cookies returned by the oauth hybrid flow (https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2618)

## Changes in this PR
- We are saving the token format and parent sid returned by the token end point during login and refresh in the user account.
- We added a class `JwtAccessToken` to allow apps to inspect the JWT encoded in the JWT-based access token.
- We modified `SalesforceWebViewCookieManager` i.e. the class responsible for hydrating the web view sessions in hybrid remote apps when JWT-based access token are in use.

## Testing
- We added tests to check that token format and parent sid are properly captured and saved.
- We added tests for `JwtAccessToken`.
- We manually verified that login/refresh works in native applications and hybrid remote applications.
- We manually verified that the IDP-SP flows work when JWT-based access token are being used.