### PR TITLE
@W-17051459: [TRUST] Improve Android Lifecycle events/actions

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -57,10 +57,8 @@ import android.webkit.URLUtil.isHttpsUrl
 import androidx.core.content.ContextCompat.RECEIVER_EXPORTED
 import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
 import androidx.core.content.ContextCompat.registerReceiver
-import androidx.lifecycle.Lifecycle.Event.ON_START
-import androidx.lifecycle.Lifecycle.Event.ON_STOP
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.window.core.layout.WindowHeightSizeClass
 import androidx.window.core.layout.WindowSizeClass
@@ -169,7 +167,7 @@ open class SalesforceSDKManager protected constructor(
     mainActivity: Class<out Activity>,
     private val loginActivity: Class<out Activity>? = null,
     internal val nativeLoginActivity: Class<out Activity>? = null,
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
 
     constructor(
         context: Context,
@@ -1461,9 +1459,9 @@ open class SalesforceSDKManager protected constructor(
                 windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT
     }
 
-    @Suppress("unused")
-    @OnLifecycleEvent(ON_STOP)
-    protected open fun onAppBackgrounded() {
+    override fun onPause(owner: LifecycleOwner) {
+        super.onPause(owner)
+
         (screenLockManager as ScreenLockManager?)?.onAppBackgrounded()
 
         // Publish analytics one-time on app background, if enabled.
@@ -1481,9 +1479,9 @@ open class SalesforceSDKManager protected constructor(
         }
     }
 
-    @Suppress("unused")
-    @OnLifecycleEvent(ON_START)
-    protected open fun onAppForegrounded() {
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+
         (screenLockManager as ScreenLockManager?)?.onAppForegrounded()
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppForegrounded()
 


### PR DESCRIPTION
🎸 _*Ready For Review!*_ 🥁

  This updates a deprecation for the `OnLifecycleEvent` code generation annotation in `SalesforceSDKManager`.  It turns out the fix was pretty simple since `SalesforceSDKManager` already registered as a `ProcessLifecycleOwner` observer.  It just needed to implement one of the `LifecycleObserver` sub-interfaces, such as `DefaultLifecycleObserver`, so the two existing lifecycle-related methods could be called without the deprecated code generation.

  I tested this on API 35 and compared how the two lifecycle methods are called in comparison to the previous version.  It certainly seems on par.