### PR TITLE
Add presentBiometricAuth to NativeLoginManager.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1551,7 +1551,7 @@ open class SalesforceSDKManager protected constructor(
         // Publish analytics one-time on app background, if enabled.
         if (SalesforceAnalyticsManager.analyticsPublishingType() == PublishOnAppBackground) {
             enqueueAnalyticsPublishWorkRequest(
-                getInstance().appContext
+                appContext
             )
         }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -82,6 +82,7 @@ import com.salesforce.androidsdk.auth.interfaces.NativeLoginResult.Success
 import com.salesforce.androidsdk.auth.interfaces.NativeLoginResult.UnknownError
 import com.salesforce.androidsdk.auth.interfaces.OtpRequestResult
 import com.salesforce.androidsdk.auth.interfaces.OtpVerificationMethod
+import com.salesforce.androidsdk.rest.ClientManager
 import com.salesforce.androidsdk.rest.RestClient.AsyncRequestCallback
 import com.salesforce.androidsdk.rest.RestRequest
 import com.salesforce.androidsdk.rest.RestRequest.RestEndpoint.LOGIN
@@ -194,62 +195,18 @@ internal class NativeLoginManager(
     }
 
     override fun presentBiometricAuth(activity: FragmentActivity): Boolean {
-        val bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
-                as? BiometricAuthenticationManager ?: return false
-
-        if (!bioAuthManager.locked || !bioAuthManager.hasBiometricOptedIn()) {
-            return false
-        }
-
         val biometricManager = BiometricManager.from(activity)
-        // TODO: Remove when min API > 29.
-        val authenticators = when {
-            SDK_INT >= R -> BIOMETRIC_STRONG or DEVICE_CREDENTIAL
-            else -> BIOMETRIC_WEAK or DEVICE_CREDENTIAL
-        }
-
-        if (biometricManager.canAuthenticate(authenticators) != BIOMETRIC_SUCCESS) {
-            return false
-        }
-
         val biometricPrompt = BiometricPrompt(
             activity,
             getMainExecutor(activity),
             object : AuthenticationCallback() {
                 override fun onAuthenticationSucceeded(result: AuthenticationResult) {
                     super.onAuthenticationSucceeded(result)
-
-                    SalesforceSDKManager.getInstance().clientManager.getRestClient(
-                        activity
-                    ) { client ->
-                        runCatching {
-                            client.oAuthRefreshInterceptor.refreshAccessToken()
-                        }.onFailure { e ->
-                            e(TAG, "Error encountered while unlocking.", e)
-                        }
-                        bioAuthManager.onUnlock()
-                        activity.finish()
-                    }
+                    onBiometricAuthenticationSucceeded(activity)
                 }
             }
         )
-
-        val username = accountManager.currentUser?.username ?: ""
-        var hasFaceUnlock = false
-        if (SDK_INT >= Q) {
-            hasFaceUnlock = activity.packageManager.hasSystemFeature(FEATURE_FACE)
-                    || activity.packageManager.hasSystemFeature(FEATURE_IRIS)
-        }
-
-        val promptInfo = BiometricPrompt.PromptInfo.Builder()
-            .setTitle(activity.resources.getString(sf__biometric_opt_in_title))
-            .setSubtitle(username)
-            .setAllowedAuthenticators(authenticators)
-            .setConfirmationRequired(hasFaceUnlock)
-            .build()
-
-        biometricPrompt.authenticate(promptInfo)
-        return true
+        return buildAndShowBiometricAuth(activity, biometricManager, biometricPrompt)
     }
 
     @VisibleForTesting
@@ -967,6 +924,70 @@ internal class NativeLoginManager(
             !isValidUsername(trim()) -> InvalidUsername
             else -> null
         }
+
+    // endregion
+
+    // region Biometric Authentication Helpers
+
+    @VisibleForTesting
+    internal fun buildAndShowBiometricAuth(
+        activity: FragmentActivity,
+        biometricManager: BiometricManager,
+        biometricPrompt: BiometricPrompt,
+    ): Boolean {
+        val bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as? BiometricAuthenticationManager ?: return false
+
+        if (!bioAuthManager.locked || !bioAuthManager.hasBiometricOptedIn()) {
+            return false
+        }
+
+        // TODO: Remove when min API > 29.
+        val authenticators = when {
+            SDK_INT >= R -> BIOMETRIC_STRONG or DEVICE_CREDENTIAL
+            else -> BIOMETRIC_WEAK or DEVICE_CREDENTIAL
+        }
+
+        if (biometricManager.canAuthenticate(authenticators) != BIOMETRIC_SUCCESS) {
+            return false
+        }
+
+        val username = accountManager.currentUser?.username ?: ""
+        var hasFaceUnlock = false
+        if (SDK_INT >= Q) {
+            hasFaceUnlock = activity.packageManager.hasSystemFeature(FEATURE_FACE)
+                    || activity.packageManager.hasSystemFeature(FEATURE_IRIS)
+        }
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(activity.resources.getString(sf__biometric_opt_in_title))
+            .setSubtitle(username)
+            .setAllowedAuthenticators(authenticators)
+            .setConfirmationRequired(hasFaceUnlock)
+            .build()
+
+        biometricPrompt.authenticate(promptInfo)
+        return true
+    }
+
+    @VisibleForTesting
+    internal fun onBiometricAuthenticationSucceeded(
+        activity: FragmentActivity,
+        clientManager: ClientManager = SalesforceSDKManager.getInstance().clientManager,
+    ) {
+        val bioAuthManager = SalesforceSDKManager.getInstance()
+            .biometricAuthenticationManager as? BiometricAuthenticationManager
+
+        clientManager.getRestClient(activity) { client ->
+            runCatching {
+                client.oAuthRefreshInterceptor.refreshAccessToken()
+            }.onFailure { e ->
+                e(TAG, "Error encountered while unlocking.", e)
+            }
+            bioAuthManager?.onUnlock()
+            activity.finish()
+        }
+    }
 
     // endregion
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -92,6 +92,7 @@ import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Compani
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getRandom128ByteKey
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getSHA256Hash
 import com.salesforce.androidsdk.util.SalesforceSDKLogger
+import com.salesforce.androidsdk.util.SalesforceSDKLogger.e
 import kotlinx.coroutines.Dispatchers.Default
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -183,10 +184,6 @@ internal class NativeLoginManager(
     }
 
     override fun getFallbackWebAuthenticationIntent(): Intent {
-        // Unlock biometric auth since the user is choosing webview auth instead.
-        (SalesforceSDKManager.getInstance().biometricAuthenticationManager
-                as? BiometricAuthenticationManager)?.onUnlock()
-
         val context = SalesforceSDKManager.getInstance().appContext
         val intent = Intent(context, SalesforceSDKManager.getInstance().webViewLoginActivityClass)
         intent.setFlags(FLAG_ACTIVITY_SINGLE_TOP)
@@ -221,8 +218,18 @@ internal class NativeLoginManager(
             object : AuthenticationCallback() {
                 override fun onAuthenticationSucceeded(result: AuthenticationResult) {
                     super.onAuthenticationSucceeded(result)
-                    bioAuthManager.onUnlock()
-                    activity.finish()
+
+                    SalesforceSDKManager.getInstance().clientManager.getRestClient(
+                        activity
+                    ) { client ->
+                        runCatching {
+                            client.oAuthRefreshInterceptor.refreshAccessToken()
+                        }.onFailure { e ->
+                            e(TAG, "Error encountered while unlocking.", e)
+                        }
+                        bioAuthManager.onUnlock()
+                        activity.finish()
+                    }
                 }
             }
         )

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -29,13 +29,29 @@ package com.salesforce.androidsdk.auth
 import android.accounts.AccountManager.KEY_INTENT
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+import android.content.pm.PackageManager.FEATURE_FACE
+import android.content.pm.PackageManager.FEATURE_IRIS
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.Q
+import android.os.Build.VERSION_CODES.R
 import android.os.Bundle
 import android.util.Base64.NO_PADDING
 import android.util.Base64.NO_WRAP
 import android.util.Base64.URL_SAFE
 import android.util.Base64.encodeToString
 import android.util.Patterns.EMAIL_ADDRESS
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+import androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS
+import androidx.biometric.BiometricPrompt
+import androidx.biometric.BiometricPrompt.AuthenticationCallback
+import androidx.biometric.BiometricPrompt.AuthenticationResult
+import androidx.core.content.ContextCompat.getMainExecutor
 import androidx.core.os.bundleOf
+import androidx.fragment.app.FragmentActivity
+import com.salesforce.androidsdk.R.string.sf__biometric_opt_in_title
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.NativeLoginManager.StartRegistrationRequestBody.UserData
 import com.salesforce.androidsdk.auth.OAuth2.AUTHORIZATION
@@ -71,6 +87,7 @@ import com.salesforce.androidsdk.rest.RestRequest
 import com.salesforce.androidsdk.rest.RestRequest.RestEndpoint.LOGIN
 import com.salesforce.androidsdk.rest.RestRequest.RestMethod.POST
 import com.salesforce.androidsdk.rest.RestResponse
+import com.salesforce.androidsdk.security.BiometricAuthenticationManager
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Companion.SHOW_BIOMETRIC
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getRandom128ByteKey
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getSHA256Hash
@@ -166,13 +183,66 @@ internal class NativeLoginManager(
     }
 
     override fun getFallbackWebAuthenticationIntent(): Intent {
+        // Unlock biometric auth since the user is choosing webview auth instead.
+        (SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as? BiometricAuthenticationManager)?.onUnlock()
+
         val context = SalesforceSDKManager.getInstance().appContext
         val intent = Intent(context, SalesforceSDKManager.getInstance().webViewLoginActivityClass)
         intent.setFlags(FLAG_ACTIVITY_SINGLE_TOP)
-        intent.putExtras(bundleOf(SHOW_BIOMETRIC to bioAuthLocked))
+        intent.putExtras(bundleOf(SHOW_BIOMETRIC to false))
         Bundle().putParcelable(KEY_INTENT, intent)
 
         return intent
+    }
+
+    override fun presentBiometricAuth(activity: FragmentActivity): Boolean {
+        val bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as? BiometricAuthenticationManager ?: return false
+
+        if (!bioAuthManager.locked || !bioAuthManager.hasBiometricOptedIn()) {
+            return false
+        }
+
+        val biometricManager = BiometricManager.from(activity)
+        // TODO: Remove when min API > 29.
+        val authenticators = when {
+            SDK_INT >= R -> BIOMETRIC_STRONG or DEVICE_CREDENTIAL
+            else -> BIOMETRIC_WEAK or DEVICE_CREDENTIAL
+        }
+
+        if (biometricManager.canAuthenticate(authenticators) != BIOMETRIC_SUCCESS) {
+            return false
+        }
+
+        val biometricPrompt = BiometricPrompt(
+            activity,
+            getMainExecutor(activity),
+            object : AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: AuthenticationResult) {
+                    super.onAuthenticationSucceeded(result)
+                    bioAuthManager.onUnlock()
+                    activity.finish()
+                }
+            }
+        )
+
+        val username = accountManager.currentUser?.username ?: ""
+        var hasFaceUnlock = false
+        if (SDK_INT >= Q) {
+            hasFaceUnlock = activity.packageManager.hasSystemFeature(FEATURE_FACE)
+                    || activity.packageManager.hasSystemFeature(FEATURE_IRIS)
+        }
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(activity.resources.getString(sf__biometric_opt_in_title))
+            .setSubtitle(username)
+            .setAllowedAuthenticators(authenticators)
+            .setConfirmationRequired(hasFaceUnlock)
+            .build()
+
+        biometricPrompt.authenticate(promptInfo)
+        return true
     }
 
     @VisibleForTesting

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/interfaces/NativeLoginManager.kt
@@ -27,6 +27,7 @@
 package com.salesforce.androidsdk.auth.interfaces
 
 import android.content.Intent
+import androidx.fragment.app.FragmentActivity
 
 enum class NativeLoginResult {
     /** Email address is not a valid format  */
@@ -81,6 +82,21 @@ interface NativeLoginManager {
      * @return the intent to be started for fallback web based authentication.
      */
     fun getFallbackWebAuthenticationIntent(): Intent
+
+    /**
+     * Presents the SDK's biometric authentication prompt to unlock the app.
+     * Call this when the app is in a biometric-locked state (i.e.,
+     * [biometricAuthenticationUsername] is non-null) and the user wants to
+     * authenticate via biometric or device credential.
+     *
+     * On successful authentication, the app will be unlocked, tokens will be
+     * refreshed, and the provided activity will be finished.
+     *
+     * @param activity The FragmentActivity from which to present the biometric prompt
+     * @return True if the biometric prompt was presented, false if biometric
+     * authentication is not available or the app is not in a locked state
+     */
+    fun presentBiometricAuth(activity: FragmentActivity): Boolean
 
     // region Salesforce Identity API Headless Registration Flow
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/BiometricAuthenticationManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/security/BiometricAuthenticationManager.kt
@@ -60,16 +60,22 @@ internal class BiometricAuthenticationManager: AppLockManager(
     }
 
     override fun lock() {
-        currentUser?.let {
+        currentUser?.let { user ->
             locked = true
-            val ctx = SalesforceSDKManager.getInstance().appContext
-            val intent = Intent(ctx, SalesforceSDKManager.getInstance().loginActivityClass)
-            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            intent.putExtras(bundleOf(SHOW_BIOMETRIC to true))
-            ctx.startActivity(intent)
-            EventsObservable.get().notifyEvent(EventsObservable.EventType.AppLocked)
+            with(SalesforceSDKManager.getInstance()) {
+                val activityClass = if (user.nativeLogin == true) {
+                    loginActivityClass
+                } else {
+                    webViewLoginActivityClass
+                }
+                val intent = Intent(appContext, activityClass)
+                intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                intent.putExtras(bundleOf(SHOW_BIOMETRIC to true))
+                appContext.startActivity(intent)
+                EventsObservable.get().notifyEvent(EventsObservable.EventType.AppLocked)
+            }
         }
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -150,9 +150,9 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
     }
     internal val showBiometricAuthenticationButton = derivedStateOf {
         with(SalesforceSDKManager.getInstance()) {
-            biometricAuthenticationManager?.let { mgr ->
-                mgr.locked && mgr.hasBiometricOptedIn()
-                        && userAccountManager.currentUser?.nativeLogin != true
+            biometricAuthenticationManager?.run {
+                locked && hasBiometricOptedIn()
+                    && userAccountManager.currentUser?.nativeLogin != true
             }
         } ?: false
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -148,7 +148,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
     internal val isIDPLoginFlowEnabled = derivedStateOf {
         SalesforceSDKManager.getInstance().isIDPLoginFlowEnabled
     }
-    internal val isBiometricAuthenticationLocked = derivedStateOf {
+    internal val showBiometricAuthenticationButton = derivedStateOf {
         with(SalesforceSDKManager.getInstance()) {
             biometricAuthenticationManager?.let { mgr ->
                 mgr.locked && mgr.hasBiometricOptedIn()

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -149,8 +149,11 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
         SalesforceSDKManager.getInstance().isIDPLoginFlowEnabled
     }
     internal val isBiometricAuthenticationLocked = derivedStateOf {
-        SalesforceSDKManager.getInstance().biometricAuthenticationManager?.let { bioAuthManager ->
-            bioAuthManager.locked && bioAuthManager.hasBiometricOptedIn()
+        with(SalesforceSDKManager.getInstance()) {
+            biometricAuthenticationManager?.let { mgr ->
+                mgr.locked && mgr.hasBiometricOptedIn()
+                        && userAccountManager.currentUser?.nativeLogin != true
+            }
         } ?: false
     }
     internal val biometricAuthenticationButtonText = mutableIntStateOf(sf__login_with_biometric)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -175,7 +175,7 @@ fun LoginView() {
 
     // Possible Buttons to show in BottomAppBar
     val bioAuthButton: LoginViewModel.BottomBarButton? =
-        if (viewModel.isBiometricAuthenticationLocked.value) {
+        if (viewModel.showBiometricAuthenticationButton.value) {
             LoginViewModel.BottomBarButton(
                 stringResource(viewModel.biometricAuthenticationButtonText.intValue)
             ) {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelMockTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelMockTest.kt
@@ -31,9 +31,13 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.accounts.UserAccountBuilder
+import com.salesforce.androidsdk.accounts.UserAccountManager
+import com.salesforce.androidsdk.accounts.UserAccountTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse
 import com.salesforce.androidsdk.config.BootConfig
+import com.salesforce.androidsdk.security.BiometricAuthenticationManager
 import com.salesforce.androidsdk.ui.LoginViewModel
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -46,8 +50,10 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -710,6 +716,96 @@ class LoginViewModelMockTest {
                 loginServer = migrationServer,
             )
         }
+    }
+
+    // endregion
+
+    // region showBiometricAuthenticationButton Tests
+
+    @Test
+    fun showBiometricAuthenticationButton_ReturnsFalse_ByDefault() {
+        assertFalse(
+            "Should not be biometric locked by default.",
+            viewModel.showBiometricAuthenticationButton.value
+        )
+    }
+
+    @Test
+    fun showBiometricAuthenticationButton_ReturnsFalse_ForNativeLoginUser() {
+        val bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        val nativeLoginUser = UserAccountBuilder.getInstance()
+            .populateFromUserAccount(UserAccountTest.createTestAccount())
+            .nativeLogin(isNativeLogin = true)
+            .build()
+        UserAccountManager.getInstance().createAccount(nativeLoginUser)
+        bioAuthManager.storeMobilePolicy(nativeLoginUser, enabled = true, timeout = 15)
+        bioAuthManager.biometricOptIn(true)
+        bioAuthManager.lock()
+
+        assertFalse(
+            "Should not report biometric locked for native login user.",
+            viewModel.showBiometricAuthenticationButton.value
+        )
+
+        bioAuthManager.locked = false
+        bioAuthManager.cleanUp(nativeLoginUser)
+    }
+
+    @Test
+    fun showBiometricAuthenticationButton_ReturnsTrue_ForNonNativeLoginUser() {
+        val bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        val account = UserAccountTest.createTestAccount()
+        UserAccountManager.getInstance().createAccount(account)
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.biometricOptIn(true)
+        bioAuthManager.lock()
+
+        assertTrue(
+            "Should report biometric locked for non-native login user.",
+            viewModel.showBiometricAuthenticationButton.value
+        )
+
+        bioAuthManager.locked = false
+        bioAuthManager.cleanUp(account)
+    }
+
+    @Test
+    fun showBiometricAuthenticationButton_ReturnsFalse_WhenNotOptedIn() {
+        val bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        val account = UserAccountTest.createTestAccount()
+        UserAccountManager.getInstance().createAccount(account)
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        // Not opted in.
+        bioAuthManager.lock()
+
+        assertFalse(
+            "Should not report biometric locked when not opted in.",
+            viewModel.showBiometricAuthenticationButton.value
+        )
+
+        bioAuthManager.locked = false
+        bioAuthManager.cleanUp(account)
+    }
+
+    @Test
+    fun showBiometricAuthenticationButton_ReturnsFalse_WhenNotLocked() {
+        val bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        val account = UserAccountTest.createTestAccount()
+        UserAccountManager.getInstance().createAccount(account)
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.biometricOptIn(true)
+        // Not locked.
+
+        assertFalse(
+            "Should not report biometric locked when not locked.",
+            viewModel.showBiometricAuthenticationButton.value
+        )
+
+        bioAuthManager.cleanUp(account)
     }
 
     // endregion

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
@@ -1,11 +1,15 @@
 package com.salesforce.androidsdk.auth
 
+import androidx.fragment.app.FragmentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
+import com.salesforce.androidsdk.accounts.UserAccountBuilder
 import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.accounts.UserAccountTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager
+import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Companion.SHOW_BIOMETRIC
+import io.mockk.mockk
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -65,7 +69,7 @@ class NativeLoginManagerTest {
         Assert.assertTrue("Should show back button when there is a logged in user.", mgr.shouldShowBackButton)
 
         val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
-        bioAuthManager.storeMobilePolicy(account, true, 15)
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
         Assert.assertTrue("Should show back if not locked.", mgr.shouldShowBackButton)
 
         bioAuthManager.lock()
@@ -81,7 +85,7 @@ class NativeLoginManagerTest {
         Assert.assertNull("Should not return username when bio auth is not enabled.", mgr.biometricAuthenticationUsername)
 
         val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
-        bioAuthManager.storeMobilePolicy(account, true, 15)
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
         Assert.assertNull("Should not return username when not locked.", mgr.biometricAuthenticationUsername)
 
         bioAuthManager.lock()
@@ -89,7 +93,69 @@ class NativeLoginManagerTest {
     }
 
 
+    @Test
+    fun testPresentBiometricAuthReturnsFalseWhenNotLocked() {
+        bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager as BiometricAuthenticationManager
+        addUserAccount()
+        val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.biometricOptIn(true)
+        // Not locked — should return false.
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        Assert.assertFalse("Should return false when not locked.", mgr.presentBiometricAuth(activity))
+    }
+
+    @Test
+    fun testPresentBiometricAuthReturnsFalseWhenNotOptedIn() {
+        bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager as BiometricAuthenticationManager
+        addUserAccount()
+        val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        // Opted out, but locked.
+        bioAuthManager.lock()
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        Assert.assertFalse("Should return false when not opted in.", mgr.presentBiometricAuth(activity))
+    }
+
+    @Test
+    fun testPresentBiometricAuthReturnsFalseWhenNoUser() {
+        // No user account — bio auth manager won't be locked.
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        Assert.assertFalse("Should return false with no user.", mgr.presentBiometricAuth(activity))
+    }
+
+    @Test
+    fun testGetFallbackWebAuthenticationIntentShowBiometricFalse() {
+        val intent = mgr.getFallbackWebAuthenticationIntent()
+        Assert.assertFalse(
+            "Fallback web auth intent should always have SHOW_BIOMETRIC=false.",
+            intent.extras?.getBoolean(SHOW_BIOMETRIC) ?: true
+        )
+    }
+
+    @Test
+    fun testBiometricAuthenticationUsernameWithNativeLoginUser() {
+        bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager as BiometricAuthenticationManager
+        addNativeLoginUserAccount()
+        val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.lock()
+        Assert.assertEquals(
+            "Should return username for native login user when locked.",
+            "test_username",
+            mgr.biometricAuthenticationUsername
+        )
+    }
+
     private fun addUserAccount() {
-        UserAccountManager.getInstance().createAccount(UserAccountTest.createTestAccount());
+        UserAccountManager.getInstance().createAccount(UserAccountTest.createTestAccount())
+    }
+
+    private fun addNativeLoginUserAccount() {
+        val account = UserAccountBuilder.getInstance()
+            .populateFromUserAccount(UserAccountTest.createTestAccount())
+            .nativeLogin(true)
+            .build()
+        UserAccountManager.getInstance().createAccount(account)
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
@@ -1,5 +1,9 @@
 package com.salesforce.androidsdk.auth
 
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
+import androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS
+import androidx.biometric.BiometricPrompt
 import androidx.fragment.app.FragmentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
@@ -9,7 +13,14 @@ import com.salesforce.androidsdk.accounts.UserAccountTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Companion.SHOW_BIOMETRIC
+import com.salesforce.androidsdk.rest.ClientManager
+import com.salesforce.androidsdk.rest.ClientManager.RestClientCallback
+import com.salesforce.androidsdk.rest.RestClient
+import com.salesforce.androidsdk.rest.RestClient.OAuthRefreshInterceptor
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -30,6 +41,7 @@ class NativeLoginManagerTest {
     fun tearDown() {
         SalesforceSDKManager.getInstance().userAccountManager
             .signoutCurrentUser(null, true, OAuth2.LogoutReason.USER_LOGOUT)
+        unmockkAll()
     }
 
     @Test
@@ -102,7 +114,9 @@ class NativeLoginManagerTest {
         bioAuthManager.biometricOptIn(true)
         // Not locked — should return false.
         val activity = mockk<FragmentActivity>(relaxed = true)
-        Assert.assertFalse("Should return false when not locked.", mgr.presentBiometricAuth(activity))
+        val mockBiometricManager = mockk<BiometricManager>()
+        val mockBiometricPrompt = mockk<BiometricPrompt>(relaxed = true)
+        Assert.assertFalse("Should return false when not locked.", mgr.buildAndShowBiometricAuth(activity, mockBiometricManager, mockBiometricPrompt))
     }
 
     @Test
@@ -114,14 +128,18 @@ class NativeLoginManagerTest {
         // Opted out, but locked.
         bioAuthManager.lock()
         val activity = mockk<FragmentActivity>(relaxed = true)
-        Assert.assertFalse("Should return false when not opted in.", mgr.presentBiometricAuth(activity))
+        val mockBiometricManager = mockk<BiometricManager>()
+        val mockBiometricPrompt = mockk<BiometricPrompt>(relaxed = true)
+        Assert.assertFalse("Should return false when not opted in.", mgr.buildAndShowBiometricAuth(activity, mockBiometricManager, mockBiometricPrompt))
     }
 
     @Test
     fun testPresentBiometricAuthReturnsFalseWhenNoUser() {
         // No user account — bio auth manager won't be locked.
         val activity = mockk<FragmentActivity>(relaxed = true)
-        Assert.assertFalse("Should return false with no user.", mgr.presentBiometricAuth(activity))
+        val mockBiometricManager = mockk<BiometricManager>()
+        val mockBiometricPrompt = mockk<BiometricPrompt>(relaxed = true)
+        Assert.assertFalse("Should return false with no user.", mgr.buildAndShowBiometricAuth(activity, mockBiometricManager, mockBiometricPrompt))
     }
 
     @Test
@@ -131,6 +149,122 @@ class NativeLoginManagerTest {
             "Fallback web auth intent should always have SHOW_BIOMETRIC=false.",
             intent.extras?.getBoolean(SHOW_BIOMETRIC) ?: true
         )
+    }
+
+    @Test
+    fun testPresentBiometricAuthReturnsFalseWhenBioAuthManagerIsNull() {
+        val sdkManager = SalesforceSDKManager.getInstance()
+        val originalBioAuthManager = sdkManager.biometricAuthenticationManager
+        try {
+            sdkManager.biometricAuthenticationManager = null
+            val activity = mockk<FragmentActivity>(relaxed = true)
+            val mockBiometricManager = mockk<BiometricManager>()
+            val mockBiometricPrompt = mockk<BiometricPrompt>(relaxed = true)
+            Assert.assertFalse(
+                "Should return false when bio auth manager is null.",
+                mgr.buildAndShowBiometricAuth(activity, mockBiometricManager, mockBiometricPrompt)
+            )
+        } finally {
+            sdkManager.biometricAuthenticationManager = originalBioAuthManager
+        }
+    }
+
+    @Test
+    fun testPresentBiometricAuthReturnsFalseWhenCannotAuthenticate() {
+        bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        addUserAccount()
+        val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.biometricOptIn(true)
+        bioAuthManager.lock()
+
+        val mockBiometricManager = mockk<BiometricManager>()
+        every { mockBiometricManager.canAuthenticate(any()) } returns BIOMETRIC_ERROR_NO_HARDWARE
+        val mockBiometricPrompt = mockk<BiometricPrompt>(relaxed = true)
+
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        Assert.assertFalse(
+            "Should return false when biometric hardware unavailable.",
+            mgr.buildAndShowBiometricAuth(activity, mockBiometricManager, mockBiometricPrompt)
+        )
+    }
+
+    @Test
+    fun testPresentBiometricAuthReturnsTrueWhenAllConditionsMet() {
+        bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        addUserAccount()
+        val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.biometricOptIn(true)
+        bioAuthManager.lock()
+
+        val mockBiometricManager = mockk<BiometricManager>()
+        every { mockBiometricManager.canAuthenticate(any()) } returns BIOMETRIC_SUCCESS
+        val mockBiometricPrompt = mockk<BiometricPrompt>(relaxed = true)
+
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        every { activity.resources.getString(any()) } returns "Biometric Auth"
+
+        Assert.assertTrue(
+            "Should return true when locked, opted in, and biometric available.",
+            mgr.buildAndShowBiometricAuth(activity, mockBiometricManager, mockBiometricPrompt)
+        )
+    }
+
+    @Test
+    fun testOnBiometricAuthenticationSucceededRefreshesAndUnlocks() {
+        bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        addUserAccount()
+        val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.lock()
+        Assert.assertTrue("Should be locked.", bioAuthManager.locked)
+
+        val mockInterceptor = mockk<OAuthRefreshInterceptor>(relaxed = true)
+        val mockClient = mockk<RestClient>(relaxed = true)
+        every { mockClient.oAuthRefreshInterceptor } returns mockInterceptor
+
+        val mockClientManager = mockk<ClientManager>()
+        every { mockClientManager.getRestClient(any(), any<RestClientCallback>()) } answers {
+            secondArg<RestClientCallback>().authenticatedRestClient(mockClient)
+        }
+
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        mgr.onBiometricAuthenticationSucceeded(activity, mockClientManager)
+
+        verify { mockInterceptor.refreshAccessToken() }
+        Assert.assertFalse("Should be unlocked after success.", bioAuthManager.locked)
+        verify { activity.finish() }
+    }
+
+    @Test
+    fun testOnBiometricAuthenticationSucceededHandlesRefreshFailure() {
+        bioAuthManager = SalesforceSDKManager.getInstance().biometricAuthenticationManager
+                as BiometricAuthenticationManager
+        addUserAccount()
+        val account = SalesforceSDKManager.getInstance().userAccountManager.currentUser
+        bioAuthManager.storeMobilePolicy(account, enabled = true, timeout = 15)
+        bioAuthManager.lock()
+
+        val mockInterceptor = mockk<OAuthRefreshInterceptor>(relaxed = true)
+        every { mockInterceptor.refreshAccessToken() } throws RuntimeException("Token refresh failed")
+        val mockClient = mockk<RestClient>(relaxed = true)
+        every { mockClient.oAuthRefreshInterceptor } returns mockInterceptor
+
+        val mockClientManager = mockk<ClientManager>()
+        every { mockClientManager.getRestClient(any(), any<RestClientCallback>()) } answers {
+            secondArg<RestClientCallback>().authenticatedRestClient(mockClient)
+        }
+
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        mgr.onBiometricAuthenticationSucceeded(activity, mockClientManager)
+
+        // Should still unlock and finish even if refresh fails.
+        Assert.assertFalse("Should be unlocked even after refresh failure.", bioAuthManager.locked)
+        verify { activity.finish() }
     }
 
     @Test

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/BiometricAuthenticationManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/security/BiometricAuthenticationManagerTest.kt
@@ -31,8 +31,11 @@ import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.accounts.UserAccountBuilder
 import com.salesforce.androidsdk.accounts.UserAccountManager
+import com.salesforce.androidsdk.accounts.UserAccountTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.auth.OAuth2
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Companion.BIO_AUTH_ENABLED
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Companion.BIO_AUTH_POLICY
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager.Companion.BIO_AUTH_TIMEOUT
@@ -192,5 +195,47 @@ class BiometricAuthenticationManagerTest {
 
         bioAuthManager.lock()
         Assert.assertTrue("Should be locked by lock() API.", bioAuthManager.locked)
+    }
+
+    @Test
+    fun testLockWithNativeLoginUser() {
+        bioAuthManager.cleanUp(userAccount)
+        val nativeLoginUser = UserAccountBuilder.getInstance()
+            .populateFromUserAccount(UserAccountTest.createTestAccount())
+            .nativeLogin(isNativeLogin = true)
+            .build()
+        UserAccountManager.getInstance().createAccount(nativeLoginUser)
+        bioAuthManager.storeMobilePolicy(nativeLoginUser, enabled = true, timeout = 1)
+
+        Assert.assertFalse("Should not be locked by default.", bioAuthManager.locked)
+        bioAuthManager.lock()
+        Assert.assertTrue("Should be locked by lock() API for native login user.", bioAuthManager.locked)
+
+        bioAuthManager.locked = false
+        Assert.assertFalse("Should be unlocked.", bioAuthManager.locked)
+        bioAuthManager.cleanUp(nativeLoginUser)
+    }
+
+    @Test
+    fun testLockWithNonNativeLoginUser() {
+        bioAuthManager.storeMobilePolicy(userAccount, enabled = true, timeout = 1)
+
+        Assert.assertFalse("Should not be locked by default.", bioAuthManager.locked)
+        bioAuthManager.lock()
+        Assert.assertTrue("Should be locked by lock() API for non-native login user.", bioAuthManager.locked)
+    }
+
+    @Test
+    fun testLockWithNoCurrentUser() {
+        bioAuthManager.cleanUp(userAccount)
+        SalesforceSDKManager.getInstance().userAccountManager
+            .signoutCurrentUser(/* frontActivity = */ null, /* showLoginPage = */ true, OAuth2.LogoutReason.USER_LOGOUT)
+
+        Assert.assertFalse("Should not be locked by default.", bioAuthManager.locked)
+        bioAuthManager.lock()
+        Assert.assertFalse("Should not be locked when there is no current user.", bioAuthManager.locked)
+
+        // Re-create the account for tearDown.
+        UserAccountManager.getInstance().createAccount(userAccount)
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
@@ -66,6 +66,7 @@ import org.junit.Test
 
 private const val DEFAULT_URL = "https://login.salesforce.com"
 private const val BUTTON_TITLE = "Test Button"
+private const val BIO_AUTH_BUTTON_TITLE = "Log In with Biometric"
 
 class LoginViewActivityTest {
 
@@ -331,6 +332,37 @@ class LoginViewActivityTest {
 
         val button = androidComposeTestRule.onNodeWithText(BUTTON_TITLE)
         button.assertDoesNotExist()
+    }
+
+    @Test
+    fun bottomAppBar_WithBiometricButton_DisplaysCorrectly() {
+        var bioAuthClicked = false
+        androidComposeTestRule.setContent {
+            DefaultBottomAppBarTestWrapper(
+                button = LoginViewModel.BottomBarButton(BIO_AUTH_BUTTON_TITLE) {
+                    bioAuthClicked = true
+                }
+            )
+        }
+
+        val bioButton = androidComposeTestRule.onNodeWithText(BIO_AUTH_BUTTON_TITLE)
+        bioButton.assertExists()
+        bioButton.assertIsDisplayed()
+        bioButton.assertIsEnabled()
+        Assert.assertFalse("Bio auth button should not be clicked yet.", bioAuthClicked)
+
+        bioButton.performClick()
+        Assert.assertTrue("Bio auth button should have been clicked.", bioAuthClicked)
+    }
+
+    @Test
+    fun bottomAppBar_WithoutBiometricButton_DoesNotShowBiometricText() {
+        androidComposeTestRule.setContent {
+            DefaultBottomAppBarTestWrapper(button = null)
+        }
+
+        val bioButton = androidComposeTestRule.onNodeWithText(BIO_AUTH_BUTTON_TITLE)
+        bioButton.assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION
This PR also prevents the Bio Auth from being prompted on fallback WebView and checks which login screen should be launched on bio auth lock.  

~~I am still looking into an issue with token refresh that is specific to native login users.~~  -> FIXED