### PR TITLE
Removing consumer key from sample apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,7 @@ yarn.lock
 index.android.bundle*
 shared/test/test_credentials.json
 shared/test/ui_test_config.json
+**/bootconfig.xml
+!libs/test/**/bootconfig.xml
 native/NativeSampleApps/AuthFlowTester/src/main/assets/
 .vscode/

--- a/install.sh
+++ b/install.sh
@@ -13,16 +13,17 @@ git submodule update
 git -C external/shared checkout -- samples/mobilesyncexplorer/bootconfig.json samples/accounteditor/bootconfig.json 2>/dev/null || true
 
 # get react native
-pushd "libs/SalesforceReact"
-rm -rf node_modules
-rm yarn.lock
-yarn install
-./node_modules/.bin/react-native bundle --platform android --dev true --entry-file node_modules/react-native-force/test/alltests.js --bundle-output ../test/SalesforceReactTest/assets/index.android.bundle --assets-dest ../test/SalesforceReactTest/assets/
-popd
+# pushd "libs/SalesforceReact"
+# rm -rf node_modules
+# rm yarn.lock
+# yarn install
+# ./node_modules/.bin/react-native bundle --platform android --dev true --entry-file node_modules/react-native-force/test/alltests.js --bundle-output ../test/SalesforceReactTest/assets/index.android.bundle --assets-dest ../test/SalesforceReactTest/assets/
+# popd
 
 # Apply bootconfig placeholder substitution. Usage:
 #   apply_bootconfig_paths [sample_file] path1 path2 ...
-# First arg is sample path (or empty for no sample). If sample is set and a path does not exist, copy sample there. Then substitute env vars.
+# First arg is sample path (or empty for no sample). If sample is set, copy sample over each path (overwriting if present).
+# Then substitute env vars.
 apply_bootconfig_paths() {
     local sample_file=""
     [ -n "$1" ] && [ -f "$1" ] && sample_file="$1"
@@ -30,16 +31,17 @@ apply_bootconfig_paths() {
     while [ $# -gt 0 ]; do
         local bootconfig="$1"
         shift
-        if [ -n "$sample_file" ] && [ ! -f "$bootconfig" ]; then
+        if [ -n "$sample_file" ]; then
             mkdir -p "$(dirname "$bootconfig")"
             cp "$sample_file" "$bootconfig"
         fi
         if [ -f "$bootconfig" ]; then
-            if [ -n "${MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY:-}" ]; then
-                gsed -i "s|__CONSUMER_KEY__|${MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY}|g" "$bootconfig"
+	    # Substitute env vars if set
+	    if [ -n "${MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY:-}" ]; then
+                gsed -i "s|__CONSUMER_KEY__|${MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY}|g" "$bootconfig"
             fi
-            if [ -n "${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
-                gsed -i "s|__REDIRECT_URI__|${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL}|g" "$bootconfig"
+            if [ -n "${MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
+                gsed -i "s|__REDIRECT_URI__|${MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL}|g" "$bootconfig"
             fi
         fi
     done
@@ -60,9 +62,9 @@ BOOTCONFIG_JSON_PATHS=(
 apply_bootconfig_paths "$BOOTCONFIG_SAMPLE" "${BOOTCONFIG_XML_PATHS[@]}"
 apply_bootconfig_paths "" "${BOOTCONFIG_JSON_PATHS[@]}"
 
-if [ -z "${MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY:-}" ] || [ -z "${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
+if [ -z "${MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY:-}" ] || [ -z "${MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
     echo ""
-    echo "Note: MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY and/or MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL are not set."
+    echo "Note: MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY and/or MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL are not set."
     echo "To run the sample applications, define these environment variables or ensure bootconfig.xml"
     echo "files exist (created from shared/bootconfig.xml.sample) with remoteAccessConsumerKey and oauthRedirectURI set."
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-# Running this script will install all dependencies needed for all of the projects 
+# Running this script will install all dependencies needed for all of the projects
+
+# Run from repo root so relative paths work regardless of invocation directory
+cd "$(dirname "$0")"
 
 # ensure that we have the correct version of all submodules
 git submodule init
 git submodule sync
 git submodule update
 
+# Restore bootconfig.json in shared submodule to committed placeholders
+git -C external/shared checkout -- samples/mobilesyncexplorer/bootconfig.json samples/accounteditor/bootconfig.json 2>/dev/null || true
 
 # get react native
 pushd "libs/SalesforceReact"
@@ -14,3 +19,51 @@ rm yarn.lock
 yarn install
 ./node_modules/.bin/react-native bundle --platform android --dev true --entry-file node_modules/react-native-force/test/alltests.js --bundle-output ../test/SalesforceReactTest/assets/index.android.bundle --assets-dest ../test/SalesforceReactTest/assets/
 popd
+
+# Apply bootconfig placeholder substitution. Usage:
+#   apply_bootconfig_paths [sample_file] path1 path2 ...
+# First arg is sample path (or empty for no sample). If sample is set and a path does not exist, copy sample there. Then substitute env vars.
+apply_bootconfig_paths() {
+    local sample_file=""
+    [ -n "$1" ] && [ -f "$1" ] && sample_file="$1"
+    shift
+    while [ $# -gt 0 ]; do
+        local bootconfig="$1"
+        shift
+        if [ -n "$sample_file" ] && [ ! -f "$bootconfig" ]; then
+            mkdir -p "$(dirname "$bootconfig")"
+            cp "$sample_file" "$bootconfig"
+        fi
+        if [ -f "$bootconfig" ]; then
+            if [ -n "${MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY:-}" ]; then
+                gsed -i "s|__CONSUMER_KEY__|${MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY}|g" "$bootconfig"
+            fi
+            if [ -n "${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
+                gsed -i "s|__REDIRECT_URI__|${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL}|g" "$bootconfig"
+            fi
+        fi
+    done
+}
+
+BOOTCONFIG_SAMPLE="shared/bootconfig.xml.sample"
+BOOTCONFIG_XML_PATHS=(
+    "libs/SalesforceSDK/res/values/bootconfig.xml"
+    "native/NativeSampleApps/RestExplorer/res/values/bootconfig.xml"
+    "native/NativeSampleApps/AuthFlowTester/src/main/res/values/bootconfig.xml"
+    "native/NativeSampleApps/ConfiguredApp/res/values/bootconfig.xml"
+)
+BOOTCONFIG_JSON_PATHS=(
+    "external/shared/samples/mobilesyncexplorer/bootconfig.json"
+    "external/shared/samples/accounteditor/bootconfig.json"
+)
+
+apply_bootconfig_paths "$BOOTCONFIG_SAMPLE" "${BOOTCONFIG_XML_PATHS[@]}"
+apply_bootconfig_paths "" "${BOOTCONFIG_JSON_PATHS[@]}"
+
+if [ -z "${MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY:-}" ] || [ -z "${MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL:-}" ]; then
+    echo ""
+    echo "Note: MSDK_IOS_REMOTE_ACCESS_CLIENT_KEY and/or MSDK_IOS_REMOTE_ACCESS_CALLBACK_URL are not set."
+    echo "To run the sample applications, define these environment variables or ensure bootconfig.xml"
+    echo "files exist (created from shared/bootconfig.xml.sample) with remoteAccessConsumerKey and oauthRedirectURI set."
+    echo ""
+fi

--- a/install.sh
+++ b/install.sh
@@ -13,12 +13,12 @@ git submodule update
 git -C external/shared checkout -- samples/mobilesyncexplorer/bootconfig.json samples/accounteditor/bootconfig.json 2>/dev/null || true
 
 # get react native
-# pushd "libs/SalesforceReact"
-# rm -rf node_modules
-# rm yarn.lock
-# yarn install
-# ./node_modules/.bin/react-native bundle --platform android --dev true --entry-file node_modules/react-native-force/test/alltests.js --bundle-output ../test/SalesforceReactTest/assets/index.android.bundle --assets-dest ../test/SalesforceReactTest/assets/
-# popd
+pushd "libs/SalesforceReact"
+rm -rf node_modules
+rm yarn.lock
+yarn install
+./node_modules/.bin/react-native bundle --platform android --dev true --entry-file node_modules/react-native-force/test/alltests.js --bundle-output ../test/SalesforceReactTest/assets/index.android.bundle --assets-dest ../test/SalesforceReactTest/assets/
+popd
 
 # Apply bootconfig placeholder substitution. Usage:
 #   apply_bootconfig_paths [sample_file] path1 path2 ...

--- a/libs/SalesforceSDK/res/values/bootconfig.xml
+++ b/libs/SalesforceSDK/res/values/bootconfig.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources>
-    <!-- Mobile SDK Sample App (cs1.mobilesdk.ee.org) -->
-    <string name="remoteAccessConsumerKey">3MVG98dostKihXN53TYStBIiS8FC2a3tE3XhGId0hQ37iQjF0xe4fxMSb2mFaWZn9e3GiLs1q67TNlyRji.Xw</string>
-    <string name="oauthRedirectURI">testsfdc:///mobilesdk/detect/oauth/done</string>
-    <string-array name="oauthScopes">
-    </string-array>
-</resources>

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_absoluteStartPage.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_absoluteStartPage.json
@@ -1,6 +1,6 @@
 {
-    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
-    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "remoteAccessConsumerKey": "__CONSUMER_KEY__",
+    "oauthRedirectURI": "__REDIRECT_URI__",
     "oauthScopes": ["api","web"],
     "isLocal": true,
     "startPage": "https://www.salesforce.com/test.html",

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_emptyOauthScopes.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_emptyOauthScopes.json
@@ -1,6 +1,6 @@
 {
-    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
-    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "remoteAccessConsumerKey": "__CONSUMER_KEY__",
+    "oauthRedirectURI": "__REDIRECT_URI__",
     "oauthScopes": [],
     "isLocal": true,
     "startPage": "index.html",

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_noOauthScopes.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_noOauthScopes.json
@@ -1,6 +1,6 @@
 {
-    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
-    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "remoteAccessConsumerKey": "__CONSUMER_KEY__",
+    "oauthRedirectURI": "__REDIRECT_URI__",
     "isLocal": true,
     "startPage": "index.html",
     "errorPage": "error.html",

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_relativeUnauthenticatedStartPage.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_relativeUnauthenticatedStartPage.json
@@ -1,6 +1,6 @@
 {
-    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
-    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "remoteAccessConsumerKey": "__CONSUMER_KEY__",
+    "oauthRedirectURI": "__REDIRECT_URI__",
     "oauthScopes": ["api","web"],
     "isLocal": false,
     "startPage": "/apex/TestPage",

--- a/libs/test/SalesforceSDKTest/assets/www/bootconfig_remoteDeferredAuthNoUnauthenticatedStartPage.json
+++ b/libs/test/SalesforceSDKTest/assets/www/bootconfig_remoteDeferredAuthNoUnauthenticatedStartPage.json
@@ -1,6 +1,6 @@
 {
-    "remoteAccessConsumerKey": "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa",
-    "oauthRedirectURI": "testsfdc:///mobilesdk/detect/oauth/done",
+    "remoteAccessConsumerKey": "__CONSUMER_KEY__",
+    "oauthRedirectURI": "__REDIRECT_URI__",
     "oauthScopes": ["api","web"],
     "isLocal": false,
     "startPage": "/apex/TestPage",

--- a/native/NativeSampleApps/AppConfigurator/src/com/salesforce/samples/appconfigurator/AppConfiguratorState.java
+++ b/native/NativeSampleApps/AppConfigurator/src/com/salesforce/samples/appconfigurator/AppConfiguratorState.java
@@ -53,8 +53,8 @@ public class AppConfiguratorState {
     private static final String DEFAULT_TARGET_APP = "com.salesforce.samples.configuredapp";
     private static final String DEFAULT_LOGIN_SERVERS = "https://test.salesforce.com,https://login.salesforce.com";
     private static final String DEFAULT_LOGIN_SERVERS_LABELS = "sandbox,production";
-    private static final String DEFAULT_REMOTE_ACCESS_CONSUMER_KEY = "3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa";
-    private static final String DEFAULT_OAUTH_REDIRECT_URI = "testsfdc:///mobilesdk/detect/oauth/done";
+    private static final String DEFAULT_REMOTE_ACCESS_CONSUMER_KEY = "__CONSUMER_KEY__";
+    private static final String DEFAULT_OAUTH_REDIRECT_URI = "__REDIRECT_URI__";
 
     // State
     private String loginServers;

--- a/native/NativeSampleApps/AuthFlowTester/src/main/res/values/bootconfig.xml
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/res/values/bootconfig.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources>
-    <string name="remoteAccessConsumerKey">3MVG98dostKihXN53TYStBIiS8FC2a3tE3XhGId0hQ37iQjF0xe4fxMSb2mFaWZn9e3GiLs1q67TNlyRji.Xw</string>
-    <string name="oauthRedirectURI">testsfdc:///mobilesdk/detect/oauth/done</string>
-</resources>

--- a/native/NativeSampleApps/ConfiguredApp/res/values/bootconfig.xml
+++ b/native/NativeSampleApps/ConfiguredApp/res/values/bootconfig.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources>
-    <!-- Mobile SDK Sample App (cs1.mobilesdk.ee.org) -->
-    <string name="remoteAccessConsumerKey">3MVG98dostKihXN53TYStBIiS8FC2a3tE3XhGId0hQ37iQjF0xe4fxMSb2mFaWZn9e3GiLs1q67TNlyRji.Xw</string>
-    <string name="oauthRedirectURI">testsfdc:///mobilesdk/detect/oauth/done</string>
-</resources>

--- a/native/NativeSampleApps/RestExplorer/res/values/bootconfig.xml
+++ b/native/NativeSampleApps/RestExplorer/res/values/bootconfig.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources>
-    <!-- Mobile SDK Sample App (cs1.mobilesdk.ee.org) -->
-    <string name="remoteAccessConsumerKey">3MVG98dostKihXN53TYStBIiS8FC2a3tE3XhGId0hQ37iQjF0xe4fxMSb2mFaWZn9e3GiLs1q67TNlyRji.Xw</string>
-    <string name="oauthRedirectURI">testsfdc:///mobilesdk/detect/oauth/done</string>
-</resources>

--- a/shared/bootconfig.xml.sample
+++ b/shared/bootconfig.xml.sample
@@ -4,4 +4,5 @@
     <!-- Replace placeholders via install script env vars or edit manually -->
     <string name="remoteAccessConsumerKey">__CONSUMER_KEY__</string>
     <string name="oauthRedirectURI">__REDIRECT_URI__</string>
+    <string-array name="oauthScopes" />
 </resources>

--- a/shared/bootconfig.xml.sample
+++ b/shared/bootconfig.xml.sample
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <!-- Replace placeholders via install script env vars or edit manually -->
+    <string name="remoteAccessConsumerKey">__CONSUMER_KEY__</string>
+    <string name="oauthRedirectURI">__REDIRECT_URI__</string>
+</resources>


### PR DESCRIPTION
Changes:

- bootconfig.xml for sample apps have been git removed
- when running install.sh, bootconfig.xml files are created for the sample apps using bootconfig.xml.sample as template 
- consumer key and call back url are set on bootconfig.xml / bootconfig.json for the sample apps using environment variables (*) if defined

(*) MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY and MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL

**Merge only after**
- https://github.com/forcedotcom/SalesforceMobileSDK-Shared/pull/539 is merged
- shared submodule is updated
