### PR TITLE
@W-19843412: [MSDK Android] Login And Developer Information Activities Do Not Pad Display Cutouts

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/DevInfoActivity.kt
@@ -31,17 +31,18 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -53,6 +54,7 @@ import androidx.compose.ui.unit.dp
 import com.salesforce.androidsdk.R
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 
+@OptIn(ExperimentalMaterial3Api::class)
 class DevInfoActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -64,7 +66,16 @@ class DevInfoActivity : ComponentActivity() {
 
         setContent {
             MaterialTheme(colorScheme = SalesforceSDKManager.getInstance().colorScheme()) {
-                DevInfoScreen(devInfoList)
+                Scaffold(
+                    contentWindowInsets = WindowInsets.safeDrawing,
+                    topBar = {
+                        TopAppBar(
+                            title = { Text(stringResource(id = R.string.sf__dev_support_title)) }
+                        )
+                    }
+                ) { innerPadding ->
+                    DevInfoScreen(innerPadding, devInfoList)
+                }
             }
         }
     }
@@ -76,24 +87,17 @@ class DevInfoActivity : ComponentActivity() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DevInfoScreen(devInfoList: List<Pair<String, String>>) {
-    Column(
+fun DevInfoScreen(
+    paddingValues: PaddingValues,
+    devInfoList: List<Pair<String, String>>,
+) {
+    LazyColumn(
+        contentPadding = paddingValues,
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
     ) {
-        TopAppBar(
-            title = { Text(stringResource(id = R.string.sf__dev_support_title)) }
-        )
-
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .windowInsetsPadding(WindowInsets.navigationBars) // Adds padding to account for system navigation bar
-        ) {
-            items(devInfoList) { (name, value) ->
-                DevInfoItem(name, value)
-            }
+        items(devInfoList) { (name, value) ->
+            DevInfoItem(name, value)
         }
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -36,6 +36,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,6 +49,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -106,8 +108,8 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.salesforce.androidsdk.R.string.sf__back_button_content_description
-import com.salesforce.androidsdk.R.string.sf__clear_cookies
 import com.salesforce.androidsdk.R.string.sf__clear_cache
+import com.salesforce.androidsdk.R.string.sf__clear_cookies
 import com.salesforce.androidsdk.R.string.sf__launch_idp
 import com.salesforce.androidsdk.R.string.sf__loading_indicator
 import com.salesforce.androidsdk.R.string.sf__more_options
@@ -190,6 +192,7 @@ fun LoginView() {
     }
 
     LoginView(
+        dynamicBackgroundColor = viewModel.dynamicBackgroundColor,
         loginUrlData = viewModel.loginUrl,
         topAppBar = topAppBar,
         webView = activity.webView,
@@ -202,6 +205,7 @@ fun LoginView() {
 
 @Composable
 internal fun LoginView(
+    dynamicBackgroundColor: MutableState<Color>,
     loginUrlData: LiveData<String>,
     topAppBar: @Composable () -> Unit,
     webView: WebView,
@@ -217,16 +221,17 @@ internal fun LoginView(
     )
 
     Scaffold(
-        topBar = topAppBar,
         bottomBar = bottomAppBar,
+        contentWindowInsets = WindowInsets.safeDrawing,
+        topBar = topAppBar,
     ) { innerPadding ->
         if (loading) {
             loadingIndicator()
         }
-
         // Load the WebView as a composable
         AndroidView(
             modifier = Modifier
+                .background(dynamicBackgroundColor.value)
                 .padding(innerPadding)
                 .graphicsLayer(alpha = alpha),
             factory = { webView },


### PR DESCRIPTION
🎸 _*Ready For Review*_ 🥁

  This relatively easy and safe fix helps two of our activities which recently migrated to Compose also pad for the display cutouts.  I've attached a video walkthrough showing the old behavior and then the updated version, though it doesn't _actually_ show the cutout in the video.  One can see the new padding when watching carefully, though.

  I tested this on a Google Pixel 8 Pro with API 36.