### PR TITLE
@W-17459651: Actionable Notifications (Android) Support For Notifications Types

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushMessaging.kt
@@ -27,8 +27,10 @@
 package com.salesforce.androidsdk.push
 
 import android.content.Context
+import android.content.Context.MODE_PRIVATE
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.content.edit
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.google.firebase.installations.FirebaseInstallations
@@ -40,6 +42,7 @@ import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.
 import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction.Register
 import com.salesforce.androidsdk.push.PushService.Companion.enqueuePushNotificationsRegistrationWork
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationOnAppForeground
+import com.salesforce.androidsdk.rest.NotificationsTypesResponseBody
 import com.salesforce.androidsdk.security.KeyStoreWrapper
 import com.salesforce.androidsdk.util.SalesforceSDKLogger
 
@@ -63,6 +66,7 @@ object PushMessaging {
     private const val REGISTRATION_ID = "c2dm_registration_id"
     private const val DEVICE_ID = "deviceId"
     private const val IN_PROGRESS = "inprogress"
+    private const val NOTIFICATIONS_TYPES = "notifications_types"
 
     // Re-register once push is setup
     @JvmStatic
@@ -218,9 +222,66 @@ object PushMessaging {
     fun getRegistrationId(context: Context, account: UserAccount?): String? {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
         return prefs.getString(REGISTRATION_ID, null)
+    }
+
+    /**
+     * Clears Salesforce notifications types for the provided user account.
+     * @param userAccount the user account
+     */
+    internal fun clearNotificationsTypes(
+        userAccount: UserAccount
+    ) {
+        val context = SalesforceSDKManager.getInstance().appContext
+        val sharedPreferences = context.getSharedPreferences(
+            getSharedPrefFile(userAccount),
+            MODE_PRIVATE
+        )
+        sharedPreferences.edit { remove(NOTIFICATIONS_TYPES) }
+    }
+
+    /**
+     * Returns Salesforce notifications types for the provided user account.
+     * @param userAccount the user account
+     * @return The Salesforce notifications types or null if there are none
+     */
+    @JvmStatic
+    fun getNotificationsTypes(
+        userAccount: UserAccount
+    ): NotificationsTypesResponseBody? {
+        val context = SalesforceSDKManager.getInstance().appContext
+        val sharedPreferences = context.getSharedPreferences(
+            getSharedPrefFile(userAccount),
+            MODE_PRIVATE
+        )
+
+        return sharedPreferences.getString(NOTIFICATIONS_TYPES, null)?.let { json ->
+            NotificationsTypesResponseBody.fromJson(json)
+        }
+    }
+
+    /**
+     * Stores the Salesforce notifications types for the provided user account.
+     * @param userAccount THe user account
+     */
+    @JvmStatic
+    internal fun setNotificationTypes(
+        userAccount: UserAccount,
+        notificationsTypes: NotificationsTypesResponseBody
+    ) {
+        val context = SalesforceSDKManager.getInstance().appContext
+        val sharedPreferences = context.getSharedPreferences(
+            getSharedPrefFile(userAccount),
+            MODE_PRIVATE
+        )
+        sharedPreferences.edit {
+            putString(
+                NOTIFICATIONS_TYPES,
+                notificationsTypes.sourceJson
+            )
+        }
     }
 
     /**
@@ -237,11 +298,11 @@ object PushMessaging {
     ) {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
-        val editor = prefs.edit()
-        editor.putString(REGISTRATION_ID, registrationId)
-        editor.apply()
+        prefs.edit {
+            putString(REGISTRATION_ID, registrationId)
+        }
     }
 
     /**
@@ -255,7 +316,7 @@ object PushMessaging {
     fun isRegistered(context: Context, account: UserAccount?): Boolean {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
         return prefs.getString(REGISTRATION_ID, null) != null
     }
@@ -270,11 +331,11 @@ object PushMessaging {
     fun clearSFDCRegistrationInfo(context: Context, account: UserAccount?) {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
-        val editor = prefs.edit()
-        editor.remove(DEVICE_ID)
-        editor.apply()
+        prefs.edit {
+            remove(DEVICE_ID)
+        }
     }
 
     /**
@@ -288,7 +349,7 @@ object PushMessaging {
     fun isRegisteredWithSFDC(context: Context, account: UserAccount?): Boolean {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
         return prefs.getString(DEVICE_ID, null) != null
     }
@@ -304,7 +365,7 @@ object PushMessaging {
     fun getDeviceId(context: Context, account: UserAccount?): String? {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
         return prefs.getString(DEVICE_ID, null)
     }
@@ -324,11 +385,11 @@ object PushMessaging {
     ) {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
-        val editor = prefs.edit()
-        editor.putLong(LAST_SFDC_REGISTRATION_TIME, lastRegistrationTime)
-        editor.apply()
+        prefs.edit {
+            putLong(LAST_SFDC_REGISTRATION_TIME, lastRegistrationTime)
+        }
     }
 
     /**
@@ -342,7 +403,7 @@ object PushMessaging {
     fun isInProgress(context: Context, account: UserAccount?): Boolean {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
         return prefs.getBoolean(IN_PROGRESS, false)
     }
@@ -357,11 +418,11 @@ object PushMessaging {
     fun clearRegistrationInfo(context: Context, account: UserAccount?) {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
-        val editor = prefs.edit()
-        editor.clear()
-        editor.apply()
+        prefs.edit {
+            clear()
+        }
     }
 
     /**
@@ -379,14 +440,14 @@ object PushMessaging {
     ) {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
-        val editor = prefs.edit()
-        editor.putString(REGISTRATION_ID, registrationId)
-        editor.putString(DEVICE_ID, deviceId)
-        editor.putLong(LAST_SFDC_REGISTRATION_TIME, System.currentTimeMillis())
-        editor.putBoolean(IN_PROGRESS, false)
-        editor.apply()
+        prefs.edit {
+            putString(REGISTRATION_ID, registrationId)
+            putString(DEVICE_ID, deviceId)
+            putLong(LAST_SFDC_REGISTRATION_TIME, System.currentTimeMillis())
+            putBoolean(IN_PROGRESS, false)
+        }
     }
 
     /**
@@ -457,11 +518,11 @@ object PushMessaging {
     ) {
         val prefs = context.getSharedPreferences(
             getSharedPrefFile(account),
-            Context.MODE_PRIVATE
+            MODE_PRIVATE
         )
-        val editor = prefs.edit()
-        editor.putBoolean(IN_PROGRESS, true)
-        editor.apply()
+        prefs.edit {
+            putBoolean(IN_PROGRESS, true)
+        }
     }
 
     private fun runPushService(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -258,7 +258,7 @@ open class PushService {
                 notificationsTypes = NotificationsApiClient(
                     apiHostName = instanceHost,
                     restClient = restClient
-                ).fetchNotificationsTypes()
+                ).fetchNotificationsTypes() ?: return
             )
         }
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -27,6 +27,7 @@
 package com.salesforce.androidsdk.push
 
 import android.content.Intent
+import androidx.core.net.toUri
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy.UPDATE
@@ -43,9 +44,11 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.push.PushMessaging.UNREGISTERED_ATTEMPT_COMPLETE_EVENT
 import com.salesforce.androidsdk.push.PushMessaging.UNREGISTERED_EVENT
+import com.salesforce.androidsdk.push.PushMessaging.clearNotificationsTypes
 import com.salesforce.androidsdk.push.PushMessaging.clearRegistrationInfo
 import com.salesforce.androidsdk.push.PushMessaging.getDeviceId
 import com.salesforce.androidsdk.push.PushMessaging.getRegistrationId
+import com.salesforce.androidsdk.push.PushMessaging.setNotificationTypes
 import com.salesforce.androidsdk.push.PushMessaging.setRegistrationId
 import com.salesforce.androidsdk.push.PushMessaging.setRegistrationInfo
 import com.salesforce.androidsdk.push.PushNotificationsRegistrationChangeWorker.PushNotificationsRegistrationAction
@@ -55,6 +58,7 @@ import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistration
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationOnAppForeground
 import com.salesforce.androidsdk.rest.ApiVersionStrings
 import com.salesforce.androidsdk.rest.ClientManager.AccMgrAuthTokenProvider
+import com.salesforce.androidsdk.rest.NotificationsApiClient
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo
 import com.salesforce.androidsdk.rest.RestRequest
@@ -203,6 +207,63 @@ open class PushService {
     )
 
     /**
+     * Called after Salesforce push notification registration.
+     *
+     * @param status the registration status. One of the
+     * `REGISTRATION_STATUS_XXX` constants
+     * @param userAccount the user account that's performing registration
+     */
+    private fun onPushNotificationRegistrationStatusInternal(
+        status: Int,
+        userAccount: UserAccount?
+    ) {
+        // Fetch and store or clear Salesforce notifications types, as applicable.
+        refreshNotificationsTypes(status, userAccount)
+
+        // Allow subclass implementation.
+        onPushNotificationRegistrationStatus(status, userAccount)
+    }
+
+    /**
+     * Refreshes Salesforce notification types or clears them based on the
+     * provided Salesforce push notification registration status.
+     * @param status the registration status. One of the
+     * `REGISTRATION_STATUS_XXX` constants
+     * @param userAccount the user account that's performing registration
+     */
+    private fun refreshNotificationsTypes(
+        status: Int,
+        userAccount: UserAccount?
+    ) {
+        when (status) {
+            REGISTRATION_STATUS_SUCCEEDED ->
+                fetchNotificationsTypes(userAccount ?: return)
+
+            UNREGISTRATION_STATUS_SUCCEEDED ->
+                clearNotificationsTypes(userAccount ?: return)
+        }
+    }
+
+    /**
+     * Fetches notifications types and stores them for the provided user
+     * account.
+     * @param userAccount the user account that's performing registration
+     */
+    private fun fetchNotificationsTypes(userAccount: UserAccount) {
+        val instanceHost = userAccount.instanceServer.toUri().host
+        val restClient = getRestClient(userAccount)
+        if (instanceHost != null && restClient != null) {
+            setNotificationTypes(
+                userAccount = userAccount,
+                notificationsTypes = NotificationsApiClient(
+                    apiHostName = instanceHost,
+                    restClient = restClient
+                ).fetchNotificationsTypes()
+            )
+        }
+    }
+
+    /**
      * Listen for changes in registration status.
      *
      * Subclasses can override this method without calling the super method.
@@ -278,7 +339,7 @@ open class PushService {
 
                 response.consume()
                 sdkManager.registerUsedAppFeature(FEATURE_PUSH_NOTIFICATIONS)
-                onPushNotificationRegistrationStatus(status, account)
+                onPushNotificationRegistrationStatusInternal(status, account)
 
                 return id
             }
@@ -286,7 +347,7 @@ open class PushService {
             SalesforceSDKLogger.e(TAG, "Push notification registration failed", throwable)
         }
 
-        onPushNotificationRegistrationStatus(REGISTRATION_STATUS_FAILED, account)
+        onPushNotificationRegistrationStatusInternal(REGISTRATION_STATUS_FAILED, account)
 
         return null
     }
@@ -342,13 +403,13 @@ open class PushService {
                     registeredId,
                     restClient
                 ).consume()
-                onPushNotificationRegistrationStatus(
+                onPushNotificationRegistrationStatusInternal(
                     UNREGISTRATION_STATUS_SUCCEEDED,
                     account
                 )
             }
         }.onFailure { throwable ->
-            onPushNotificationRegistrationStatus(
+            onPushNotificationRegistrationStatusInternal(
                 UNREGISTRATION_STATUS_FAILED,
                 account
             )
@@ -520,7 +581,7 @@ open class PushService {
                 OneTimeWorkRequest.Builder(PushNotificationsRegistrationChangeWorker::class.java)
                     .setInputData(workData)
                     .setConstraints(constraints)
-                    .build().also {  workRequest ->
+                    .build().also { workRequest ->
                         workManager.enqueueUniqueWork(
                             PUSH_NOTIFICATIONS_UNREGISTRATION_WORK_NAME,
                             REPLACE,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsApiClient.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsApiClient.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.androidsdk.rest
+
+import com.salesforce.androidsdk.rest.RestRequest.RestMethod.GET
+
+/**
+ * Provides REST client methods for a variety of notifications API endpoints.
+ * - `/connect/notifications/types`
+ *
+ * See https://salesforce.quip.com/KGU3ALoXRCjK#RcfABAPLVfg
+ * TODO: Replace the documentation link with the final documentation. ECJ20250310
+ *
+ * @param apiHostName The Salesforce Notifications API hostname
+ * @param restClient The REST client to use
+ */
+class NotificationsApiClient(
+    private val apiHostName: String,
+    private val restClient: RestClient
+) {
+
+    /**
+     * Submit a request to the Notifications API Types endpoint.
+     * @return The endpoint's response
+     */
+    @Suppress("unused")
+    @Throws(SfapApiException::class)
+    fun fetchNotificationsTypes(): NotificationsTypesResponseBody {
+
+        // Submit the request.
+        val restRequest = RestRequest(
+            GET,
+            "https://$apiHostName/services/data/v64.0/connect/notifications/types",
+            mutableMapOf<String, String>()
+        )
+        val restResponse = restClient.sendSync(restRequest)
+        val responseBodyString = restResponse.asString()
+
+        return if (restResponse.isSuccess && responseBodyString != null) {
+            NotificationsTypesResponseBody.fromJson(responseBodyString)
+        } else {
+            val errorResponseBody = SfapApiErrorResponseBody.fromJson(responseBodyString)
+            throw SfapApiException(
+                errorCode = errorResponseBody.errorCode,
+                message = responseBodyString,
+                messageCode = errorResponseBody.messageCode,
+                source = responseBodyString
+            )
+        }
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsApiClient.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsApiClient.kt
@@ -27,7 +27,10 @@
 
 package com.salesforce.androidsdk.rest
 
+import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.rest.ApiVersionStrings.API_PREFIX
 import com.salesforce.androidsdk.rest.RestRequest.RestMethod.GET
+import com.salesforce.androidsdk.util.SalesforceSDKLogger
 
 /**
  * Provides REST client methods for a variety of notifications API endpoints.
@@ -50,12 +53,20 @@ class NotificationsApiClient(
      */
     @Suppress("unused")
     @Throws(SfapApiException::class)
-    fun fetchNotificationsTypes(): NotificationsTypesResponseBody {
+    fun fetchNotificationsTypes(): NotificationsTypesResponseBody? {
+        val context = SalesforceSDKManager.getInstance().appContext
 
         // Submit the request.
+        val apiVersion = ApiVersionStrings.getVersionNumber(context)
+        // TODO: Remove once MSDK default API version is 64 or greater.
+        if (apiVersion < "v64.0") {
+            SalesforceSDKLogger.w(TAG, "Cannot request Salesforce push notifications types with API less than v64.0")
+            return null
+        }
+
         val restRequest = RestRequest(
             GET,
-            "https://$apiHostName/services/data/v64.0/connect/notifications/types",
+            "https://$apiHostName/${ApiVersionStrings.getBasePath()}/connect/notifications/types",
             mutableMapOf<String, String>()
         )
         val restResponse = restClient.sendSync(restRequest)
@@ -72,5 +83,9 @@ class NotificationsApiClient(
                 source = responseBodyString
             )
         }
+    }
+
+    companion object {
+        private const val TAG = "NotificationsApiClient"
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsTypesResponseBody.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsTypesResponseBody.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.rest
+
+import com.salesforce.androidsdk.rest.SfapApiClient.Companion.jsonIgnoreUnknownKeys
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a Notifications API Types endpoint response.
+ * See https://salesforce.quip.com/KGU3ALoXRCjK#RcfABAPLVfg
+ * TODO: Replace the documentation link with the final documentation. ECJ20250310
+ */
+@Serializable
+data class NotificationsTypesResponseBody(
+    val notificationTypes: Array<NotificationType>? = null
+) {
+
+    /** The original JSON used to initialize this response body */
+    var sourceJson: String? = null
+        private set
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NotificationsTypesResponseBody
+
+        if (notificationTypes != null) {
+            if (other.notificationTypes == null) return false
+            if (!notificationTypes.contentEquals(other.notificationTypes)) return false
+        } else if (other.notificationTypes != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return notificationTypes?.contentHashCode() ?: 0
+    }
+
+    @Serializable
+    data class NotificationType(
+        val actionGroups: Array<ActionGroup>? = null,
+        val apiName: String? = null,
+        val label: String? = null,
+        val type: String? = null
+    ) {
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as NotificationType
+
+            if (actionGroups != null) {
+                if (other.actionGroups == null) return false
+                if (!actionGroups.contentEquals(other.actionGroups)) return false
+            } else if (other.actionGroups != null) return false
+            if (apiName != other.apiName) return false
+            if (label != other.label) return false
+            if (type != other.type) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = actionGroups?.contentHashCode() ?: 0
+            result = 31 * result + (apiName?.hashCode() ?: 0)
+            result = 31 * result + (label?.hashCode() ?: 0)
+            result = 31 * result + (type?.hashCode() ?: 0)
+            return result
+        }
+
+        @Serializable
+        data class ActionGroup(
+            val actions: Array<Action>? = null
+        ) {
+
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as ActionGroup
+
+                if (actions != null) {
+                    if (other.actions == null) return false
+                    if (!actions.contentEquals(other.actions)) return false
+                } else if (other.actions != null) return false
+
+                return true
+            }
+
+            override fun hashCode(): Int {
+                return actions?.contentHashCode() ?: 0
+            }
+
+            @Serializable
+            data class Action(
+                val actionKey: String? = null,
+                val label: String? = null,
+                val name: String? = null,
+                val type: String? = null
+            )
+        }
+    }
+
+    // region Companion
+
+    companion object {
+
+        /**
+         * Returns a Notification Types API endpoint response from the JSON
+         * text.
+         * @param json The JSON text
+         * @return The Notification Types API endpoint response
+         */
+        fun fromJson(json: String): NotificationsTypesResponseBody {
+
+            val result = jsonIgnoreUnknownKeys.decodeFromString<NotificationsTypesResponseBody>(json)
+            result.sourceJson = json
+            return result
+        }
+    }
+
+    // endregion
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -72,8 +72,10 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
 
     /** TopAppBar Color.  Defaults to WebView background color. */
     open var topBarColor: Color? = null
+
     /** TopAppBar text.  Defaults to login server url. */
     open var titleText: String? = null
+
     /**
      * TopAppBar text Color.  Defaults to black on light backgrounds and white
      * on dark backgrounds.  Back and menu buttons will match this color.
@@ -96,6 +98,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
     // Override App Bars
     /** TopAppBar that will be used instead of the default. */
     open val topAppBar: (@Composable () -> Unit)? = null
+
     /** BottomAppBar that will be used instead of the default. */
     open val bottomAppBar: (@Composable () -> Unit)? = null
 
@@ -129,10 +132,13 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
 
     /** Additional Auth Values used for login. */
     open var additionalParameters = hashMapOf<String, String>()
+
     /** JWT string used for JWT Auth Flow. */
     var jwt: String? = null
+
     /** Connected App/External Client App client Id. */
     protected open var clientId: String = bootConfig.remoteAccessConsumerKey
+
     /** Authorization Display Type used for login. */
     protected open val authorizationDisplayType =
         SalesforceSDKManager.getInstance().appContext.getString(oauth_display_type)
@@ -269,10 +275,21 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
         frontdoorBridgeCodeVerifier = null
     }
 
-    // returns a valid https server url or null if the users input is invalid.
+    /**
+     * Returns a valid HTTPS server URL or null if the provided user input is
+     * invalid.
+     * @param url The user input URL to validate and return
+     * @return The validated server URL or null if the provided URL wasn't a
+     * valid URL
+     */
     internal fun getValidServerUrl(url: String): String? {
         if (!url.contains(".")) return null
         if (url.substringAfterLast(".").isEmpty()) return null
+        runCatching {
+            URI(url)
+        }.onFailure {
+            return null
+        }
 
         return when {
             URLUtil.isHttpsUrl(url) -> url

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushMessagingTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushMessagingTest.kt
@@ -1,0 +1,63 @@
+package com.salesforce.androidsdk.app
+
+import android.os.Bundle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.push.PushMessaging
+import com.salesforce.androidsdk.rest.NotificationsTypesResponseBody
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for `PushMessaging`.
+ */
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class PushMessagingTest {
+
+    @Test
+    fun testClearNotificationsTypes() {
+
+        PushMessaging.setNotificationTypes(
+            userAccount = user,
+            notificationsTypes = NotificationsTypesResponseBody.fromJson(NOTIFICATIONS_TYPES_JSON)
+        )
+
+        Assert.assertEquals(
+            NOTIFICATIONS_TYPES_JSON,
+            PushMessaging.getNotificationsTypes(user)?.sourceJson
+        )
+
+        PushMessaging.clearNotificationsTypes(user)
+
+        Assert.assertNull(PushMessaging.getNotificationsTypes(user))
+    }
+
+    @Test
+    fun testSetNotificationsTypes() {
+
+        PushMessaging.setNotificationTypes(
+            userAccount = user,
+            notificationsTypes = NotificationsTypesResponseBody.fromJson(NOTIFICATIONS_TYPES_JSON)
+        )
+
+        Assert.assertEquals(
+            NOTIFICATIONS_TYPES_JSON,
+            PushMessaging.getNotificationsTypes(user)?.sourceJson
+        )
+    }
+
+    companion object {
+
+        private const val NOTIFICATIONS_TYPES_JSON =
+            "{\"notificationTypes\":[{\"actionGroups\":[{\"actions\":[{\"actionKey\":\"new_acc_and_opp__new_account\",\"label\":\"New Account\",\"name\":\"new_account\",\"type\":\"NotificationApiAction\"},{\"actionKey\":\"new_acc_and_opp__new_opportunity\",\"label\":\"New Opportunity\",\"name\":\"new_opportunity\",\"type\":\"NotificationApiAction\"}],\"name\":\"new_acc_and_opp\"},{\"actions\":[{\"actionKey\":\"updateCase__escalate\",\"label\":\"Escalate\",\"name\":\"escalate\",\"type\":\"NotificationApiAction\"},{\"actionKey\":\"updateCase__raise_priority\",\"label\":\"Raise Priority\",\"name\":\"raise_priority\",\"type\":\"NotificationApiAction\"}],\"name\":\"updateCase\"}],\"apiName\":\"actionable_notif_test_type\",\"label\":\"Actionable Notification Test Type\",\"type\":\"actionable_notif_test_type\"},{\"apiName\":\"approval_request\",\"label\":\"Approval requests\",\"type\":\"approval_request\"},{\"apiName\":\"chatter_comment_on_post\",\"label\":\"New comments on a post\",\"type\":\"chatter_comment_on_post\"},{\"apiName\":\"chatter_group_mention\",\"label\":\"Group mentions on a post\",\"type\":\"chatter_group_mention\"},{\"apiName\":\"chatter_mention\",\"label\":\"Individual mentions on a post\",\"type\":\"chatter_mention\"},{\"apiName\":\"group_announce\",\"label\":\"Group manager announcements\",\"type\":\"group_announce\"},{\"apiName\":\"group_post\",\"label\":\"Posts to a group\",\"type\":\"group_post\"},{\"apiName\":\"personal_analytic\",\"label\":\"Salesforce Classic report updates\",\"type\":\"personal_analytic\"},{\"apiName\":\"profile_post\",\"label\":\"Posts to a profile\",\"type\":\"profile_post\"},{\"apiName\":\"stream_post\",\"label\":\"Posts to a stream\",\"type\":\"stream_post\"},{\"apiName\":\"task_delegated_to\",\"label\":\"Task assignments\",\"type\":\"task_delegated_to\"}]}"
+
+        private val user = UserAccount(Bundle().apply {
+            putString("orgId", "org-1")
+            putString("userId", "user-1-1")
+        })
+    }
+
+}


### PR DESCRIPTION
🎸 *_Ready For Review_* 🤘🏻

This adds support for fetching, storing, retrieving and clearing the new Salesforce push notifications types on SFDC registration and unregistration.