### PR TITLE
Saving API instance URL in user account

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -63,6 +63,7 @@ public class UserAccount {
 	public static final String LOGIN_SERVER = "loginServer";
 	public static final String ID_URL = "idUrl";
 	public static final String INSTANCE_SERVER = "instanceServer";
+	public static final String API_INSTANCE_SERVER = "apiInstanceServer";
 	public static final String ORG_ID = "orgId";
 	public static final String USER_ID = "userId";
 	public static final String USERNAME = "username";
@@ -109,6 +110,7 @@ public class UserAccount {
 	private String loginServer;
 	private String idUrl;
 	private String instanceServer;
+	private String apiInstanceServer;
 	private String orgId;
 	private String userId;
 	private String username;
@@ -144,41 +146,42 @@ public class UserAccount {
 	/**
 	 * Parameterized constructor.
 	 *
-	 * @param authToken Auth token.
-	 * @param refreshToken Refresh token.
-	 * @param loginServer Login server.
-	 * @param idUrl Identity URL.
-	 * @param instanceServer Instance server.
-	 * @param orgId Org ID.
-	 * @param userId User ID.
-	 * @param username Username.
-	 * @param accountName Account name.
-	 * @param communityId Community ID.
-	 * @param communityUrl Community URL.
-	 * @param firstName First Name.
-	 * @param lastName Last Name.
-	 * @param displayName Display Name.
-	 * @param email Email.
-	 * @param photoUrl Photo URL.
-	 * @param thumbnailUrl Thumbnail URL.
-	 * @param additionalOauthValues Additional OAuth values.
-	 * @param lightningDomain Lightning domain.
-	 * @param lightningSid Lightning SID.
-	 * @param vfDomain VF domain.
-	 * @param vfSid VF SID.
-	 * @param contentDomain Content domain.
-	 * @param contentSid Content SID.
-	 * @param nativeLogin If the account was added with native auth.
-	 * @param language User's language,
-	 * @param locale User's locale,
-	 * @param cookieClientSrc cookie client src
-	 * @param cookieSidClient cookie sid client
-	 * @param sidCookieName sid cookie name
-	 * @param clientId oauth client id
-	 * @param parentSid parent sid
-	 * @param tokenFormat token format
-	 * @param beaconChildConsumerKey beacon child consumer key
+	 * @param authToken                 Auth token.
+	 * @param refreshToken              Refresh token.
+	 * @param loginServer               Login server.
+	 * @param idUrl                     Identity URL.
+	 * @param instanceServer            Instance server.
+	 * @param orgId                     Org ID.
+	 * @param userId                    User ID.
+	 * @param username                  Username.
+	 * @param accountName               Account name.
+	 * @param communityId               Community ID.
+	 * @param communityUrl              Community URL.
+	 * @param firstName                 First Name.
+	 * @param lastName                  Last Name.
+	 * @param displayName               Display Name.
+	 * @param email                     Email.
+	 * @param photoUrl                  Photo URL.
+	 * @param thumbnailUrl              Thumbnail URL.
+	 * @param additionalOauthValues     Additional OAuth values.
+	 * @param lightningDomain           Lightning domain.
+	 * @param lightningSid              Lightning SID.
+	 * @param vfDomain                  VF domain.
+	 * @param vfSid                     VF SID.
+	 * @param contentDomain             Content domain.
+	 * @param contentSid                Content SID.
+	 * @param nativeLogin               If the account was added with native auth.
+	 * @param language                  User's language,
+	 * @param locale                    User's locale,
+	 * @param cookieClientSrc           cookie client src
+	 * @param cookieSidClient           cookie sid client
+	 * @param sidCookieName             sid cookie name
+	 * @param clientId                  oauth client id
+	 * @param parentSid                 parent sid
+	 * @param tokenFormat               token format
+	 * @param beaconChildConsumerKey    beacon child consumer key
 	 * @param beaconChildConsumerSecret beacon child consumer secret
+	 * @param apiInstanceServer         API instance server
 	 */
 	UserAccount(String authToken, String refreshToken,
 				String loginServer, String idUrl, String instanceServer,
@@ -190,12 +193,13 @@ public class UserAccount {
 				String  contentDomain, String contentSid, String csrfToken, Boolean nativeLogin,
 				String language, String locale, String cookieClientSrc, String cookieSidClient,
 				String sidCookieName, String clientId, String parentSid, String tokenFormat,
-				String beaconChildConsumerKey, String beaconChildConsumerSecret) {
+				String beaconChildConsumerKey, String beaconChildConsumerSecret, String apiInstanceServer) {
 		this.authToken = authToken;
 		this.refreshToken = refreshToken;
 		this.loginServer = loginServer;
 		this.idUrl = idUrl;
 		this.instanceServer = instanceServer;
+		this.apiInstanceServer = apiInstanceServer;
 		this.orgId = orgId;
 		this.userId = userId;
 		this.username = username;
@@ -244,6 +248,7 @@ public class UserAccount {
 			loginServer = object.optString(LOGIN_SERVER, null);
 			idUrl = object.optString(ID_URL, null);
 			instanceServer = object.optString(INSTANCE_SERVER, null);
+			apiInstanceServer = object.optString(API_INSTANCE_SERVER, null);
 			orgId = object.optString(ORG_ID, null);
 			userId = object.optString(USER_ID, null);
 			username = object.optString(USERNAME, null);
@@ -301,6 +306,7 @@ public class UserAccount {
 			loginServer = bundle.getString(LOGIN_SERVER);
 			idUrl = bundle.getString(ID_URL);
 			instanceServer = bundle.getString(INSTANCE_SERVER);
+			apiInstanceServer = bundle.getString(API_INSTANCE_SERVER);
 			orgId = bundle.getString(ORG_ID);
 			userId = bundle.getString(USER_ID);
 			username = bundle.getString(USERNAME);
@@ -387,6 +393,15 @@ public class UserAccount {
 	 */
 	public String getInstanceServer() {
 		return instanceServer;
+	}
+
+	/**
+	 * Returns the API instance server for this user account.
+	 *
+	 * @return API instance server.
+	 */
+	public String getApiInstanceServer() {
+		return apiInstanceServer;
 	}
 
 	/**
@@ -911,6 +926,7 @@ public class UserAccount {
 			object.put(LOGIN_SERVER, loginServer);
 			object.put(ID_URL, idUrl);
 			object.put(INSTANCE_SERVER, instanceServer);
+			object.put(API_INSTANCE_SERVER, apiInstanceServer);
 			object.put(ORG_ID, orgId);
 			object.put(USER_ID, userId);
 			object.put(USERNAME, username);
@@ -968,6 +984,7 @@ public class UserAccount {
 		object.putString(LOGIN_SERVER, loginServer);
 		object.putString(ID_URL, idUrl);
 		object.putString(INSTANCE_SERVER, instanceServer);
+		object.putString(API_INSTANCE_SERVER, apiInstanceServer);
 		object.putString(ORG_ID, orgId);
 		object.putString(USER_ID, userId);
 		object.putString(USERNAME, username);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
@@ -38,6 +38,7 @@ class UserAccountBuilder private constructor() {
     private var loginServer: String? = null
     private var idUrl: String? = null
     private var instanceServer: String? = null
+    private var apiInstanceServer: String? = null
     private var orgId: String? = null
     private var userId: String? = null
     private var username: String? = null
@@ -84,6 +85,7 @@ class UserAccountBuilder private constructor() {
         return authToken(tr.authToken)
             .refreshToken(tr.refreshToken)
             .instanceServer(tr.instanceUrl)
+            .apiInstanceServer(tr.apiInstanceUrl)
             .idUrl(tr.idUrl)
             .orgId(tr.orgId)
             .userId(tr.userId)
@@ -139,6 +141,7 @@ class UserAccountBuilder private constructor() {
             .loginServer(userAccount.loginServer)
             .idUrl(userAccount.idUrl)
             .instanceServer(userAccount.instanceServer)
+            .apiInstanceServer(userAccount.apiInstanceServer)
             .orgId(userAccount.orgId)
             .userId(userAccount.userId)
             .username(userAccount.username)
@@ -232,6 +235,16 @@ class UserAccountBuilder private constructor() {
      */
     fun instanceServer(instanceServer: String?): UserAccountBuilder {
         return if (!allowUnset && instanceServer == null) this else apply { this.instanceServer = instanceServer }
+    }
+
+    /**
+     * Sets api instance server.
+     *
+     * @param apiInstanceServer API instance server.
+     * @return Instance of this class.
+     */
+    fun apiInstanceServer(apiInstanceServer: String?): UserAccountBuilder {
+        return if (!allowUnset && apiInstanceServer == null) this else apply { this.apiInstanceServer = apiInstanceServer }
     }
 
     /**
@@ -566,12 +579,43 @@ class UserAccountBuilder private constructor() {
      */
     fun build(): UserAccount {
         return UserAccount(
-            authToken, refreshToken, loginServer, idUrl, instanceServer, orgId,
-            userId, username, accountName, communityId, communityUrl, firstName, lastName,
-            displayName, email, photoUrl, thumbnailUrl, additionalOauthValues, lightningDomain,
-            lightningSid, vfDomain, vfSid, contentDomain, contentSid, csrfToken, nativeLogin,
-            language, locale, cookieClientSrc, cookieSidClient, sidCookieName, clientId,
-            parentSid, tokenFormat, beaconChildConsumerKey, beaconChildConsumerSecret
+            authToken,
+            refreshToken,
+            loginServer,
+            idUrl,
+            instanceServer,
+            orgId,
+            userId,
+            username,
+            accountName,
+            communityId,
+            communityUrl,
+            firstName,
+            lastName,
+            displayName,
+            email,
+            photoUrl,
+            thumbnailUrl,
+            additionalOauthValues,
+            lightningDomain,
+            lightningSid,
+            vfDomain,
+            vfSid,
+            contentDomain,
+            contentSid,
+            csrfToken,
+            nativeLogin,
+            language,
+            locale,
+            cookieClientSrc,
+            cookieSidClient,
+            sidCookieName,
+            clientId,
+            parentSid,
+            tokenFormat,
+            beaconChildConsumerKey,
+            beaconChildConsumerSecret,
+            apiInstanceServer
         )
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -509,6 +509,7 @@ public class UserAccountManager {
 		final String loginServer = decryptUserData(account, AuthenticatorService.KEY_LOGIN_URL, encryptionKey);
 		final String idUrl = decryptUserData(account, AuthenticatorService.KEY_ID_URL, encryptionKey);
 		final String instanceServer = decryptUserData(account, AuthenticatorService.KEY_INSTANCE_URL, encryptionKey);
+		final String apiInstanceServer = decryptUserData(account, AuthenticatorService.KEY_API_INSTANCE_URL, encryptionKey);
 		final String orgId = decryptUserData(account, AuthenticatorService.KEY_ORG_ID, encryptionKey);
 		final String userId = decryptUserData(account, AuthenticatorService.KEY_USER_ID, encryptionKey);
 		final String username = decryptUserData(account, AuthenticatorService.KEY_USERNAME, encryptionKey);
@@ -562,6 +563,7 @@ public class UserAccountManager {
 					.loginServer(loginServer)
 					.idUrl(idUrl)
 					.instanceServer(instanceServer)
+					.apiInstanceServer(apiInstanceServer)
 					.orgId(orgId)
 					.userId(userId)
 					.username(username)
@@ -710,6 +712,7 @@ public class UserAccountManager {
 		extras.putString(AuthenticatorService.KEY_LOGIN_URL, SalesforceSDKManager.encrypt(userAccount.getLoginServer(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_ID_URL, SalesforceSDKManager.encrypt(userAccount.getIdUrl(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_INSTANCE_URL, SalesforceSDKManager.encrypt(userAccount.getInstanceServer(), encryptionKey));
+		extras.putString(AuthenticatorService.KEY_API_INSTANCE_URL, SalesforceSDKManager.encrypt(userAccount.getApiInstanceServer(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_CLIENT_ID, SalesforceSDKManager.encrypt(userAccount.getClientId(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_ORG_ID, SalesforceSDKManager.encrypt(userAccount.getOrgId(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_USER_ID, SalesforceSDKManager.encrypt(userAccount.getUserId(), encryptionKey));

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -58,6 +58,7 @@ public class AuthenticatorService extends Service {
     // Keys to extra info in the account.
     public static final String KEY_LOGIN_URL = "loginUrl";
     public static final String KEY_INSTANCE_URL = "instanceUrl";
+    public static final String KEY_API_INSTANCE_URL = "apiInstanceUrl";
     public static final String KEY_USER_ID = "userId";
     public static final String KEY_CLIENT_ID = "clientId";
     public static final String KEY_ORG_ID = "orgId";

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -97,6 +97,7 @@ public class OAuth2 {
     protected static final String FORMAT = "format";
     private static final String ID = "id";
     private static final String INSTANCE_URL = "instance_url";
+    private static final String API_INSTANCE_URL = "api_instance_url";
     protected static final String JSON = "json";
     private static final String MOBILE_POLICY = "mobile_policy";
     private static final String SCREEN_LOCK_TIMEOUT = "screen_lock";
@@ -808,6 +809,7 @@ public class OAuth2 {
         public String authToken;
         public String refreshToken;
         public String instanceUrl;
+        public String apiInstanceUrl;
         public String idUrl;
         public String idUrlWithInstance;
         public String orgId;
@@ -844,6 +846,7 @@ public class OAuth2 {
                 authToken = callbackUrlParams.get(ACCESS_TOKEN);
                 refreshToken = callbackUrlParams.get(REFRESH_TOKEN);
                 instanceUrl = callbackUrlParams.get(INSTANCE_URL);
+                apiInstanceUrl = callbackUrlParams.get(API_INSTANCE_URL);
                 idUrl = callbackUrlParams.get(ID);
                 code = callbackUrlParams.get(CODE);
                 computeOtherFields();
@@ -903,6 +906,7 @@ public class OAuth2 {
                 Log.d(TAG, "parsedResponse-->" + parsedResponse);
                 authToken = parsedResponse.getString(ACCESS_TOKEN);
                 instanceUrl = parsedResponse.getString(INSTANCE_URL);
+                apiInstanceUrl = parsedResponse.getString(API_INSTANCE_URL);
                 idUrl = parsedResponse.getString(ID);
                 computeOtherFields();
                 if (parsedResponse.has(REFRESH_TOKEN)) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/test/TestCredentials.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/test/TestCredentials.java
@@ -30,6 +30,7 @@ import android.content.Context;
 
 import com.salesforce.androidsdk.R;
 import com.salesforce.androidsdk.rest.ApiVersionStrings;
+import com.salesforce.androidsdk.util.JSONObjectHelper;
 import com.salesforce.androidsdk.util.ResourceReaderHelper;
 
 import org.json.JSONObject;
@@ -49,6 +50,7 @@ public class TestCredentials {
     public static String USER_ID;
     public static String LOGIN_URL;
     public static String INSTANCE_URL;
+    public static String API_INSTANCE_URL;
     public static String COMMUNITY_URL;
     public static String IDENTITY_URL;
     public static String CLIENT_ID;
@@ -69,6 +71,7 @@ public class TestCredentials {
             USER_ID = json.getString("user_id");
             LOGIN_URL = json.getString("test_login_domain");
             INSTANCE_URL = json.getString("instance_url");
+            API_INSTANCE_URL = JSONObjectHelper.optString(json, "api_instance_url");
             COMMUNITY_URL = json.optString("community_url", INSTANCE_URL /* in case the test_credentials.json was obtained for a user / org without community setup */);
             IDENTITY_URL = json.getString("identity_url");
             CLIENT_ID = json.getString("test_client_id");

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -69,6 +69,7 @@ public class UserAccountTest {
     public static final String TEST_USERNAME = "test_username";
     public static final String TEST_LOGIN_URL = "https://test.salesforce.com";
     public static final String TEST_INSTANCE_URL = "https://cs1.salesforce.com";
+    public static final String TEST_API_INSTANCE_URL = "https://api.salesforce.com";
     public static final String TEST_IDENTITY_URL = "https://test.salesforce.com/" + TEST_ORG_ID + "/" + TEST_USER_ID;
     public static final String TEST_COMMUNITY_URL = "https://mobilesdk.cs1.my.salesforce.com";
     public static final String TEST_AUTH_TOKEN = "test_auth_token";
@@ -375,6 +376,7 @@ public class UserAccountTest {
         object.put(UserAccount.LOGIN_SERVER, TEST_LOGIN_URL);
         object.put(UserAccount.ID_URL, TEST_IDENTITY_URL);
         object.put(UserAccount.INSTANCE_SERVER, TEST_INSTANCE_URL);
+        object.put(UserAccount.API_INSTANCE_SERVER, TEST_API_INSTANCE_URL);
         object.put(UserAccount.ORG_ID, TEST_ORG_ID);
         object.put(UserAccount.USER_ID, TEST_USER_ID);
         object.put(UserAccount.USERNAME, TEST_USERNAME);
@@ -419,6 +421,7 @@ public class UserAccountTest {
         object.putString(UserAccount.LOGIN_SERVER, TEST_LOGIN_URL);
         object.putString(UserAccount.ID_URL, TEST_IDENTITY_URL);
         object.putString(UserAccount.INSTANCE_SERVER, TEST_INSTANCE_URL);
+        object.putString(UserAccount.API_INSTANCE_SERVER, TEST_API_INSTANCE_URL);
         object.putString(UserAccount.ORG_ID, TEST_ORG_ID);
         object.putString(UserAccount.USER_ID, TEST_USER_ID);
         object.putString(UserAccount.USERNAME, TEST_USERNAME);
@@ -463,6 +466,7 @@ public class UserAccountTest {
                 .loginServer(TEST_LOGIN_URL)
                 .idUrl(TEST_IDENTITY_URL)
                 .instanceServer(TEST_INSTANCE_URL)
+                .apiInstanceServer(TEST_API_INSTANCE_URL)
                 .orgId(TEST_ORG_ID)
                 .userId(TEST_USER_ID)
                 .username(TEST_USERNAME)
@@ -529,6 +533,7 @@ public class UserAccountTest {
         Assert.assertEquals("Login server URL should match", TEST_LOGIN_URL, account.getLoginServer());
         Assert.assertEquals("Identity URL should match", TEST_IDENTITY_URL, account.getIdUrl());
         Assert.assertEquals("Instance URL should match", TEST_INSTANCE_URL, account.getInstanceServer());
+        Assert.assertEquals("API instance URL should match", TEST_API_INSTANCE_URL, account.getApiInstanceServer());
         Assert.assertEquals("Org ID should match", TEST_ORG_ID, account.getOrgId());
         Assert.assertEquals("User ID should match", TEST_USER_ID, account.getUserId());
         Assert.assertEquals("User name should match", TEST_USERNAME, account.getUsername());
@@ -575,6 +580,7 @@ public class UserAccountTest {
         Assert.assertEquals("Login server URL should match", TEST_LOGIN_URL, account.getLoginServer());
         Assert.assertEquals("Identity URL should match", TEST_IDENTITY_URL, account.getIdUrl());
         Assert.assertEquals("Instance URL should match", TEST_INSTANCE_URL, account.getInstanceServer());
+        Assert.assertEquals("API instance URL should match", TEST_API_INSTANCE_URL, account.getApiInstanceServer());
         Assert.assertEquals("Org ID should match", TEST_ORG_ID_2, account.getOrgId());
         Assert.assertEquals("User ID should match", TEST_USER_ID_2, account.getUserId());
         Assert.assertEquals("User name should match", TEST_USERNAME_2, account.getUsername());
@@ -646,6 +652,7 @@ public class UserAccountTest {
         params.put("access_token", TEST_AUTH_TOKEN);
         params.put("refresh_token", TEST_REFRESH_TOKEN);
         params.put("instance_url", TEST_INSTANCE_URL);
+        params.put("api_instance_url", TEST_API_INSTANCE_URL);
         params.put("id", TEST_IDENTITY_URL);
         params.put("sfdc_community_id", TEST_COMMUNITY_ID);
         params.put("sfdc_community_url", TEST_COMMUNITY_URL);

--- a/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/ExplorerActivity.java
+++ b/native/NativeSampleApps/RestExplorer/src/com/salesforce/samples/restexplorer/ExplorerActivity.java
@@ -791,6 +791,7 @@ public class ExplorerActivity extends SalesforceActivity {
 		credsMap.put("test_redirect_uri", config.getOauthRedirectURI());
 		credsMap.put("refresh_token", user.getRefreshToken());
 		credsMap.put("instance_url", user.getInstanceServer());
+		credsMap.put("api_instance_url", user.getApiInstanceServer());
 		credsMap.put("identity_url", user.getIdUrl());
 		credsMap.put("access_token", "__NOT_REQUIRED__");
 		credsMap.put("organization_id", user.getOrgId());


### PR DESCRIPTION
- token end point response contains api_instance_url (when sfap_api scope is being used)
- this value is now captured and saved in the user account
- tests were updated
- test_credentials.json exported by RestExplorer and used in tests now includes api instance server

TBD?: passing this value to SfapApiClient directly