### PR TITLE
Fix auth flow regressions.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -587,7 +587,6 @@ open class LoginActivity : FragmentActivity() {
         )
 
         viewModel.clearCookies()
-        viewModel.resetFrontDoorBridgeUrl()
         // Displays the error in a toast, clears cookies and reloads the login page
         runOnUiThread {
             makeText(this, "$error : $errorDesc", LENGTH_LONG).show()

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -442,15 +442,19 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
     }
 
     /**
-     * Generates an OAuth authorization URL for token migration.
-     * @param server The login server URL
-     * @param migrationOAuthConfig The OAuth config to use for migration
+     * Generates an OAuth authorization URL for token migration given a login
+     * [server] and [migrationOAuthConfig].
      */
     internal fun generateMigrationAuthorizationPath(
         server: String,
         migrationOAuthConfig: OAuthConfig,
         sdkManager: SalesforceSDKManager = SalesforceSDKManager.getInstance(),
     ): String {
+        // Set oAuthConfig so downstream migration steps (TokenMigrationClientManager's
+        // callback URL match and doCodeExchange's consumerKey/redirectUri) use the
+        // migration config rather than the default boot config.
+        oAuthConfig = migrationOAuthConfig
+
         val codeVerifier = getRandom128ByteKey().also { codeVerifier = it }
         val codeChallenge = getSHA256Hash(codeVerifier)
 
@@ -569,7 +573,8 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
         loginUrl.value = webViewUrl
 
         // Launch the browser custom tab when applicable.
-        if (sdkManager.isBrowserLoginEnabled || singleServerCustomTabActivity) {
+        if ((sdkManager.isBrowserLoginEnabled || singleServerCustomTabActivity)
+            && !isUsingFrontDoorBridge) {
             onBrowserCustomTabReady?.invoke(browserTabUrl)
         }
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelMockTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelMockTest.kt
@@ -37,6 +37,7 @@ import com.salesforce.androidsdk.accounts.UserAccountTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse
 import com.salesforce.androidsdk.config.BootConfig
+import com.salesforce.androidsdk.config.OAuthConfig
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager
 import com.salesforce.androidsdk.ui.LoginViewModel
 import io.mockk.coEvery
@@ -48,6 +49,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertFalse
@@ -714,6 +716,71 @@ class LoginViewModelMockTest {
                 mockOnSuccess,
                 tokenMigration = true,
                 loginServer = migrationServer,
+            )
+        }
+    }
+
+    @Test
+    fun migrationFlow_DoCodeExchange_UsesMigrationConfig_NotBootConfig() = runBlocking {
+        val migrationConsumerKey = "migration_consumer_key_xyz"
+        val migrationRedirectUri = "migrationapp://callback"
+        val migrationConfig = OAuthConfig(
+            consumerKey = migrationConsumerKey,
+            redirectUri = migrationRedirectUri,
+            scopes = listOf("api", "refresh_token"),
+        )
+        val migrationServer = "https://test.salesforce.com"
+        val testCode = "test_auth_code"
+        val mockOnError: (String, String?, Throwable?) -> Unit = mockk(relaxed = true)
+        val mockOnSuccess: (UserAccount) -> Unit = mockk(relaxed = true)
+        val mockTokenResponse: TokenEndpointResponse = mockk(relaxed = true)
+
+        // Force OAuth2 class initialization before mocking to avoid ExceptionInInitializerError
+        OAuth2.TIMESTAMP_FORMAT
+        mockkStatic(OAuth2::class)
+        every {
+            OAuth2.exchangeCode(any(), any(), any(), any(), any(), any())
+        } returns mockTokenResponse
+
+        // Spy so we can short-circuit account creation, leaving exchangeCode as the observable.
+        val spyViewModel = spyk(viewModel)
+        coEvery {
+            spyViewModel.onAuthFlowComplete(any(), any(), any(), any(), any())
+        } just runs
+
+        // Sanity: distinct from boot config so a missing side effect would surface.
+        assertFalse(
+            "Test setup error: migration consumerKey must differ from boot config",
+            migrationConsumerKey == bootConfig.remoteAccessConsumerKey,
+        )
+        assertFalse(
+            "Test setup error: migration redirectUri must differ from boot config",
+            migrationRedirectUri == bootConfig.oauthRedirectURI,
+        )
+
+        // Drive the real migration sequence: URL generation, then code exchange.
+        spyViewModel.generateMigrationAuthorizationPath(
+            server = migrationServer,
+            migrationOAuthConfig = migrationConfig,
+        )
+        spyViewModel.doCodeExchange(
+            testCode,
+            onAuthFlowError = mockOnError,
+            onAuthFlowSuccess = mockOnSuccess,
+            loginServer = migrationServer,
+            tokenMigration = true,
+        )
+        Thread.sleep(200)
+
+        // Token exchange must be performed with MIGRATION credentials.
+        verify {
+            OAuth2.exchangeCode(
+                /* httpAccessor = */ any(),
+                /* loginServer = */ any(),
+                /* clientId = */ migrationConsumerKey,
+                /* code = */ testCode,
+                /* codeVerifier = */ any(),
+                /* callbackUrl = */ migrationRedirectUri,
             )
         }
     }


### PR DESCRIPTION
- Ensure `LoginViewModel`'s `oAuthConfig` is set in to the migration config when generating the authorization path so code exchange succeeds
   - New unit test added to catch this.
- Check `isUsingFrontDoorBridge` to ensure CustomTab does not cover QR Code login.
- Remove unnecessary (second) call to `resetFrontDoorBridgeUrl`.