### PR TITLE
Add advanced auth testing for Beacon apps

### DIFF
--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -84,7 +84,7 @@ jobs:
             --results-history-name=AuthFlowTester \
             --no-performance-metrics \
             --test-targets="${PR_TESTS}" \
-            --timeout=10m \ 
+            --timeout=10m \
             --num-flaky-test-attempts=1
       - name: Run All Single User Tests
         continue-on-error: true

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -67,7 +67,9 @@ jobs:
             class com.salesforce.samples.authflowtester.ECALoginTests#testECAOpaque_DefaultScopes, \
             class com.salesforce.samples.authflowtester.ECALoginTests#testECAJwt_AllScopes, \
             class com.salesforce.samples.authflowtester.TokenMigrationTest#testMigrate_ECA_AddMoreScopes, \
-            class com.salesforce.samples.authflowtester.MultiUserLoginTests#testSameApp_SameScopes_uniqueTokens"
+            class com.salesforce.samples.authflowtester.MultiUserLoginTests#testSameApp_SameScopes_uniqueTokens, \
+            class com.salesforce.samples.authflowtester.BeaconLoginTests#testBeaconOpaque_DefaultScopes, \
+            class com.salesforce.samples.authflowtester.AdvancedAuthBeaconLoginTests#testBeaconOpaque_DefaultScopes"
           
           gcloud firebase test android run \
             --project mobile-apps-firebase-test \

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -59,6 +59,18 @@ Beacon app login tests for lightweight authentication use cases, covering both o
 | `testBeaconJwt_SubsetScopes` | Beacon JWT | Subset |
 | `testBeaconJwt_AllScopes` | Beacon JWT | All |
 
+#### AdvancedAuthBeaconLoginTests
+Tests for Beacon app login flows using advanced authentication with Chrome Custom Tabs. This class runs the same tests as BeaconLoginTests but uses the advanced_auth login host. Requires intent filters in AndroidManifest.xml matching the beacon redirect URIs (`beaconadvancedopaque://success/done` and `beaconadvancedjwt://success/done`).
+
+| Test | App Config | Scopes | Login Host |
+|------|-----------|--------|------------|
+| `testBeaconOpaque_DefaultScopes` | Beacon Opaque | Default | Advanced Auth |
+| `testBeaconOpaque_SubsetScopes` | Beacon Opaque | Subset | Advanced Auth |
+| `testBeaconOpaque_AllScopes` | Beacon Opaque | All | Advanced Auth |
+| `testBeaconJwt_DefaultScopes` | Beacon JWT | Default | Advanced Auth |
+| `testBeaconJwt_SubsetScopes` | Beacon JWT | Subset | Advanced Auth |
+| `testBeaconJwt_AllScopes` | Beacon JWT | All | Advanced Auth |
+
 #### AdvancedAuthLoginTests (WIP)
 Tests login via advanced authentication hosts that use Chrome Custom Tabs instead of the in-app WebView. Skipped on API ≤ 31 in Firebase Test Lab due to outdated Chrome.
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/AdvancedAuthBeaconLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/AdvancedAuthBeaconLoginTests.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.samples.authflowtester
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
+import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
+import org.junit.runner.RunWith
+
+/**
+ * Tests for login flows using Beacon app configurations with advanced authentication.
+ * This class runs the same tests as BeaconLoginTests but uses the advanced_auth login host
+ * with Chrome Custom Tabs instead of the in-app WebView.
+ *
+ * NB: Requires intent filters in AndroidManifest.xml matching the beacon redirect URIs:
+ * - beaconadvancedopaque://success/done (for Beacon Opaque)
+ * - beaconadvancedjwt://success/done (for Beacon JWT)
+ *
+ * NB: Tests use the second user from ui_test_config.json (advanced_auth host) to avoid
+ * login conflicts when running in parallel with regular auth tests.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class AdvancedAuthBeaconLoginTests : BeaconLoginTests() {
+
+    // region Test Configuration
+
+    /**
+     * Override to use advanced authentication login host.
+     */
+    override fun loginHostConfig(): KnownLoginHostConfig {
+        return KnownLoginHostConfig.ADVANCED_AUTH
+    }
+
+    /**
+     * Override to use second user to avoid login conflicts when running in parallel.
+     */
+    override fun userConfig(): KnownUserConfig {
+        return KnownUserConfig.SECOND
+    }
+
+    // endregion
+}

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/BeaconLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/BeaconLoginTests.kt
@@ -31,36 +31,75 @@ import androidx.test.filters.LargeTest
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.BEACON_OPAQUE
-import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.SUBSET
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
+import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.ALL
+import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.SUBSET
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Tests for login flows using Beacon app configurations.
  * Beacon apps are lightweight authentication apps for specific use cases.
+ *
+ * NB: Tests use the first user from ui_test_config.json
  */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-class BeaconLoginTests: AuthFlowTest() {
+open class BeaconLoginTests: AuthFlowTest() {
+
+    // region Test Configuration
+
+    /**
+     * Returns the login host configuration to use for tests.
+     * Subclasses can override this to use a different login host.
+     */
+    open fun loginHostConfig(): KnownLoginHostConfig {
+        return KnownLoginHostConfig.REGULAR_AUTH
+    }
+
+    /**
+     * Returns the user configuration to use for tests.
+     * Subclasses can override this to use a different user.
+     */
+    open fun userConfig(): KnownUserConfig {
+        return KnownUserConfig.FIRST
+    }
+
+    // endregion
+
     // region Beacon Opaque Tests
 
     // Login with Beacon opaque using default scopes and web server flow.
     @Test
-    fun testBeaconOpaque_DefaultScopes() {
-        loginAndValidate(knownAppConfig = BEACON_OPAQUE)
+    open fun testBeaconOpaque_DefaultScopes() {
+        loginAndValidate(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = loginHostConfig(),
+            knownUserConfig = userConfig()
+        )
     }
 
     // Login with Beacon opaque using subset of scopes and web server flow.
     @Test
-    fun testBeaconOpaque_SubsetScopes() {
-        loginAndValidate(knownAppConfig = BEACON_OPAQUE, scopeSelection = SUBSET)
+    open fun testBeaconOpaque_SubsetScopes() {
+        loginAndValidate(
+            knownAppConfig = BEACON_OPAQUE,
+            scopeSelection = SUBSET,
+            knownLoginHostConfig = loginHostConfig(),
+            knownUserConfig = userConfig()
+        )
     }
 
     // Login with Beacon opaque using all scopes and web server flow.
     @Test
-    fun testBeaconOpaque_AllScopes() {
-        loginAndValidate(knownAppConfig = BEACON_OPAQUE, scopeSelection = ALL)
+    open fun testBeaconOpaque_AllScopes() {
+        loginAndValidate(
+            knownAppConfig = BEACON_OPAQUE,
+            scopeSelection = ALL,
+            knownLoginHostConfig = loginHostConfig(),
+            knownUserConfig = userConfig()
+        )
     }
 
     // endregion
@@ -69,20 +108,34 @@ class BeaconLoginTests: AuthFlowTest() {
 
     // Login with Beacon JWT using default scopes and web server flow.
     @Test
-    fun testBeaconJwt_DefaultScopes() {
-        loginAndValidate(knownAppConfig = KnownAppConfig.BEACON_JWT)
+    open fun testBeaconJwt_DefaultScopes() {
+        loginAndValidate(
+            knownAppConfig = KnownAppConfig.BEACON_JWT,
+            knownLoginHostConfig = loginHostConfig(),
+            knownUserConfig = userConfig()
+        )
     }
 
     // Login with Beacon JWT using subset of scopes and web server flow.
     @Test
-    fun testBeaconJwt_SubsetScopes() {
-        loginAndValidate(knownAppConfig = KnownAppConfig.BEACON_JWT, scopeSelection = SUBSET)
+    open fun testBeaconJwt_SubsetScopes() {
+        loginAndValidate(
+            knownAppConfig = KnownAppConfig.BEACON_JWT,
+            scopeSelection = SUBSET,
+            knownLoginHostConfig = loginHostConfig(),
+            knownUserConfig = userConfig()
+        )
     }
 
     // Login with Beacon JWT using all scopes and web server flow.
     @Test
-    fun testBeaconJwt_AllScopes() {
-        loginAndValidate(knownAppConfig = KnownAppConfig.BEACON_JWT, scopeSelection = ALL)
+    open fun testBeaconJwt_AllScopes() {
+        loginAndValidate(
+            knownAppConfig = KnownAppConfig.BEACON_JWT,
+            scopeSelection = ALL,
+            knownLoginHostConfig = loginHostConfig(),
+            knownUserConfig = userConfig()
+        )
     }
 
     // endregion

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthorizationPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthorizationPageObject.kt
@@ -39,6 +39,13 @@ import com.salesforce.androidsdk.R as sdkR
 
 private const val TAG = "AuthorizationPageObject"
 private const val MAX_RETRIES = 5
+/**
+ * Short timeout for checking optional UI elements. Used for:
+ * - Local Chrome UI (password save dialog) that appears immediately or not at all
+ * - Server-rendered Allow button polling (500ms × 5 retries = 2.5s total, combined
+ *   with SLEEP_TIME_MS initial wait = ~5s total for server-side rendering)
+ */
+private const val QUICK_CHECK_TIMEOUT_MS = 500L
 
 /**
  * Handles the OAuth authorization "Allow" button that may appear
@@ -52,12 +59,13 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
     )
 
     /**
-     * After login: the authorization WebView is expected.  Scrolls and
-     * polls for the Allow button.  Returns early if the main app UI
-     * appears (approval was auto-granted or previously remembered).
+     * After login: the OAuth authorization page is expected (in WebView for REGULAR_AUTH,
+     * or Chrome Custom Tab for ADVANCED_AUTH). Scrolls and polls for the Allow button.
+     * Returns early if the main app UI appears (approval was auto-granted or previously
+     * remembered).
      */
     fun tapAllowAfterLogin(knownLoginHostConfig: KnownLoginHostConfig) {
-        // Let the WebView redirect to authorization page.
+        // Let the browser/WebView redirect to OAuth authorization page.
         Thread.sleep(SLEEP_TIME_MS)
 
         when(knownLoginHostConfig) {
@@ -76,8 +84,8 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
         val neverButton = device.findObject(
             UiSelector().resourceId("com.android.chrome:id/button_secondary")
         )
-        infoBar.waitForExists(TIMEOUT_MS)
-        if (neverButton.waitForExists(TIMEOUT_MS)) {
+        if (infoBar.waitForExists(QUICK_CHECK_TIMEOUT_MS) &&
+            neverButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
             neverButton.click()
         }
     }
@@ -87,13 +95,18 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
         val app = AuthFlowTesterPageObject(composeTestRule)
         swipeUp()
 
+        // Note: The Allow button is server-rendered on Salesforce's OAuth page.
+        // We use a short timeout (500ms) per check but loop MAX_RETRIES times,
+        // giving us 5 × 500ms = 2.5s of total polling. Combined with the
+        // SLEEP_TIME_MS (2.5s) before this method, we have ~5s total to find
+        // the button, balancing speed with reliability for server-side rendering.
         repeat(MAX_RETRIES) {
             if (app.isAppLoaded()) {
                 Log.i(TAG, "Left login screen — no approval needed.")
                 return
             }
 
-            if (allowButton.waitForExists(TIMEOUT_MS)) {
+            if (allowButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
                 allowButton.click()
                 Log.i(TAG, "Tapped Allow after login.")
                 return
@@ -105,13 +118,16 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
     private fun tapAllowInWebView() {
         swipeUp()
 
+        // Note: Short timeout per check (500ms) × MAX_RETRIES = 2.5s total polling.
+        // Combined with SLEEP_TIME_MS (2.5s) before this method = ~5s total for
+        // server-rendered Allow button to appear.
         repeat(MAX_RETRIES) {
             if (!loginActivityExists()) {
                 Log.i(TAG, "Left login screen — no approval needed.")
                 return
             }
 
-            if (allowButton.waitForExists(TIMEOUT_MS)) {
+            if (allowButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
                 allowButton.click()
                 Log.i(TAG, "Tapped Allow after login.")
                 return
@@ -127,7 +143,9 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
      */
     fun tapAllowAfterMigration() {
         // Wait for the page to load, swipe, then poll for the Allow button.
-        allowButton.waitForExists(TIMEOUT_MS)
+        // Note: Short timeout (500ms) per check × MAX_RETRIES = 2.5s total
+        // polling for server-rendered Allow button.
+        allowButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)
         swipeUp()
 
         repeat(MAX_RETRIES) {
@@ -138,7 +156,7 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
                 return
             }
 
-            if (allowButton.waitForExists(TIMEOUT_MS)) {
+            if (allowButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
                 allowButton.click()
                 Log.i(TAG, "Tapped Allow after migration.")
                 return

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
@@ -56,7 +56,7 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         if (!usernameField.waitForExists(TIMEOUT_MS)) {
             throw AssertionError("Username field not found in Custom Tab")
         }
-        usernameField.clearTextField()
+        usernameField.click()
         usernameField.setText(name)
     }
 
@@ -67,7 +67,7 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         if (!passwordField.waitForExists(TIMEOUT_MS)) {
             throw AssertionError("Password field not found in Custom Tab")
         }
-        passwordField.clearTextField()
+        passwordField.click()
         passwordField.setText(password)
     }
 
@@ -108,12 +108,15 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         }
     }
 
-    fun tapCloseButton() {
+    fun tapCloseButton(): Boolean {
         val closeButton = device.findObject(
             UiSelector().resourceId("com.android.chrome:id/close_button")
         )
-        if (closeButton.waitForExists(TIMEOUT_MS)) {
+        return if (closeButton.waitForExists(TIMEOUT_MS)) {
             closeButton.click()
+            true
+        } else {
+            false
         }
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
@@ -34,6 +34,12 @@ import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 
 private const val RETRY_COUNT = 3
+/**
+ * Short timeout for checking optional local Chrome UI elements that either appear
+ * immediately or not at all (e.g., first-run dialogs, password save prompts).
+ * These are not dependent on server-side rendering.
+ */
+private const val QUICK_CHECK_TIMEOUT_MS = 500L
 
 /**
  * Handles Custom Tab interactions.
@@ -93,16 +99,16 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         )
 
         repeat(times = RETRY_COUNT) {
-            if (continueButton.waitForExists(TIMEOUT_MS)) {
+            if (continueButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
                 continueButton.click()
                 return@repeat
-            } else if (legacyContinueButton.waitForExists(TIMEOUT_MS)) {
+            } else if (legacyContinueButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
                 legacyContinueButton.click()
                 return@repeat
             }
         }
 
-        if (noButton.waitForExists(TIMEOUT_MS)) {
+        if (noButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
             noButton.click()
             return
         }
@@ -112,7 +118,7 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         val closeButton = device.findObject(
             UiSelector().resourceId("com.android.chrome:id/close_button")
         )
-        return if (closeButton.waitForExists(TIMEOUT_MS)) {
+        return if (closeButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
             closeButton.click()
             true
         } else {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
@@ -27,8 +27,11 @@
 package com.salesforce.samples.authflowtester.pageObjects
 
 import androidx.compose.ui.test.ComposeTimeoutException
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -135,8 +138,10 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
             throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for server picker bottom sheet to appear", e)
         }
 
-        // Select the server matching the URL
-        composeTestRule.onNodeWithText(url, substring = true).performClick()
+        // Select the server matching the URL (filter for clickable node if multiple matches)
+        composeTestRule.onAllNodesWithText(url, substring = true)
+            .filterToOne(hasClickAction())
+            .performClick()
         composeTestRule.waitForIdle()
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -80,13 +80,30 @@ abstract class AuthFlowTest {
     @After
     open fun cleanup() {
         with(SalesforceSDKManager.getInstance()) {
-            userAccountManager.authenticatedUsers.forEach { userAccount ->
+            userAccountManager.authenticatedUsers?.forEach { userAccount ->
                 logout(
                     account = userAccountManager.buildAccount(userAccount),
                     frontActivity = null,
                     showLoginPage = false,
                 )
             }
+        }
+    }
+
+    /**
+     * Ensures we're on REGULAR_AUTH server before opening Login Options.
+     * Server selection is "sticky" so previous test might have left it on ADVANCED_AUTH.
+     */
+    private fun ensureRegularAuthServer() {
+        // First, close any Chrome Custom Tab that might be open from previous test
+        val chromeTab = ChromeCustomTabPageObject(composeTestRule)
+        if (chromeTab.tapCloseButton()) {
+            Thread.sleep(500)  // Wait for Chrome tab to close
+
+            // Now change to REGULAR_AUTH in WebView context
+            val tempLoginPage = LoginPageObject(composeTestRule)
+            tempLoginPage.changeServer(REGULAR_AUTH)
+            Thread.sleep(500)  // Wait for server change to take effect
         }
     }
 
@@ -102,6 +119,8 @@ abstract class AuthFlowTest {
             REGULAR_AUTH -> LoginPageObject(composeTestRule)
             ADVANCED_AUTH -> ChromeCustomTabPageObject(composeTestRule)
         }
+
+        ensureRegularAuthServer()
 
         if (!useWebServerFlow || !useHybridAuthToken ||
             knownAppConfig != CA_OPAQUE || scopeSelection != EMPTY) {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -95,14 +95,18 @@ abstract class AuthFlowTest {
      * Server selection is "sticky" so previous test might have left it on ADVANCED_AUTH.
      */
     private fun ensureRegularAuthServer() {
-        // First, close any Chrome Custom Tab that might be open from previous test
+        // Close any Chrome Custom Tab that might be open from previous test
         val chromeTab = ChromeCustomTabPageObject(composeTestRule)
         if (chromeTab.tapCloseButton()) {
             Thread.sleep(500)  // Wait for Chrome tab to close
+        }
 
-            // Now change to REGULAR_AUTH in WebView context
-            val tempLoginPage = LoginPageObject(composeTestRule)
-            tempLoginPage.changeServer(REGULAR_AUTH)
+        // Switch back to REGULAR_AUTH using LoginServerManager
+        val regularAuthUrl = testConfig.getLoginHost(REGULAR_AUTH).url
+        val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        val regularAuthServer = loginServerManager.getLoginServerFromURL(regularAuthUrl)
+        if (regularAuthServer != null) {
+            loginServerManager.setSelectedLoginServer(regularAuthServer)
             Thread.sleep(500)  // Wait for server change to take effect
         }
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/main/AndroidManifest.xml
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/AndroidManifest.xml
@@ -32,6 +32,26 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+
+            <!-- Intent filter for advanced authentication with Beacon Opaque app -->
+            <intent-filter>
+                <data android:scheme="beaconadvancedopaque"
+                    android:host="success"
+                    android:path="/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <!-- Intent filter for advanced authentication with Beacon JWT app -->
+            <intent-filter>
+                <data android:scheme="beaconadvancedjwt"
+                    android:host="success"
+                    android:path="/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/native/NativeSampleApps/AuthFlowTester/src/main/res/xml/servers.xml
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/res/xml/servers.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <servers>
     <server name="UITests" url="https://authflowtestingmsdksdb38.test1.my.pc-rnd.salesforce.com" />
+    <server name="UITests Adv Auth" url="https://advauthflowtestingmsdksdb38.test1.my.pc-rnd.salesforce.com" />
     <server name="Production" url="https://login.salesforce.com" />
     <server name="Sandbox" url="https://test.salesforce.com" />
     <server name="SDK Production" url="https://mobilesdk.my.salesforce.com" />


### PR DESCRIPTION
## Summary
- Add `AdvancedAuthBeaconLoginTests` to test Beacon apps via Chrome Custom Tabs
- Make `BeaconLoginTests` extensible with template methods for login host/user config  
- Fix Chrome Custom Tab text entry by clicking fields before setText
- Add pre-flight server reset to ensure WebView context for login options UI