### PR TITLE
Fix singleServerCustomTabActivity loading while waiting for PKCE.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -278,7 +278,8 @@ open class LoginActivity : FragmentActivity() {
             // Check if the user backed out of the custom tab.
             if (result.resultCode == Activity.RESULT_CANCELED) {
                 if (viewModel.singleServerCustomTabActivity) {
-                    finish()
+                    // Show blank page and spinner until PKCE is done.
+                    viewModel.loginUrl.value = ABOUT_BLANK
                 } else {
                     // Don't show server picker if we are re-authenticating with cookie.
                     clearWebView(showServerPicker = !sharedBrowserSession)
@@ -1192,7 +1193,7 @@ open class LoginActivity : FragmentActivity() {
                 val useLightIcons = titleTextColorLight ?: topAppBarDark ?: dynamicThemeIsDark
                 WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightStatusBars = useLightIcons
             }.also {
-                if (!viewModel.authFinished.value) {
+                if (!viewModel.authFinished.value && url != ABOUT_BLANK) {
                     viewModel.loading.value = false
                 }
             }


### PR DESCRIPTION
Before, on the left, would show the apps launch screen (instead of the login screen again) if they have one.  Right is the fix.
<img src="https://github.com/user-attachments/assets/d8573c20-01f3-4721-9ba2-5ad127008b15" width="350"> | <img src="https://github.com/user-attachments/assets/b6dcc7e1-2b45-4cbc-848b-c5e73ffc5134" width="350"> 
