### PR TITLE
Restructure Nightly jobs to prevent flappers.

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,12 +6,36 @@ on:
   # This lets us trigger the workflow from a browser.
   workflow_dispatch:
 
+# Run the native libraries first so that the native, Hybrid and React MobileSync tests 
+# don't run simultaniously (to prevents flappers).
 jobs:
-  android-nightly:
+  android-nightly-core:
     strategy:
       fail-fast: false
       matrix:
-        lib: [SalesforceAnalytics, SalesforceSDK, SmartStore, MobileSync, SalesforceHybrid, SalesforceReact]
+        lib: [SalesforceAnalytics, SalesforceSDK, SmartStore, MobileSync]
+    uses: ./.github/workflows/reusable-workflow.yaml
+    with:
+      lib: ${{ matrix.lib }}
+    secrets: inherit
+  android-nightly-Hybrid:
+    if: success() || failure()
+    needs: [android-nightly-core]
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: [SalesforceHybrid]
+    uses: ./.github/workflows/reusable-workflow.yaml
+    with:
+      lib: ${{ matrix.lib }}
+    secrets: inherit
+  android-nightly-React:
+    if: success() || failure()
+    needs: [android-nightly-Hybrid]
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: [SalesforceReact]
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -84,9 +84,11 @@ jobs:
           IS_PR: ${{ inputs.is_pr }}
         run: |
           LEVELS_TO_TEST=$FULL_API_RANGE
+          RETRIES=0
 
           if $IS_PR ; then
             LEVELS_TO_TEST=$PR_API_VERSION
+            RETRIES=2
           fi
 
           mkdir firebase_results
@@ -104,7 +106,8 @@ jobs:
                 --directories-to-pull=/sdcard \
                 --results-dir=${GCLOUD_RESULTS_DIR} \
                 --results-history-name=${{ inputs.lib }} \
-                --timeout=20m --no-auto-google-login --no-record-video --no-performance-metrics --num-flaky-test-attempts=1 || true
+                --timeout=20m --no-auto-google-login --no-record-video --no-performance-metrics \
+                --num-flaky-test-attempts=${RETRIES} || true
             done
       - name: Copy Test Results
         continue-on-error: true
@@ -130,16 +133,28 @@ jobs:
                 mkdir firebase_${LEVEL}
                 gsutil -m cp -r -U "`gsutil ls gs://test-lab-w87i9sz6q175u-kwp8ium6js0zw/${GCLOUD_RESULTS_DIR} | tail -1`*" ./firebase_${LEVEL}/
                 mv firebase_${LEVEL}/test_result_1.xml firebase_results/api_${LEVEL}_test_result.xml
-              else
-                if $IS_PR ; then
-                  echo "No test results found"
-                  exit 1
-                fi
               fi
             done
+
+            # Move one result to the directory expected for code coverge.
+            mv firebase_${PR_API_VERSION} firebase
+      # Use this reporter for PRs because it correctly displays flapping/retried tests.
+      - name: Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: ${{ inputs.is_pr }}
+        with:
+          check_name: ${{ inputs.lib }} Test Results
+          job_name: ${{ inputs.lib }} Test Results
+          require_tests: true
+          check_retries: true
+          flaky_summary: true
+          fail_on_failure: true
+          detailed_summary: true
+          report_paths: 'firebase_results/**.xml'
+      # Use this reporter for Nightly tests because it displays results per API level.
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()
+        if: ${{ ! inputs.is_pr }}
         with:
           name: ${{ inputs.lib }} Test Results
           path: firebase_results/**.xml    
@@ -148,9 +163,10 @@ jobs:
         if: success() || failure()
         run: |
           ./gradlew libs:${{ inputs.lib }}:convertCodeCoverage
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: success() || failure()
         with:
+          files: libs/${{ inputs.lib }}/build/reports/jacoco/convertedCodeCoverage/convertedCodeCoverage.xml
           flags: ${{ inputs.lib }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Other improvements:
- Fixed Code Coverage reporting.
- Use of two different Test Reporters (for now?):
   - One for PRs:  This action understands and correctly reports "flaky" tests and tests that Firebase has re-run.  But it does not display multiple test runs well (stating 2k+ tests ran and 1 failed does not tell me which API version it failed on).  I have opened an issue asking for multi file support.
   - One for Nightlies: This action displays test results per file, so it is easy to tell what API levels tests pass or fail on.  Reports tests that fail at first and succeed on the re-run as failures.  I have commented on the issue asking for flaky/re-run support.
-  Increased the number of re-run attempts for PRs to 2 and decreased it to 0 for nightly runs (largely due to reporters).