### PR TITLE
Fix status bar icon color.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -97,6 +97,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getMainExecutor
 import androidx.core.net.toUri
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.FragmentActivity
 import com.salesforce.androidsdk.R.color.sf__background
 import com.salesforce.androidsdk.R.color.sf__background_dark
@@ -917,6 +918,10 @@ open class LoginActivity : FragmentActivity() {
 
                 viewModel.dynamicBackgroundColor.value = validateAndExtractBackgroundColor(result)
                     ?: return@evaluateJavascript
+
+                // Ensure Status Bar Icons are readable no matter which OS theme is used.
+                val useLightIcons = viewModel.dynamicBackgroundTheme.value == DARK
+                WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = useLightIcons
             }.also {
                 if (!viewModel.authFinished.value) {
                     viewModel.loading.value = false


### PR DESCRIPTION
By default the color of the icons in the status bar is determined by the OS based on if the user has set it to light or dark theme. This causes a readability problem if the user is in light theme and we display a dark status bar (to match the webview):
<img width="414" alt="Screenshot 2025-04-11 at 4 09 01 PM" src="https://github.com/user-attachments/assets/efb59dd3-1baa-4ed0-b017-dc5b166b86dd" />


In this PR I am using our `dynamicBackgroundTheme` to set the window's `isAppearanceLightStatusBars`, which results in the status bar always being readable:
![dynamic_status_bar_icons](https://github.com/user-attachments/assets/ce6c6e8a-a313-44aa-b9b4-41b4f2efe9ac)
