### PR TITLE
Update Maven Central publishing from OSSRH to Central Portal.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
     dependencies {
         classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("io.github.gradle-nexus:publish-plugin:1.1.0")
+        classpath("io.github.gradle-nexus:publish-plugin:2.0.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
         classpath("org.jacoco:org.jacoco.core:0.8.12")
     }

--- a/publish/publish-root.gradle
+++ b/publish/publish-root.gradle
@@ -1,6 +1,5 @@
-ext["ossrhToken"] = ''
-ext["ossrhTokenPassword"] = ''
-ext["sonatypeStagingProfileId"] = ''
+ext["centralPortalToken"] = ''
+ext["centralPortalTokenPassword"] = ''
 ext["signing.keyId"] = ''
 ext["signing.password"] = ''
 ext["signing.key"] = ''
@@ -11,9 +10,8 @@ if (secretPropsFile.exists()) {
     new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
     p.each { name, value -> ext[name] = value }
 } else {
-    ext["ossrhToken"] = System.getenv('OSSRH_TOKEN')
-    ext["ossrhTokenPassword"] = System.getenv('OSSRH_TOKEN_PASSWORD')
-    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+    ext["centralPortalToken"] = System.getenv('CENTRAL_PORTAL_TOKEN')
+    ext["centralPortalTokenPassword"] = System.getenv('CENTRAL_PORTAL_TOKEN_PASSWORD')
     ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
     ext["signing.key"] = System.getenv('SIGNING_KEY')
@@ -22,9 +20,9 @@ if (secretPropsFile.exists()) {
 nexusPublishing {
     repositories {
         sonatype {
-            stagingProfileId = sonatypeStagingProfileId
-            username = ossrhToken
-            password = ossrhTokenPassword
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            username = centralPortalToken
+            password = centralPortalTokenPassword
         }
     }
 }

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -11,3 +11,4 @@ fi
 ./gradlew libs:SalesforceReact:publishReleasePublicationToSonatypeRepository
 ./gradlew libs:SmartStore:publishReleasePublicationToSonatypeRepository
 ./gradlew libs:MobileSync:publishReleasePublicationToSonatypeRepository
+./gradlew publishToSonatype closeSonatypeStagingRepository


### PR DESCRIPTION
These changes allow us to publish to the new Maven Central Portal via the [OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/), which is documented as:

> The Portal OSSRH Staging API is a partial reimplementation of the OSSRH / Nexus Repository Manager 2 Staging APIs. The intent of this service is to enable publishers who are using existing plugins to have a smooth migration to the Central Publisher Portal. We hope that over time plugins will adopt the [Portal API](https://central.sonatype.org/publish/publish-portal-api/) rather than rely on this service.

It does not sound like this intermediate API is going away anytime soon, but we should eventually upgrade to the new API when the Gradle Plugin we use supports it or an official Gradle Plugin is _finally_ released.  