### PR TITLE
Instantiate login webview by lazy to ensure only one is ever created.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -182,9 +182,8 @@ open class LoginActivity : FragmentActivity() {
     // Webview and Clients
     protected open val webViewClient = AuthWebViewClient()
     protected open val webChromeClient = WebChromeClient()
-    open val webView: WebView
-        @SuppressLint("SetJavaScriptEnabled")
-        get() = WebView(this.baseContext).apply {
+    open val webView: WebView by lazy {
+        WebView(this.baseContext).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -193,8 +192,10 @@ open class LoginActivity : FragmentActivity() {
             webChromeClient = this@LoginActivity.webChromeClient
             setBackgroundColor(Color.Transparent.toArgb())
             settings.domStorageEnabled = true /* Salesforce Welcome Discovery requires this */
+            @SuppressLint("SetJavaScriptEnabled")
             settings.javaScriptEnabled = true
         }
+    }
 
     // Private variables
     private var wasBackgrounded = false


### PR DESCRIPTION
This was not a problem for our UIAutomator2 tests, but teams using Appium's web context could potentially experience issues switching context prior to this change.  This is Chrome inspector:
<img width="851" height="281" alt="Screenshot 2025-08-09 at 12 26 16 PM" src="https://github.com/user-attachments/assets/5b855821-5c01-4746-802d-e8ec2affd3b3" />

<img width="863" height="168" alt="Screenshot 2025-08-09 at 12 19 49 PM" src="https://github.com/user-attachments/assets/07569a7e-22af-4e12-8d93-28fe88e6ddf0" />
