### PR TITLE
@W-17920337: [MSDK Android] `MobileSyncTest` Test Suite Fails Due To Removal Of Login Options

### DIFF
--- a/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/ManagerTestCase.java
+++ b/libs/test/MobileSyncTest/src/com/salesforce/androidsdk/mobilesync/manager/ManagerTestCase.java
@@ -52,7 +52,6 @@ import com.salesforce.androidsdk.mobilesync.util.Constants;
 import com.salesforce.androidsdk.mobilesync.util.MobileSyncLogger;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
 import com.salesforce.androidsdk.rest.ClientManager;
-import com.salesforce.androidsdk.rest.ClientManager.LoginOptions;
 import com.salesforce.androidsdk.rest.RestClient;
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo;
 import com.salesforce.androidsdk.rest.RestRequest;
@@ -110,10 +109,11 @@ abstract public class ManagerTestCase {
         if (MobileSyncSDKManager.getInstance() == null) {
             eq.waitForEvent(EventType.AppCreateComplete, 5000);
         }
-        final LoginOptions loginOptions = new LoginOptions(LOGIN_URL,
-        		TEST_CALLBACK_URL, CLIENT_ID, TEST_SCOPES);
-        final ClientManager clientManager = new ClientManager(targetContext,
-        		TestCredentials.ACCOUNT_TYPE, loginOptions, true);
+        final ClientManager clientManager = new ClientManager(
+                targetContext,
+                TestCredentials.ACCOUNT_TYPE,
+                true
+        );
         clientManager.createNewAccount(ACCOUNT_NAME,
         		USERNAME, TestCredentials.REFRESH_TOKEN,
         		TEST_AUTH_TOKEN, INSTANCE_URL,


### PR DESCRIPTION
🎸 *_Ready For Review_* 🥁

This gets the tests compiling again, but I do notice some test failures for both 12.x and 13.x in the suite that look like this.  If I recall, I always used to get these when testing against MobileSDK.

```
Wrong total size expected:<4> but was:<0>
```

<img width="1706" alt="Screenshot 2025-02-26 at 18 46 23" src="https://github.com/user-attachments/assets/93d4a5c2-19f2-42ea-9e49-07845742e2a0" />
