### PR TITLE
Fix rare race condition crash.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/AppLockManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/AppLockManager.kt
@@ -31,6 +31,7 @@ import android.content.SharedPreferences
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.util.EventsObservable
+import androidx.core.content.edit
 
 typealias Policy = Pair<Boolean, Int>
 
@@ -84,17 +85,17 @@ internal abstract class AppLockManager(
     }
 
     open fun storeMobilePolicy(account: UserAccount, enabled: Boolean, timeout: Int) {
-        getAccountPrefs(account).edit()
-            .putBoolean(enabledKey, enabled)
-            .putInt(timeoutKey, timeout)
-            .apply()
+        getAccountPrefs(account).edit {
+            putBoolean(enabledKey, enabled)
+                .putInt(timeoutKey, timeout)
+        }
     }
 
     open fun cleanUp(account: UserAccount) {
-        val editor = getAccountPrefs(account).edit()
-        getAccountPrefs(account).all.keys.forEach { key ->
-            editor.remove(key)
+        getAccountPrefs(account).edit {
+            getAccountPrefs(account).all.keys.forEach { key ->
+                remove(key)
+            }
         }
-        editor.apply()
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/BiometricAuthenticationManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/BiometricAuthenticationManager.kt
@@ -34,6 +34,7 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.security.interfaces.BiometricAuthenticationManager
 import com.salesforce.androidsdk.ui.BiometricAuthOptInPrompt
 import com.salesforce.androidsdk.util.EventsObservable
+import androidx.core.content.edit
 
 internal class BiometricAuthenticationManager: AppLockManager(
     BIO_AUTH_POLICY, BIO_AUTH_ENABLED, BIO_AUTH_TIMEOUT
@@ -42,7 +43,7 @@ internal class BiometricAuthenticationManager: AppLockManager(
     @Suppress("INAPPLICABLE_JVM_NAME")
     @get:JvmName("isEnabled")
     override val enabled: Boolean
-        get() { return currentUser != null && getPolicy(currentUser!!).first }
+        get() = currentUser?.let { getPolicy(it).first } == true
     private val currentUser: UserAccount?
         get() { return SalesforceSDKManager.getInstance().userAccountManager.currentUser }
 
@@ -74,9 +75,7 @@ internal class BiometricAuthenticationManager: AppLockManager(
 
     override fun biometricOptIn(optIn: Boolean) {
         currentUser?.let { user ->
-            getAccountPrefs(user).edit()
-                .putBoolean(USER_BIO_OPT_IN, optIn)
-                .apply()
+            getAccountPrefs(user).edit { putBoolean(USER_BIO_OPT_IN, optIn) }
         }
     }
 
@@ -94,8 +93,7 @@ internal class BiometricAuthenticationManager: AppLockManager(
 
     override fun enableNativeBiometricLoginButton(enabled: Boolean) {
         currentUser?.let { user ->
-            getAccountPrefs(user)
-                .edit().putBoolean(BIO_AUTH_NATIVE_BUTTON, enabled).apply()
+            getAccountPrefs(user).edit { putBoolean(BIO_AUTH_NATIVE_BUTTON, enabled) }
         }
     }
 


### PR DESCRIPTION
Stack Trace:

     Fatal Exception: java.lang.NullPointerException:
    at com.salesforce.androidsdk.security.BiometricAuthenticationManager.isEnabled(BiometricAuthenticationManager.kt:44)
    at com.salesforce.androidsdk.security.BiometricAuthenticationManager.shouldAllowRefresh(BiometricAuthenticationManager.kt:94)
    at com.salesforce.androidsdk.rest.RestClient$OAuthRefreshInterceptor.shouldRefresh(RestClient.java:703)
    at com.salesforce.androidsdk.rest.RestClient$OAuthRefreshInterceptor.intercept(RestClient.java:718)
    at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
    at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
    at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
    at java.lang.Thread.run(Thread.java:1012)

This PR has a 1 line fix and a few changes to get rid of warnings.