### PR TITLE
Update SQLCipher to 4.16.0

### DIFF
--- a/.claude/skills/update-sqlcipher/SKILL.md
+++ b/.claude/skills/update-sqlcipher/SKILL.md
@@ -178,7 +178,9 @@ When creating the PR:
 
 Recent SQLCipher updates in the project:
 
-- **4.10.0** - Current version (PR #2744)
+- **4.16.0** - SQLite 3.53.1, LibTomCrypt 1.18.2 (2026-05-12)
+- **4.15.0** - Previous version
+- **4.10.0** - Previous version (PR #2744)
 - **4.9.0** - Previous version (PR #2717)
 - **4.7.2** - Introduced `onCorruption()` API change (PR #2698)
 - **4.6.1** - Stable version (PR #2605)

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 dependencies {
     api(project(":libs:SalesforceSDK"))
     api("androidx.sqlite:sqlite:2.6.2")
-    api("net.zetetic:sqlcipher-android:4.15.0")
+    api("net.zetetic:sqlcipher-android:4.16.0")
     implementation("androidx.core:core-ktx:1.18.0")
     androidTestImplementation("androidx.test:runner:1.7.0")
     androidTestImplementation("androidx.test:rules:1.7.0")

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -116,7 +116,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	 */
 	@Test
 	public void testSQLCipherVersion() {
-		Assert.assertEquals("Wrong sqlcipher version", "4.15.0 community", store.getSQLCipherVersion());
+		Assert.assertEquals("Wrong sqlcipher version", "4.16.0 community", store.getSQLCipherVersion());
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Updates SQLCipher from 4.15.0 to 4.16.0 in the Android SDK.

## Changes
- Updated `libs/SmartStore/build.gradle.kts`: SQLCipher dependency from 4.15.0 to 4.16.0
- Updated `SmartStoreTest.java`: Version test expects "4.16.0 community"
- Updated update-sqlcipher skill documentation

## SQLCipher 4.16.0 Details
- **SQLite Version**: 3.53.1 (updated from 3.46.1)
- **Cipher Provider**: LibTomCrypt 1.18.2 (unchanged)
- **Changes**: Bug fixes for allocation issues and reduced mlock warnings on Android
- **API Changes**: None
- **Release Notes**: https://github.com/sqlcipher/sqlcipher/releases/tag/v4.16.0

## Testing
- Build: ✅ `./gradlew libs:SmartStore:assembleDebug` passed
- Version expectations updated based on SQLCipher 4.16.0 specifications
- Connected tests should be run on device/emulator to verify full functionality

## Related PRs
- iOS: https://github.com/wmathurin/SalesforceMobileSDK-iOS/pull/new/sqlcipher-4.16
- iOS-Hybrid: https://github.com/wmathurin/SalesforceMobileSDK-iOS-Hybrid/pull/new/sqlcipher-4.16
- iOS-Specs: https://github.com/wmathurin/SalesforceMobileSDK-iOS-Specs/pull/new/sqlcipher-4.16