### PR TITLE
Make shouldShowBackButton value open.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -603,26 +603,33 @@ open class LoginActivity : FragmentActivity() {
         }
     }
 
-    private fun handleBackBehavior() {
-        // If app is using Native Login this activity is a fallback and can be dismissed.
-        if (SalesforceSDKManager.getInstance().nativeLoginActivity != null) {
-            setResult(RESULT_CANCELED)
-            finish()
-            return // If we don't call return here moveTaskToBack can also be called below.
-        }
+    internal fun handleBackBehavior() {
+        with(SalesforceSDKManager.getInstance()) {
+            // If app is using Native Login this activity is a fallback and can be dismissed.
+            if (nativeLoginActivity != null) {
+                setResult(RESULT_CANCELED)
+                finish()
+                return // If we don't call return here moveTaskToBack can also be called below.
+            }
 
-        // Do nothing if locked
-        if (SalesforceSDKManager.getInstance().biometricAuthenticationManager?.locked == false) {
-            /*
-             * If there are no accounts signed in, the login screen needs to go
-             * away and go back to the home screen. However, if the login screen
-             * has been brought up from the switcher screen, the back button
-             * should take the user back to the previous screen.
-             */
-            wasBackgrounded = true
-            when (SalesforceSDKManager.getInstance().userAccountManager.authenticatedUsers) {
-                null -> moveTaskToBack(true)
-                else -> finish()
+            // Do nothing if locked
+            if (biometricAuthenticationManager?.locked == false) {
+                /*
+                 * If there are no accounts signed in, the login screen needs to go
+                 * away and go back to the home screen. However, if the login screen
+                 * has been brought up from the switcher screen, the back button
+                 * should take the user back to the previous screen.
+                 *
+                 * shouldShowBackButton normally checks for authenticated users,
+                 * but trust the app if it has been overridden.
+                 */
+                wasBackgrounded = true
+                if (userAccountManager.authenticatedUsers != null || viewModel.shouldShowBackButton) {
+                    setResult(RESULT_CANCELED)
+                    finish()
+                } else {
+                    moveTaskToBack(true)
+                }
             }
         }
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -181,7 +181,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
     open val singleServerCustomTabActivity = false
 
     /** Value representing if the back button should be shown on the login view. */
-    val shouldShowBackButton = with(SalesforceSDKManager.getInstance()) {
+    open val shouldShowBackButton = with(SalesforceSDKManager.getInstance()) {
         !(userAccountManager.authenticatedUsers.isNullOrEmpty() || biometricAuthenticationManager?.locked ?: false)
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -151,7 +151,7 @@ fun LoginView() {
             clearCookies = { viewModel.clearCookies() },
             reloadWebView = { viewModel.reloadWebView() },
             shouldShowBackButton = viewModel.shouldShowBackButton,
-            finish = { activity.finish() },
+            finish = { activity.handleBackBehavior() },
         )
     }
 


### PR DESCRIPTION
This pretty important for the deferred login scenario, but not critical since it does not affect the devices back button/gesture.  

Despite this being a one line change I thought quite a big about the making the value `open` vs changing it to `var`. Ultimately, it comes down to steering the app to interact with the SDK in the most desirable way.  Making it open means they need to extend our ViewModel to define the value.  IMO this is a far better alternative to setting the value on our ViewModel since it would have to be done from a class that extends `LoginActivity`.  

Edit:  I have also improved the back logic so an app that defines `shouldShowBackButton` does not also need to extend LoginActivity to override `fixBackButtonBehavior` for older devices.  

Perhaps `fixBackButtonBehavior` should be deprecated since this should remove most of the need for it to be public and subclasses still have access to the Activities `onKeyDown`. 🤔 