### PR TITLE
Fix LoginView nav bar when button is not shown.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -47,10 +47,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -100,7 +98,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -373,7 +370,7 @@ internal fun DefaultBottomAppBar(
         targetValue = if (loading) LOADING_ALPHA else VISIBLE_ALPHA,
         animationSpec = tween(durationMillis = SLOW_ANIMATION_MS),
     )
-    val heightModifier = if (button == null) {
+    val heightModifier = if (button == null || !showButton) {
         Modifier.height(WindowInsets.navigationBars.getBottom(LocalDensity.current).pxToDp())
     } else {
         Modifier.defaultMinSize()
@@ -383,10 +380,9 @@ internal fun DefaultBottomAppBar(
         containerColor = backgroundColor.value,
         contentPadding = PaddingValues(0.dp),
         modifier = heightModifier.graphicsLayer(alpha = alpha),
-        windowInsets = WindowInsets.navigationBars,
     ) {
         AnimatedVisibility(
-            visible = showButton && (button != null),
+            visible = showButton,
             enter = fadeIn(animationSpec = tween(durationMillis = SLOW_ANIMATION_MS)),
             exit = fadeOut(animationSpec = tween(durationMillis = SLOW_ANIMATION_MS)),
         ) {


### PR DESCRIPTION
Recently we made a change to not show the BottomAppBar at all if there was no button to display in an effort to increase the amount of webview shown (especially for landscape).  However, this causes the problem of not setting a color for the nav bar because we are not displaying anything there.  This isn't very noticeable with the default login background (in light mode) but other background colors make it very obvious.  For example this is what the default login screen looks like in dark mode:
![share_1008949639482774475](https://github.com/user-attachments/assets/f2f150bb-af7f-4e80-b464-1990c502f47a)

This PR fixes this and the original issue by always displaying the BottomAppBar and adjusting it's height based on whether or not we are showing a button.  The appearance when showing a button is unchanged, but the color and height are fixed when there is no button:
![Screenshot_20250227-093833](https://github.com/user-attachments/assets/60a825fe-3e02-4397-9514-44abcf64a709)
![Screenshot_20250227-093854](https://github.com/user-attachments/assets/af53a844-4e55-4b42-a4ae-996c87691caf)