### PR TITLE
Update CodeCov requirements.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,37 +6,83 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "35...85"
+  range: "60...80"
 
   status:
+    # Overall Library Requirements
     project:
       default: false  # disable the default status that measures entire project
       SalesforceAnalytics:
+        threshold: 0%
         paths:
           - "libs/SalesforceAnalytics/src/"
         flags:
           - SalesforceAnalytics
       SalesforceSDK:
+        threshold: 0%
         paths:
           - "libs/SalesforceSDK/src/"
         flags:
           - SalesforceSDK
       SalesforceHybrid:
+        threshold: 0%
         paths:
           - "libs/SalesforceHybrid/src/"
         flags:
           - SalesforceHybrid
       SmartStore:
+        threshold: 0%
         paths:
           - "libs/SmartStore/src/"
         flags:
           - SmartStore
       MobileSync:
+        threshold: 0%
         paths: 
           - "libs/MobileSync/src/"
         flags: 
           - MobileSync
       SalesforceReact:
+        threshold: 0%
+        paths:
+          - "libs/SalesforceReact/src/"
+        flags:
+          - SalesforceReact
+
+    # Pull Request Requirements
+    patch: 
+      SalesforceAnalytics:
+        target: 80%
+        paths:
+          - "libs/SalesforceAnalytics/src/"
+        flags:
+          - SalesforceAnalytics
+      SalesforceSDK:
+        target: 80%
+        paths:
+          - "libs/SalesforceSDK/src/"
+        flags:
+          - SalesforceSDK
+      SalesforceHybrid:
+        target: 80%
+        paths:
+          - "libs/SalesforceHybrid/src/"
+        flags:
+          - SalesforceHybrid
+      SmartStore:
+        target: 80%
+        paths:
+          - "libs/SmartStore/src/"
+        flags:
+          - SmartStore
+      MobileSync:
+        target: 80%
+        paths: 
+          - "libs/MobileSync/src/"
+        flags: 
+          - MobileSync
+      SalesforceReact:
+        target: 80%
         paths:
           - "libs/SalesforceReact/src/"
         flags:


### PR DESCRIPTION
- Add `threshold: 0%` to all libraries.  This will fail a check if a PR lowers the overall coverage of a library by any amount. 
- Add new `patch` section with `target: 80%` for each library.  This will create a check per library that will ensures new code added in a PR has at least 80% coverage.  

I could have required a specific coverage amount (like 80%) per library but most are no where near where we ideally want them.  Instead, these rules should encourage us to organically work towards that goal.