### PR TITLE
Added Null check to prevent crash for TrailHead Go Android

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -655,7 +655,6 @@ public class ClientManager {
         /**
          * Build a LoginOptions from the given bundle
          * @param options - bundle
-         * @return
          */
         public static LoginOptions fromBundle(Bundle options) {
             if (options == null) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -658,6 +658,9 @@ public class ClientManager {
          * @return
          */
         public static LoginOptions fromBundle(Bundle options) {
+            if (options == null) {
+                return new LoginOptions(null, null, null, null, null, null); // To prevent crash if null Bundle is passed
+            }
             Map<String, String> additionalParameters = null;
             final Serializable serializable = options.getSerializable(KEY_ADDL_PARAMS);
             if (serializable != null) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/AppLockManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/AppLockManager.kt
@@ -63,9 +63,9 @@ internal abstract class AppLockManager(
         EventsObservable.get().notifyEvent(EventsObservable.EventType.AppUnlocked)
     }
 
-    fun getAccountPrefs(account: UserAccount): SharedPreferences {
+    fun getAccountPrefs(account: UserAccount?): SharedPreferences {
         val ctx = SalesforceSDKManager.getInstance().appContext
-        return ctx.getSharedPreferences(policyKey + account.userLevelFilenameSuffix, Context.MODE_PRIVATE)
+        return ctx.getSharedPreferences(policyKey + account?.userLevelFilenameSuffix, Context.MODE_PRIVATE)
     }
 
     fun getGlobalPrefs(): SharedPreferences {
@@ -73,7 +73,7 @@ internal abstract class AppLockManager(
         return ctx.getSharedPreferences(policyKey, Context.MODE_PRIVATE)
     }
 
-    fun getPolicy(account: UserAccount): Policy {
+    fun getPolicy(account: UserAccount?): Policy {
         val accountPolicy = getAccountPrefs(account)
         return accountPolicy.getBoolean(enabledKey, false) to accountPolicy.getInt(timeoutKey, 0)
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerTest.java
@@ -165,6 +165,15 @@ public class ClientManagerTest {
     }
 
     /**
+     * Test setting/get of Login Options as a null bundle
+     */
+    @Test
+    public void testLoginOptionsWithNullBundle() {
+        LoginOptions loginOptions = LoginOptions.fromBundle(null);
+        Assert.assertNotNull("LoginOptions from bundle must not be null", loginOptions);
+    }
+
+    /**
      * Test createNewAccount
      */
     @Test
@@ -505,6 +514,13 @@ public class ClientManagerTest {
         Assert.assertArrayEquals(new String[] { "some-scope", "some-other-scope"}, loginOptions.getOauthScopes());
         Assert.assertEquals("some-jwt", loginOptions.getJwt());
 
+    }
+
+    @Test
+    public void testLoginOptionsNullFromBundleWithSafeLoginUrl() {
+        // Expect the LoginOptions to have the same login url
+        LoginOptions loginOptions = LoginOptions.fromBundleWithSafeLoginUrl(null);
+        Assert.assertNotNull(loginOptions.getLoginUrl());
     }
 
     /**


### PR DESCRIPTION
[com.salesforce.trailheadgo.app_issue_fa4327a6a3154091d49279fa5eba233c_crash_session_6722C99202280001286FF83BCF5223CF_DNE_0_v2_stacktrace.txt](https://github.com/user-attachments/files/17622028/com.salesforce.trailheadgo.app_issue_fa4327a6a3154091d49279fa5eba233c_crash_session_6722C99202280001286FF83BCF5223CF_DNE_0_v2_stacktrace.txt)

https://console.firebase.google.com/project/trailhead-go/crashlytics/app/android:com.salesforce.trailheadgo.app/issues/3acb1308797bc3f5179c50ae5d9d0335?time=last-ninety-days&types=crash&versions=4.1.1%20(4)%20(4010101)&sessionEventKey=672B3B16020000015F77FD9E92962BED_2012546185538799571

https://console.firebase.google.com/project/trailhead-go/crashlytics/app/android:com.salesforce.trailheadgo.app/issues/fa4327a6a3154091d49279fa5eba233c?time=last-ninety-days&types=crash&versions=4.1.1%20(4)%20(4010101)
