### PR TITLE
@W-21981288: OkHttp 5 upgrade — fix deprecated API usages

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/SalesforceNetworkPlugin.java
@@ -295,7 +295,7 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
 
     private static RequestBody buildRequestBody(JSONObject params, JSONObject fileParams) throws URISyntaxException {
         if (fileParams == null || fileParams.length() == 0) {
-            return RequestBody.create(RestRequest.MEDIA_TYPE_JSON, params.toString());
+            return RequestBody.create(params.toString(), RestRequest.MEDIA_TYPE_JSON);
         } else {
             final MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
             final Iterator<String> keys = params.keys();
@@ -324,7 +324,7 @@ public class SalesforceNetworkPlugin extends ForcePlugin {
                             final URI url = new URI(fileParam.optString(FILE_URL_KEY));
                             final File file = new File(url);
                             final MediaType mediaType = MediaType.parse(mimeType);
-                            builder.addFormDataPart(fileKeyStr, name, RequestBody.create(mediaType, file));
+                            builder.addFormDataPart(fileKeyStr, name, RequestBody.create(file, mediaType));
                         }
                     }
                 }

--- a/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
+++ b/libs/SalesforceReact/src/com/salesforce/androidsdk/reactnative/bridge/SalesforceNetReactBridge.java
@@ -255,7 +255,7 @@ public class SalesforceNetReactBridge extends ReactContextBaseJavaModule {
     }
 
     private static RequestBody buildRequestBody(Map<String, Object> params, Map<String, Map<String, String>> fileParams) throws URISyntaxException {
-        final RequestBody paramsRequestBody = RequestBody.create(RestRequest.MEDIA_TYPE_JSON, new JSONObject(params).toString());
+        final RequestBody paramsRequestBody = RequestBody.create(new JSONObject(params).toString(), RestRequest.MEDIA_TYPE_JSON);
         if (fileParams.isEmpty()) {
             return paramsRequestBody;
         } else {
@@ -272,7 +272,7 @@ public class SalesforceNetReactBridge extends ReactContextBaseJavaModule {
                 URI url = new URI(fileParam.get(FILE_URL_KEY));
                 File file = new File(url);
                 MediaType mediaType = MediaType.parse(mimeType);
-                builder.addFormDataPart(fileParamName, name, RequestBody.create(mediaType, file));
+                builder.addFormDataPart(fileParamName, name, RequestBody.create(file, mediaType));
             }
             return builder.build();
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AILTNPublisher.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/analytics/AILTNPublisher.java
@@ -125,8 +125,8 @@ public class AILTNPublisher implements AnalyticsPublisher {
              * required to achieve this by adding an additional interceptor to determine content length.
              * See this post for more details: https://github.com/square/okhttp/issues/350#issuecomment-123105641.
              */
-            final RequestBody requestBody = setContentLength(gzipCompressedBody(RequestBody.create(RestRequest.MEDIA_TYPE_JSON,
-                    body.toString())));
+            final RequestBody requestBody = setContentLength(gzipCompressedBody(RequestBody.create(body.toString(),
+                    RestRequest.MEDIA_TYPE_JSON)));
             final Map<String, String> requestHeaders = new HashMap<>();
             requestHeaders.put(CONTENT_ENCODING, GZIP);
             requestHeaders.put(CONTENT_LENGTH, Long.toString(requestBody.contentLength()));

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/HttpAccess.java
@@ -126,7 +126,7 @@ public class HttpAccess {
      */
     public OkHttpClient.Builder createNewClientBuilder() {
         ConnectionSpec connectionSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                .tlsVersions(TlsVersion.TLS_1_1, TlsVersion.TLS_1_2)
+                .tlsVersions(TlsVersion.TLS_1_2)
                 .build();
         return new OkHttpClient.Builder()
                 .connectionSpecs(Collections.singletonList(connectionSpec))

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -98,7 +98,7 @@ public class RestRequest {
     /**
      * application/json media type
      */
-    public static final MediaType MEDIA_TYPE_JSON = MediaType.parse("application/json; charset=utf-8");
+    public static final MediaType MEDIA_TYPE_JSON = MediaType.get("application/json; charset=utf-8");
 
     /**
      * utf_8 charset
@@ -319,7 +319,7 @@ public class RestRequest {
         this.method = method;
         this.endpoint = endpoint;
         this.path = path;
-        this.requestBody = requestBodyAsJson == null ? null : RequestBody.create(MEDIA_TYPE_JSON, requestBodyAsJson.toString());
+        this.requestBody = requestBodyAsJson == null ? null : RequestBody.create(requestBodyAsJson.toString(), MEDIA_TYPE_JSON);
         this.additionalHttpHeaders = additionalHttpHeaders;
         this.requestBodyAsJson = requestBodyAsJson;
     }
@@ -386,7 +386,7 @@ public class RestRequest {
     public static RestRequest getRequestForSingleAccess(String redirectUri) throws UnsupportedEncodingException {
         RequestBody requestBody = RequestBody.create(
                 "redirect_uri=" + URLEncoder.encode(redirectUri, UTF_8),
-                MediaType.parse("application/x-www-form-urlencoded")
+                MediaType.get("application/x-www-form-urlencoded")
         );
         return new RestRequest(RestMethod.POST, RestEndpoint.INSTANCE, RestAction.SINGLEACCESS.getPath(), requestBody, null);
     }
@@ -751,7 +751,7 @@ public class RestRequest {
         for (SObjectTree objectTree : objectTrees) {
             jsonTrees.put(objectTree.asJSON());
         }
-        RequestBody body = RequestBody.create(MEDIA_TYPE_JSON, JSONObjectHelper.makeJSONObject(RECORDS, jsonTrees).toString());
+        RequestBody body = RequestBody.create(JSONObjectHelper.makeJSONObject(RECORDS, jsonTrees).toString(), MEDIA_TYPE_JSON);
         return new RestRequest(RestMethod.POST, RestAction.SOBJECT_TREE.getPath(apiVersion, objectType), body);
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/files/FileRequests.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/files/FileRequests.java
@@ -201,7 +201,7 @@ public class FileRequests extends ApiRequests {
         MultipartBody.Builder builder = new MultipartBody.Builder();
         if (title != null) builder.addFormDataPart("title", title);
         if (description != null) builder.addFormDataPart("desc", description);
-        builder.addFormDataPart("fileData", name, RequestBody.create(mediaType, theFile));
+        builder.addFormDataPart("fileData", name, RequestBody.create(theFile, mediaType));
         return new RestRequest(RestMethod.POST, base("connect/files/users").appendPath("me").toString(), builder.build(), HTTP_HEADERS);
     }
 
@@ -210,6 +210,6 @@ public class FileRequests extends ApiRequests {
         share.put("ContentDocumentId", fileId);
         share.put("LinkedEntityId", entityId);
         share.put("ShareType", shareType);
-        return RequestBody.create(RestRequest.MEDIA_TYPE_JSON, new JSONObject(share).toString());
+        return RequestBody.create(new JSONObject(share).toString(), RestRequest.MEDIA_TYPE_JSON);
     }
 }


### PR DESCRIPTION
## Summary

- The OkHttp version bump from `4.12.0` to `5.3.2` was done in PR #2871 (@W-21471024, Compose Material 3 v1.4.0 update)
- This PR addresses the follow-on API modernization required by OkHttp 5

## Changes

- **`HttpAccess.java`**: Removed `TlsVersion.TLS_1_1` from `ConnectionSpec` — TLS 1.1 was deprecated by RFC 8996 in 2021 and unsupported on modern Android
- **`RestRequest.java`**: Switched `MediaType.parse()` → `MediaType.get()` for hardcoded strings; flipped `RequestBody.create(MediaType, content)` to `create(content, MediaType)`
- **`AILTNPublisher.java`**: Flipped `RequestBody.create()` arg order
- **`FileRequests.java`**: Flipped `RequestBody.create()` arg order (2 occurrences)
- **`SalesforceNetworkPlugin.java`**: Flipped `RequestBody.create()` arg order (2 occurrences)
- **`SalesforceNetReactBridge.java`**: Flipped `RequestBody.create()` arg order (2 occurrences)

## Notes

- `MediaType.parse(mimeType)` calls that take runtime user-supplied MIME type strings were intentionally left as `parse()` (returns null on invalid) rather than changed to `get()` (throws)
- The old `RequestBody.create(MediaType, content)` form is still present in OkHttp 5 for Java backward compat but is deprecated

## Test plan

- [ ] Build `SalesforceSDK`, `SalesforceHybrid`, and `SalesforceReact` libraries
- [ ] Run `SalesforceSDKTest` suite (REST client, file upload, analytics publishing)
- [ ] Verify login and REST calls work end-to-end in a hybrid and React Native app