### PR TITLE
Protect against null intent extras.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -113,6 +113,7 @@ import com.salesforce.androidsdk.util.EventsObservable.EventType.AuthWebViewCrea
 import com.salesforce.androidsdk.util.EventsObservable.EventType.LoginActivityCreateComplete
 import com.salesforce.androidsdk.util.SalesforceSDKLogger.d
 import com.salesforce.androidsdk.util.SalesforceSDKLogger.e
+import com.salesforce.androidsdk.util.SalesforceSDKLogger.w
 import com.salesforce.androidsdk.util.UriFragmentParser.parse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
@@ -179,7 +180,11 @@ open class LoginActivity : AppCompatActivity(), OAuthWebviewHelperEvents {
         // Determine login options for Salesforce Identity API UI Bridge front door URL use or choose defaults.
         val loginOptions = when {
             isUsingFrontDoorBridge -> salesforceSDKManager.loginOptions
-            else -> fromBundleWithSafeLoginUrl(intent.extras)
+            else -> fromBundleWithSafeLoginUrl(intent.extras ?:
+                SalesforceSDKManager.getInstance().loginOptions.asBundle().also {
+                    w(TAG, "intent.extras was null, but should contain LoginOptions bundle.")
+                }
+            )
         }
 
         // Protect against screenshots


### PR DESCRIPTION
`intent.extras` should never be null, we set it everywhere we instantiate our LoginActivity or the class the app provides.  However, according to #2633 it is somehow possible but the root cause is not yet known.  This is a defensive solution to the crash that does not pass a null `LoginOptions` bundle to `OAuthWebviewHelper`.