### PR TITLE
Migrate doc generation from Javadoc to Dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
         classpath("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.21")
         classpath("org.jacoco:org.jacoco.core:0.8.14")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.20")
     }
 }
 
@@ -31,4 +32,17 @@ allprojects {
             languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
         }
     }
+}
+
+apply(plugin = "org.jetbrains.dokka")
+
+subprojects {
+    if (path.startsWith(":libs:")) {
+        apply(plugin = "org.jetbrains.dokka")
+    }
+}
+
+tasks.named<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>("dokkaHtmlMultiModule") {
+    moduleName.set("SalesforceSDK 14.0 API")
+    outputDirectory.set(rootDir.resolve("doc"))
 }

--- a/tools/generate_doc.sh
+++ b/tools/generate_doc.sh
@@ -3,5 +3,5 @@ if [ ! -d "external" ]
 then
     echo "You must run this tool from the root directory of your repo clone"
 else
-    javadoc -d doc -author -version -verbose -use -doctitle "SalesforceSDK 14.0 API" -sourcepath "libs/SalesforceAnalytics/src:libs/SalesforceSDK/src:libs/SmartStore/src:libs/MobileSync/src:libs/SalesforceHybrid/src:libs/SalesforceReact/src" -subpackages com
+    ./gradlew dokkaHtmlMultiModule
 fi


### PR DESCRIPTION
## Summary

- Replaces the raw `javadoc` CLI invocation in `tools/generate_doc.sh` with `./gradlew dokkaHtmlMultiModule`
- Adds the Dokka Gradle plugin (v1.9.20) to the buildscript classpath in `build.gradle.kts`
- Applies the plugin at the root (for multi-module HTML aggregation) and to all `:libs:*` subprojects
- Output directory remains `doc/` at the repo root — no change to the release/gh-pages workflow

## Why Dokka

Dokka is JetBrains' official documentation engine for Kotlin. It understands KDoc natively (Javadoc does not), produces modern searchable HTML, and integrates directly with Gradle — no separate tool installation required. As the codebase moves to Kotlin-first, this ensures doc comments are rendered correctly.

## Test plan

- [ ] Run `./tools/generate_doc.sh` from the repo root and verify `doc/index.html` is generated
- [ ] Open `doc/index.html` and confirm all six library modules appear (SalesforceAnalytics, SalesforceSDK, SmartStore, MobileSync, SalesforceHybrid, SalesforceReact)
- [ ] Verify KDoc comments on Kotlin classes render correctly in the output