### PR TITLE
Fix status bar icon color for all cases.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -921,11 +921,10 @@ open class LoginActivity : FragmentActivity() {
                     ?: return@evaluateJavascript
 
                 // Ensure Status Bar Icons are readable no matter which OS theme is used.
-                val useLightIcons = when {
-                    viewModel.titleTextColor != null -> viewModel.titleTextColor!!.luminance() < 0.5
-                    viewModel.topBarColor != null -> viewModel.topBarColor!!.luminance() < 0.5
-                    else -> viewModel.dynamicBackgroundTheme.value == DARK
-                }
+                val titleTextColorLight = viewModel.titleTextColor?.luminance()?.let { it < 0.5 }
+                val topAppBarDark = viewModel.topBarColor?.luminance()?.let { it < 0.5 }
+                val dynamicThemeIsDark = viewModel.dynamicBackgroundTheme.value == DARK
+                val useLightIcons = titleTextColorLight ?: topAppBarDark ?: dynamicThemeIsDark
                 WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = useLightIcons
             }.also {
                 if (!viewModel.authFinished.value) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -93,6 +93,7 @@ import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.getMainExecutor
@@ -920,7 +921,11 @@ open class LoginActivity : FragmentActivity() {
                     ?: return@evaluateJavascript
 
                 // Ensure Status Bar Icons are readable no matter which OS theme is used.
-                val useLightIcons = viewModel.dynamicBackgroundTheme.value == DARK
+                val useLightIcons = when {
+                    viewModel.titleTextColor != null -> viewModel.titleTextColor!!.luminance() < 0.5
+                    viewModel.topBarColor != null -> viewModel.topBarColor!!.luminance() < 0.5
+                    else -> viewModel.dynamicBackgroundTheme.value == DARK
+                }
                 WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = useLightIcons
             }.also {
                 if (!viewModel.authFinished.value) {


### PR DESCRIPTION
This is a followup to #2703, which insured the status bar icons were always visible for any dynamic status bar color.  However, it did not take into account that the app can specify a static top app bar color.  