### PR TITLE
@W-16580498: [Android] Hook to propagate MSDK logs to other systems

### DIFF
--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -77,6 +77,10 @@ android {
         buildConfig = true
     }
 
+    kotlin {
+        jvmToolchain(17)
+    }
+
     val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {
         group = "Coverage"
         description = "Convert coverage.ec from Firebase Test Lab to XML that is usable by CodeCov."

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiver.kt
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-present, salesforce.com, inc.
+ * Copyright (c) 2024-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiver.kt
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiver.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.analytics.logger
+
+import com.salesforce.androidsdk.analytics.logger.SalesforceLogger.Level
+
+/**
+ * Any object that can be registered with Salesforce logger and receive issued
+ * log entries.
+ */
+interface SalesforceLogReceiver {
+
+    /**
+     * Receives a log entry.
+     * @param level The log entry's level
+     * @param tag The log entry's tag
+     * @param message The log entry's message
+     */
+    fun receive(
+        level: Level,
+        tag: String,
+        message: String
+    )
+
+    /**
+     * Receives a log entry.
+     * @param level The log entry's level
+     * @param tag The log entry's tag
+     * @param message The log entry's message
+     * @param throwable The log entry's throwable
+     */
+    fun receive(
+        level: Level,
+        tag: String,
+        message: String,
+        throwable: Throwable? = null
+    )
+}

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiverFactory.kt
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiverFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-present, salesforce.com, inc.
+ * Copyright (c) 2024-present, salesforce.com, inc.
  * All rights reserved.
  * Redistribution and use of this software in source and binary forms, with or
  * without modification, are permitted provided that the following conditions

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiverFactory.kt
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogReceiverFactory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.analytics.logger
+
+/**
+ * Any object that can be registered with Salesforce logger to create log
+ * receivers.
+ */
+interface SalesforceLogReceiverFactory {
+
+    /**
+     * Creates a log receiver for the named component.
+     * @param componentName The logger's named component
+     */
+    fun create(componentName: String): SalesforceLogReceiver
+}

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
@@ -56,7 +56,7 @@ public class SalesforceLogger {
     /**
      * The factory for Salesforce log receivers.  Defaults to null
      */
-    public static SalesforceLogReceiverFactory logReceiverFactory;
+    private static SalesforceLogReceiverFactory logReceiverFactory;
 
     private static final String TAG = "SalesforceLogger";
     private static final String LOG_LINE_FORMAT = "TIME: %s, LEVEL: %s, TAG: %s, MESSAGE: %s";
@@ -94,6 +94,18 @@ public class SalesforceLogger {
     private final SalesforceLogReceiver logReceiver;
 
     private Level logLevel;
+
+    /**
+     * Sets the factory for Salesforce log receivers.
+     *
+     * @param logReceiverFactory The factory for Salesforce log receivers
+     * @noinspection unused
+     */
+    public synchronized static void setLogReceiverFactory(
+            SalesforceLogReceiverFactory logReceiverFactory
+    ) {
+        SalesforceLogger.logReceiverFactory = logReceiverFactory;
+    }
 
     /**
      * Returns the Salesforce logger instance associated with the named component.  The logger will

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
@@ -31,6 +31,7 @@ import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.util.Log;
 
 import java.io.IOException;
@@ -52,6 +53,11 @@ import java.util.concurrent.Executors;
  */
 public class SalesforceLogger {
 
+    /**
+     * The factory for Salesforce log receivers.  Defaults to null
+     */
+    public static SalesforceLogReceiverFactory logReceiverFactory;
+
     private static final String TAG = "SalesforceLogger";
     private static final String LOG_LINE_FORMAT = "TIME: %s, LEVEL: %s, TAG: %s, MESSAGE: %s";
     private static final String LOG_LINE_FORMAT_WITH_EXCEPTION = "TIME: %s, LEVEL: %s, TAG: %s, MESSAGE: %s, EXCEPTION: %s";
@@ -71,7 +77,7 @@ public class SalesforceLogger {
         DEBUG(2),
         VERBOSE(1);
 
-        private Integer severity;
+        private final Integer severity;
 
         Level(int severity) {
             this.severity = severity;
@@ -79,23 +85,57 @@ public class SalesforceLogger {
     }
 
     private FileLogger fileLogger;
-    private Context context;
-    private String componentName;
+    private final Context context;
+    private final String componentName;
+
+    /**
+     * The Salesforce log receiver to receive all logs issued by this Salesforce logger
+     */
+    private final SalesforceLogReceiver logReceiver;
+
     private Level logLevel;
 
     /**
-     * Returns a logger instance associated with a named component.
+     * Returns the Salesforce logger instance associated with the named component.  The logger will
+     * be created if needed and without any additional Salesforce log receiver.
      *
-     * @param componentName Component name.
-     * @param context Context.
-     * @return Logger instance.
+     * @param componentName The component name
+     * @param context       The Android context
+     * @return Either a new or existing Salesforce logger for the named component
      */
-    public synchronized static SalesforceLogger getLogger(String componentName, Context context) {
+    public synchronized static SalesforceLogger getLogger(String componentName,
+                                                          Context context) {
+        return getLogger(componentName, context, null);
+    }
+
+    /**
+     * Returns the Salesforce logger instance associated with the named component.  The logger will
+     * be created if needed and with the specified Salesforce log receiver.
+     *
+     * @param componentName         The component name
+     * @param context               The Android context
+     * @param salesforceLogReceiver The Salesforce log receiver to receive all logs issued by the
+     *                              Salesforce logger
+     * @return Either a new or existing Salesforce logger for the named component
+     */
+    public synchronized static SalesforceLogger getLogger(String componentName,
+                                                          Context context,
+                                                          SalesforceLogReceiver salesforceLogReceiver) {
         if (LOGGERS == null) {
             LOGGERS = new ConcurrentHashMap<>();
         }
+
+        // Resolve the log receiver from parameters or the factory.
+        SalesforceLogReceiver salesforceLogReceiverResolved = salesforceLogReceiver;
+        if (salesforceLogReceiverResolved == null && logReceiverFactory != null) {
+            salesforceLogReceiverResolved = logReceiverFactory.create(componentName);
+        }
+
         if (!LOGGERS.containsKey(componentName)) {
-            final SalesforceLogger logger = new SalesforceLogger(componentName, context);
+            final SalesforceLogger logger = new SalesforceLogger(
+                    componentName,
+                    context,
+                    salesforceLogReceiverResolved);
             LOGGERS.put(componentName, logger);
         }
         return LOGGERS.get(componentName);
@@ -107,11 +147,11 @@ public class SalesforceLogger {
      * @return Set of components being logged.
      */
     public synchronized static Set<String> getComponents() {
-        if (LOGGERS == null || LOGGERS.size() == 0) {
+        if (LOGGERS == null || LOGGERS.isEmpty()) {
             return null;
         }
         Set<String> components = LOGGERS.keySet();
-        if (components.size() == 0) {
+        if (components.isEmpty()) {
             components = null;
         }
         return components;
@@ -124,9 +164,21 @@ public class SalesforceLogger {
         LOGGERS = null;
     }
 
-    private SalesforceLogger(String componentName, Context context) {
+    /**
+     * Creates a new Salesforce logger.
+     *
+     * @param componentName         The named component the logger will be associated with
+     * @param context               The Android context
+     * @param salesforceLogReceiver The Salesforce log receiver to receive all logs issued by the
+     *                              Salesforce logger
+     */
+    private SalesforceLogger(
+            String componentName,
+            Context context,
+            SalesforceLogReceiver salesforceLogReceiver) {
         this.context = context;
         this.componentName = componentName;
+        this.logReceiver = salesforceLogReceiver;
         readLoggerPrefs();
         try {
             fileLogger = new FileLogger(context, componentName);
@@ -148,8 +200,8 @@ public class SalesforceLogger {
                     }
                 }
             }
-        } catch (PackageManager.NameNotFoundException e) {
-            debugMode = true;
+        } catch (NameNotFoundException e) {
+            /* Intentionally blank */
         }
         return debugMode;
     }
@@ -158,6 +210,7 @@ public class SalesforceLogger {
      * Returns the instance of FileLogger associated with this component.
      *
      * @return FileLogger instance.
+     * @noinspection unused
      */
     public FileLogger getFileLogger() {
         return fileLogger;
@@ -183,6 +236,8 @@ public class SalesforceLogger {
 
     /**
      * Disables file logging.
+     *
+     * @noinspection unused
      */
     public synchronized void disableFileLogging() {
         if (fileLogger != null) {
@@ -194,6 +249,7 @@ public class SalesforceLogger {
      * Enables file logging.
      *
      * @param maxSize Maximum number of log lines allowed to be stored at a time.
+     * @noinspection unused
      */
     public synchronized void enableFileLogging(int maxSize) {
         if (fileLogger != null) {
@@ -205,6 +261,7 @@ public class SalesforceLogger {
      * Returns if file logging is enabled or not.
      *
      * @return True - if enabled, False - otherwise.
+     * @noinspection unused
      */
     public boolean isFileLoggingEnabled() {
         int maxSize = 0;
@@ -217,7 +274,7 @@ public class SalesforceLogger {
     /**
      * Logs an error log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
      */
     public void e(String tag, String message) {
@@ -227,9 +284,9 @@ public class SalesforceLogger {
     /**
      * Logs an error log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
-     * @param e Exception to be logged.
+     * @param e       Exception to be logged.
      */
     public void e(String tag, String message, Throwable e) {
         log(Level.ERROR, tag, message, e);
@@ -238,7 +295,7 @@ public class SalesforceLogger {
     /**
      * Logs a warning log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
      */
     public void w(String tag, String message) {
@@ -248,9 +305,9 @@ public class SalesforceLogger {
     /**
      * Logs a warning log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
-     * @param e Exception to be logged.
+     * @param e       Exception to be logged.
      */
     public void w(String tag, String message, Throwable e) {
         log(Level.WARN, tag, message, e);
@@ -259,7 +316,7 @@ public class SalesforceLogger {
     /**
      * Logs an info log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
      */
     public void i(String tag, String message) {
@@ -269,9 +326,9 @@ public class SalesforceLogger {
     /**
      * Logs an info log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
-     * @param e Exception to be logged.
+     * @param e       Exception to be logged.
      */
     public void i(String tag, String message, Throwable e) {
         log(Level.INFO, tag, message, e);
@@ -280,7 +337,7 @@ public class SalesforceLogger {
     /**
      * Logs a debug log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
      */
     public void d(String tag, String message) {
@@ -290,9 +347,9 @@ public class SalesforceLogger {
     /**
      * Logs a debug log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
-     * @param e Exception to be logged.
+     * @param e       Exception to be logged.
      */
     public void d(String tag, String message, Throwable e) {
         log(Level.DEBUG, tag, message, e);
@@ -301,7 +358,7 @@ public class SalesforceLogger {
     /**
      * Logs a verbose log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
      */
     public void v(String tag, String message) {
@@ -311,9 +368,9 @@ public class SalesforceLogger {
     /**
      * Logs a verbose log line.
      *
-     * @param tag Log tag.
+     * @param tag     Log tag.
      * @param message Log message.
-     * @param e Exception to be logged.
+     * @param e       Exception to be logged.
      */
     public void v(String tag, String message, Throwable e) {
         log(Level.VERBOSE, tag, message, e);
@@ -322,8 +379,8 @@ public class SalesforceLogger {
     /**
      * Logs a log line of the specified level.
      *
-     * @param level Log level.
-     * @param tag Log tag.
+     * @param level   Log level.
+     * @param tag     Log tag.
      * @param message Log message.
      */
     public void log(Level level, String tag, String message) {
@@ -346,64 +403,60 @@ public class SalesforceLogger {
                 case VERBOSE:
                     Log.v(tag, message);
                     break;
-                default:
-                    Log.d(tag, message);
             }
             logToFile(getTimeFromUTC(), level, tag, message, null);
+
+            if (logReceiver != null) logReceiver.receive(level, tag, message);
         }
     }
 
-  /**
-   * Logs a log line of the specified level.
-   *
-   * @param level Log level.
-   * @param tag Log tag.
-   * @param message Log message.
-   * @param e Exception to be logged.
-   */
-  public void log(Level level, String tag, String message, Throwable e) {
-      if (level.severity >= logLevel.severity) {
-          switch (level) {
-              case OFF:
-                break;
-            case ERROR:
-                Log.e(tag, message, e);
-                break;
-            case WARN:
-                Log.w(tag, message, e);
-                break;
-            case INFO:
-                Log.i(tag, message, e);
-                break;
-            case DEBUG:
-                Log.d(tag, message, e);
-                break;
-            case VERBOSE:
-                Log.v(tag, message, e);
-                break;
-            default:
-                Log.d(tag, message, e);
-          }
-          logToFile(getTimeFromUTC(), level, tag, message, e);
-      }
+    /**
+     * Logs a log line of the specified level.
+     *
+     * @param level   Log level.
+     * @param tag     Log tag.
+     * @param message Log message.
+     * @param e       Exception to be logged.
+     */
+    public void log(Level level, String tag, String message, Throwable e) {
+        if (level.severity >= logLevel.severity) {
+            switch (level) {
+                case OFF:
+                    break;
+                case ERROR:
+                    Log.e(tag, message, e);
+                    break;
+                case WARN:
+                    Log.w(tag, message, e);
+                    break;
+                case INFO:
+                    Log.i(tag, message, e);
+                    break;
+                case DEBUG:
+                    Log.d(tag, message, e);
+                    break;
+                case VERBOSE:
+                    Log.v(tag, message, e);
+                    break;
+            }
+            logToFile(getTimeFromUTC(), level, tag, message, e);
+
+            if (logReceiver != null) logReceiver.receive(level, tag, message, e);
+        }
     }
 
     private void logToFile(final String curTime, final Level level, final String tag,
                            final String message, final Throwable e) {
-        THREAD_POOL.execute(new Runnable() {
-
-            @Override
-            public void run() {
-                if (fileLogger != null) {
-                    String logLine;
-                    if (e != null) {
-                        logLine = String.format(LOG_LINE_FORMAT_WITH_EXCEPTION, curTime, level,
-                                tag, message, Log.getStackTraceString(e));
-                    } else {
-                        logLine = String.format(LOG_LINE_FORMAT, curTime, level, tag, message);
-                    }
-                    fileLogger.addLogLine(logLine);
+        THREAD_POOL.execute(() -> {
+            if (fileLogger != null) {
+                String logLine;
+                if (e != null) {
+                    logLine = String.format(LOG_LINE_FORMAT_WITH_EXCEPTION, curTime, level,
+                            tag, message, Log.getStackTraceString(e));
+                } else {
+                    logLine = String.format(LOG_LINE_FORMAT, curTime, level, tag, message);
                 }
+                fileLogger.addLogLine(logLine);
             }
         });
     }
@@ -419,7 +472,7 @@ public class SalesforceLogger {
         final SharedPreferences sp = context.getSharedPreferences(SF_LOGGER_PREFS, Context.MODE_PRIVATE);
         final SharedPreferences.Editor e = sp.edit();
         e.putString(componentName, level.toString());
-        e.commit();
+        e.apply();
         logLevel = level;
     }
 
@@ -445,6 +498,6 @@ public class SalesforceLogger {
         final SharedPreferences sp = context.getSharedPreferences(SF_LOGGER_PREFS, Context.MODE_PRIVATE);
         final SharedPreferences.Editor e = sp.edit();
         e.clear();
-        e.commit();
+        e.apply();
     }
 }


### PR DESCRIPTION
🎸 _*Ready For Review!*_ 🥁

  This adds a new concept of "log receivers" to the SDK's existing logging infrastructure, plus a "factory" which can be registered by the app to create and register these receivers to named components in the logging flow.  The factory object could be a bridge to the app's dependency injection framework, such as Hilt.

  I tried this out in the template apps and the overall pattern gave the app what I expected.  I marked this ready for review with the anticipation we might have to discuss the naming convention a bit.  I thought over names such as "adapter", "destination", "target" or "handler" before settling on "receiver". I though this was a good semantic since the object only has to "receive" the log entry - What happens after that is entirely up to the implementation and our interface names don't provide implementation bias.

  I added some logic to ensure the app can also choose their own handling for our notion of component names.  In my template app, I tried a few patterns such a using a single logger that didn't use the provided component name or concatenated it to the message by mapping instances of receiver objects to component name.  We can add some sample code for this into the MSDK docs.

  As always, thanks for reading!