### PR TITLE
Switch to new user before sending user switch intent.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -201,6 +201,8 @@ internal suspend fun onAuthFlowComplete(
 
     // Save the user account
     addAccount(account)
+    userAccountManager.createAccount(account)
+    userAccountManager.switchToUser(account)
 
     // Init user logging
     SalesforceAnalyticsManager.getInstance(account)?.updateLoggingPrefs()
@@ -218,8 +220,6 @@ internal suspend fun onAuthFlowComplete(
         else -> USER_SWITCH_TYPE_DEFAULT
     }
     userAccountManager.sendUserSwitchIntent(userSwitchType, null)
-    userAccountManager.createAccount(account)
-    userAccountManager.switchToUser(account)
 
     // Kickoff the end of the flow before storing mobile policy to prevent launching
     // the main activity over/after the screen lock.


### PR DESCRIPTION
This fixes the issue of the current user not being set correctly when we notify the app of the user switch.