### PR TITLE
LoginViewModel Customization (and cleanup)

### DIFF
--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -29,6 +29,7 @@
     <string name="sf__login_with_biometric">Log In with Biometric</string>
     <string name="sf__setup_biometric_unlock">Setup Biometric Unlock</string>
     <string name="sf__back_button_content_description">Back</string>
+    <string name="sf__loading_indicator">Loading</string>
 
     <!-- Server picker -->
     <string name="sf__auth_login_production">Production</string>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
@@ -126,7 +126,12 @@ public class LoginServerManager {
 
 		// Selection has been saved before.
 		if (name != null && url != null) {
-			selectedServer.postValue(new LoginServer(name, url, isCustom));
+			LoginServer server = new LoginServer(name, url, isCustom);
+
+			// Only notify livedata consumers if the value has changed.
+			if (!server.equals(selectedServer.getValue())) {
+				selectedServer.postValue(server);
+			}
 		} else {
 
 			// First time selection defaults to the first server on the list.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -283,7 +283,7 @@ open class LoginActivity : FragmentActivity() {
         viewModel.selectedServer.observe(this) {
             if (viewModel.singleServerCustomTabActivity) {
                 // Skip fetching authorization and show custom tab immediately.
-                viewModel.reloadWebview()
+                viewModel.reloadWebView()
                 viewModel.loginUrl.value?.let { url ->
                     loadLoginPageInCustomTab(url, customTabLauncher)
                 }
@@ -454,7 +454,7 @@ open class LoginActivity : FragmentActivity() {
                                 key = getPrivateKey(this, alias)
                             }
 
-                            viewModel.reloadWebview()
+                            viewModel.reloadWebView()
                         }.onFailure { throwable ->
                             e(TAG, "Exception thrown while retrieving X.509 certificate", throwable)
                         }
@@ -582,7 +582,7 @@ open class LoginActivity : FragmentActivity() {
         // Displays the error in a toast, clears cookies and reloads the login page
         runOnUiThread {
             makeText(this, "$error : $errorDesc", LENGTH_LONG).show()
-            viewModel.reloadWebview()
+            viewModel.reloadWebView()
         }
     }
 
@@ -834,7 +834,7 @@ open class LoginActivity : FragmentActivity() {
                         jwtFlowError()
                     } else {
                         viewModel.authCodeForJwtFlow = tokenResponse.authToken
-                        viewModel.reloadWebview()
+                        viewModel.reloadWebView()
                     }
                 }
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -68,19 +68,23 @@ import java.net.URI
 
 open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
 
-    // Default TopAppBar Customization
+    // DefaultTopAppBar Customization
 
-    /** Default TopAppBar Color. */
+    /** TopAppBar Color.  Defaults to WebView background color. */
     open var topBarColor: Color? = null
-
-    /**  */
+    /** TopAppBar text.  Defaults to login server url. */
     open var titleText: String? = null
+    /**
+     * TopAppBar text Color.  Defaults to black on light backgrounds and white
+     * on dark backgrounds.  Back and menu buttons will match this color.
+     */
     open var titleTextColor: Color? = null
 
     /** Loading Indicator */
     val loadingIndicator: (@Composable () -> Unit)? = null
 
-    // Default BottomAppBar Customization
+    // DefaultBottomAppBar Customization
+
     /**
      * A custom button to display on the login view bottom app bar.
      *
@@ -88,7 +92,6 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
      * or the Identity Provider flow is enabled.
      */
     open val customBottomBarButton = mutableStateOf<BottomBarButton?>(null)
-
 
     // Override App Bars
     val topAppBar: (@Composable () -> Unit)? = null

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginServerListItem.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginServerListItem.kt
@@ -178,28 +178,31 @@ fun LoginServerListItem(
             if (server.isCustom) {
                 CompositionLocalProvider(LocalRippleConfiguration provides null) {
                     val scope = rememberCoroutineScope()
-                    IconButton(
-                        onClick = {
-                            deleting = true
-                            scope.launch {
-                                delay(DELETE_ANIMATION_TIME.toLong())
-                                confirmDeleteFocus.requestFocus()
-                            }
-                        },
-                        enabled = !deleting,
-                        interactionSource = null,
-                        modifier = Modifier
-                            .padding(end = PADDING_SIZE.dp)
-                            .size(ICON_SIZE.dp)
-                            .offset { offset },
-                    ) {
-                        Icon(
-                            Icons.TwoTone.Delete,
-                            contentDescription = stringResource(sf__server_remove_content_description),
-                            tint = colorScheme.secondary.copy(
-                                alpha = if (deleting) 0f else 1f
-                            ),
-                        )
+
+                    ToolTipWrapper(sf__server_remove_content_description) { removeDescription ->
+                        IconButton(
+                            onClick = {
+                                deleting = true
+                                scope.launch {
+                                    delay(DELETE_ANIMATION_TIME.toLong())
+                                    confirmDeleteFocus.requestFocus()
+                                }
+                            },
+                            enabled = !deleting,
+                            interactionSource = null,
+                            modifier = Modifier
+                                .padding(end = PADDING_SIZE.dp)
+                                .size(ICON_SIZE.dp)
+                                .offset { offset },
+                        ) {
+                            Icon(
+                                Icons.TwoTone.Delete,
+                                contentDescription = removeDescription,
+                                tint = colorScheme.secondary.copy(
+                                    alpha = if (deleting) 0f else 1f
+                                ),
+                            )
+                        }
                     }
                 }
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginServerListItem.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginServerListItem.kt
@@ -63,7 +63,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -125,7 +124,6 @@ fun LoginServerListItem(
         derivedStateOf { with(density) { rowSizePixels.height.toDp() } }
     }
     val confirmDeleteFocus = remember { FocusRequester() }
-    LaunchedEffect(Unit) { /* Necessary for accessibility */ }
 
     Box {
         Row(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -28,8 +28,13 @@ package com.salesforce.androidsdk.ui.components
 
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.res.Configuration
+import android.webkit.WebView
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -41,7 +46,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.BottomAppBar
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
@@ -52,13 +56,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -67,217 +74,463 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.salesforce.androidsdk.R.color.sf__on_primary
-import com.salesforce.androidsdk.R.color.sf__primary_color
 import com.salesforce.androidsdk.R.string.sf__back_button_content_description
 import com.salesforce.androidsdk.R.string.sf__clear_cookies
 import com.salesforce.androidsdk.R.string.sf__launch_idp
-import com.salesforce.androidsdk.R.string.sf__login_title
 import com.salesforce.androidsdk.R.string.sf__more_options
 import com.salesforce.androidsdk.R.string.sf__pick_server
 import com.salesforce.androidsdk.R.string.sf__reload
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.ui.LoginActivity
 import com.salesforce.androidsdk.ui.LoginViewModel
+import com.salesforce.androidsdk.ui.theme.SFColors
+import com.salesforce.androidsdk.ui.theme.sfDarkColors
+import com.salesforce.androidsdk.ui.theme.sfLightColors
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Preview
+internal const val PADDING_SIZE = 12
+internal const val HEADER_TEXT_SIZE = 20
+internal const val TEXT_SIZE = 16
+internal const val CORNER_RADIUS = 12
+internal const val STROKE_WIDTH = 1
+internal const val BUTTON_HEIGHT = 48
+internal const val LEVEL_3_ELEVATION = 6
+internal const val HIDDEN_ALPHA = 0.0f
+internal const val VISIBLE_ALPHA = 100.0f
+internal const val LOADING_INDICATOR_SIZE = 50
+
 @Composable
 fun LoginView() {
     val activity: LoginActivity = LocalContext.current.getActivity() as LoginActivity
-    val viewModel: LoginViewModel = viewModel(factory = SalesforceSDKManager.getInstance().loginViewModelFactory)
-
-    val loginUrl: String = viewModel.loginUrl.observeAsState().value ?: ""
-    var showMenu by remember { mutableStateOf(false) }
+    val viewModel: LoginViewModel =
+        viewModel(factory = SalesforceSDKManager.getInstance().loginViewModelFactory)
     val titleText = if (viewModel.isUsingFrontDoorBridge) {
         viewModel.frontdoorBridgeServer ?: ""
     } else {
         viewModel.titleText ?: viewModel.defaultTitleText
     }
 
-    /*
-     * Note: Login view contents comply with two themes: Either the dynamic
-     * theme or the system theme based on their location in the layout.
-     */
-    // Dynamic colors derived from the web view content's background.
-    val dynamicBackgroundColor = viewModel.dynamicBackgroundColor.value
-    val dynamicHeaderTextColor = viewModel.dynamicHeaderTextColor.value
+    val topAppBar = viewModel.topAppBar ?: {
+        DefaultTopAppBar(
+            backgroundColor = viewModel.topBarColor ?: viewModel.dynamicBackgroundColor.value,
+            titleText = titleText,
+            titleTextColor = viewModel.titleTextColor ?: viewModel.dynamicHeaderTextColor.value,
+            showServerPicker = viewModel.showServerPicker,
+            clearCookies = { viewModel.clearCookies() },
+            reloadWebView = { viewModel.reloadWebView() },
+            shouldShowBackButton = viewModel.shouldShowBackButton,
+            finish = { activity.finish() },
+        )
+    }
 
-    // Dynamic colors which may by overridden by the view model.
-    val dynamicCustomizableTopBarColor = viewModel.topBarColor ?: viewModel.dynamicBackgroundColor.value
-
-    // System theme colors.
-    val themeRippleConfiguration = RippleConfiguration(color = colorScheme.onSecondary)
-
-    Scaffold(
-        topBar = {
-            @OptIn(ExperimentalMaterial3Api::class)
-            CenterAlignedTopAppBar(
-                expandedHeight = if (viewModel.showTopBar) TopAppBarDefaults.TopAppBarExpandedHeight else 0.dp,
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = dynamicCustomizableTopBarColor),
-                title = viewModel.titleComposable ?: {
-                    Text(
-                        text = titleText,
-                        color = dynamicHeaderTextColor,
-                        fontWeight = FontWeight.Bold,
-                    )
-                },
-                actions = @Composable {
-                    IconButton(
-                        onClick = { showMenu = !showMenu },
-                        colors = IconButtonColors(
-                            containerColor = Color.Transparent,
-                            contentColor = dynamicHeaderTextColor,
-                            disabledContainerColor = Color.Transparent,
-                            disabledContentColor = Color.Transparent,
-                        ),
-                    ) {
-                        Icon(Icons.Default.MoreVert, contentDescription = stringResource(sf__more_options))
-                    }
-                    CompositionLocalProvider(LocalRippleConfiguration provides themeRippleConfiguration) {
-                        DropdownMenu(
-                            expanded = showMenu,
-                            onDismissRequest = { showMenu = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(sf__pick_server)) },
-                                onClick = {
-                                    viewModel.showServerPicker.value = true
-                                    showMenu = false
-                                },
-                            )
-                            DropdownMenuItem(
-                                onClick = {
-                                    viewModel.clearCookies()
-                                    viewModel.reloadWebview()
-                                },
-                                text = { Text(stringResource(sf__clear_cookies)) },
-                            )
-                            DropdownMenuItem(
-                                onClick = { viewModel.reloadWebview() },
-                                text = { Text(stringResource(sf__reload)) },
-                            )
-                        }
-                    }
-                },
-                navigationIcon = {
-                    if (viewModel.shouldShowBackButton) {
-                        IconButton(
-                            onClick = { activity.finish() },
-                            colors = IconButtonColors(
-                                containerColor = Color.Transparent,
-                                contentColor = dynamicHeaderTextColor,
-                                disabledContainerColor = Color.Transparent,
-                                disabledContentColor = Color.Transparent,
-                            ),
-                        ) {
-                            Icon(
-                                Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = stringResource(sf__back_button_content_description),
-                            )
-                        }
-                    }
-                }
-            )
-        },
-        bottomBar = {
-            BottomAppBar(containerColor = dynamicBackgroundColor) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    if (viewModel.showBottomBarButtons.value) {
-                        if (viewModel.isBiometricAuthenticationLocked.value) {
-                            LoginBottomBarButton(viewModel.biometricAuthenticationButtonText.intValue) {
-                                activity.onBioAuthClick()
-                            }
-                        } else if (viewModel.isIDPLoginFlowEnabled.value) {
-                            LoginBottomBarButton(sf__launch_idp) {
-                                activity.onIDPLoginClick()
-                            }
-                        } else if (viewModel.customBottomBarButton.value != null) {
-                            viewModel.customBottomBarButton.value?.run {
-                                LoginBottomBarButton(title) { onClick }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-    ) { innerPadding ->
-        if (viewModel.loading.value) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
+    // Possible Buttons to show in BottomAppBar
+    val bioAuthButton: LoginViewModel.BottomBarButton? =
+        if (viewModel.isBiometricAuthenticationLocked.value) {
+            LoginViewModel.BottomBarButton(
+                stringResource(viewModel.biometricAuthenticationButtonText.intValue)
             ) {
-                CircularProgressIndicator(
-                    modifier = Modifier
-                        .size(50.dp)
-                        .fillMaxSize(),
-                )
+                viewModel.biometricAuthenticationButtonAction
             }
+        } else null
+    val idpButton =
+        if (viewModel.isIDPLoginFlowEnabled.value) {
+            LoginViewModel.BottomBarButton(stringResource(sf__launch_idp)) {
+                activity.onIDPLoginClick()
+            }
+        } else null
+    val customButton =
+        with(viewModel.customBottomBarButton.value) {
+            if (this != null) {
+                LoginViewModel.BottomBarButton(title) { onClick }
+            } else null
         }
 
-        // Load the webview as a composable
+    val bottomAppBar = viewModel.bottomAppBar ?: {
+        DefaultBottomAppBar(
+            backgroundColor = viewModel.dynamicBackgroundColor,
+            button = bioAuthButton ?: idpButton ?: customButton
+        )
+    }
+
+    LoginView(
+        loginUrlData = viewModel.loginUrl,
+        topAppBar = topAppBar,
+        webView = activity.webView,
+        loading = viewModel.loading.value,
+        loadingIndicator = viewModel.loadingIndicator ?: { DefaultLoadingIndicator() },
+        bottomAppBar = bottomAppBar,
+        showServerPicker = viewModel.showServerPicker,
+    )
+}
+
+@Composable
+internal fun LoginView(
+    loginUrlData: LiveData<String>,
+    topAppBar: @Composable () -> Unit,
+    webView: WebView,
+    loading: Boolean,
+    loadingIndicator: @Composable () -> Unit,
+    bottomAppBar: @Composable () -> Unit,
+    showServerPicker: MutableState<Boolean>,
+) {
+    val loginUrl = loginUrlData.observeAsState()
+
+    Scaffold(
+        topBar = topAppBar,
+        bottomBar = bottomAppBar,
+    ) { innerPadding ->
+        if (loading) {
+            loadingIndicator()
+        }
+
+        // Load the WebView as a composable
         AndroidView(
             modifier = Modifier
                 .padding(innerPadding)
-                .alpha(if (viewModel.loading.value) 0.0f else 100.0f),
-            factory = { activity.webView },
-            update = { it.loadUrl(loginUrl) },
+                .alpha(if (loading) HIDDEN_ALPHA else VISIBLE_ALPHA),
+            factory = { webView },
+            update = { it.loadUrl(loginUrl.value ?: "") },
         )
 
-        if (viewModel.showServerPicker.value) {
+        if (showServerPicker.value) {
             PickerBottomSheet(PickerStyle.LoginServerPicker)
         }
     }
 }
 
-/**
- * Composes a button for the bottom bar.
- * @param textStringRes The button's text string resource
- * @param onClick The button's on click behavior
- */
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Preview
-fun LoginBottomBarButton(
-    textStringRes: Int = sf__login_title,
-    onClick: () -> Unit = {}
+internal fun DefaultTopAppBar(
+    backgroundColor: Color,
+    titleText: String,
+    titleTextColor: Color,
+    showServerPicker: MutableState<Boolean>,
+    clearCookies: () -> Unit,
+    reloadWebView: () -> Unit,
+    shouldShowBackButton: Boolean,
+    finish: () -> Unit,
 ) {
-    Button(
-        onClick = onClick,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(50.dp)
-            .padding(start = 20.dp, end = 20.dp),
-        shape = (RoundedCornerShape(5.dp)),
-        colors = ButtonDefaults.buttonColors(
-            containerColor = colorResource(id = sf__primary_color),
-            contentColor = colorResource(id = sf__on_primary)
-        )
+    var showMenu by remember { mutableStateOf(false) }
+
+    CenterAlignedTopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = backgroundColor),
+        title = {
+            Text(
+                text = titleText,
+                color = titleTextColor,
+                fontSize = HEADER_TEXT_SIZE.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        actions = @Composable {
+            IconButton(
+                onClick = { showMenu = !showMenu },
+                colors = IconButtonColors(
+                    containerColor = Color.Transparent,
+                    contentColor = titleTextColor,
+                    disabledContainerColor = Color.Transparent,
+                    disabledContentColor = Color.Transparent,
+                ),
+            ) {
+                Icon(Icons.Default.MoreVert, contentDescription = stringResource(sf__more_options))
+            }
+            CompositionLocalProvider(
+                LocalRippleConfiguration provides RippleConfiguration(color = colorScheme.onSecondary)
+            ) {
+                DropdownMenu(
+                    expanded = showMenu,
+                    onDismissRequest = { showMenu = false },
+                ) {
+                    MenuItem(stringResource(sf__pick_server)) {
+                        showServerPicker.value = true
+                        showMenu = false
+                    }
+                    MenuItem(stringResource(sf__clear_cookies)) {
+                        clearCookies()
+                        reloadWebView()
+                    }
+                    MenuItem(stringResource(sf__reload)) {
+                        reloadWebView()
+                    }
+                }
+            }
+        },
+        navigationIcon = {
+            if (shouldShowBackButton) {
+                IconButton(
+                    onClick = { finish() },
+                    colors = IconButtonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = titleTextColor,
+                        disabledContainerColor = Color.Transparent,
+                        disabledContentColor = Color.Transparent,
+                    ),
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(sf__back_button_content_description),
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Composable
+internal fun DefaultLoadingIndicator() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = stringResource(id = textStringRes),
-            fontSize = 14.sp
+        CircularProgressIndicator(
+            modifier = Modifier
+                .size(LOADING_INDICATOR_SIZE.dp)
+                .fillMaxSize(),
         )
     }
 }
 
-// Get access to host activity from within Compose.  tailrec makes this safe.
+@Composable
+internal fun MenuItem(
+    text: String,
+    onClick: () -> Unit,
+) {
+    DropdownMenuItem(
+        text = {
+            Text(
+                text = text,
+                fontWeight = FontWeight.Light,
+                fontSize = TEXT_SIZE.sp
+            )
+        },
+        onClick = onClick,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DefaultBottomAppBar(
+    backgroundColor: MutableState<Color>,
+    button: LoginViewModel.BottomBarButton?,
+) {
+    BottomAppBar(containerColor = backgroundColor.value) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            if (button != null) {
+                val buttonShape = RoundedCornerShape(CORNER_RADIUS.dp)
+                CompositionLocalProvider(
+                     LocalRippleConfiguration provides RippleConfiguration(color = colorScheme.onSecondary)
+                ) {
+                    OutlinedButton(
+                        onClick = button.onClick,
+                        modifier = Modifier
+                            .padding(PADDING_SIZE.dp)
+                            .height(BUTTON_HEIGHT.dp)
+                            .fillMaxWidth()
+                            .shadow(LEVEL_3_ELEVATION.dp, buttonShape),
+                        shape = buttonShape,
+                        contentPadding = PaddingValues(PADDING_SIZE.dp),
+                        border = BorderStroke(
+                            width = STROKE_WIDTH.dp,
+                            color = Color(SFColors.outlineColor(LocalContext.current)),
+                        ),
+                        colors = ButtonDefaults.outlinedButtonColors(containerColor = Color.White)
+                    ) {
+                        Text(
+                            text = button.title,
+                            color = Color(SFColors.primaryColor(LocalContext.current)),
+                            fontSize = TEXT_SIZE.sp,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Get access to host activity from within Compose.  tail rec makes this safe.
 private tailrec fun Context.getActivity(): FragmentActivity? = when (this) {
     is FragmentActivity -> this
     is ContextWrapper -> baseContext.getActivity()
     else -> null
 }
 
+// Note: the light and dark previews should look the same.
+@Preview
+@Preview("Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES, backgroundColor = 0xFF181818)
+@Composable
+private fun AppBarPreview() {
+    val loginUrl = "https://login.salesforce.com"
+    val backgroundColor = Color(red = 244, green = 246, blue = 249)
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultTopAppBar(
+            backgroundColor = backgroundColor,
+            titleText = loginUrl,
+            titleTextColor = Color.Black,
+            showServerPicker = remember { mutableStateOf(false) },
+            clearCookies = { },
+            reloadWebView = { },
+            shouldShowBackButton = false,
+            finish = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AppBarBackButtonPreview() {
+    val loginUrl = "https://login.salesforce.com"
+    val backgroundColor = Color(red = 244, green = 246, blue = 249)
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultTopAppBar(
+            backgroundColor = backgroundColor,
+            titleText = loginUrl,
+            titleTextColor = Color.Black,
+            showServerPicker = remember { mutableStateOf(false) },
+            clearCookies = { },
+            reloadWebView = { },
+            shouldShowBackButton = true,
+            finish = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AppBarDarkPreview() {
+    val loginUrl = "https://login.salesforce.com"
+    val backgroundColor = Color(0xFF181818)
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultTopAppBar(
+            backgroundColor = backgroundColor,
+            titleText = loginUrl,
+            titleTextColor = Color.White,
+            showServerPicker = remember { mutableStateOf(false) },
+            clearCookies = { },
+            reloadWebView = { },
+            shouldShowBackButton = true,
+            finish = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BlueAppBarPreview() {
+    val loginUrl = "https://login.salesforce.com"
+    val backgroundColor = sfLightColors().primary
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultTopAppBar(
+            backgroundColor = backgroundColor,
+            titleText = loginUrl,
+            titleTextColor = Color.White,
+            showServerPicker = remember { mutableStateOf(false) },
+            clearCookies = { },
+            reloadWebView = { },
+            shouldShowBackButton = true,
+            finish = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CustomTextAppBarPreview() {
+    val backgroundColor = sfLightColors().primary
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultTopAppBar(
+            backgroundColor = backgroundColor,
+            titleText = "Log In",
+            titleTextColor = Color.White,
+            showServerPicker = remember { mutableStateOf(false) },
+            clearCookies = { },
+            reloadWebView = { },
+            shouldShowBackButton = false,
+            finish = { },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LongCustomTextAppBarPreview() {
+    val backgroundColor = Color.White
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultTopAppBar(
+            backgroundColor = backgroundColor,
+            titleText = "https://mobilesdk.my.salesforce.com",
+            titleTextColor = Color.Black,
+            showServerPicker = remember { mutableStateOf(false) },
+            clearCookies = { },
+            reloadWebView = { },
+            shouldShowBackButton = true,
+            finish = { },
+        )
+    }
+}
+
+@Preview("Light Mode", showBackground = true, widthDp = 100, heightDp = 100)
+@Preview(
+    "Dark Mode",
+    showBackground = true,
+    widthDp = 100,
+    heightDp = 100,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    backgroundColor = 0xFF181818
+)
+@Composable
+private fun LoadingIndicatorPreview() {
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultLoadingIndicator()
+    }
+}
+
+// Note: the light and dark previews should look the same.
+@Preview
+@Preview("Dark Mode", uiMode = Configuration.UI_MODE_NIGHT_YES, backgroundColor = 0xFF181818)
+@Composable
+private fun BottomBarPreview() {
+    val backgroundColor = Color.White
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultBottomAppBar(
+            backgroundColor = remember { mutableStateOf(backgroundColor) },
+            button = LoginViewModel.BottomBarButton(
+                title = "Login Button Preview",
+                onClick = { }
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun BottomBarRedPreview() {
+    val backgroundColor = Color(0xFF900603)
+    MaterialTheme(colorScheme = if (isSystemInDarkTheme()) sfDarkColors() else sfLightColors()) {
+        DefaultBottomAppBar(
+            backgroundColor = remember { mutableStateOf(backgroundColor) },
+            button = LoginViewModel.BottomBarButton(
+                title = "Login Button Preview",
+                onClick = { }
+            )
+        )
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -78,6 +78,8 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -90,6 +92,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.salesforce.androidsdk.R.string.sf__back_button_content_description
 import com.salesforce.androidsdk.R.string.sf__clear_cookies
 import com.salesforce.androidsdk.R.string.sf__launch_idp
+import com.salesforce.androidsdk.R.string.sf__loading_indicator
 import com.salesforce.androidsdk.R.string.sf__more_options
 import com.salesforce.androidsdk.R.string.sf__pick_server
 import com.salesforce.androidsdk.R.string.sf__reload
@@ -297,10 +300,12 @@ internal fun DefaultLoadingIndicator() {
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
+        val description = stringResource(sf__loading_indicator)
         CircularProgressIndicator(
             modifier = Modifier
                 .size(LOADING_INDICATOR_SIZE.dp)
-                .fillMaxSize(),
+                .fillMaxSize()
+                .semantics { contentDescription = description },
         )
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -278,9 +278,11 @@ internal fun DefaultTopAppBar(
                     MenuItem(stringResource(sf__clear_cookies)) {
                         clearCookies()
                         reloadWebView()
+                        showMenu = false
                     }
                     MenuItem(stringResource(sf__reload)) {
                         reloadWebView()
+                        showMenu = false
                     }
                 }
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -138,7 +138,6 @@ enum class PickerStyle {
 
 internal const val ICON_SIZE = 32
 internal const val HEADER_PADDING_SIZE = 16
-internal const val SLOW_ANIMATION_MS = 500
 internal const val TEXT_SELECTION_ALPHA = 0.2f
 
 
@@ -149,12 +148,10 @@ fun PickerBottomSheet(pickerStyle: PickerStyle) {
     val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
     val userAccountManager = SalesforceSDKManager.getInstance().userAccountManager
     val activity = LocalContext.current.getActivity()
-    val backgroundColor = SalesforceSDKManager.getInstance().colorScheme().background
     val onNewLoginServerSelected = { newSelectedServer: Any?, closePicker: Boolean ->
         if (newSelectedServer != null && newSelectedServer is LoginServer) {
             viewModel.showServerPicker.value = !closePicker
             viewModel.loading.value = true
-            viewModel.dynamicBackgroundColor.value = backgroundColor
             SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer = newSelectedServer
         }
     }
@@ -188,7 +185,6 @@ fun PickerBottomSheet(pickerStyle: PickerStyle) {
         loginServerManager.addCustomLoginServer(name, url)
         viewModel.showServerPicker.value = false
         viewModel.loading.value = true
-        viewModel.dynamicBackgroundColor.value = backgroundColor
     }
 
     when (pickerStyle) {
@@ -438,8 +434,13 @@ internal fun PickerBottomSheet(
                                             ) {
                                                 Text(
                                                     text = when (pickerStyle) {
-                                                        PickerStyle.LoginServerPicker -> stringResource(sf__custom_url_button)
-                                                        PickerStyle.UserAccountPicker -> stringResource(sf__add_new_account)
+                                                        PickerStyle.LoginServerPicker -> stringResource(
+                                                            sf__custom_url_button
+                                                        )
+
+                                                        PickerStyle.UserAccountPicker -> stringResource(
+                                                            sf__add_new_account
+                                                        )
                                                     },
                                                     color = colorScheme.primary,
                                                     fontSize = TEXT_SIZE.sp,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -277,20 +277,22 @@ internal fun PickerBottomSheet(
                         enter = fadeIn(),
                         exit = fadeOut(),
                     ) {
-                        IconButton(
-                            onClick = { addingNewServer = false },
-                            colors = IconButtonColors(
-                                containerColor = Color.Transparent,
-                                contentColor = colorScheme.secondary,
-                                disabledContainerColor = Color.Transparent,
-                                disabledContentColor = Color.Transparent,
-                            ),
-                            modifier = Modifier.size(ICON_SIZE.dp),
-                        ) {
-                            Icon(
-                                Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = stringResource(sf__back_button_content_description),
-                            )
+                        ToolTipWrapper(sf__back_button_content_description) { backButtonDescription ->
+                            IconButton(
+                                onClick = { addingNewServer = false },
+                                colors = IconButtonColors(
+                                    containerColor = Color.Transparent,
+                                    contentColor = colorScheme.secondary,
+                                    disabledContainerColor = Color.Transparent,
+                                    disabledContentColor = Color.Transparent,
+                                ),
+                                modifier = Modifier.size(ICON_SIZE.dp),
+                            ) {
+                                Icon(
+                                    Icons.AutoMirrored.Filled.ArrowBack,
+                                    contentDescription = backButtonDescription,
+                                )
+                            }
                         }
                     }
                     // Picker Title Text
@@ -311,20 +313,22 @@ internal fun PickerBottomSheet(
                         fontWeight = FontWeight.SemiBold,
                     )
                     // Close Button
-                    IconButton(
-                        onClick = { coroutineScope.launch { sheetState.hide() } },
-                        colors = IconButtonColors(
-                            containerColor = Color.Transparent,
-                            contentColor = colorScheme.secondary,
-                            disabledContainerColor = Color.Transparent,
-                            disabledContentColor = Color.Transparent,
-                        ),
-                        modifier = Modifier.size(ICON_SIZE.dp),
-                    ) {
-                        Icon(
-                            Icons.Default.Close,
-                            contentDescription = stringResource(sf__server_close_button_content_description),
-                        )
+                    ToolTipWrapper(sf__server_close_button_content_description) { closeButtonDescription ->
+                        IconButton(
+                            onClick = { coroutineScope.launch { sheetState.hide() } },
+                            colors = IconButtonColors(
+                                containerColor = Color.Transparent,
+                                contentColor = colorScheme.secondary,
+                                disabledContainerColor = Color.Transparent,
+                                disabledContentColor = Color.Transparent,
+                            ),
+                            modifier = Modifier.size(ICON_SIZE.dp),
+                        ) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = closeButtonDescription,
+                            )
+                        }
                     }
                 }
                 HorizontalDivider(thickness = STROKE_WIDTH.dp, color = colorScheme.surfaceVariant)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -83,7 +83,6 @@ import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -129,6 +128,7 @@ import com.salesforce.androidsdk.ui.LoginViewModel
 import com.salesforce.androidsdk.ui.theme.hintTextColor
 import com.salesforce.androidsdk.ui.theme.sfDarkColors
 import com.salesforce.androidsdk.ui.theme.sfLightColors
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 enum class PickerStyle {
@@ -236,6 +236,15 @@ internal fun PickerBottomSheet(
         PickerStyle.UserAccountPicker -> stringResource(sf__account_picker_content_description)
     }
     val themeRippleConfiguration = RippleConfiguration(color = colorScheme.onSecondary)
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        coroutineScope.launch {
+            delay(SLOW_ANIMATION_MS.toLong())
+            pickerFocus.requestFocus()
+        }
+    }
+
     CompositionLocalProvider(LocalRippleConfiguration provides themeRippleConfiguration) {
         ModalBottomSheet(
             onDismissRequest = { /* Do nothing */ },
@@ -255,7 +264,6 @@ internal fun PickerBottomSheet(
                     .focusRequester(pickerFocus)
                     .focusable(),
             ) {
-                SideEffect { pickerFocus.requestFocus() }
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -303,7 +311,6 @@ internal fun PickerBottomSheet(
                         fontWeight = FontWeight.SemiBold,
                     )
                     // Close Button
-                    val coroutineScope = rememberCoroutineScope()
                     IconButton(
                         onClick = { coroutineScope.launch { sheetState.hide() } },
                         colors = IconButtonColors(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -136,13 +136,8 @@ enum class PickerStyle {
     UserAccountPicker,
 }
 
-internal const val PADDING_SIZE = 12
 internal const val ICON_SIZE = 32
-internal const val HEADER_TEXT_SIZE = 20
 internal const val HEADER_PADDING_SIZE = 16
-internal const val TEXT_SIZE = 16
-internal const val CORNER_RADIUS = 9
-internal const val STROKE_WIDTH = 1
 internal const val SLOW_ANIMATION_MS = 500
 internal const val TEXT_SELECTION_ALPHA = 0.2f
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -110,7 +110,7 @@ class LoginViewModelTest {
         val originalCodeChallenge = getSHA256Hash(viewModel.codeVerifier)
         Assert.assertTrue(viewModel.loginUrl.value!!.contains(originalCodeChallenge))
 
-        viewModel.reloadWebview()
+        viewModel.reloadWebView()
         val newCodeChallenge = getSHA256Hash(viewModel.codeVerifier)
         Assert.assertNotNull(newCodeChallenge)
         Assert.assertNotEquals(originalCodeChallenge, newCodeChallenge)
@@ -126,7 +126,7 @@ class LoginViewModelTest {
 
         viewModel.jwt = FAKE_JWT
         viewModel.authCodeForJwtFlow = FAKE_JWT_FLOW_AUTH
-        viewModel.reloadWebview()
+        viewModel.reloadWebView()
         Assert.assertNotEquals(expectedUrl, viewModel.loginUrl.value)
 
         codeChallenge = getSHA256Hash(viewModel.codeVerifier)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
@@ -305,11 +305,11 @@ class LoginViewActivityTest {
         )
         val button = androidComposeTestRule.onNodeWithText(BUTTON_TITLE)
 
-        backButton.assertIsNotDisplayed()
-        titleText.assertIsNotDisplayed()
-        menu.assertIsNotDisplayed()
+        backButton.assertIsDisplayed()
+        titleText.assertIsDisplayed()
+        menu.assertIsDisplayed()
         loadingIndicator.assertIsDisplayed()
-        button.assertIsNotDisplayed()
+        button.assertIsDisplayed()
     }
 
     // test (not) loading
@@ -380,8 +380,10 @@ class LoginViewActivityTest {
     private fun DefaultBottomAppBarTestWrapper(
         backgroundColor: MutableState<Color> = mutableStateOf(Color.White),
         button: LoginViewModel.BottomBarButton? = null,
+        loading: Boolean = false,
+        showButton: Boolean = true,
     ) {
-        DefaultBottomAppBar(backgroundColor, button)
+        DefaultBottomAppBar(backgroundColor, button, loading, showButton)
     }
 
     /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2025-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.ui
+
+import android.webkit.WebView
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.liveData
+import com.salesforce.androidsdk.R
+import com.salesforce.androidsdk.ui.components.DefaultBottomAppBar
+import com.salesforce.androidsdk.ui.components.DefaultLoadingIndicator
+import com.salesforce.androidsdk.ui.components.DefaultTopAppBar
+import com.salesforce.androidsdk.ui.components.LoginView
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+private const val DEFAULT_URL = "https://login.salesforce.com"
+private const val BUTTON_TITLE = "Test Button"
+
+class LoginViewActivityTest {
+
+    @get:Rule
+    val androidComposeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun topAppBar_Default_DisplaysCorrectly() {
+        androidComposeTestRule.setContent {
+            DefaultTopAppBarTestWrapper()
+        }
+
+        val backButton = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__back_button_content_description)
+        )
+        val titleText = androidComposeTestRule.onNodeWithText(DEFAULT_URL)
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+
+        backButton.assertDoesNotExist()
+        titleText.assertIsDisplayed()
+        menu.assertIsDisplayed()
+    }
+
+    @Test
+    fun topAppBar_TapBackButton_CallsFinish() {
+        var finishCalled = false
+        androidComposeTestRule.setContent {
+            DefaultTopAppBarTestWrapper(
+                shouldShowBackButton = true,
+                finish = { finishCalled = true }
+            )
+        }
+
+        val backButton = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__back_button_content_description)
+        )
+        val titleText = androidComposeTestRule.onNodeWithText(DEFAULT_URL)
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+
+        backButton.assertExists()
+        backButton.assertIsDisplayed()
+        titleText.assertIsDisplayed()
+        menu.assertIsDisplayed()
+        Assert.assertFalse("Finish should not be called yet", finishCalled)
+
+        // Tap Back Button
+        backButton.performClick()
+        Assert.assertTrue("Finish not called.", finishCalled)
+    }
+
+    @Test
+    fun topAppBar_ChangeServerButton_OpensServerPicker() {
+        var showPicker: MutableState<Boolean>? = null
+        androidComposeTestRule.setContent {
+            showPicker = remember { mutableStateOf(false) }
+            DefaultTopAppBarTestWrapper(
+                showServerPicker = showPicker!!
+            )
+        }
+
+        val backButton = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__back_button_content_description)
+        )
+        val titleText = androidComposeTestRule.onNodeWithText(DEFAULT_URL)
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+        val changeServerButton = androidComposeTestRule.onNodeWithText(
+            androidComposeTestRule.activity.getString(R.string.sf__pick_server)
+        )
+
+        backButton.assertDoesNotExist()
+        titleText.assertIsDisplayed()
+        menu.assertIsDisplayed()
+
+        menu.performClick()
+        changeServerButton.assertIsDisplayed()
+        Assert.assertFalse("Picker should not be shown yet.", showPicker!!.value)
+
+        changeServerButton.performClick()
+        Assert.assertTrue("Picker should be shown.", showPicker!!.value)
+    }
+
+    @Test
+    fun topAppBar_ClearCookiesButton_ClearsCookiesAndReloads() {
+        var clearCookiesCalled = false
+        var reloadCalled = false
+        androidComposeTestRule.setContent {
+            DefaultTopAppBarTestWrapper(
+                clearCookies = { clearCookiesCalled = true },
+                reloadWebView = { reloadCalled = true },
+            )
+        }
+
+        val backButton = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__back_button_content_description)
+        )
+        val titleText = androidComposeTestRule.onNodeWithText(DEFAULT_URL)
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+        val clearCookiesButton = androidComposeTestRule.onNodeWithText(
+            androidComposeTestRule.activity.getString(R.string.sf__clear_cookies)
+        )
+
+        backButton.assertDoesNotExist()
+        titleText.assertIsDisplayed()
+        menu.assertIsDisplayed()
+
+        menu.performClick()
+        clearCookiesButton.assertIsDisplayed()
+        Assert.assertFalse("Clear cookies should not be called yet.", clearCookiesCalled)
+        Assert.assertFalse("Reload should not be called yet.", reloadCalled)
+
+        clearCookiesButton.performClick()
+        Assert.assertTrue("Clear cookies should be called.", clearCookiesCalled)
+        Assert.assertTrue("Reload should be called.", reloadCalled)
+    }
+
+    @Test
+    fun topAppBar_ReloadButton_CallsReload() {
+        var reloadCalled = false
+        androidComposeTestRule.setContent {
+            DefaultTopAppBarTestWrapper(
+                reloadWebView = { reloadCalled = true },
+            )
+        }
+
+        val backButton = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__back_button_content_description)
+        )
+        val titleText = androidComposeTestRule.onNodeWithText(DEFAULT_URL)
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+        val reloadButton = androidComposeTestRule.onNodeWithText(
+            androidComposeTestRule.activity.getString(R.string.sf__reload)
+        )
+
+        backButton.assertDoesNotExist()
+        titleText.assertIsDisplayed()
+        menu.assertIsDisplayed()
+
+        menu.performClick()
+        reloadButton.assertIsDisplayed()
+        Assert.assertFalse("Reload should not be called yet.", reloadCalled)
+
+        reloadButton.performClick()
+        Assert.assertTrue("Reload should be called.", reloadCalled)
+    }
+
+    @Test
+    fun bottomAppBar_WithNoButton_DisplaysCorrectly() {
+        androidComposeTestRule.setContent {
+            DefaultBottomAppBarTestWrapper()
+        }
+
+        val button = androidComposeTestRule.onNodeWithText(BUTTON_TITLE)
+        button.assertDoesNotExist()
+    }
+
+    @Test
+    fun bottomAppBar_WithButton_DisplaysCorrectly() {
+        var buttonClicked = false
+        androidComposeTestRule.setContent {
+            DefaultBottomAppBarTestWrapper(button = LoginViewModel.BottomBarButton(BUTTON_TITLE) {
+                buttonClicked = true
+            })
+        }
+
+        val button = androidComposeTestRule.onNodeWithText(BUTTON_TITLE)
+        button.assertExists()
+        button.assertIsDisplayed()
+        button.assertIsEnabled()
+        Assert.assertFalse("Button should not be clicked yet.", buttonClicked)
+
+        button.performClick()
+        Assert.assertTrue("Button should have been clicked.", buttonClicked)
+    }
+
+    @Test
+    fun loginView_DefaultComponents_DisplayCorrectly() {
+        androidComposeTestRule.setContent {
+            LoginViewTestWrapper(
+                topAppBar = {
+                    DefaultTopAppBarTestWrapper(shouldShowBackButton = true)
+                },
+                bottomAppBar = {
+                    DefaultBottomAppBarTestWrapper(button = LoginViewModel.BottomBarButton(BUTTON_TITLE) {})
+                },
+                loading = false,
+            )
+        }
+
+        val backButton = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__back_button_content_description)
+        )
+        val titleText = androidComposeTestRule.onNodeWithText(DEFAULT_URL)
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+        val loadingIndicator = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__loading_indicator)
+        )
+        val button = androidComposeTestRule.onNodeWithText(BUTTON_TITLE)
+
+        backButton.assertIsDisplayed()
+        titleText.assertIsDisplayed()
+        menu.assertIsDisplayed()
+        loadingIndicator.assertIsNotDisplayed()
+        button.assertIsDisplayed()
+    }
+
+    @Test
+    fun loginView_Loading_DisplayCorrectly() {
+        androidComposeTestRule.setContent {
+            LoginViewTestWrapper(
+                topAppBar = {
+                    DefaultTopAppBarTestWrapper(shouldShowBackButton = true)
+                },
+                bottomAppBar = {
+                    DefaultBottomAppBarTestWrapper(button = LoginViewModel.BottomBarButton(BUTTON_TITLE) {})
+                },
+                loading = true,
+            )
+        }
+
+        val backButton = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__back_button_content_description)
+        )
+        val titleText = androidComposeTestRule.onNodeWithText(DEFAULT_URL)
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+        val loadingIndicator = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__loading_indicator)
+        )
+        val button = androidComposeTestRule.onNodeWithText(BUTTON_TITLE)
+
+        backButton.assertIsNotDisplayed()
+        titleText.assertIsNotDisplayed()
+        menu.assertIsNotDisplayed()
+        loadingIndicator.assertIsDisplayed()
+        button.assertIsNotDisplayed()
+    }
+
+    // test (not) loading
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun loginView_CustomComponents_DisplayCorrectly() {
+        val customTopAppBar = @Composable {
+            LargeTopAppBar(
+                title = { Text("Test") },
+                modifier = Modifier.semantics { contentDescription = "CustomTopAppBar" }
+            )
+        }
+        val customLoadingIndicator = @Composable {
+            LinearProgressIndicator(
+                modifier = Modifier.semantics { contentDescription = "CustomLoadingIndicator" }
+            )
+        }
+        val customBottomAppBar = @Composable {
+            BottomAppBar(
+                content = { },
+                modifier = Modifier.semantics { contentDescription = "CustomBottomAppBar" },
+            )
+        }
+
+        androidComposeTestRule.setContent {
+            LoginViewTestWrapper(
+                topAppBar = customTopAppBar,
+                loading = true,
+                loadingIndicator = customLoadingIndicator,
+                bottomAppBar = customBottomAppBar,
+            )
+        }
+
+        val topAppBar = androidComposeTestRule.onNodeWithContentDescription("CustomTopAppBar")
+        val loadingIndicator = androidComposeTestRule.onNodeWithContentDescription("CustomLoadingIndicator")
+        val bottomAppBar = androidComposeTestRule.onNodeWithContentDescription("CustomBottomAppBar")
+
+        topAppBar.assertIsDisplayed()
+        loadingIndicator.assertIsDisplayed()
+        bottomAppBar.assertIsDisplayed()
+    }
+
+    /**
+     * This wrapper makes most component input optional so it is more clear what the test is actually doing.
+     */
+    @Composable
+    private fun DefaultTopAppBarTestWrapper(
+        backgroundColor: Color = Color.White,
+        titleText: String = DEFAULT_URL,
+        titleTextColor: Color = Color.Black,
+        showServerPicker: MutableState<Boolean> = remember { mutableStateOf(false) },
+        clearCookies: () -> Unit = { },
+        reloadWebView: () -> Unit = { },
+        shouldShowBackButton: Boolean = false,
+        finish: () -> Unit = { },
+    ) {
+        DefaultTopAppBar(
+            backgroundColor, titleText, titleTextColor, showServerPicker, clearCookies,
+            reloadWebView, shouldShowBackButton, finish
+        )
+    }
+
+    /**
+     * This wrapper makes most component input optional so it is more clear what the test is actually doing.
+     */
+    @Composable
+    private fun DefaultBottomAppBarTestWrapper(
+        backgroundColor: MutableState<Color> = mutableStateOf(Color.White),
+        button: LoginViewModel.BottomBarButton? = null,
+    ) {
+        DefaultBottomAppBar(backgroundColor, button)
+    }
+
+    /**
+     * This wrapper makes most component input optional so it is more clear what the test is actually doing.
+     */
+    @Composable
+    private fun LoginViewTestWrapper(
+        loginUrlData: LiveData<String> = liveData { DEFAULT_URL },
+        topAppBar: @Composable () -> Unit = { DefaultTopAppBarTestWrapper() },
+        webView: WebView = WebView(LocalContext.current),
+        loading: Boolean = false,
+        loadingIndicator: @Composable () -> Unit = { DefaultLoadingIndicator() },
+        bottomAppBar: @Composable () -> Unit = { DefaultBottomAppBarTestWrapper() },
+        showServerPicker: MutableState<Boolean> = mutableStateOf(false),
+    ) {
+        LoginView(loginUrlData, topAppBar, webView, loading, loadingIndicator, bottomAppBar, showServerPicker)
+    }
+}


### PR DESCRIPTION
<img width="2533" alt="Screenshot 2025-02-14 at 4 09 36 PM" src="https://github.com/user-attachments/assets/b50ac73c-c915-478a-847f-376981149fdc" />

Tooltips:
<img width="1634" alt="Screenshot 2025-02-17 at 9 19 40 PM" src="https://github.com/user-attachments/assets/ec04bfe2-e0e8-449f-b269-14279bef6de7" />


TODO List:
- [X] Add simple header, loading indicator and bottom button customization options.
- [X] Allow the app to replace TopAppBar and BottomAppBar.
- [X] Fix bottom button style.  
- [X] Cleanup magic numbers.  
- [X] Add previews.
- [X] Add Compose Semantic Tests.
- [X] Improve loading animation. 
- [X] Fix TopAppBar and BottomAppBar visible while loading.
- [X] Fix WebView reloading when Change Server menu shows
- [X] Fix TopAppBar and WebView being visible when showing Login Server Picker after backing out of Custom Tab.
- [X] Improved TalkBack Accessibility focus.
- [X] Added Tooltips to all Icon Buttons.