### PR TITLE
@W-17247702: Remove getBuildConfigValue reflection usage

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1480,32 +1480,8 @@ open class SalesforceSDKManager protected constructor(
 
     /** Indicates if this is a debug build */
     internal val isDebugBuild
-        get() = getBuildConfigValue(
-            appContext,
-            "DEBUG"
-        ) as Boolean
+        get() = DEBUG
 
-    /**
-     * Gets a field from the project's build configuration.
-     *
-     * @param context An Android context providing the build configuration's
-     * package
-     * @param fieldName The name of the build configuration field
-     * @return The value of the build configuration field or null if the field
-     * is not found
-     */
-    private fun getBuildConfigValue(
-        context: Context,
-        @Suppress("SameParameterValue") fieldName: String
-    ) = runCatching {
-        Class.forName(
-            "${context.packageName ?: ""}.BuildConfig"
-        ).getField(
-            fieldName
-        )[null]
-    }.onFailure { e ->
-        e(TAG, "getBuildConfigValue failed", e)
-    }.getOrDefault(DEBUG)
 
     /**
      * Indicates if the The Salesforce Mobile SDK user interface dark theme is


### PR DESCRIPTION
Replace reflection-based BuildConfig access with direct use of SDK's BuildConfig.DEBUG constant to fix obfuscation compatibility issues and ClassNotFoundException errors.

NB: The buildConfig feature was already enabled, the import com.salesforce.androidsdk.BuildConfig.DEBUG was already at the top of the file (line 74), but the code was still using reflection to access the consumer app's BuildConfig instead of the SDK's own BuildConfig.
