### PR TITLE
Updated test to save/retrieve large values

### DIFF
--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueEncryptedFileStoreTest.java
@@ -276,7 +276,7 @@ public class KeyValueEncryptedFileStoreTest {
     @Test
     public void testSaveLargeStreamGetLargeStream() throws IOException {
         final String key = "largeStreamKey";
-        final int dataSize = 5 * 1024 * 1024; // 16MB
+        final int dataSize = 5 * 1024 * 1024; // 5MB
 
         // Generate and save large stream
         try (InputStream largeStream = getLargeStringStream(dataSize)) {


### PR DESCRIPTION
The test no longer creates large strings (neither before writing nor after reading).

That is however insufficient to avoid the OOM since the underlying implementation read all the bytes in memory for encryption/decryption. So I lowered the size of the test data.

NB: I did attempt to implement a memory-efficient kv-store using CipherOutputStream and CipherInputStream (see https://github.com/wmathurin/SalesforceMobileSDK-Android/commit/047def6df7510ff9d84e866d83ab7f1a1457184e)
- it was noticeably slower
- it also caused OOMs ! Maybe Android's Conscrypt AES-GCM cipher implementation has internal buffering !! ??