### PR TITLE
Beacon support

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -93,7 +93,9 @@ public class UserAccount {
 	public static final String CLIENT_ID = "clientId";
 	public static final String PARENT_SID = "parentSid";
 	public static final String TOKEN_FORMAT = "tokenFormat";
-;
+	public static final String BEACON_CHILD_CONSUMER_KEY = "beacon_child_consumer_key";
+	public static final String BEACON_CHILD_CONSUMER_SECRET = "beacon_child_consumer_secret";
+
 	private static final String TAG = "UserAccount";
 	private static final String FORWARD_SLASH = "/";
 	private static final String UNDERSCORE = "_";
@@ -136,6 +138,8 @@ public class UserAccount {
 	private String parentSid;
 	private String tokenFormat;
 	private Map<String, String> additionalOauthValues;
+	private String beaconChildConsumerKey;
+	private String beaconChildConsumerSecret;
 
 	/**
 	 * Parameterized constructor.
@@ -173,6 +177,8 @@ public class UserAccount {
 	 * @param clientId oauth client id
 	 * @param parentSid parent sid
 	 * @param tokenFormat token format
+	 * @param beaconChildConsumerKey beacon child consumer key
+	 * @param beaconChildConsumerSecret beacon child consumer secret
 	 */
 	UserAccount(String authToken, String refreshToken,
 				String loginServer, String idUrl, String instanceServer,
@@ -183,7 +189,8 @@ public class UserAccount {
 				String lightningDomain, String lightningSid, String vfDomain, String vfSid,
 				String  contentDomain, String contentSid, String csrfToken, Boolean nativeLogin,
 				String language, String locale, String cookieClientSrc, String cookieSidClient,
-				String sidCookieName, String clientId, String parentSid, String tokenFormat) {
+				String sidCookieName, String clientId, String parentSid, String tokenFormat,
+				String beaconChildConsumerKey, String beaconChildConsumerSecret) {
 		this.authToken = authToken;
 		this.refreshToken = refreshToken;
 		this.loginServer = loginServer;
@@ -218,6 +225,8 @@ public class UserAccount {
 		this.clientId = clientId;
 		this.parentSid = parentSid;
 		this.tokenFormat = tokenFormat;
+		this.beaconChildConsumerKey = beaconChildConsumerKey;
+		this.beaconChildConsumerSecret = beaconChildConsumerSecret;
 		SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_USER_AUTH);
 	}
 
@@ -265,6 +274,8 @@ public class UserAccount {
 			clientId = object.optString(CLIENT_ID, null);
 			parentSid = object.optString(PARENT_SID, null);
 			tokenFormat = object.optString(TOKEN_FORMAT, null);
+			beaconChildConsumerKey = object.optString(BEACON_CHILD_CONSUMER_KEY, null);
+			beaconChildConsumerSecret = object.optString(BEACON_CHILD_CONSUMER_SECRET, null);
 			additionalOauthValues = MapUtil.addJSONObjectToMap(object, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -318,6 +329,8 @@ public class UserAccount {
 			clientId = bundle.getString(CLIENT_ID);
 			parentSid = bundle.getString(PARENT_SID);
 			tokenFormat = bundle.getString(TOKEN_FORMAT);
+			beaconChildConsumerKey = bundle.getString(BEACON_CHILD_CONSUMER_KEY);
+			beaconChildConsumerSecret = bundle.getString(BEACON_CHILD_CONSUMER_SECRET);
 			additionalOauthValues = MapUtil.addBundleToMap(bundle, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -612,6 +625,15 @@ public class UserAccount {
 	}
 
 	/**
+	 * Returns the oauth client id to use for refresh
+	 * In the case of beacon app, the beacon child consumer key returned during login should be used instead of the configured consumer key
+	 * @return client id to use for refresh.
+	 */
+	public String getClientIdForRefresh() {
+		return !TextUtils.isEmpty(beaconChildConsumerKey) ? beaconChildConsumerKey : clientId;
+	}
+
+	/**
 	 * Returns the parent sid.
 	 *
 	 * @return parent sid.
@@ -627,6 +649,24 @@ public class UserAccount {
 	 */
 	public String getTokenFormat() {
 		return tokenFormat;
+	}
+
+	/**
+	 * Returns the beacon child consumer key .
+	 *
+	 * @return beacon child consumer key.
+	 */
+	public String getBeaconChildConsumerKey() {
+		return beaconChildConsumerKey;
+	}
+
+	/**
+	 * Returns the beacon child consumer secret.
+	 *
+	 * @return beacon child consumer secret.
+	 */
+	public String getBeaconChildConsumerSecret() {
+		return beaconChildConsumerSecret;
 	}
 
 	/**
@@ -897,6 +937,8 @@ public class UserAccount {
 			object.put(SID_COOKIE_NAME, sidCookieName);
 			object.put(PARENT_SID, parentSid);
 			object.put(TOKEN_FORMAT, tokenFormat);
+			object.put(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
+			object.put(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 			object = MapUtil.addMapToJSONObject(additionalOauthValues, additionalOauthKeys, object);
 		} catch (JSONException e) {
 			SalesforceSDKLogger.e(TAG, "Unable to convert to JSON", e);
@@ -954,6 +996,8 @@ public class UserAccount {
 		object.putString(CLIENT_ID, clientId);
 		object.putString(PARENT_SID, parentSid);
 		object.putString(TOKEN_FORMAT, tokenFormat);
+		object.putString(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
+		object.putString(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 		object = MapUtil.addMapToBundle(additionalOauthValues, additionalOauthKeys, object);
 		return object;
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
@@ -68,6 +68,8 @@ class UserAccountBuilder private constructor() {
     private var tokenFormat: String? = null
     private var additionalOauthValues: Map<String, String>? = null
     private var allowUnset = true
+    private var beaconChildConsumerKey: String? = null
+    private var beaconChildConsumerSecret: String? = null
 
     /**
      * Set fields from token end point response
@@ -100,6 +102,8 @@ class UserAccountBuilder private constructor() {
             .sidCookieName(tr.sidCookieName)
             .parentSid(tr.parentSid)
             .tokenFormat(tr.tokenFormat)
+            .beaconChildConsumerKey(tr.beaconChildConsumerKey)
+            .beaconChildConsumerSecret(tr.beaconChildConsumerSecret)
     }
 
     /**
@@ -164,6 +168,8 @@ class UserAccountBuilder private constructor() {
             .clientId(userAccount.clientId)
             .parentSid(userAccount.parentSid)
             .tokenFormat(userAccount.tokenFormat)
+            .beaconChildConsumerKey(userAccount.beaconChildConsumerKey)
+            .beaconChildConsumerSecret(userAccount.beaconChildConsumerSecret)
     }
 
     /**
@@ -534,6 +540,26 @@ class UserAccountBuilder private constructor() {
     }
 
     /**
+     * Sets beacon child consumer key
+     *
+     * @param beaconChildConsumerKey beacon child consumer key
+     * @return Instance of this class.
+     */
+    fun beaconChildConsumerKey(beaconChildConsumerKey: String?): UserAccountBuilder {
+        return if (!allowUnset && beaconChildConsumerKey == null) this else apply { this.beaconChildConsumerKey = beaconChildConsumerKey }
+    }
+
+    /**
+     * Sets beacon child consumer secret
+     *
+     * @param beaconChildConsumerSecret beacon child consumer secret
+     * @return Instance of this class.
+     */
+    fun beaconChildConsumerSecret(beaconChildConsumerSecret: String?): UserAccountBuilder {
+        return if (!allowUnset && beaconChildConsumerSecret == null) this else apply { this.beaconChildConsumerSecret = beaconChildConsumerSecret }
+    }
+
+    /**
      * Builds and returns a UserAccount object.
      *
      * @return UserAccount object.
@@ -545,7 +571,7 @@ class UserAccountBuilder private constructor() {
             displayName, email, photoUrl, thumbnailUrl, additionalOauthValues, lightningDomain,
             lightningSid, vfDomain, vfSid, contentDomain, contentSid, csrfToken, nativeLogin,
             language, locale, cookieClientSrc, cookieSidClient, sidCookieName, clientId,
-            parentSid, tokenFormat
+            parentSid, tokenFormat, beaconChildConsumerKey, beaconChildConsumerSecret
         )
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -536,6 +536,8 @@ public class UserAccountManager {
 		final String clientId = decryptUserData(account, AuthenticatorService.KEY_CLIENT_ID, encryptionKey);
 		final String parentSid = decryptUserData(account, AuthenticatorService.KEY_PARENT_SID, encryptionKey);
 		final String tokenFormat = decryptUserData(account, AuthenticatorService.KEY_TOKEN_FORMAT, encryptionKey);
+		final String beaconChildConsumerKey = decryptUserData(account, AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_KEY, encryptionKey);
+		final String beaconChildConsumerSecret = decryptUserData(account, AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_SECRET, encryptionKey);
 
 		Map<String, String> additionalOauthValues = null;
 		List<String> additionalOauthKeys = SalesforceSDKManager.getInstance().getAdditionalOauthKeys();
@@ -587,6 +589,8 @@ public class UserAccountManager {
 					.clientId(clientId)
 					.parentSid(parentSid)
 					.tokenFormat(tokenFormat)
+					.beaconChildConsumerKey(beaconChildConsumerKey)
+					.beaconChildConsumerSecret(beaconChildConsumerSecret)
 					.additionalOauthValues(additionalOauthValues)
 					.build();
 		}
@@ -733,6 +737,8 @@ public class UserAccountManager {
 		extras.putString(AuthenticatorService.KEY_SID_COOKIE_NAME, SalesforceSDKManager.encrypt(userAccount.getSidCookieName(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_PARENT_SID, SalesforceSDKManager.encrypt(userAccount.getParentSid(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_TOKEN_FORMAT, SalesforceSDKManager.encrypt(userAccount.getTokenFormat(), encryptionKey));
+		extras.putString(AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_KEY, SalesforceSDKManager.encrypt(userAccount.getBeaconChildConsumerKey(), encryptionKey));
+		extras.putString(AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_SECRET, SalesforceSDKManager.encrypt(userAccount.getBeaconChildConsumerSecret(), encryptionKey));
 
 		final List<String> additionalOauthKeys = SalesforceSDKManager.getInstance().getAdditionalOauthKeys();
 		if (additionalOauthKeys != null && !additionalOauthKeys.isEmpty()) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -86,6 +86,8 @@ public class AuthenticatorService extends Service {
     public static final String KEY_SID_COOKIE_NAME = "sidCookieName";
     public static final String KEY_PARENT_SID = "parentSid";
     public static final String KEY_TOKEN_FORMAT = "tokenFormat";
+    public static final String KEY_BEACON_CHILD_CONSUMER_KEY = "beacon_child_consumer_key";
+    public static final String KEY_BEACON_CHILD_CONSUMER_SECRET = "beacon_child_consumer_secret";
 
     private static final String TAG = "AuthenticatorService";
 
@@ -129,7 +131,7 @@ public class AuthenticatorService extends Service {
             try {
                 final Map<String,String> addlParamsMap = originalUserAccount.getAdditionalOauthValues();
                 final OAuth2.TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT,
-                        new URI(originalUserAccount.getLoginServer()), originalUserAccount.getClientId(), originalUserAccount.getRefreshToken(), addlParamsMap);
+                        new URI(originalUserAccount.getLoginServer()), originalUserAccount.getClientIdForRefresh(), originalUserAccount.getRefreshToken(), addlParamsMap);
 
                 UserAccount updatedUserAccount = UserAccountBuilder.getInstance()
                         .populateFromUserAccount(originalUserAccount)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -821,8 +821,8 @@ public class OAuth2 {
                 sidCookieName = callbackUrlParams.get(SID_COOKIE_NAME);
                 parentSid = callbackUrlParams.get(PARENT_SID);
                 tokenFormat = callbackUrlParams.get(TOKEN_FORMAT);
-                beaconChildConsumerKey = callbackUrlParams.get(BEACON_CHILD_CONSUMER_KEY);
-                beaconChildConsumerSecret = callbackUrlParams.get(BEACON_CHILD_CONSUMER_SECRET);
+
+                // NB: beacon apps not supported with user agent flow so no beacon child fields expected
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);
@@ -888,6 +888,7 @@ public class OAuth2 {
                 parentSid = parsedResponse.optString(PARENT_SID);
                 tokenFormat = parsedResponse.optString(TOKEN_FORMAT);
 
+                // Beacon child fields expected when using a beacon app and web server flow
                 if (parsedResponse.has(BEACON_CHILD_CONSUMER_KEY)) {
                     beaconChildConsumerKey = parsedResponse.getString(BEACON_CHILD_CONSUMER_KEY);
                 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -196,6 +196,8 @@ public class OAuth2 {
     private static final String SID_COOKIE_NAME = "sidCookieName";
     private static final String PARENT_SID = "parent_sid";
     private static final String TOKEN_FORMAT = "token_format";
+    private static final String BEACON_CHILD_CONSUMER_SECRET = "beacon_child_consumer_secret";
+    private static final String BEACON_CHILD_CONSUMER_KEY = "beacon_child_consumer_key";
 
     public static final DateFormat TIMESTAMP_FORMAT;
     static {
@@ -778,6 +780,8 @@ public class OAuth2 {
         public String sidCookieName;
         public String parentSid;
         public String tokenFormat;
+        public String beaconChildConsumerKey;
+        public String beaconChildConsumerSecret;
 
         /**
          * Parameterized constructor built during login flow.
@@ -817,6 +821,8 @@ public class OAuth2 {
                 sidCookieName = callbackUrlParams.get(SID_COOKIE_NAME);
                 parentSid = callbackUrlParams.get(PARENT_SID);
                 tokenFormat = callbackUrlParams.get(TOKEN_FORMAT);
+                beaconChildConsumerKey = callbackUrlParams.get(BEACON_CHILD_CONSUMER_KEY);
+                beaconChildConsumerSecret = callbackUrlParams.get(BEACON_CHILD_CONSUMER_SECRET);
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);
@@ -881,6 +887,13 @@ public class OAuth2 {
                 sidCookieName = parsedResponse.optString(SID_COOKIE_NAME);
                 parentSid = parsedResponse.optString(PARENT_SID);
                 tokenFormat = parsedResponse.optString(TOKEN_FORMAT);
+
+                if (parsedResponse.has(BEACON_CHILD_CONSUMER_KEY)) {
+                    beaconChildConsumerKey = parsedResponse.getString(BEACON_CHILD_CONSUMER_KEY);
+                }
+                if (parsedResponse.has(BEACON_CHILD_CONSUMER_SECRET)) {
+                    beaconChildConsumerSecret = parsedResponse.getString(BEACON_CHILD_CONSUMER_SECRET);
+                }
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -784,7 +784,7 @@ public class OAuth2 {
         public String beaconChildConsumerSecret;
 
         /**
-         * Parameterized constructor built during login flow.
+         * Parameterized constructor built from params during user agent login flow.
          *
          * @param callbackUrlParams Callback URL parameters.
          * @param additionalOauthKeys Additional oauth keys.
@@ -830,7 +830,7 @@ public class OAuth2 {
         }
 
         /**
-         * Parameterized constructor built during login flow.
+         * Parameterized constructor built from params during user agent login flow.
          *
          * @param callbackUrlParams Callback URL parameters.
          */
@@ -840,31 +840,31 @@ public class OAuth2 {
                     : null);
         }
 
-
         /**
-         * Parameterized constructor built from refresh flow response.
+         * Parameterized constructor built from refresh flow response
+         * or code exchange response (web server login flow).
          *
          * @param response Token endpoint response.
+         * @param additionalOauthKeys Additional oauth keys.
          */
-        public TokenEndpointResponse(Response response) {
+        @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+        public TokenEndpointResponse(Response response, List<String> additionalOauthKeys) {
             try {
                 final JSONObject parsedResponse = (new RestResponse(response)).asJSONObject();
                 Log.d(TAG, "parsedResponse-->" + parsedResponse);
                 authToken = parsedResponse.getString(ACCESS_TOKEN);
                 instanceUrl = parsedResponse.getString(INSTANCE_URL);
-                idUrl  = parsedResponse.getString(ID);
+                idUrl = parsedResponse.getString(ID);
                 computeOtherFields();
                 if (parsedResponse.has(REFRESH_TOKEN)) {
                     refreshToken = parsedResponse.getString(REFRESH_TOKEN);
                 }
                 if (parsedResponse.has(SFDC_COMMUNITY_ID)) {
-                	communityId = parsedResponse.getString(SFDC_COMMUNITY_ID);
+                    communityId = parsedResponse.getString(SFDC_COMMUNITY_ID);
                 }
                 if (parsedResponse.has(SFDC_COMMUNITY_URL)) {
-                	communityUrl = parsedResponse.getString(SFDC_COMMUNITY_URL);
+                    communityUrl = parsedResponse.getString(SFDC_COMMUNITY_URL);
                 }
-                final SalesforceSDKManager sdkManager = SalesforceSDKManager.getInstance();
-                final List<String> additionalOauthKeys = sdkManager.getAdditionalOauthKeys();
                 if (additionalOauthKeys != null && !additionalOauthKeys.isEmpty()) {
                     additionalOauthValues = new HashMap<>();
                     for (final String key : additionalOauthKeys) {
@@ -898,6 +898,18 @@ public class OAuth2 {
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);
             }
+        }
+
+        /**
+         * Parameterized constructor built from refresh flow response
+         * or code exchange response (web server login flow).
+         *
+         * @param response Token endpoint response.
+         */
+        public TokenEndpointResponse(Response response) {
+            this(response, SalesforceSDKManager.getInstance() != null
+                    ? SalesforceSDKManager.getInstance() .getAdditionalOauthKeys()
+                    : null);
         }
 
         private void computeOtherFields() throws URISyntaxException {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -470,7 +470,7 @@ public class ClientManager {
             final Map<String,String> addlParamsMap = originalUserAccount.getAdditionalOauthValues();
             try {
                 final OAuth2.TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT,
-                        new URI(originalUserAccount.getLoginServer()), originalUserAccount.getClientId(), refreshToken, addlParamsMap);
+                        new URI(originalUserAccount.getLoginServer()), originalUserAccount.getClientIdForRefresh(), refreshToken, addlParamsMap);
 
                 UserAccount updatedUserAccount = UserAccountBuilder.getInstance()
                         .populateFromUserAccount(originalUserAccount)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -95,6 +95,8 @@ public class UserAccountTest {
     public static final String TEST_CLIENT_ID = "test-client-id";
     public static final String TEST_PARENT_SID = "test-parent-sid";
     public static final String TEST_TOKEN_FORMAT = "test-token-format";
+    public static final String TEST_BEACON_CHILD_CONSUMER_KEY = "test-beacon-child-consumer-key";
+    public static final String TEST_BEACON_CHILD_CONSUMER_SECRET = "test-beacon-child-consumer-secret";
 
     // other user
     public static final String TEST_ORG_ID_2 = "test_org_id_2";
@@ -178,6 +180,26 @@ public class UserAccountTest {
                 .accountName(TEST_ACCOUNT_NAME_2)
                 .build();
         checkOtherTestAccount(otherUserAccount);
+    }
+
+    @Test
+    public void testGetClientIdForRefresh() {
+        UserAccount userWithBeaconChildKey = createTestAccount();
+        Assert.assertEquals("Beacon child consumer key should match", TEST_BEACON_CHILD_CONSUMER_KEY, userWithBeaconChildKey.getBeaconChildConsumerKey());
+        Assert.assertEquals("Beacon child consumer secret should match", TEST_BEACON_CHILD_CONSUMER_SECRET, userWithBeaconChildKey.getBeaconChildConsumerSecret());
+        Assert.assertEquals("Client id should match", TEST_CLIENT_ID, userWithBeaconChildKey.getClientId());
+        Assert.assertEquals("Client id for refresh should be beacon child client id", TEST_BEACON_CHILD_CONSUMER_KEY, userWithBeaconChildKey.getClientIdForRefresh());
+
+        UserAccount userWithoutBeaconChildKey = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(userWithBeaconChildKey)
+                .beaconChildConsumerKey(null)
+                .beaconChildConsumerSecret(null)
+                .build();
+
+        Assert.assertNull("Beacon child consumer key should be null", userWithoutBeaconChildKey.getBeaconChildConsumerKey());
+        Assert.assertNull("Beacon child consumer secret should be null", userWithoutBeaconChildKey.getBeaconChildConsumerSecret());
+        Assert.assertEquals("Client id should match", TEST_CLIENT_ID, userWithoutBeaconChildKey.getClientId());
+        Assert.assertEquals("Client id for refresh should be client id", TEST_CLIENT_ID, userWithoutBeaconChildKey.getClientIdForRefresh());
     }
 
     /**
@@ -355,6 +377,8 @@ public class UserAccountTest {
         object.put(UserAccount.SID_COOKIE_NAME, TEST_SID_COOKIE_NAME);
         object.put(UserAccount.PARENT_SID, TEST_PARENT_SID);
         object.put(UserAccount.TOKEN_FORMAT, TEST_TOKEN_FORMAT);
+        object.put(UserAccount.BEACON_CHILD_CONSUMER_KEY, TEST_BEACON_CHILD_CONSUMER_KEY);
+        object.put(UserAccount.BEACON_CHILD_CONSUMER_SECRET, TEST_BEACON_CHILD_CONSUMER_SECRET);
         object = MapUtil.addMapToJSONObject(createAdditionalOauthValues(), createAdditionalOauthKeys(), object);
         return object;
     }
@@ -399,6 +423,8 @@ public class UserAccountTest {
         object.putString(UserAccount.CLIENT_ID, TEST_CLIENT_ID);
         object.putString(UserAccount.PARENT_SID, TEST_PARENT_SID);
         object.putString(UserAccount.TOKEN_FORMAT, TEST_TOKEN_FORMAT);
+        object.putString(UserAccount.BEACON_CHILD_CONSUMER_KEY, TEST_BEACON_CHILD_CONSUMER_KEY);
+        object.putString(UserAccount.BEACON_CHILD_CONSUMER_SECRET, TEST_BEACON_CHILD_CONSUMER_SECRET);
         object = MapUtil.addMapToBundle(createAdditionalOauthValues(), createAdditionalOauthKeys(), object);
         return object;
     }
@@ -441,6 +467,8 @@ public class UserAccountTest {
                 .clientId(TEST_CLIENT_ID)
                 .parentSid(TEST_PARENT_SID)
                 .tokenFormat(TEST_TOKEN_FORMAT)
+                .beaconChildConsumerKey(TEST_BEACON_CHILD_CONSUMER_KEY)
+                .beaconChildConsumerSecret(TEST_BEACON_CHILD_CONSUMER_SECRET)
                 .additionalOauthValues(createAdditionalOauthValues())
                 .build();
     }
@@ -494,7 +522,8 @@ public class UserAccountTest {
         Assert.assertEquals("Sid cookie name should match", TEST_SID_COOKIE_NAME, account.getSidCookieName());
         Assert.assertEquals("Parent sid should match", TEST_PARENT_SID, account.getParentSid());
         Assert.assertEquals("Token format should match", TEST_TOKEN_FORMAT, account.getTokenFormat());
-
+        Assert.assertEquals("Beacon child consumer key should match", TEST_BEACON_CHILD_CONSUMER_KEY, account.getBeaconChildConsumerKey());
+        Assert.assertEquals("Beacon child consumer secret should match", TEST_BEACON_CHILD_CONSUMER_SECRET, account.getBeaconChildConsumerSecret());
         Assert.assertEquals("Additional OAuth values should match", createAdditionalOauthValues(), account.getAdditionalOauthValues());
     }
 
@@ -534,6 +563,8 @@ public class UserAccountTest {
         Assert.assertEquals("Sid cookie name should match", TEST_SID_COOKIE_NAME, account.getSidCookieName());
         Assert.assertEquals("Parent sid should match", TEST_PARENT_SID, account.getParentSid());
         Assert.assertEquals("Token format should match", TEST_TOKEN_FORMAT, account.getTokenFormat());
+        Assert.assertEquals("Beacon child consumer key should match", TEST_BEACON_CHILD_CONSUMER_KEY, account.getBeaconChildConsumerKey());
+        Assert.assertEquals("Beacon child consumer secret should match", TEST_BEACON_CHILD_CONSUMER_SECRET, account.getBeaconChildConsumerSecret());
         Assert.assertEquals("Additional OAuth values should match", createAdditionalOauthValues(), account.getAdditionalOauthValues());
     }
 
@@ -569,7 +600,8 @@ public class UserAccountTest {
         params.put("sidCookieName", TEST_SID_COOKIE_NAME);
         params.put("parent_sid", TEST_PARENT_SID);
         params.put("token_format", TEST_TOKEN_FORMAT);
-
+        params.put("beacon_child_consumer_key", TEST_BEACON_CHILD_CONSUMER_KEY);
+        params.put("beacon_child_consumer_secret", TEST_BEACON_CHILD_CONSUMER_SECRET);
         return new OAuth2.TokenEndpointResponse(params, createAdditionalOauthKeys());
     }
 


### PR DESCRIPTION
- Saving beacon child consumer key and secret in user account when returned in token end point response
- Using beacon child consumer key instead of configured consumer key if available
- Updated tests
- Tested manually with beacon app setup in test environment (na54)