### PR TITLE
@W-17459669: Android 16 support

### DIFF
--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -57,8 +57,7 @@
         <activity android:name="com.salesforce.androidsdk.auth.idp.IDPAuthCodeActivity"
             android:excludeFromRecents="true"
             android:theme="@style/SalesforceSDK"
-            android:exported="true"
-            android:screenOrientation="portrait" />
+            android:exported="true" />
 
         <!--  Dev info activity -->
         <activity android:name="com.salesforce.androidsdk.ui.DevInfoActivity"


### PR DESCRIPTION
🎸 _*Ready For Review*_ 🥁

  This resolves the [Github issue](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/issues/409#issue-3027790487) which was linked in the work item where MSDK's Android manifest orientation restrictions were causing publishing warnings for apps.  The simple solution appears to be simply removing the restriction since the activity lays out and performs the same in all orientations and has a very simple layout.

  Is there more context to this issue?

  According to our discussion today, I shelved all the other available "Android 16" updates for future work, if that's OK.  There's plenty of code and troubleshooting there that's already done, at least.