### PR TITLE
Add ability to provide SQLCipher license key

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -370,6 +370,9 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 
 	static class DBHook implements SQLiteDatabaseHook {
 		public void preKey(SQLiteConnection connection) {
+			if (SmartStore.LICENSE_KEY != null) {
+				connection.executeForString(String.format("PRAGMA cipher_license = '%s'", SmartStore.LICENSE_KEY), new Object[]{}, null);
+			}
 		}
 
 		/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -370,9 +370,9 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 
 	static class DBHook implements SQLiteDatabaseHook {
 		public void preKey(SQLiteConnection connection) {
-            if (SmartStore.LICENSE_KEY != null) {
-                connection.executeForString(String.format("PRAGMA cipher_license = '%s'", SmartStore.LICENSE_KEY), new Object[]{}, null);
-            }
+			if (SmartStore.LICENSE_KEY != null) {
+				connection.executeForString(String.format("PRAGMA cipher_license = '%s'", SmartStore.LICENSE_KEY), new Object[]{}, null);
+			}
 		}
 
 		/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/DBOpenHelper.java
@@ -370,9 +370,9 @@ public class DBOpenHelper extends SQLiteOpenHelper {
 
 	static class DBHook implements SQLiteDatabaseHook {
 		public void preKey(SQLiteConnection connection) {
-			if (SmartStore.LICENSE_KEY != null) {
-				connection.executeForString(String.format("PRAGMA cipher_license = '%s'", SmartStore.LICENSE_KEY), new Object[]{}, null);
-			}
+            if (SmartStore.LICENSE_KEY != null) {
+                connection.executeForString(String.format("PRAGMA cipher_license = '%s'", SmartStore.LICENSE_KEY), new Object[]{}, null);
+            }
 		}
 
 		/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -129,7 +129,7 @@ public class SmartStore  {
 	 * @param licenseKey
 	 */
 	public static void setLicenseKey(String licenseKey) {
-        LICENSE_KEY = licenseKey;
+		LICENSE_KEY = licenseKey;
 	}
 
 	/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -129,7 +129,7 @@ public class SmartStore  {
 	 * @param licenseKey
 	 */
 	public static void setLicenseKey(String licenseKey) {
-		LICENSE_KEY = licenseKey;
+        LICENSE_KEY = licenseKey;
 	}
 
 	/**

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -119,6 +119,19 @@ public class SmartStore  {
 	// background executor
 	private final ExecutorService threadPool = Executors.newFixedThreadPool(1);
 
+	// Needed when using commercial or enterprise editions of SQLCipher
+	protected static String LICENSE_KEY = null;
+
+	/**
+	 * Set license key for SQLCipher
+	 * Needed when using commercial or enterprise editions of SQLCipher
+	 * Should be called before using SmartStore
+	 * @param licenseKey
+	 */
+	public static void setLicenseKey(String licenseKey) {
+		LICENSE_KEY = licenseKey;
+	}
+
 	/**
      * Changes the encryption key on the smartstore.
      *


### PR DESCRIPTION
Needed in order to use commercial or enterprise editions of SQLCipher.

## Testing
- Put the aar for SQLCipher commercial or enterprise edition in the `libs/SmartStore` folder.
- Change `libs/SmartStore/build.gradle.kts`
  - Replace dependency for SQLCipher e.g.
```
-    api("net.zetetic:sqlcipher-android:4.6.1")
+    api(files("sqlcipher-android-fips-4.6.1.aar"))
```
  - Add to packaging
```
        jniLibs {
            keepDebugSymbols += setOf("*/*/libfips.so", "*/*/libfipscnf.so")
            useLegacyPackaging = true
        }
```
- Change `libs/test/SmartStoreTest/src/com/salesforce/androidsdk/TestForceApp.java`
  - Add the following to `onCreate()` before everything else
```
SmartStore.setLicenseKey("--YOUR-SQLCIPHER-LICENSE-KEY--")
```
## Expected Result
Only the testSQLCipherVersion should fail, it will report the SQLCipher edition you are using instead of community e.g.
```
Wrong sqlcipher version expected:<4.6.1 [community]> but was:<4.6.1 [FIPS zetetic]>
``` 