### PR TITLE
Fix date and time pickers in login webview.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -186,7 +186,7 @@ open class LoginActivity : FragmentActivity() {
     @VisibleForTesting(otherwise = PROTECTED)
     open val webChromeClient = WebChromeClient()
     open val webView: WebView by lazy {
-        WebView(this.baseContext).apply {
+        WebView(this).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
This extremely simple change fixes the issue because the default `WebChromeClient` handles the Javascript interaction/callback and provides the Android OS Date or Time picker out of the box... if it is supplied an _Activity_ `Context` by the WebView.  