### PR TITLE
@W-21006714: singleServerCustomTabActivity is malfunctioning (13.2)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -1547,6 +1547,7 @@ open class LoginActivity : FragmentActivity() {
                 if (activity.viewModel.singleServerCustomTabActivity) {
                     // Show blank page and spinner until PKCE is done.
                     activity.viewModel.loginUrl.value = ABOUT_BLANK
+                    finish()
                 } else {
                     // Don't show server picker if we are re-authenticating with cookie.
                     activity.clearWebView(showServerPicker = !activity.sharedBrowserSession)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -215,7 +215,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
      * Since browser based authentication requires PKCE (and therefore the Web Server flow) the User Agent flow
      * cannot be used while in this mode.
      */
-    open val singleServerCustomTabActivity = true
+    open val singleServerCustomTabActivity = false
 
     /** Value representing if the back button should be shown on the login view. */
     open val shouldShowBackButton = with(SalesforceSDKManager.getInstance()) {
@@ -622,7 +622,8 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
         private val scope: CoroutineScope = viewModelScope,
     ) : Observer<String> {
         override fun onChanged(value: String) {
-            if ((sdkManager.isBrowserLoginEnabled || singleServerCustomTabActivity) && !viewModel.isUsingFrontDoorBridge) {
+            val useBrowserCustomTab = sdkManager.isBrowserLoginEnabled || singleServerCustomTabActivity
+            if (useBrowserCustomTab && !viewModel.isUsingFrontDoorBridge) {
                 scope.launch {
                     viewModel.browserCustomTabUrl.value = viewModel.getAuthorizationUrl(
                         server = value,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -215,7 +215,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
      * Since browser based authentication requires PKCE (and therefore the Web Server flow) the User Agent flow
      * cannot be used while in this mode.
      */
-    open val singleServerCustomTabActivity = false
+    open val singleServerCustomTabActivity = true
 
     /** Value representing if the back button should be shown on the login view. */
     open val shouldShowBackButton = with(SalesforceSDKManager.getInstance()) {
@@ -571,7 +571,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
         private val scope: CoroutineScope = viewModelScope,
     ) : Observer<String?> {
         override fun onChanged(value: String?) {
-            if (!sdkManager.isBrowserLoginEnabled && !viewModel.isUsingFrontDoorBridge && value != null) {
+            if (!sdkManager.isBrowserLoginEnabled && !singleServerCustomTabActivity && !viewModel.isUsingFrontDoorBridge && value != null) {
                 val valueUrl = value.toUri()
                 val loginUrl = viewModel.loginUrl.value?.toUri()
 
@@ -622,7 +622,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
         private val scope: CoroutineScope = viewModelScope,
     ) : Observer<String> {
         override fun onChanged(value: String) {
-            if (sdkManager.isBrowserLoginEnabled && !viewModel.isUsingFrontDoorBridge) {
+            if ((sdkManager.isBrowserLoginEnabled || singleServerCustomTabActivity) && !viewModel.isUsingFrontDoorBridge) {
                 scope.launch {
                     viewModel.browserCustomTabUrl.value = viewModel.getAuthorizationUrl(
                         server = value,

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -779,6 +779,132 @@ class LoginViewModelTest {
     }
 
     @Test
+    fun loginViewModel_loginUrlObserver_ignoresLoginUrlWhenBrowserLoginEnabledAndSingleServerCustomTabActivityEnabled() = runTest {
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+
+        val valueOld = null
+        val valueNew = "https://www.example.com" // IETF-Reserved Test Domain
+
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.isBrowserLoginEnabled } returns true
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        val loginUrl = mockk<MediatorLiveData<String>>(relaxed = true)
+        every { loginUrl.value } returns valueOld
+        every { viewModel.singleServerCustomTabActivity } returns true
+        every { viewModel.loginUrl } returns loginUrl
+        val observer = viewModel.LoginUrlSource(sdkManager, viewModel, scope)
+
+        observer.onChanged(valueNew)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            viewModel.getAuthorizationUrl(
+                valueNew,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun loginViewModel_loginUrlObserver_ignoresLoginUrlWhenBrowserLoginDisabledAndSingleServerCustomTabActivityEnabled() = runTest {
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+
+        val valueOld = null
+        val valueNew = "https://www.example.com" // IETF-Reserved Test Domain
+
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        val loginUrl = mockk<MediatorLiveData<String>>(relaxed = true)
+        every { loginUrl.value } returns valueOld
+        every { viewModel.singleServerCustomTabActivity } returns true
+        every { viewModel.loginUrl } returns loginUrl
+        val observer = viewModel.LoginUrlSource(sdkManager, viewModel, scope)
+
+        observer.onChanged(valueNew)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            viewModel.getAuthorizationUrl(
+                valueNew,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun loginViewModel_loginUrlObserver_ignoresLoginUrlWhenBrowserLoginDisabledAndSingleServerCustomTabActivityEnabledAndFrontDoorBridgeActive() = runTest {
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+
+        val valueOld = null
+        val valueNew = "https://www.example.com" // IETF-Reserved Test Domain
+
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        val loginUrl = mockk<MediatorLiveData<String>>(relaxed = true)
+        every { loginUrl.value } returns valueOld
+        every { viewModel.singleServerCustomTabActivity } returns true
+        every { viewModel.isUsingFrontDoorBridge } returns true
+        every { viewModel.loginUrl } returns loginUrl
+        val observer = viewModel.LoginUrlSource(sdkManager, viewModel, scope)
+
+        observer.onChanged(valueNew)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            viewModel.getAuthorizationUrl(
+                valueNew,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun loginViewModel_loginUrlObserver_ignoresLoginUrlWhenBrowserLoginDisabledAndSingleServerCustomTabActivityEnabledAndFrontDoorBridgeActiveAndValueNull() = runTest {
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+
+        val valueOld = null
+        val valueNew = "https://www.example.com" // IETF-Reserved Test Domain
+
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        val loginUrl = mockk<MediatorLiveData<String>>(relaxed = true)
+        every { loginUrl.value } returns valueOld
+        every { viewModel.singleServerCustomTabActivity } returns true
+        every { viewModel.isUsingFrontDoorBridge } returns true
+        every { viewModel.loginUrl } returns loginUrl
+        val observer = viewModel.LoginUrlSource(sdkManager, viewModel, scope)
+
+        observer.onChanged(null)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            viewModel.getAuthorizationUrl(
+                valueNew,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun loginViewModel_loginUrlObserver_ignoresWhenBrowserLoginEnabled() = runTest {
 
         val dispatcher = StandardTestDispatcher(testScheduler)
@@ -916,6 +1042,88 @@ class LoginViewModelTest {
             any(),
             any(),
         ) }
+    }
+
+    @Test
+    fun loginViewModel_browserCustomTabObserver_setsBrowserCustomTabUrl_whenSingleServerCustomTabActivityEnabledAndNotUsingFrontDoorBridge() = runTest {
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        every { viewModel.singleServerCustomTabActivity } returns true
+        val observer = viewModel.BrowserCustomTabUrlSource(sdkManager, viewModel, scope)
+
+        val value = "https://www.example.com" // IETF-Reserved Test Domain
+
+        observer.onChanged(value)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) {
+            viewModel.getAuthorizationUrl(
+                value,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun loginViewModel_browserCustomTabObserver_ignoresBrowserCustomTabUrl_whenBrowserLoginDisabledAndSingleServerCustomTabActivityDisabledAndNotUsingFrontDoorBridge() = runTest {
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        every { viewModel.singleServerCustomTabActivity } returns false
+        val observer = viewModel.BrowserCustomTabUrlSource(sdkManager, viewModel, scope)
+
+        val value = "https://www.example.com" // IETF-Reserved Test Domain
+
+        observer.onChanged(value)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            viewModel.getAuthorizationUrl(
+                value,
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun loginViewModel_browserCustomTabObserver_ignoresBrowserCustomTabUrl_whenBrowserLoginDisabledAndSingleServerCustomTabActivityDisabledAndUsingFrontDoorBridge() = runTest {
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        every { viewModel.singleServerCustomTabActivity } returns false
+        every { viewModel.isUsingFrontDoorBridge } returns true
+        val observer = viewModel.BrowserCustomTabUrlSource(sdkManager, viewModel, scope)
+
+        val value = "https://www.example.com" // IETF-Reserved Test Domain
+
+        observer.onChanged(value)
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            viewModel.getAuthorizationUrl(
+                value,
+                any(),
+                any(),
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
🎸 _*Ready For Review*_ 🥁

  This is the 13.2 counterpart for https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2831

  This resolves issues with the function of the `singleServerCustomTabActivity` property which was introduced in MSDK 13.0.0.  The logic worked as intended at that time, but had regressed partially in 13.1.0 and fully in the pending 13.1.1 release.

  The MSDK sample apps behave in exactly the same way with this update as they did in 13.1.0.  Here's a video that demonstrates that in the REST Explorer sample app.  Note that the activity timing in this sample app isn't perfect since this app is not built as the target app would be and defaults to the login view instead of an app activity.
[Screen_recording_20260122_180115.webm](https://github.com/user-attachments/assets/8157c690-4f35-416e-a2a1-13116cb71414)

  Also, this property now has detailed unit tests and high code coverage to prevent future regression.
