### PR TITLE
Biometric Authentication bugfixes

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/AppLockManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/AppLockManager.kt
@@ -56,7 +56,9 @@ internal abstract class AppLockManager(
     }
 
     fun onAppBackgrounded() {
-        lastBackgroundTimestamp = System.currentTimeMillis()
+        if (!locked) {
+            lastBackgroundTimestamp = System.currentTimeMillis()
+        }
     }
 
     fun onUnlock() {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -163,7 +163,7 @@ fun LoginView() {
             LoginViewModel.BottomBarButton(
                 stringResource(viewModel.biometricAuthenticationButtonText.intValue)
             ) {
-                viewModel.biometricAuthenticationButtonAction
+                viewModel.biometricAuthenticationButtonAction.value?.invoke() ?: activity.onBioAuthClick()
             }
         } else null
     val idpButton =


### PR DESCRIPTION
- Check if app is still locked before resetting lastBackgroundTimestamp.  This allowed users of React Native apps to the lock with a specific set of steps.  This issue did not affect Native or Cordova Hybrid apps.
- Fix Biometric Authentication button on Login screen not triggering action on press.