### PR TITLE
Adding back SalesforceSDK's bootconfig.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ shared/test/test_credentials.json
 shared/test/ui_test_config.json
 **/bootconfig.xml
 !libs/test/**/bootconfig.xml
+!libs/SalesforceSDK/**/bootconfig.xml
 native/NativeSampleApps/AuthFlowTester/src/main/assets/
 .vscode/

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,6 @@ apply_bootconfig_paths() {
 
 BOOTCONFIG_SAMPLE="shared/bootconfig.xml.sample"
 BOOTCONFIG_XML_PATHS=(
-    "libs/SalesforceSDK/res/values/bootconfig.xml"
     "native/NativeSampleApps/RestExplorer/res/values/bootconfig.xml"
     "native/NativeSampleApps/AuthFlowTester/src/main/res/values/bootconfig.xml"
     "native/NativeSampleApps/ConfiguredApp/res/values/bootconfig.xml"

--- a/libs/SalesforceSDK/res/values/bootconfig.xml
+++ b/libs/SalesforceSDK/res/values/bootconfig.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <string name="remoteAccessConsumerKey">__CONSUMER_KEY__</string>
+    <string name="oauthRedirectURI">__REDIRECT_URI__</string>
+    <string-array name="oauthScopes"></string-array>
+</resources>


### PR DESCRIPTION
- that way templates will compile without having to run SalesforceMobileSDK-Android's install.sh
- consumer key / callback should NOT be inserted in there - they should be inserted in the application's bootconfig