### PR TITLE
Fix unit tests that fail based on API level.

### DIFF
--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginServerManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginServerManagerTest.java
@@ -262,7 +262,8 @@ public class LoginServerManagerTest {
         assertProduction(loginServerManager.getSelectedLoginServer());
 
         loginServerManager.addCustomLoginServer(CUSTOM_NAME, CUSTOM_URL);
-        assertCustom(loginServerManager.getLoginServers().getLast());
+        List<LoginServer> addedServers = loginServerManager.getLoginServers();
+        assertCustom(addedServers.get(addedServers.size() - 1));
         assertCustom(loginServerManager.getSelectedLoginServer());
 
         loginServerManager = new LoginServerManager(
@@ -279,7 +280,8 @@ public class LoginServerManagerTest {
         assertFalse(servers.get(2).isCustom);
         assertOther(servers.get(3));
 
-        assertCustom(loginServerManager.getLoginServers().getLast());
+        List<LoginServer> finalAddServers = loginServerManager.getLoginServers();
+        assertCustom(finalAddServers.get(finalAddServers.size() - 1));
         assertCustom(loginServerManager.getSelectedLoginServer());
     }
 
@@ -305,7 +307,8 @@ public class LoginServerManagerTest {
         assertProduction(loginServerManager.getSelectedLoginServer());
 
         loginServerManager.addCustomLoginServer(CUSTOM_NAME, CUSTOM_URL);
-        assertCustom(loginServerManager.getLoginServers().getLast());
+        List<LoginServer> addedServers = loginServerManager.getLoginServers();
+        assertCustom(addedServers.get(addedServers.size() - 1));
         assertCustom(loginServerManager.getSelectedLoginServer());
 
         loginServerManager = new LoginServerManager(
@@ -322,7 +325,8 @@ public class LoginServerManagerTest {
         assertSandbox(servers.get(2));
         assertOther(servers.get(3));
 
-        assertCustom(loginServerManager.getLoginServers().getLast());
+        List<LoginServer> finalUpdateServers = loginServerManager.getLoginServers();
+        assertCustom(finalUpdateServers.get(finalUpdateServers.size() - 1));
         assertCustom(loginServerManager.getSelectedLoginServer());
     }
 
@@ -348,7 +352,8 @@ public class LoginServerManagerTest {
         assertProduction(loginServerManager.getSelectedLoginServer());
 
         loginServerManager.addCustomLoginServer(CUSTOM_NAME, CUSTOM_URL);
-        assertCustom(loginServerManager.getLoginServers().getLast());
+        List<LoginServer> addedServers = loginServerManager.getLoginServers();
+        assertCustom(addedServers.get(addedServers.size() - 1));
         assertCustom(loginServerManager.getSelectedLoginServer());
 
         loginServerManager = new LoginServerManager(
@@ -361,7 +366,8 @@ public class LoginServerManagerTest {
         assertProduction(servers.get(0));
         assertOther(servers.get(1));
 
-        assertCustom(loginServerManager.getLoginServers().getLast());
+        List<LoginServer> finalRemoveServers = loginServerManager.getLoginServers();
+        assertCustom(finalRemoveServers.get(finalRemoveServers.size() - 1));
         assertCustom(loginServerManager.getSelectedLoginServer());
     }
 
@@ -709,7 +715,8 @@ public class LoginServerManagerTest {
         loginServerManager.reorderCustomLoginServer(loginServerManager.getLoginServers().indexOf(updatedCustomLoginServer), loginServerManager.getLoginServers().size() - 1);
 
         // Verify the updated custom login server is now the last login server in the list.
-        assertEquals(loginServerManager.getLoginServers().getLast(), updatedCustomLoginServer);
+        List<LoginServer> reorderedServers = loginServerManager.getLoginServers();
+        assertEquals(reorderedServers.get(reorderedServers.size() - 1), updatedCustomLoginServer);
     }
 
     public static void assertProduction(LoginServer server) {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/ScreenLockViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/ScreenLockViewModelTest.kt
@@ -27,6 +27,7 @@
 package com.salesforce.androidsdk.auth
 
 import android.os.Build.VERSION_CODES.Q
+import android.os.Build.VERSION_CODES.R
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
@@ -59,7 +60,7 @@ class ScreenLockViewModelTest {
 
     @Test
     fun viewModel_biometricAuthenticators_updatesOn_api30Plus() {
-        val biometricAuthenticators = viewModel.biometricAuthenticators()
+        val biometricAuthenticators = viewModel.biometricAuthenticators(R)
         assertEquals(BIOMETRIC_STRONG or DEVICE_CREDENTIAL, biometricAuthenticators)
     }
 


### PR DESCRIPTION
- `List.getLast()` is a Java 21 API.  Even though our _project_ supports Java 21, older versions of Android did not.  That means the the use of that API immediately fails when the test runs on older devices.
- API < 30 will always return `BIOMETRIC_WEAK`.  