### PR TITLE
@W-15287195: Add ProGuard consumer rules to prevent logout failures

### DIFF
--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 
     defaultConfig {
         minSdk = 28
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     buildTypes {

--- a/libs/MobileSync/consumer-rules.pro
+++ b/libs/MobileSync/consumer-rules.pro
@@ -1,0 +1,18 @@
+# Salesforce Mobile SDK - MobileSync Consumer ProGuard Rules
+# These rules are automatically applied to apps that consume this SDK library
+
+# Keep SyncUpTarget subclasses - instantiated via reflection in SyncUpTarget.fromJSON
+-keep class com.salesforce.androidsdk.mobilesync.target.SyncUpTarget {
+    public <init>(...);
+}
+-keep class * extends com.salesforce.androidsdk.mobilesync.target.SyncUpTarget {
+    public <init>(org.json.JSONObject);
+}
+
+# Keep SyncDownTarget subclasses - instantiated via reflection in SyncDownTarget.fromJSON
+-keep class com.salesforce.androidsdk.mobilesync.target.SyncDownTarget {
+    public <init>(...);
+}
+-keep class * extends com.salesforce.androidsdk.mobilesync.target.SyncDownTarget {
+    public <init>(org.json.JSONObject);
+}

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -66,6 +66,7 @@ android {
 
     defaultConfig {
         minSdk = 28
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     buildTypes {

--- a/libs/SalesforceSDK/consumer-rules.pro
+++ b/libs/SalesforceSDK/consumer-rules.pro
@@ -1,0 +1,20 @@
+# Salesforce Mobile SDK - Consumer ProGuard Rules
+# These rules are automatically applied to apps that consume this SDK library
+
+# Keep PushService and subclasses - instantiated via reflection in PushNotificationsRegistrationChangeWorker
+-keep class com.salesforce.androidsdk.push.PushService {
+    public <init>(...);
+}
+-keep class * extends com.salesforce.androidsdk.push.PushService {
+    public <init>(...);
+}
+
+# Keep Transform implementations - instantiated via reflection in SalesforceAnalyticsManager
+-keep class * implements com.salesforce.androidsdk.analytics.transform.Transform {
+    public <init>(...);
+}
+
+# Keep AnalyticsPublisher implementations - instantiated via reflection in SalesforceAnalyticsManager
+-keep class * extends com.salesforce.androidsdk.analytics.AnalyticsPublisher {
+    public <init>(...);
+}

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -31,6 +31,7 @@ android {
 
     defaultConfig {
         minSdk = 28
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     buildTypes {

--- a/libs/SmartStore/consumer-rules.pro
+++ b/libs/SmartStore/consumer-rules.pro
@@ -1,0 +1,10 @@
+# Salesforce Mobile SDK - SmartStore Consumer ProGuard Rules
+# These rules are automatically applied to apps that consume this SDK library
+
+# Keep LongOperation subclasses - instantiated via reflection in LongOperation.LongOperationType
+-keep class com.salesforce.androidsdk.smartstore.store.LongOperation {
+    public <init>(...);
+}
+-keep class * extends com.salesforce.androidsdk.smartstore.store.LongOperation {
+    public <init>(...);
+}


### PR DESCRIPTION
Adds consumer-rules.pro files to SalesforceSDK, SmartStore, and MobileSync libraries to preserve classes instantiated via reflection. This fixes logout failures when consuming apps are built with ProGuard/R8 enabled.

The issue occurred because:
- PushService is instantiated via reflection in PushNotificationsRegistrationChangeWorker
- Transform and AnalyticsPublisher are instantiated via reflection in SalesforceAnalyticsManager
- LongOperation subclasses are instantiated via reflection in SmartStore
- SyncUpTarget and SyncDownTarget are instantiated via reflection in MobileSync

Without consumer rules, ProGuard/R8 removes or obfuscates these classes' constructors, causing reflection to fail at runtime.

Changes:
- Created libs/SalesforceSDK/consumer-rules.pro with rules for PushService, Transform, and AnalyticsPublisher
- Created libs/SmartStore/consumer-rules.pro with rules for LongOperation
- Created libs/MobileSync/consumer-rules.pro with rules for SyncUpTarget and SyncDownTarget
- Updated build.gradle.kts files to include consumerProguardFiles() configuration

Consumer rules are automatically packaged with the library and applied to consuming apps, eliminating the need for manual ProGuard configuration.