### PR TITLE
Make test results more readable.

### DIFF
--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -148,10 +148,8 @@ jobs:
           check_retries: true
           flaky_summary: true
           fail_on_failure: true
-          detailed_summary: true
           group_reports: false
           include_passed: true
-          skip_success_summary: true
           include_empty_in_summary: false
           simplified_summary: true
           report_paths: 'firebase_results/**.xml'


### PR DESCRIPTION
Remove the "detailed summary" of individual test results as there appears to be no way to only list test failures.  This makes it a little annoying to dig in to see which test failed, but as it stands now the report is basically unusable.  Take the screenshot below as an example, you have to scroll through (357 x 8) **2856 lines** to find the one test failure 🙅 

![Screenshot 2025-05-19 at 11 44 22 AM](https://github.com/user-attachments/assets/20c0d95a-df4d-458f-94b0-aaa451be78cf)
