### PR TITLE
Re-register all users for push notifications with new keys when upgrading to Mobile SDK 13

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManager.java
@@ -127,6 +127,9 @@ public class SalesforceSDKUpgradeManager {
             if (installedVersion.isLessThan(new SdkVersion(12, 0, 0, false))) {
                 updateFromBefore12_0_0();
             }
+            if (installedVersion.isLessThan(new SdkVersion(13, 0, 2, false))) {
+                updateFromBefore13_0_2();
+            }
             if (installedVersion.isLessThan(new SdkVersion(15, 0, 0, false))) {
                 migrateAccountType();
             }
@@ -306,6 +309,10 @@ public class SalesforceSDKUpgradeManager {
         PushMessaging.setReRegistrationRequested(true);
     }
 
+    private void updateFromBefore13_0_2() {
+        // Re-register all users for push notifications with new keys once push is setup
+        PushMessaging.setReRegistrationRequested(true);
+    }
 
     /*
      *  Migrate any accounts with account_type "com.salesforce.androidsdk" to a unique value.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKUpgradeManagerTest.kt
@@ -174,9 +174,24 @@ class SalesforceSDKUpgradeManagerTest {
     }
 
     @Test
-    fun testUpgradeAfter12() {
+    fun testUpgradeFromBefore1302() {
+        // Set version to a version before 13.0.2
+        setVersion("12.2.0")
+
+        // Create public key for push notifications
+        KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)
+
+        // Upgrade to latest
+        upgradeMgr.upgrade()
+
+        // Make sure re-registration is requested
+        Assert.assertTrue(PushMessaging.reRegistrationRequested)
+    }
+
+    @Test
+    fun testUpgradeAfter1302() {
         // Set version to 12.0.0
-        setVersion("12.0.0")
+        setVersion("13.0.2")
 
         // Create public key for push notifications
         KeyStoreWrapper.getInstance().getRSAPublicString(PushService.pushNotificationKeyName)


### PR DESCRIPTION
Without this, an application will not be able to decrypt encrypted push notifications if:
- it was first installed with Mobile SDK 11.x or older
- **it has elected to disable re-registration entirely** by changing https://github.com/forcedotcom/SalesforceMobileSDK-Android/blob/e435f54e8359c8399edd94d65e2fe3d54dfb2d60/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt#L571