### PR TITLE
@W-18648586: Gradle upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 apply(plugin = "io.github.gradle-nexus.publish-plugin")
 apply(from = "${rootDir}/publish/publish-root.gradle")
 
@@ -11,7 +13,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
         classpath("org.jacoco:org.jacoco.core:0.8.12")
     }
 }
@@ -23,10 +25,10 @@ allprojects {
     // Ensure that we do not use newer language features that would make the SDK incompatible with
     // apps that do not target the latest version of Kotlin.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-        kotlinOptions {
-            freeCompilerArgs += arrayOf("-Xopt-in=kotlin.RequiresOptIn")
-            apiVersion = "1.6"
-            languageVersion = "1.6"
+        compilerOptions {
+            freeCompilerArgs.add("-Xopt-in=kotlin.RequiresOptIn")
+            apiVersion.set(KotlinVersion.KOTLIN_2_0)
+            languageVersion.set(KotlinVersion.KOTLIN_2_0)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.8.2")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
         classpath("org.jacoco:org.jacoco.core:0.8.12")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-
 apply(plugin = "io.github.gradle-nexus.publish-plugin")
 apply(from = "${rootDir}/publish/publish-root.gradle")
 
@@ -13,7 +11,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
         classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
         classpath("org.jacoco:org.jacoco.core:0.8.12")
     }
 }
@@ -25,10 +23,10 @@ allprojects {
     // Ensure that we do not use newer language features that would make the SDK incompatible with
     // apps that do not target the latest version of Kotlin.
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-        compilerOptions {
-            freeCompilerArgs.add("-Xopt-in=kotlin.RequiresOptIn")
-            apiVersion.set(KotlinVersion.KOTLIN_2_0)
-            languageVersion.set(KotlinVersion.KOTLIN_2_0)
+        kotlinOptions {
+            freeCompilerArgs += arrayOf("-Xopt-in=kotlin.RequiresOptIn")
+            apiVersion = "1.6"
+            languageVersion = "1.6"
         }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 
 dependencies {
     implementation("com.android.tools.build:gradle:8.10.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:8.8.2")
+    implementation("com.android.tools.build:gradle:8.10.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:2.0.21")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -11,10 +11,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.accounteditor"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -11,18 +11,18 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.accounteditor"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api(project(":libs:SalesforceHybrid"))
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
 }
 
 android {
@@ -21,8 +21,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -11,10 +11,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.mobilesyncexplorerhybrid"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -11,18 +11,18 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.mobilesyncexplorerhybrid"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api(project(":libs:SalesforceHybrid"))
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
 }
 
 android {
@@ -21,8 +21,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -11,9 +11,9 @@ plugins {
 
 dependencies {
     api(project(":libs:SmartStore"))
-    api("androidx.appcompat:appcompat:1.7.0")
-    api("androidx.appcompat:appcompat-resources:1.7.0")
-    implementation("androidx.core:core-ktx:1.15.0")
+    api("androidx.appcompat:appcompat:1.7.1")
+    api("androidx.appcompat:appcompat-resources:1.7.1")
+    implementation("androidx.core:core-ktx:1.16.0")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
@@ -88,7 +88,7 @@ android {
         }
 
         sourceDirectories.setFrom("${project.projectDir}/src/main/java")
-        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val fileFilter = arrayListOf("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
         val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
         val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
         classDirectories.setFrom(javaTree, kotlinTree)

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     namespace = "com.salesforce.androidsdk.mobilesync"
     testNamespace = "com.salesforce.androidsdk.mobilesync.tests"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 28
@@ -38,8 +38,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -48,8 +48,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/MobileSyncTest")
-            java.srcDir("../test/MobileSyncTest/src")
-            resources.srcDir("../test/MobileSyncTest/src")
+            java.srcDirs(arrayOf("../test/MobileSyncTest/src"))
+            resources.srcDirs(arrayOf("../test/MobileSyncTest/src"))
             res.srcDirs(arrayOf("../test/MobileSyncTest/res"))
         }
     }

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -38,8 +38,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -48,8 +48,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/MobileSyncTest")
-            java.srcDirs(arrayOf("../test/MobileSyncTest/src"))
-            resources.srcDirs(arrayOf("../test/MobileSyncTest/src"))
+            java.srcDir("../test/MobileSyncTest/src")
+            resources.srcDir("../test/MobileSyncTest/src")
             res.srcDirs(arrayOf("../test/MobileSyncTest/res"))
         }
     }

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     namespace = "com.salesforce.androidsdk.mobilesync"
     testNamespace = "com.salesforce.androidsdk.mobilesync.tests"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 dependencies {
     api("com.squareup:tape:1.2.3")
     api("io.github.pilgr:paperdb:2.7.2")
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
@@ -91,7 +91,7 @@ android {
         }
 
         sourceDirectories.setFrom("${project.projectDir}/src/main/java")
-        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val fileFilter = arrayListOf("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
         val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
         val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
         classDirectories.setFrom(javaTree, kotlinTree)

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -22,7 +22,7 @@ android {
     namespace = "com.salesforce.androidsdk.analytics"
     testNamespace = "com.salesforce.androidsdk.analytics.tests"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 28
@@ -37,8 +37,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -47,8 +47,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceAnalyticsTest")
-            java.srcDir("../test/SalesforceAnalyticsTest/src")
-            resources.srcDir("../test/SalesforceAnalyticsTest/src")
+            java.srcDirs(arrayOf("../test/SalesforceAnalyticsTest/src"))
+            resources.srcDirs(arrayOf("../test/SalesforceAnalyticsTest/src"))
             res.srcDirs(arrayOf("../test/SalesforceAnalyticsTest/res"))
         }
     }

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -22,7 +22,7 @@ android {
     namespace = "com.salesforce.androidsdk.analytics"
     testNamespace = "com.salesforce.androidsdk.analytics.tests"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -37,8 +37,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -47,8 +47,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceAnalyticsTest")
-            java.srcDirs(arrayOf("../test/SalesforceAnalyticsTest/src"))
-            resources.srcDirs(arrayOf("../test/SalesforceAnalyticsTest/src"))
+            java.srcDir("../test/SalesforceAnalyticsTest/src")
+            resources.srcDir("../test/SalesforceAnalyticsTest/src")
             res.srcDirs(arrayOf("../test/SalesforceAnalyticsTest/res"))
         }
     }

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     namespace = "com.salesforce.androidsdk.hybrid"
     testNamespace = "com.salesforce.androidsdk.phonegap"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -43,8 +43,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -53,8 +53,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceHybridTest")
-            java.srcDirs(arrayOf("../test/SalesforceHybridTest/src"))
-            resources.srcDirs(arrayOf("../test/SalesforceHybridTest/src"))
+            java.srcDir("../test/SalesforceHybridTest/src")
+            resources.srcDir("../test/SalesforceHybridTest/src")
             res.srcDirs(arrayOf("../test/SalesforceHybridTest/res"))
         }
     }

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     namespace = "com.salesforce.androidsdk.hybrid"
     testNamespace = "com.salesforce.androidsdk.phonegap"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 28
@@ -43,8 +43,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -53,8 +53,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceHybridTest")
-            java.srcDir("../test/SalesforceHybridTest/src")
-            resources.srcDir("../test/SalesforceHybridTest/src")
+            java.srcDirs(arrayOf("../test/SalesforceHybridTest/src"))
+            resources.srcDirs(arrayOf("../test/SalesforceHybridTest/src"))
             res.srcDirs(arrayOf("../test/SalesforceHybridTest/res"))
         }
     }

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -14,11 +14,11 @@ plugins {
 dependencies {
     api(project(":libs:MobileSync"))
     api("org.apache.cordova:framework:13.0.0")
-    api("androidx.appcompat:appcompat:1.7.0")
-    api("androidx.appcompat:appcompat-resources:1.7.0")
-    api("androidx.webkit:webkit:1.12.1")
+    api("androidx.appcompat:appcompat:1.7.1")
+    api("androidx.appcompat:appcompat-resources:1.7.1")
+    api("androidx.webkit:webkit:1.14.0")
     api("androidx.core:core-splashscreen:1.0.1")
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
@@ -97,7 +97,7 @@ android {
         }
 
         sourceDirectories.setFrom("${project.projectDir}/src/main/java")
-        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val fileFilter = arrayListOf("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
         val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
         val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
         classDirectories.setFrom(javaTree, kotlinTree)

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     namespace = "com.salesforce.androidsdk.reactnative"
     testNamespace = "com.salesforce.androidsdk.reactnative.tests"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 28
@@ -57,8 +57,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -67,8 +67,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceReactTest")
-            java.srcDir("../test/SalesforceReactTest/src")
-            resources.srcDir("../test/SalesforceReactTest/src")
+            java.srcDirs(arrayOf("../test/SalesforceReactTest/src"))
+            resources.srcDirs(arrayOf("../test/SalesforceReactTest/src"))
             res.srcDirs(arrayOf("../test/SalesforceReactTest/res"))
         }
     }

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -57,8 +57,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -67,8 +67,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceReactTest")
-            java.srcDirs(arrayOf("../test/SalesforceReactTest/src"))
-            resources.srcDirs(arrayOf("../test/SalesforceReactTest/src"))
+            java.srcDir("../test/SalesforceReactTest/src")
+            resources.srcDir("../test/SalesforceReactTest/src")
             res.srcDirs(arrayOf("../test/SalesforceReactTest/res"))
         }
     }

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -42,7 +42,7 @@ android {
     namespace = "com.salesforce.androidsdk.reactnative"
     testNamespace = "com.salesforce.androidsdk.reactnative.tests"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28
@@ -170,7 +170,7 @@ afterEvaluate {
         tasks.getByName("preDebugAndroidTestBuild").dependsOn(
             tasks.getByName("buildReactTestBundleIfNotExists")
         )
-    } catch (πignored: Throwable) {
+    } catch (ignored: Throwable) {
         println("The preDebugAndroidTestBuild task was not found.")
     }
 }

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 dependencies {
     api(project(":libs:MobileSync"))
     api("com.facebook.react:react-android:0.79.3")
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
@@ -170,7 +170,7 @@ afterEvaluate {
         tasks.getByName("preDebugAndroidTestBuild").dependsOn(
             tasks.getByName("buildReactTestBundleIfNotExists")
         )
-    } catch (ignored: Throwable) {
+    } catch (πignored: Throwable) {
         println("The preDebugAndroidTestBuild task was not found.")
     }
 }

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -11,33 +11,33 @@ plugins {
 }
 
 dependencies {
-    val composeVersion = "1.7.7"
-    val livecycleVersion = "2.8.7"
-    val androidXActivityVersion = "1.10.0"
+    val composeVersion = "1.8.2"
+    val livecycleVersion = "2.8.7" // Update requires Kotlin 2.
+    val androidXActivityVersion = "1.10.1"
 
     api(project(":libs:SalesforceAnalytics"))
     api("com.squareup.okhttp3:okhttp:4.12.0")
-    api("com.google.firebase:firebase-messaging:24.1.0")
-    api("androidx.core:core:1.15.0")
+    api("com.google.firebase:firebase-messaging:24.1.1")
+    api("androidx.core:core:1.16.0")
     api("androidx.browser:browser:1.8.0")
-    api("androidx.work:work-runtime-ktx:2.10.0")
+    api("androidx.work:work-runtime-ktx:2.10.1")
 
     implementation("com.google.android.material:material:1.12.0")  // remove this when all xml is gone
-    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.biometric:biometric:1.2.0-alpha05")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.activity:activity-ktx:$androidXActivityVersion")
     implementation("androidx.activity:activity-compose:$androidXActivityVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-service:$livecycleVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-    implementation("androidx.window:window:1.3.0")
-    implementation("androidx.window:window-core:1.3.0")
-    implementation("androidx.compose.material3:material3-android:1.3.1")
-    implementation(platform("androidx.compose:compose-bom:2025.01.01"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3") // Update requires Kotlin 2.
+    implementation("androidx.window:window:1.4.0")
+    implementation("androidx.window:window-core:1.4.0")
+    implementation("androidx.compose.material3:material3-android:1.3.2")
+    implementation(platform("androidx.compose:compose-bom:2025.06.00"))
     implementation("androidx.compose.foundation:foundation-android:$composeVersion")
     implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
     implementation("androidx.compose.ui:ui-tooling-preview-android:$composeVersion")
@@ -114,6 +114,7 @@ android {
         compose = true
     }
 
+    @Suppress("UnstableApiUsage")
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.14"
     }
@@ -130,7 +131,7 @@ android {
         }
 
         sourceDirectories.setFrom("${project.projectDir}/src/main/java")
-        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val fileFilter = arrayListOf("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
         val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
         val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
         classDirectories.setFrom(javaTree, kotlinTree)

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -8,11 +8,12 @@ plugins {
     `publish-module`
     jacoco
     kotlin("plugin.serialization") version "2.0.21"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21"
 }
 
 dependencies {
     val composeVersion = "1.8.2"
-    val livecycleVersion = "2.8.7" // Update requires Kotlin 2.
+    val livecycleVersion = "2.9.1"
     val androidXActivityVersion = "1.10.1"
 
     api(project(":libs:SalesforceAnalytics"))
@@ -28,30 +29,35 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.activity:activity-ktx:$androidXActivityVersion")
-    implementation("androidx.activity:activity-compose:$androidXActivityVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$livecycleVersion")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-service:$livecycleVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3") // Update requires Kotlin 2.
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     implementation("androidx.window:window:1.4.0")
     implementation("androidx.window:window-core:1.4.0")
-    implementation("androidx.compose.material3:material3-android:1.3.2")
-    implementation(platform("androidx.compose:compose-bom:2025.06.00"))
-    implementation("androidx.compose.foundation:foundation-android:$composeVersion")
-    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
-    implementation("androidx.compose.ui:ui-tooling-preview-android:$composeVersion")
-    implementation("androidx.compose.material:material:$composeVersion")
-
-    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
 
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.arch.core:core-testing:2.2.0")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
     androidTestImplementation("io.mockk:mockk-android:1.14.0")
+
+    // Note: Compose dependencies are synchronized with the content in the Compose set up guide for easier migration to new versions.
+    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.compose.material3:material3:1.3.2")
+
+    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
+    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
+
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
+
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
+    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
 }
 
 android {
@@ -73,8 +79,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -83,8 +89,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceSDKTest")
-            java.srcDirs(arrayOf("../test/SalesforceSDKTest/src"))
-            resources.srcDirs(arrayOf("../test/SalesforceSDKTest/src"))
+            java.srcDir("../test/SalesforceSDKTest/src")
+            resources.srcDir("../test/SalesforceSDKTest/src")
             res.srcDirs(arrayOf("../test/SalesforceSDKTest/res"))
             @Suppress("UnstableApiUsage")
             assets.directories.add("../../shared/test")
@@ -112,11 +118,6 @@ android {
         aidl = true
         buildConfig = true
         compose = true
-    }
-
-    @Suppress("UnstableApiUsage")
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
     }
 
     val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -64,7 +64,7 @@ android {
     namespace = "com.salesforce.androidsdk"
     testNamespace = "com.salesforce.androidsdk.tests"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -8,12 +8,11 @@ plugins {
     `publish-module`
     jacoco
     kotlin("plugin.serialization") version "2.0.21"
-    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21"
 }
 
 dependencies {
     val composeVersion = "1.8.2"
-    val livecycleVersion = "2.9.1"
+    val livecycleVersion = "2.8.7" // Update requires Kotlin 2.
     val androidXActivityVersion = "1.10.1"
 
     api(project(":libs:SalesforceAnalytics"))
@@ -29,42 +28,37 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.activity:activity-ktx:$androidXActivityVersion")
+    implementation("androidx.activity:activity-compose:$androidXActivityVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$livecycleVersion")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$livecycleVersion")
     implementation("androidx.lifecycle:lifecycle-service:$livecycleVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3") // Update requires Kotlin 2.
     implementation("androidx.window:window:1.4.0")
     implementation("androidx.window:window-core:1.4.0")
+    implementation("androidx.compose.material3:material3-android:1.3.2")
+    implementation(platform("androidx.compose:compose-bom:2025.06.00"))
+    implementation("androidx.compose.foundation:foundation-android:$composeVersion")
+    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
+    implementation("androidx.compose.ui:ui-tooling-preview-android:$composeVersion")
+    implementation("androidx.compose.material:material:$composeVersion")
+
+    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
 
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.arch.core:core-testing:2.2.0")
-    androidTestImplementation("io.mockk:mockk-android:1.14.0")
-
-    // Note: Compose dependencies are synchronized with the content in the Compose set up guide for easier migration to new versions.
-    val composeBom = platform("androidx.compose:compose-bom:2025.05.00")
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
-    implementation("androidx.compose.material3:material3:1.3.2")
-
-    implementation("androidx.compose.ui:ui-tooling-preview:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-tooling:$composeVersion")
-
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$composeVersion")
-
-    implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
-    implementation("androidx.compose.runtime:runtime-livedata:$composeVersion")
+    androidTestImplementation("io.mockk:mockk-android:1.14.0")
 }
 
 android {
     namespace = "com.salesforce.androidsdk"
     testNamespace = "com.salesforce.androidsdk.tests"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 28
@@ -79,8 +73,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -89,8 +83,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SalesforceSDKTest")
-            java.srcDir("../test/SalesforceSDKTest/src")
-            resources.srcDir("../test/SalesforceSDKTest/src")
+            java.srcDirs(arrayOf("../test/SalesforceSDKTest/src"))
+            resources.srcDirs(arrayOf("../test/SalesforceSDKTest/src"))
             res.srcDirs(arrayOf("../test/SalesforceSDKTest/res"))
             @Suppress("UnstableApiUsage")
             assets.directories.add("../../shared/test")
@@ -118,6 +112,11 @@ android {
         aidl = true
         buildConfig = true
         compose = true
+    }
+
+    @Suppress("UnstableApiUsage")
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
 
     val convertCodeCoverage: TaskProvider<JacocoReport> = tasks.register<JacocoReport>("convertedCodeCoverage") {

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     //noinspection GradleDependency -  Needs to line up with supported SQLCipher version.
     api("androidx.sqlite:sqlite:2.2.0")
     api("net.zetetic:sqlcipher-android:4.9.0")
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     androidTestImplementation("androidx.test:runner:1.6.2")
     androidTestImplementation("androidx.test:rules:1.6.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
@@ -94,7 +94,7 @@ android {
         }
 
         sourceDirectories.setFrom("${project.projectDir}/src/main/java")
-        val fileFilter = arrayListOf("**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+        val fileFilter = arrayListOf("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
         val javaTree = fileTree("${project.projectDir}/build/intermediates/javac/debug") { setExcludes(fileFilter) }
         val kotlinTree = fileTree("${project.projectDir}/build/tmp/kotlin-classes/debug") { setExcludes(fileFilter) }
         classDirectories.setFrom(javaTree, kotlinTree)

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -42,8 +42,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -53,8 +53,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SmartStoreTest")
-            java.srcDirs(arrayOf("../test/SmartStoreTest/src"))
-            resources.srcDirs(arrayOf("../test/SmartStoreTest/src"))
+            java.srcDir("../test/SmartStoreTest/src")
+            resources.srcDir("../test/SmartStoreTest/src")
             res.srcDirs(arrayOf("../test/SmartStoreTest/res"))
         }
     }

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     namespace = "com.salesforce.androidsdk.smartstore"
     testNamespace = "com.salesforce.androidsdk.smartstore.tests"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 28
@@ -42,8 +42,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -53,8 +53,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/SmartStoreTest")
-            java.srcDir("../test/SmartStoreTest/src")
-            resources.srcDir("../test/SmartStoreTest/src")
+            java.srcDirs(arrayOf("../test/SmartStoreTest/src"))
+            resources.srcDirs(arrayOf("../test/SmartStoreTest/src"))
             res.srcDirs(arrayOf("../test/SmartStoreTest/res"))
         }
     }

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -27,7 +27,7 @@ android {
     namespace = "com.salesforce.androidsdk.smartstore"
     testNamespace = "com.salesforce.androidsdk.smartstore.tests"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -11,18 +11,18 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.appconfigurator"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api(project(":libs:SalesforceSDK"))
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
 }
 
 android {

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -11,10 +11,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.appconfigurator"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -21,8 +21,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 
 dependencies {
     api(project(":libs:SalesforceSDK"))
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("androidx.appcompat:appcompat-resources:1.7.0")
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.appcompat:appcompat-resources:1.7.1")
+    implementation("androidx.core:core-ktx:1.16.0")
 }
 
 android {

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -13,10 +13,10 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.configuredapp"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -13,18 +13,18 @@ dependencies {
 android {
     namespace = "com.salesforce.samples.configuredapp"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -23,8 +23,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -29,10 +29,10 @@ android {
     namespace = "com.salesforce.samples.restexplorer"
     testNamespace = "com.salesforce.samples.restexplorer.tests"
 
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
-        targetSdk = 36
+        targetSdk = 35
         minSdk = 28
     }
 
@@ -45,8 +45,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDir("src")
-            resources.srcDir("src")
+            java.srcDirs(arrayOf("src"))
+            resources.srcDirs(arrayOf("src"))
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -55,8 +55,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/RestExplorerTest")
-            java.srcDir("../test/RestExplorerTest/src")
-            resources.srcDir("../test/RestExplorerTest/src")
+            java.srcDirs(arrayOf("../test/RestExplorerTest/src"))
+            resources.srcDirs(arrayOf("../test/RestExplorerTest/src"))
             res.srcDirs(arrayOf("../test/RestExplorerTest/res"))
         }
     }

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -5,15 +5,15 @@ plugins {
 
 dependencies {
     implementation(project(":libs:SalesforceSDK"))
-    implementation("androidx.core:core-ktx:1.15.0")
-    implementation("androidx.tracing:tracing:1.2.0")
+    implementation("androidx.core:core-ktx:1.16.0")
+    implementation("androidx.tracing:tracing:1.3.0")
     implementation("com.google.android.material:material:1.12.0")
     androidTestImplementation("androidx.test:runner:1.5.1") {
         exclude("com.android.support", "support-annotations")
     }
 
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("androidx.appcompat:appcompat-resources:1.7.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.appcompat:appcompat-resources:1.7.1")
 
     androidTestImplementation("androidx.test:rules:1.5.0") {
         exclude("com.android.support", "support-annotations")

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -29,10 +29,10 @@ android {
     namespace = "com.salesforce.samples.restexplorer"
     testNamespace = "com.salesforce.samples.restexplorer.tests"
 
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
-        targetSdk = 35
+        targetSdk = 36
         minSdk = 28
     }
 

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -45,8 +45,8 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("AndroidManifest.xml")
-            java.srcDirs(arrayOf("src"))
-            resources.srcDirs(arrayOf("src"))
+            java.srcDir("src")
+            resources.srcDir("src")
             aidl.srcDirs(arrayOf("src"))
             renderscript.srcDirs(arrayOf("src"))
             res.srcDirs(arrayOf("res"))
@@ -55,8 +55,8 @@ android {
 
         getByName("androidTest") {
             setRoot("../test/RestExplorerTest")
-            java.srcDirs(arrayOf("../test/RestExplorerTest/src"))
-            resources.srcDirs(arrayOf("../test/RestExplorerTest/src"))
+            java.srcDir("../test/RestExplorerTest/src")
+            resources.srcDir("../test/RestExplorerTest/src")
             res.srcDirs(arrayOf("../test/RestExplorerTest/res"))
         }
     }


### PR DESCRIPTION
🎸 _*Ready For Review!*_ 🥁

This updates MSDK Android to the latest Gradle and Android Gradle Plugin plus a few other dependency updates.  However, it doesn't take the next two steps of updating to Kotlin 2 and the Kotlin Compose Compiler Gradle Plugin or Android API 36.

Note: There are two really valuable "future" commits on this branch history that actually have working code for the two deferred steps.  We can cherry pick those in when the time comes for some serious effort reduction since that's completed.