### PR TITLE
Fix Github Actions PR event checks.

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,12 +1,13 @@
 name: Nightly Tests
 
 on: 
-  workflow_dispatch:
   schedule:
     - cron: "0 5 * * 2,6"  # cron is UTC, this translates to 10 PM PST Mon and Fri.
+  # This lets us trigger the workflow from a browser.
+  workflow_dispatch:
 
 jobs:
-  ios-pr:
+  android-nightly:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,7 +37,7 @@ jobs:
           # We need a sufficient depth or Danger will occasionally run into issues checking which files were modified.
           fetch-depth: 100
           # This is dangerous without the member check
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,8 +3,7 @@ name: Pull Request
 on:
   # Dangerious without Member Check setup!
   pull_request_target:
-    branches:
-      - dev
+    branches: [dev, master]
 
 jobs:
   test-orchestrator:
@@ -58,4 +57,5 @@ jobs:
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
+      is_pr: true
     secrets: inherit

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -1,11 +1,13 @@
 on:
-    workflow_dispatch:
-    workflow_call:
-      inputs:
-        lib:
-          required: true
-          type: string
-    
+  workflow_call:
+    inputs:
+      lib:
+        required: true
+        type: string
+      is_pr:
+        type: boolean
+        default: false
+  
 jobs:
   test-android:
     runs-on: ubuntu-latest
@@ -42,15 +44,16 @@ jobs:
         with:
           gradle-version: 8.7
       - name: Run Lint
-        if: ${{ github.event_name }} == 'pull_request'
+        if: ${{ inputs.is_pr }}
         run: |
           ./gradlew libs:${{ inputs.lib }}:lint
       - uses: ruby/setup-ruby@v1
+        if: ${{ inputs.is_pr }}
         with:
           ruby-version: '3.2'
           bundler-cache: true
       - name: Report Static Analysis
-        if: ${{ github.event_name }} == 'pull_request'
+        if: ${{ inputs.is_pr }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LIB: ${{ inputs.lib }}
@@ -68,13 +71,14 @@ jobs:
         if: success() || failure()
       - name: Run Tests
         if: success() || failure()
-        run: |
+        env:
           # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          DEFAULT_API_VERSION="34" 
-          FULL_API_RANGE="28 29 30 31 32 33 34 35"
-
+          DEFAULT_API_VERSION: "34" 
+          FULL_API_RANGE: "28 29 30 31 32 33 34 35"
+          IS_PR: ${{ inputs.is_pr }}
+        run: |
           DEVICES=""
-          if [[ ${{ github.event_name == 'pull_request' }} ]]; then
+          if $IS_PR ; then
             DEVICES="--device model=MediumPhone.arm,version=${DEFAULT_API_VERSION},locale=en,orientation=portrait "
           else
             for LEVEL in $FULL_API_RANGE

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -15,9 +15,14 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.is_pr }}
         with:
           # We need a sufficient depth or Danger will occasionally run into issues checking which files were modified.
           fetch-depth: 100
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v4
+        if: ${{ ! inputs.is_pr }}
+        with:
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         env: 


### PR DESCRIPTION
This PR adds a `is_pr` input parameter to our reusable-workflow.  The value of `github.event_name` changes from `pull_request` (or however the original flow started) to `workflow_call` in the reusale-workflow since that is technically how the _reusable-workflow was triggered_.  

CI will fail because it runs the workflow file on `dev`.  Tested [here](https://github.com/brandonpage/SalesforceMobileSDK-iOS/pull/13).