### PR TITLE
Redact tokens and other sensitive values passed into SalesforceSDKLogger.

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/LogRedactor.kt
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/LogRedactor.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.analytics.logger
+
+private const val VISIBLE_CHARS = 4
+
+private val SENSITIVE_JSON_PATTERN = Regex(
+    pattern = """("(?:access_token|refresh_token|id_token|csrf_token|sid""" +
+        """|lightning_sid|visualforce_sid|content_sid|parent_sid""" +
+        """|cookie-sid_Client|cookie-clientSrc""" +
+        """|beacon_child_consumer_secret)"\s*:\s*")([^"]+)(")""",
+    option = RegexOption.IGNORE_CASE,
+)
+
+private val SENSITIVE_URL_PATTERN = Regex(
+    pattern = """([?&](?:access_token|sid|token)=)([^&\s]+)""",
+    option = RegexOption.IGNORE_CASE,
+)
+
+internal fun String.mask(): String {
+    if (length <= VISIBLE_CHARS) return "*".repeat(length)
+    return "*".repeat(length - VISIBLE_CHARS) + substring(length - VISIBLE_CHARS)
+}
+
+fun String.redactSensitiveData(): String {
+    var result = SENSITIVE_JSON_PATTERN.replace(this) { match ->
+        "${match.groupValues[1]}${match.groupValues[2].mask()}${match.groupValues[3]}"
+    }
+    result = SENSITIVE_URL_PATTERN.replace(result) { match ->
+        "${match.groupValues[1]}${match.groupValues[2].mask()}"
+    }
+    return result
+}

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/SalesforceLogger.java
@@ -389,6 +389,20 @@ public class SalesforceLogger {
     }
 
     /**
+     * Redacts sensitive tokens and credentials from a log message.
+     * Delegates to the Kotlin extension {@code String.redactSensitiveData()}.
+     *
+     * @param message The original log message.
+     * @return The message with sensitive values masked, showing only the last 4 characters.
+     */
+    static String redact(String message) {
+        if (message == null) {
+            return null;
+        }
+        return LogRedactorKt.redactSensitiveData(message);
+    }
+
+    /**
      * Logs a log line of the specified level.
      *
      * @param level   Log level.
@@ -397,6 +411,7 @@ public class SalesforceLogger {
      */
     public void log(Level level, String tag, String message) {
         if (level.severity >= logLevel.severity) {
+            message = redact(message);
             switch (level) {
                 case OFF:
                     break;
@@ -432,6 +447,7 @@ public class SalesforceLogger {
      */
     public void log(Level level, String tag, String message, Throwable e) {
         if (level.severity >= logLevel.severity) {
+            message = redact(message);
             switch (level) {
                 case OFF:
                     break;

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Random;
 import java.util.Set;
 
 /**
@@ -50,11 +51,14 @@ public class SalesforceLoggerTest {
 
     private static final String TEST_COMPONENT_1 = "TestComponent1";
     private static final String TEST_COMPONENT_2 = "TestComponent2";
+    private static final String ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final int VISIBLE_CHARS = 4;
 
     private Context targetContext;
+    private final Random random = new Random();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         SalesforceLogger.flushComponents();
         SalesforceLogger.resetLoggerPrefs(targetContext);
@@ -63,7 +67,7 @@ public class SalesforceLoggerTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         SalesforceLogger.flushComponents();
         SalesforceLogger.resetLoggerPrefs(targetContext);
     }
@@ -106,5 +110,305 @@ public class SalesforceLoggerTest {
         logger.setLogLevel(SalesforceLogger.Level.VERBOSE);
         logLevel = logger.getLogLevel();
         Assert.assertEquals("Log levels should be the same", SalesforceLogger.Level.VERBOSE, logLevel);
+    }
+
+    /**
+     * Test that null input returns null.
+     */
+    @Test
+    public void testRedactNull() {
+        Assert.assertNull("Redact of null should return null", SalesforceLogger.redact(null));
+    }
+
+    /**
+     * Test that an empty string is unchanged.
+     */
+    @Test
+    public void testRedactEmptyString() {
+        Assert.assertEquals("Empty string should be unchanged", "", SalesforceLogger.redact(""));
+    }
+
+    /**
+     * Test that a message without sensitive data is unchanged.
+     */
+    @Test
+    public void testRedactNonSensitiveMessage() {
+        final String message = "User logged in successfully";
+        Assert.assertEquals("Non-sensitive message should be unchanged", message, SalesforceLogger.redact(message));
+    }
+
+    /**
+     * Test that access_token is redacted in JSON.
+     */
+    @Test
+    public void testRedactAccessToken() {
+        final String value = randomString(23);
+        final String input = "{\"access_token\":\"" + value + "\"}";
+        final String expected = "{\"access_token\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("access_token should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that refresh_token is redacted in JSON.
+     */
+    @Test
+    public void testRedactRefreshToken() {
+        final String value = randomString(43);
+        final String input = "{\"refresh_token\":\"" + value + "\"}";
+        final String expected = "{\"refresh_token\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("refresh_token should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that id_token is redacted in JSON.
+     */
+    @Test
+    public void testRedactIdToken() {
+        final String value = randomString(51);
+        final String input = "{\"id_token\":\"" + value + "\"}";
+        final String expected = "{\"id_token\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("id_token should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that csrf_token is redacted in JSON.
+     */
+    @Test
+    public void testRedactCsrfToken() {
+        final String value = randomString(10);
+        final String input = "{\"csrf_token\":\"" + value + "\"}";
+        final String expected = "{\"csrf_token\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("csrf_token should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that sid is redacted in JSON.
+     */
+    @Test
+    public void testRedactSid() {
+        final String value = randomString(17);
+        final String input = "{\"sid\":\"" + value + "\"}";
+        final String expected = "{\"sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("sid should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that lightning_sid is redacted in JSON.
+     */
+    @Test
+    public void testRedactLightningSid() {
+        final String value = randomString(17);
+        final String input = "{\"lightning_sid\":\"" + value + "\"}";
+        final String expected = "{\"lightning_sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("lightning_sid should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that visualforce_sid is redacted in JSON.
+     */
+    @Test
+    public void testRedactVisualforceSid() {
+        final String value = randomString(10);
+        final String input = "{\"visualforce_sid\":\"" + value + "\"}";
+        final String expected = "{\"visualforce_sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("visualforce_sid should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that content_sid is redacted in JSON.
+     */
+    @Test
+    public void testRedactContentSid() {
+        final String value = randomString(15);
+        final String input = "{\"content_sid\":\"" + value + "\"}";
+        final String expected = "{\"content_sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("content_sid should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that parent_sid is redacted in JSON.
+     */
+    @Test
+    public void testRedactParentSid() {
+        final String value = randomString(14);
+        final String input = "{\"parent_sid\":\"" + value + "\"}";
+        final String expected = "{\"parent_sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("parent_sid should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that beacon_child_consumer_secret is redacted in JSON.
+     */
+    @Test
+    public void testRedactBeaconChildConsumerSecret() {
+        final String value = randomString(11);
+        final String input = "{\"beacon_child_consumer_secret\":\"" + value + "\"}";
+        final String expected = "{\"beacon_child_consumer_secret\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("beacon_child_consumer_secret should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that multiple sensitive keys in one JSON message are all redacted.
+     */
+    @Test
+    public void testRedactMultipleJsonKeys() {
+        final String accessValue = randomString(8);
+        final String refreshValue = randomString(10);
+        final String input = "{\"access_token\":\"" + accessValue + "\",\"refresh_token\":\"" + refreshValue
+                + "\",\"instance_url\":\"https://na1.salesforce.com\"}";
+        final String expected = "{\"access_token\":\"" + expectedMask(accessValue)
+                + "\",\"refresh_token\":\"" + expectedMask(refreshValue)
+                + "\",\"instance_url\":\"https://na1.salesforce.com\"}";
+        Assert.assertEquals("Multiple sensitive keys should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that JSON keys with spaces around colon are redacted.
+     */
+    @Test
+    public void testRedactJsonWithSpaces() {
+        final String value = randomString(8);
+        final String input = "{\"access_token\" : \"" + value + "\"}";
+        final String expected = "{\"access_token\" : \"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("JSON with spaces around colon should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that access_token in a URL query parameter is redacted.
+     */
+    @Test
+    public void testRedactUrlAccessToken() {
+        final String value = randomString(15);
+        final String input = "https://instance.salesforce.com/secur/frontdoor.jsp?access_token=" + value;
+        final String expected = "https://instance.salesforce.com/secur/frontdoor.jsp?access_token=" + expectedMask(value);
+        Assert.assertEquals("URL access_token should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that sid in a URL query parameter is redacted.
+     */
+    @Test
+    public void testRedactUrlSid() {
+        final String value = randomString(12);
+        final String input = "https://instance.salesforce.com/secur/frontdoor.jsp?sid=" + value + "&retURL=/home";
+        final String expected = "https://instance.salesforce.com/secur/frontdoor.jsp?sid=" + expectedMask(value)
+                + "&retURL=/home";
+        Assert.assertEquals("URL sid should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that token in a URL query parameter is redacted.
+     */
+    @Test
+    public void testRedactUrlToken() {
+        final String value = randomString(6);
+        final String input = "https://example.com/callback?token=" + value + "&state=xyz";
+        final String expected = "https://example.com/callback?token=" + expectedMask(value) + "&state=xyz";
+        Assert.assertEquals("URL token should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that non-sensitive URL parameters are preserved.
+     */
+    @Test
+    public void testRedactUrlPreservesNonSensitive() {
+        final String input = "https://example.com/path?display=touch&retURL=/home";
+        Assert.assertEquals("Non-sensitive URL params should be unchanged", input, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test redaction with a realistic full token endpoint response.
+     */
+    @Test
+    public void testRedactFullTokenResponse() {
+        final String accessVal = randomString(21);
+        final String refreshVal = randomString(13);
+        final String idTokenVal = randomString(20);
+        final String lightningSidVal = randomString(9);
+        final String csrfVal = randomString(7);
+        final String input = "parsedResponse-->{\"access_token\":\"" + accessVal + "\"," +
+                "\"refresh_token\":\"" + refreshVal + "\"," +
+                "\"instance_url\":\"https://na1.salesforce.com\"," +
+                "\"id\":\"https://login.salesforce.com/id/00Dxx/005xx\"," +
+                "\"id_token\":\"" + idTokenVal + "\"," +
+                "\"lightning_sid\":\"" + lightningSidVal + "\"," +
+                "\"csrf_token\":\"" + csrfVal + "\"}";
+        final String result = SalesforceLogger.redact(input);
+        Assert.assertFalse("access_token value should not appear", result.contains(accessVal));
+        Assert.assertFalse("refresh_token value should not appear", result.contains(refreshVal));
+        Assert.assertFalse("id_token value should not appear", result.contains(idTokenVal));
+        Assert.assertFalse("lightning_sid value should not appear", result.contains(lightningSidVal));
+        Assert.assertFalse("csrf_token value should not appear", result.contains(csrfVal));
+        Assert.assertTrue("instance_url value should be preserved", result.contains("https://na1.salesforce.com"));
+        Assert.assertTrue("id value should be preserved", result.contains("https://login.salesforce.com/id/00Dxx/005xx"));
+        Assert.assertTrue("Masked output should contain stars", result.contains("***"));
+    }
+
+    /**
+     * Test that mixed JSON and URL content is fully redacted.
+     */
+    @Test
+    public void testRedactMixedContent() {
+        final String jsonTokenVal = randomString(12);
+        final String urlSidVal = randomString(10);
+        final String input = "Response: {\"access_token\":\"" + jsonTokenVal + "\"} from https://example.com?sid=" + urlSidVal;
+        final String result = SalesforceLogger.redact(input);
+        Assert.assertFalse("JSON token should not appear", result.contains(jsonTokenVal));
+        Assert.assertFalse("URL sid should not appear", result.contains(urlSidVal));
+    }
+
+    /**
+     * Test that values with 4 or fewer characters are fully masked.
+     */
+    @Test
+    public void testRedactShortValue() {
+        final String value = randomString(2);
+        final String input = "{\"sid\":\"" + value + "\"}";
+        final String expected = "{\"sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("Short values should be fully masked", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that values with exactly 4 characters are fully masked.
+     */
+    @Test
+    public void testRedactExactly4CharValue() {
+        final String value = randomString(4);
+        final String input = "{\"sid\":\"" + value + "\"}";
+        final String expected = "{\"sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("4-char values should be fully masked", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that values with 5 characters show only the last 4.
+     */
+    @Test
+    public void testRedact5CharValue() {
+        final String value = randomString(5);
+        final String input = "{\"sid\":\"" + value + "\"}";
+        final String expected = "{\"sid\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("5-char values should show last 4", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Generates a random alphanumeric string of the given length.
+     */
+    private String randomString(int length) {
+        final StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(ALPHANUMERIC.charAt(random.nextInt(ALPHANUMERIC.length())));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Computes the expected masked value: stars replacing all but the last 4 characters.
+     * Values of 4 or fewer characters are fully masked with stars.
+     */
+    private static String expectedMask(String value) {
+        if (value.length() <= VISIBLE_CHARS) {
+            return "*".repeat(value.length());
+        }
+        return "*".repeat(value.length() - VISIBLE_CHARS) + value.substring(value.length() - VISIBLE_CHARS);
     }
 }


### PR DESCRIPTION
Check all JSON and URL formatted text for sensitive values and mask all but the last 4 characters. 

Ex:
> OAuth2                   D  parsedResponse-->{"signature":"tO832buRTray1RT3FVs\/iu5qLRCdmbibFThOkh7YfCs=","lightning_sid":"************************************************************************************************************uuFO","csrf_token":"******************************************************************************************************************************************************************************************************************************************************************************************************************************************KDM=","visualforce_domain":"msdk-enhanced-dev-ed--c.vf.force.com","instance_url":"https:\/\/msdk-enhanced-dev-ed.my.salesforce.com","cookie-clientSrc":"*********5.11","token_type":"Bearer","sidCookieName":"sid","issued_at":"1776286260849","access_token":"************************************************************************************************************XTb3","refresh_token":"***********************************************************************************Tdqa","content_domain":"msdk-enhanced-dev-ed.file.force.com","scope":"lightning visualforce refresh_token web chatter_api id api content","visualforce_sid":"************************************************************************************************************nWef","id":"https:\/\/login.salesforce.com\/id\/00D6A000001juNkUAI\/0056A000001JXyrQAG","content_sid":"************************************************************************************************************u8OD","lightning_domain":"msdk-enhanced-dev-ed.lightning.force.com","cookie-sid_Client":"******************juNk"}

