### PR TITLE
Changing min sdk from 26 to 28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,15 +366,14 @@ workflows:
               pr: [ true ]
 
   # GUI Driven "Triggers" Schedule
-  # Monday    8 PM - API 26
   # Monday    9 PM - API 28
   # Monday   10 PM - API 30
   # Monday   11 PM - API 32
   # Tuesday  12 AM - API 34
-  # Friday    8 PM - API 27
   # Friday    9 PM - API 29
   # Friday   10 PM - API 31
   # Friday   11 PM - API 33
+  # Saturday 12 AM - API 35
   nightly-tests:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
 
 aliases:
   # Docker image tags can be found here: https://circleci.com/developer/images/image/cimg/android
-  - &cimg cimg/android:2024.04.1-node
+  - &cimg cimg/android:2025.01.1-node
   # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
   - &default-api-level 34
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 cdvCompileSdkVersion=34
-cdvMinSdkVersion=26
+cdvMinSdkVersion=28
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         targetSdk = 34
-        minSdk = 26
+        minSdk = 28
     }
 
     sourceSets {

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         targetSdk = 34
-        minSdk = 26
+        minSdk = 28
     }
 
     sourceSets {

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 28
     }
 
     buildTypes {

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 28
     }
 
     buildTypes {

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/security/Encryptor.java
@@ -26,7 +26,6 @@
  */
 package com.salesforce.androidsdk.analytics.security;
 
-import android.os.Build;
 import android.text.TextUtils;
 import android.util.Base64;
 
@@ -45,14 +44,10 @@ import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.MGF1ParameterSpec;
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.spec.IvParameterSpec;
-import javax.crypto.spec.OAEPParameterSpec;
-import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
@@ -373,14 +368,7 @@ public class Encryptor {
             byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
             Mac sha;
 
-            /*
-             * TODO: Remove this check once minAPI >= 28.
-             */
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                sha = Mac.getInstance(MAC_TRANSFORMATION);
-            } else {
-                sha = Mac.getInstance(MAC_TRANSFORMATION, getLegacyEncryptionProvider());
-            }
+            sha = Mac.getInstance(MAC_TRANSFORMATION);
             final SecretKeySpec keySpec = new SecretKeySpec(keyBytes, sha.getAlgorithm());
             sha.init(keySpec);
             byte[] sig = sha.doFinal(dataBytes);
@@ -638,19 +626,12 @@ public class Encryptor {
             } else if (CipherMode.RSA_OAEP_SHA256 == cipherMode) {
                 cipher = Cipher.getInstance(cipherMode.fullName, BOUNCY_CASTLE_WORKAROUND);
             } else if (CipherMode.AES_CBC_CIPHER == cipherMode) {
-                cipher = Cipher.getInstance(cipherMode.fullName, getLegacyEncryptionProvider());
+                cipher = Cipher.getInstance(cipherMode.fullName);
             }
         } catch (Exception e) {
             SalesforceAnalyticsLogger.e(null, TAG,
                     "No cipher transformation available", e);
         }
         return cipher;
-    }
-
-    /*
-     * TODO: Remove this method and its usages once minAPI >= 28.
-     */
-    private static String getLegacyEncryptionProvider() {
-        return BOUNCY_CASTLE;
     }
 }

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -31,7 +31,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 28
     }
 
     buildTypes {

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -47,7 +47,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 28
     }
 
     buildTypes {

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -8,14 +8,6 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
-
-    <!--
-        USE_FINGERPRINT is available from API 23 to API 27
-        TODO: should be removed once minAPI > 27
-    -->
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-
-    <!-- USE_BIOMETRIC is available on API 28 and higher -->
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
     <application>

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -39,7 +39,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 28
     }
 
     buildTypes {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/KeyStoreWrapper.java
@@ -239,18 +239,12 @@ public class KeyStoreWrapper {
                         .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1, KeyProperties.ENCRYPTION_PADDING_RSA_OAEP);
 
                 /*
-                 * TODO: Remove this check once minVersion > 28.
+                 * Disabling StrongBox based on Google's recommendation - it's not a good
+                 * fit for this use case, since the key will need to be retrieved multiple
+                 * times. Besides, StrongBox Keymaster is available only on a few devices,
+                 * such as the Pixel 3 and Pixel 3 XL at this time.
                  */
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-
-                    /*
-                     * Disabling StrongBox based on Google's recommendation - it's not a good
-                     * fit for this use case, since the key will need to be retrieved multiple
-                     * times. Besides, StrongBox Keymaster is available only on a few devices,
-                     * such as the Pixel 3 and Pixel 3 XL at this time.
-                     */
-                    keyGenParameterSpecBuilder.setIsStrongBoxBacked(false);
-                }
+                keyGenParameterSpecBuilder.setIsStrongBoxBacked(false);
                 kpg.initialize(keyGenParameterSpecBuilder.build());
                 kpg.generateKeyPair();
             }
@@ -273,18 +267,12 @@ public class KeyStoreWrapper {
                         .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1);
 
                 /*
-                 * TODO: Remove this check once minVersion > 28.
+                 * Disabling StrongBox based on Google's recommendation - it's not a good
+                 * fit for this use case, since the key will need to be retrieved multiple
+                 * times. Besides, StrongBox Keymaster is available only on a few devices,
+                 * such as the Pixel 3 and Pixel 3 XL at this time.
                  */
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-
-                    /*
-                     * Disabling StrongBox based on Google's recommendation - it's not a good
-                     * fit for this use case, since the key will need to be retrieved multiple
-                     * times. Besides, StrongBox Keymaster is available only on a few devices,
-                     * such as the Pixel 3 and Pixel 3 XL at this time.
-                     */
-                    keyGenParameterSpecBuilder.setIsStrongBoxBacked(false);
-                }
+                keyGenParameterSpecBuilder.setIsStrongBoxBacked(false);
                 kpg.initialize(keyGenParameterSpecBuilder.build());
                 kpg.generateKeyPair();
             }

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -32,7 +32,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 28
     }
 
     buildTypes {

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -17,7 +17,7 @@ android {
 
     defaultConfig {
         targetSdk = 35
-        minSdk = 26
+        minSdk = 28
     }
 
     sourceSets {

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         targetSdk = 35
-        minSdk = 26
+        minSdk = 28
     }
 
     sourceSets {

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         targetSdk = 35
-        minSdk = 26
+        minSdk = 28
     }
 
     buildTypes {


### PR DESCRIPTION
Changes:
- Changed minSdk from 26 to 28
- Removed checks for 28/Android.P in code
- No longer using BC provider (see https://android-developers.googleblog.com/2018/03/cryptography-changes-in-android-p.html)

NB: Also updated GUI driven [triggers](https://app.circleci.com/settings/project/github/forcedotcom/SalesforceMobileSDK-Android/triggers) on Circle CI (removed 26, 27 and added 35)

