### PR TITLE
Fix nightly test runs.

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         lib: [SalesforceAnalytics, SalesforceSDK, SmartStore, MobileSync, SalesforceHybrid, SalesforceReact]
-
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly Tests
 
 on: 
   schedule:
-    - cron: "0 5 * * 2,6"  # cron is UTC, this translates to 10 PM PST Mon and Fri.
+    - cron: "0 6 * * 2,6"  # cron is UTC, this translates to 10 PM PST Mon and Fri.
   # This lets us trigger the workflow from a browser.
   workflow_dispatch:
 

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -75,55 +75,74 @@ jobs:
       - uses: 'google-github-actions/setup-gcloud@v2'
         if: success() || failure()
       - name: Run Tests
+        continue-on-error: true
         if: success() || failure()
         env:
           # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          DEFAULT_API_VERSION: "34" 
+          PR_API_VERSION: "34" 
           FULL_API_RANGE: "28 29 30 31 32 33 34 35"
           IS_PR: ${{ inputs.is_pr }}
         run: |
-          DEVICES=""
+          LEVELS_TO_TEST=$FULL_API_RANGE
+
           if $IS_PR ; then
-            DEVICES="--device model=MediumPhone.arm,version=${DEFAULT_API_VERSION},locale=en,orientation=portrait "
-          else
-            for LEVEL in $FULL_API_RANGE
+            LEVELS_TO_TEST=$PR_API_VERSION
+          fi
+
+          mkdir firebase_results
+          for LEVEL in $LEVELS_TO_TEST
             do
-                DEVICES+="--device model=MediumPhone.arm,version=${LEVEL},locale=en,orientation=portrait "
+              GCLOUD_RESULTS_DIR=${{ inputs.lib }}-api-${LEVEL}-build-${{github.run_number}}
+
+              gcloud firebase test android run \
+                --project mobile-apps-firebase-test \
+                --type instrumentation \
+                --app "native/NativeSampleApps/RestExplorer/build/outputs/apk/debug/RestExplorer-debug.apk" \
+                --test=libs/${{ inputs.lib }}/build/outputs/apk/androidTest/debug/${{ inputs.lib }}-debug-androidTest.apk \
+                --device model=MediumPhone.arm,version=${LEVEL},locale=en,orientation=portrait \
+                --environment-variables coverage=true,coverageFile="/sdcard/coverage.ec" \
+                --directories-to-pull=/sdcard \
+                --results-dir=${GCLOUD_RESULTS_DIR} \
+                --results-history-name=${{ inputs.lib }} \
+                --timeout=20m --no-auto-google-login --no-record-video --no-performance-metrics --num-flaky-test-attempts=1 || true
             done
-          fi
-
-          COMMAND="gcloud firebase test android run "
-          COMMAND+="--project mobile-apps-firebase-test "
-          COMMAND+="--type instrumentation "
-          COMMAND+="--app \"native/NativeSampleApps/RestExplorer/build/outputs/apk/debug/RestExplorer-debug.apk\" "
-          COMMAND+="--test=libs/${{ inputs.lib }}/build/outputs/apk/androidTest/debug/${{ inputs.lib }}-debug-androidTest.apk "
-          COMMAND+="${DEVICES}"
-          COMMAND+="--environment-variables coverage=true,coverageFile=\"/sdcard/coverage.ec\" "
-          COMMAND+="--directories-to-pull=/sdcard  "
-          COMMAND+="--results-dir=${{ inputs.lib }}-${{github.run_number}} "
-          COMMAND+="--results-history-name=${{ inputs.lib }} "
-          COMMAND+="--timeout=20m --no-auto-google-login --no-record-video --no-performance-metrics --num-flaky-test-attempts=1"
-
-          eval "$COMMAND"
       - name: Copy Test Results
+        continue-on-error: true
         if: success() || failure()
+        env:
+          # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
+          PR_API_VERSION: "34" 
+          FULL_API_RANGE: "28 29 30 31 32 33 34 35"
+          IS_PR: ${{ inputs.is_pr }}
         run: |
-          gsutil ls gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/${{ inputs.lib }}-${{github.run_number}} > /dev/null 2>&1
-          if [ $? == 0 ]
-          then
-            mkdir -p firebase/results
-            gsutil -m cp -r -U "`gsutil ls gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/${{ inputs.lib }}-${{github.run_number}} | tail -1`*" ./firebase/
-            mv firebase/test_result_1.xml firebase/results
-          else
-            echo "No test results found"
-            exit 1
+          LEVELS_TO_TEST=$FULL_API_RANGE
+
+          if $IS_PR ; then
+            LEVELS_TO_TEST=$PR_API_VERSION
           fi
+
+          for LEVEL in $LEVELS_TO_TEST
+            do
+              GCLOUD_RESULTS_DIR=${{ inputs.lib }}-api-${LEVEL}-build-${{github.run_number}}
+
+              gsutil ls gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/${GCLOUD_RESULTS_DIR} > /dev/null 2>&1
+              if [ $? == 0 ] ; then
+                mkdir firebase_${LEVEL}
+                gsutil -m cp -r -U "`gsutil ls gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/${GCLOUD_RESULTS_DIR} | tail -1`*" ./firebase_${LEVEL}/
+                mv firebase_${LEVEL}/test_result_1.xml firebase_results/api_${LEVEL}_test_result.xml
+              else
+                if $IS_PR ; then
+                  echo "No test results found"
+                  exit 1
+                fi
+              fi
+            done
       - name: Test Report
         uses: dorny/test-reporter@v1
         if: success() || failure()
         with:
           name: ${{ inputs.lib }} Test Results
-          path: firebase/results/*.xml    
+          path: firebase_results/**.xml    
           reporter: java-junit
       - name: Convert Code Coverage
         if: success() || failure()


### PR DESCRIPTION
This PR changes the Nightly test structure from running one Firebase Test Lab with all supported API levels simultaneously to running them sequentially.  

If we try to run 8 instances (API 28 to 35) of our tests at once, matrixes across all of our libraries, it is simply too many simultaneous API calls to the server and the tokens gets invalidated.  This also probably would have lead to a lot of flapping tests in MobileSync when manipulating data on the server.  

Here is an example of the report from a test I ran with just 28 and 35:
<img width="650" alt="Screenshot 2025-01-31 at 4 22 47 PM" src="https://github.com/user-attachments/assets/731d2378-76a6-48b4-be52-4dcd82df0c30" />

In production it will show all (8 as of now) supported API levels in a single report page per library:


<img width="872" alt="Screenshot 2025-01-31 at 6 37 28 PM" src="https://github.com/user-attachments/assets/867638f5-4c72-4ba0-8d88-0c89278f6ebe" />
