### PR TITLE
@W-19704630: [MSDK Android] Login Activity Tests Failing Only In CI - Ignore For 13.1

### DIFF
--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
@@ -39,9 +39,11 @@ import com.salesforce.androidsdk.ui.LoginActivity.Companion.EXTRA_KEY_LOGIN_HOST
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@Ignore("This test will pass only via Android Studio for local developer workstations.  It fails consistently in continuous integration.  Until this is resolved, this test will be ignored.")
 @RunWith(AndroidJUnit4::class)
 class LoginActivityTest {
 


### PR DESCRIPTION
🎸 _*Ready For Review*_ 🥁

  This really simple non-functional update ignores a test that used to pass both for developer workstations and our CI.  That test now consistently fails in CI and seems to be causing the CI run to take much longer than before.  Also, it is blocking the generation of code coverage reports.  The previous is unfortunate since this test was created primarily for code coverage, alas.

  I'll create a work item for the new release to diagnose the issue and restore this test.