### PR TITLE
Fix user logout issue during V11→V13 app upgrades caused by failed OAEP re-encryption

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/SalesforceKeyGenerator.java
@@ -176,6 +176,12 @@ public class SalesforceKeyGenerator {
 
         // Encrypt and store unique id if it was just created, or if it had to be decrypted with old cipher mode
         if (storeUniqueId) {
+            // Check if existing key supports OAEP padding, recreate if not
+            if (!KeyStoreWrapper.getInstance().keySupportsOAEPPadding(KEYSTORE_ALIAS)) {
+                SalesforceSDKLogger.i(TAG, "Key doesn't support OAEP padding, recreating key pair with OAEP support");
+                KeyStoreWrapper.getInstance().deleteKey(KEYSTORE_ALIAS);
+            }
+            
             final PublicKey publicKey = KeyStoreWrapper.getInstance().getRSAPublicKey(KEYSTORE_ALIAS);
             final String encryptedKey = Encryptor.encryptWithRSA(publicKey, uniqueId, Encryptor.CipherMode.RSA_OAEP_SHA256);
             storeInSharedPrefs(ID_PREFIX + name, encryptedKey);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/KeyStoreWrapperTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/KeyStoreWrapperTest.java
@@ -58,6 +58,7 @@ public class KeyStoreWrapperTest {
 
     private static final String KEY_1 = "key_1";
     private static final String KEY_2 = "key_2";
+    private static final String KEY_OAEP_TEST = "key_oaep_test";
     private static final int RSA_LENGTH = 2048;
 
     @Before
@@ -72,6 +73,7 @@ public class KeyStoreWrapperTest {
         final KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.getInstance();
         keyStoreWrapper.deleteKey(KEY_1);
         keyStoreWrapper.deleteKey(KEY_2);
+        keyStoreWrapper.deleteKey(KEY_OAEP_TEST);
     }
 
     @Test
@@ -196,6 +198,27 @@ public class KeyStoreWrapperTest {
 
         // Also works without the upgrade step
         tryNewOrUpgradedClientAgainstNewOrOldServer(false, false, false);
+    }
+
+    @Test
+    public void testKeySupportsOAEPPadding() {
+        final KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.getInstance();
+        Assert.assertNotNull("KeyStoreWrapper instance should not be null", keyStoreWrapper);
+
+        // Create a legacy key pair without OAEP padding support
+        keyStoreWrapper.legacyCreateKeysIfNecessary("RSA", KEY_OAEP_TEST, RSA_LENGTH);
+        
+        // Verify the legacy key does NOT support OAEP padding
+        Assert.assertFalse("Legacy key should not support OAEP padding", 
+                keyStoreWrapper.keySupportsOAEPPadding(KEY_OAEP_TEST));
+
+        // Delete the legacy key and create a modern key pair
+        keyStoreWrapper.deleteKey(KEY_OAEP_TEST);
+        keyStoreWrapper.getRSAPublicKey(KEY_OAEP_TEST, RSA_LENGTH); // This creates the key with modern spec
+        
+        // Verify the modern key DOES support OAEP padding
+        Assert.assertTrue("Modern key should support OAEP padding", 
+                keyStoreWrapper.keySupportsOAEPPadding(KEY_OAEP_TEST));
     }
 
     /**


### PR DESCRIPTION
**Issue:**
After upgrading from SDK V11 to V13, users were unexpectedly logged out when restarting the app a second time. The failure sequence was:

1. **V11 behavior**: Stored unique ID encrypted with PKCS1 using PKCS1-only keys
2. **V13 first run after upgrade**:
   - Attempts OAEP decryption (fails - stored with PKCS1)
   - Falls back to PKCS1 decryption (succeeds - gets unique ID)
   - Attempts to re-encrypt and store with OAEP for future use
   - OAEP encryption fails silently because V11 keys don't support OAEP padding
3. **V13 second run** (app restart):
   - Attempts OAEP decryption (fails - OAEP storage failed in step 2)
   - Falls back to PKCS1 decryption (fails - old PKCS1 version overwritten)
   - Unique ID becomes unreadable → refresh tokens can't be decrypted → user logout

**Root Cause:**
V13's upgrade logic assumed all keys support OAEP padding, but V11 keys were created with `ENCRYPTION_PADDING_RSA_PKCS1` only. The failed OAEP re-encryption corrupted the stored unique ID, breaking access to all encrypted user data.

**Solution:**
- Added `keySupportsOAEPPadding()` method to inspect key capabilities via KeyInfo
- Enhanced SalesforceKeyGenerator to detect legacy keys and recreate them with full OAEP support BEFORE attempting OAEP operations
- Added test coverage for legacy vs modern key detection

**Impact:**
- Eliminates unexpected user logouts during V11→V13 upgrades
- Ensures seamless session preservation across app versions
- Users maintain access to their encrypted data without re-authentication
- All upgraded apps automatically transition to modern OAEP encryption

**Files Modified:**
- KeyStoreWrapper.java: Added keySupportsOAEPPadding() method
- SalesforceKeyGenerator.java: Added proactive key upgrade logic
- KeyStoreWrapperTest.java: Added test for key capability detection