### PR TITLE
@W-19100006: [Android] QR code login not working with webserver flow disabled

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -162,7 +162,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
             // First, an in-use Salesforce Identity API UI Bridge front-door bridge URL takes precedence.
             if (isUsingFrontDoorBridge) {
                 // A front-door bridge URL accompanied by a PKCE code verifier requires Web Server Flow.  Otherwise, User Agent-Flow must be used.
-                codeVerifier != null
+                frontdoorBridgeCodeVerifier != null
             }
             // Second, when not using a front-door bridge URL, the app's preferences can be used.
             else {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -144,12 +144,30 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
     protected open val authorizationDisplayType =
         SalesforceSDKManager.getInstance().appContext.getString(oauth_display_type)
 
+    /**
+     * Determines use of OAuth 2.0 Web Server Flow or User-Agent Flow.
+     *
+     * When a Salesforce Identity API UI Bridge Front-Door URL is in use for log
+     * in and it has a PKCE/Code verifier Web Server Flow will be Enabled.  For
+     * a Front-Door Bridge URL without a PKCE/Code Verifier User-Agent Flow will
+     * be enabled.
+     *
+     * When no Front-Door Bridge URL is in use, Web Server Flow is
+     * enabled when web server authentication or browser login are enabled.
+     * @return True if Web Server Flow is enabled, false if User-Agent Flow is
+     * enabled.
+     */
     internal val useWebServerFlow: Boolean
         get() = with(SalesforceSDKManager.getInstance()) {
-            // Browser based authentication requires the Web Server flow for PKCE security.
-            (useWebServerAuthentication || isBrowserLoginEnabled)
-                    // QR Code login may require User Agent flow.
-                    && !(isUsingFrontDoorBridge && frontdoorBridgeCodeVerifier == null)
+            // First, an in-use Salesforce Identity API UI Bridge front-door bridge URL takes precedence.
+            if (isUsingFrontDoorBridge) {
+                // A front-door bridge URL accompanied by a PKCE code verifier requires Web Server Flow.  Otherwise, User Agent-Flow must be used.
+                codeVerifier != null
+            }
+            // Second, when not using a front-door bridge URL, the app's preferences can be used.
+            else {
+                useWebServerAuthentication || isBrowserLoginEnabled
+            }
         }
 
     /**


### PR DESCRIPTION
🎸 _*Ready For Review*_ 🥁

  This provides two bug fixes for QR Code Log In.

  One, it corrects the `useWebServerFlow` property so that the presence of the front-door bridge URL drives the logic and its associated code verifier determines between Web Server and User-Agent Flow.  The app's two properties are used as they always have been only if there's no in-flight QR Code Log In.

  Second, it updates `LoginActivity` so that `onNewIntent` can receive a QR Code Log In URL just as it now does for Salesforce Welcome Discovery URLs.  The logic that was fixed in `onCreate` for QR Code Log In is now tidy in their own methods.

  This has been tested by Tao He in the `main` branch of SApp.