### PR TITLE
Cherry Pick Fix Refresh Token Rotation. (#2884)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -26,6 +26,8 @@
  */
 package com.salesforce.androidsdk.accounts;
 
+import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -372,6 +374,46 @@ public class UserAccount {
 	 * @return Refresh token.
 	 */
 	public String getRefreshToken() {
+		if (accountName != null) {
+			try {
+				final AccountManager accMrg = AccountManager.get(SalesforceSDKManager.getInstance().getAppContext());
+				final String accountType = SalesforceSDKManager.getInstance().getAccountType();
+				for (Account account : accMrg.getAccountsByType(accountType)) {
+					if (accountName.equals(account.name)) {
+						final String encryptedPassword = accMrg.getPassword(account);
+						if (encryptedPassword != null) {
+							final String newestRefreshToken = SalesforceSDKManager.decrypt(
+									encryptedPassword, SalesforceSDKManager.getEncryptionKey());
+							if (newestRefreshToken != null) {
+								return newestRefreshToken;
+							}
+						}
+						break;
+					}
+				}
+			} catch (Exception e) {
+				SalesforceSDKLogger.w(TAG,
+						"Failed to read latest refresh token from AccountManager; using in-memory value",
+						e);
+			}
+		}
+		return refreshToken;
+	}
+
+	/**
+	 * Returns the in-memory refresh token snapshot, without consulting
+	 * {@link AccountManager}.
+	 *
+	 * Intended for persistence call sites that are about to write a refresh
+	 * token to storage (account creation, update, token migration, duplicate
+	 * user reconciliation).  Using {@link #getRefreshToken()} at those sites
+	 * would read back the value currently persisted in {@link AccountManager}
+	 * — i.e. the value we are about to overwrite — instead of the value the
+	 * caller built this {@code UserAccount} with.
+	 *
+	 * @return The refresh token field as set at construction time.
+	 */
+	public String getRefreshTokenForPersistence() {
 		return refreshToken;
 	}
 
@@ -948,7 +990,7 @@ public class UserAccount {
 		JSONObject object = new JSONObject();
 		try {
 			object.put(AUTH_TOKEN, authToken);
-			object.put(REFRESH_TOKEN, refreshToken);
+			object.put(REFRESH_TOKEN, getRefreshToken());
 			object.put(LOGIN_SERVER, loginServer);
 			object.put(ID_URL, idUrl);
 			object.put(INSTANCE_SERVER, instanceServer);
@@ -1007,7 +1049,7 @@ public class UserAccount {
 	Bundle toBundle(List<String> additionalOauthKeys) {
 		Bundle object = new Bundle();
 		object.putString(AUTH_TOKEN, authToken);
-		object.putString(REFRESH_TOKEN, refreshToken);
+		object.putString(REFRESH_TOKEN, getRefreshToken());
 		object.putString(LOGIN_SERVER, loginServer);
 		object.putString(ID_URL, idUrl);
 		object.putString(INSTANCE_SERVER, instanceServer);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -442,7 +442,7 @@ public class UserAccountManager {
 		final Bundle extras = buildAuthBundle(userAccount);
 
 		Account acc = new Account(userAccount.getAccountName(), accountType);
-		String password = SalesforceSDKManager.encrypt(userAccount.getRefreshToken(), encryptionKey);
+		String password = SalesforceSDKManager.encrypt(userAccount.getRefreshTokenForPersistence(), encryptionKey);
 		boolean success = accountManager.addAccountExplicitly(acc, password, new Bundle());
 
 		// Add account will fail if the account already exists, so update refresh token.
@@ -486,6 +486,16 @@ public class UserAccountManager {
 
 		for (final String key : extras.keySet()) {
 			accountManager.setUserData(account, key, extras.getString(key));
+		}
+
+		// The refresh token is stored as the Account's password (see createAccount), not as user data,
+		// so buildAuthBundle does not include it.  Persist it explicitly here so that server-side
+		// Use the in-memory snapshot rather than getRefreshToken(), which now performs a live lookup
+		// against AccountManager and would return the updated value we may be about to write.
+		final String refreshToken = userAccount.getRefreshTokenForPersistence();
+		if (refreshToken != null) {
+			final String encryptionKey = SalesforceSDKManager.getEncryptionKey();
+			accountManager.setPassword(account, SalesforceSDKManager.encrypt(refreshToken, encryptionKey));
 		}
 
 		return extras;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -465,8 +465,13 @@ internal fun handleDuplicateUserAccount(
             clearCaches()
             userAccountManager.clearCachedCurrentUser()
 
-            // Revoke existing refresh token
-            if (account.refreshToken != duplicateUserAccount.refreshToken) {
+            // Revoke existing refresh token.  Compare the new account's in-memory
+            // snapshot (the value just issued by the server) against the duplicate
+            // account's snapshot (the value currently persisted).  Using
+            // getRefreshToken() here would do a live AccountManager lookup for
+            // both UserAccounts and return the same persisted value, suppressing
+            // the revocation and leaking the prior refresh token.
+            if (account.refreshTokenForPersistence != duplicateUserAccount.refreshTokenForPersistence) {
                 runCatching {
                     URI(duplicateUserAccount.instanceServer)
                 }.onFailure { throwable ->
@@ -481,7 +486,7 @@ internal fun handleDuplicateUserAccount(
                         revokeRefreshToken(
                             HttpAccess.DEFAULT,
                             uri,
-                            duplicateUserAccount.refreshToken,
+                            duplicateUserAccount.refreshTokenForPersistence,
                             OAuth2.LogoutReason.REFRESH_TOKEN_ROTATED,
                         )
                     }
@@ -515,7 +520,8 @@ private fun UserAccountManager.persistAccount(
     acctManager: AccountManager = AccountManager.get(SalesforceSDKManager.getInstance().appContext),
 ) {
     val account = Account(userAccount.accountName, accountType)
-    val password = SalesforceSDKManager.encrypt(userAccount.refreshToken, encryptionKey)
+    // Encrypt the in-memory snapshot rather than getRefreshToken(), which performs a lookup.
+    val password = SalesforceSDKManager.encrypt(userAccount.refreshTokenForPersistence, encryptionKey)
     val created = acctManager.addAccountExplicitly(account, password, /* userdata = */ Bundle())
 
     // addAccountExplicitly fails if the account already exists, so update the refresh token.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -354,7 +354,8 @@ public class ClientManager {
         private final Object lock = new Object();
         private final ClientManager clientManager;
         private String lastNewAuthToken;
-        private final String refreshToken;
+        // Mutable to support server-side Refresh Token Rotation (RTR).
+        private String refreshToken;
         private String lastNewInstanceUrl;
         private long lastRefreshTime = -1 /* never refreshed */;
 
@@ -505,6 +506,12 @@ public class ClientManager {
                 UserAccountManager.getInstance().updateAccount(account, updatedUserAccount);
                 updatedUserAccount.downloadProfilePhoto();
                 UserAccountManager.getInstance().clearCachedCurrentUser();
+
+                // Handle server-side Refresh Token Rotation: if the response contained a new refresh token,
+                // update this provider's cached copy.
+                if (tr.refreshToken != null && !tr.refreshToken.equals(refreshToken)) {
+                    refreshToken = tr.refreshToken;
+                }
 
                 return updatedUserAccount;
             } catch (OAuth2.OAuthFailedException ofe) {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
@@ -109,6 +109,89 @@ public class UserAccountManagerTest {
         checkSameUserAccount(userAccount, restoredUserAccount);
     }
 
+    /*
+     * Server-side Refresh Token Rotation (RTR) regression test.
+     *
+     * The refresh token is persisted as the Account's password and is read back via accountManager.getPassword().
+     * updateAccount must therefore persist a rotated refresh token via setPassword.
+     */
+    @Test
+    public void testUpdateAccountPersistsRotatedRefreshToken() {
+        final UserAccount original = UserAccountTest.createTestAccount();
+        userAccMgr.createAccount(original);
+        final Account account = userAccMgr.getCurrentAccount();
+        Assert.assertEquals(
+                "Initial refresh token should round-trip through AccountManager",
+                UserAccountTest.TEST_REFRESH_TOKEN,
+                userAccMgr.buildUserAccount(account).getRefreshToken());
+
+        // Simulate a server-side refresh token rotation by building a
+        // UserAccount with a new refresh token value and updating.
+        final String rotatedRefreshToken = "rotated_refresh_token";
+        final UserAccount rotated = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(original)
+                .refreshToken(rotatedRefreshToken)
+                .build();
+        userAccMgr.updateAccount(account, rotated);
+
+        // The persisted refresh token must reflect the rotated value.
+        final UserAccount reloaded = userAccMgr.buildUserAccount(account);
+        Assert.assertEquals(
+                "Rotated refresh token should be persisted by updateAccount",
+                rotatedRefreshToken,
+                reloaded.getRefreshToken());
+
+        // Encryption (AES-GCM with a random IV) is non-deterministic, so
+        // compare against the decrypted password rather than re-encrypting
+        // the expected value.
+        final String encryptionKey = SalesforceSDKManager.getEncryptionKey();
+        Assert.assertEquals(
+                "Rotated refresh token should be used as the account password.",
+                rotatedRefreshToken,
+                SalesforceSDKManager.decrypt(accMgr.getPassword(account), encryptionKey));
+    }
+
+    /*
+     * Server-side Refresh Token Rotation (RTR) regression test.
+     *
+     * A UserAccount snapshot built from the persisted Account must reflect a
+     * subsequent rotation of the refresh token via updateAccount, even when
+     * the snapshot itself was built before the rotation.  This guards the
+     * live-lookup behavior of UserAccount.getRefreshToken().
+     */
+    @Test
+    public void testGetRefreshTokenReflectsLatestPersistedValue() {
+        final UserAccount original = UserAccountTest.createTestAccount();
+        userAccMgr.createAccount(original);
+        final Account account = userAccMgr.getCurrentAccount();
+
+        // Snapshot taken before rotation.
+        final UserAccount staleUser = userAccMgr.buildUserAccount(account);
+        Assert.assertEquals(
+                "Initial refresh token should be observed via the snapshot",
+                UserAccountTest.TEST_REFRESH_TOKEN,
+                staleUser.getRefreshToken());
+
+        // Rotate via updateAccount.
+        final String rotatedRefreshToken = "rotated_refresh_token";
+        final UserAccount rotated = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(original)
+                .refreshToken(rotatedRefreshToken)
+                .build();
+        userAccMgr.updateAccount(account, rotated);
+
+        Assert.assertEquals(
+                "Initial refresh token should be observed via the snapshot",
+                UserAccountTest.TEST_REFRESH_TOKEN,
+                staleUser.getRefreshTokenForPersistence());
+        // The previously-built snapshot should now observe the rotated value
+        // through its live lookup against AccountManager.
+        Assert.assertEquals(
+                "Snapshot built before rotation should reflect the latest persisted refresh token",
+                rotatedRefreshToken,
+                staleUser.getRefreshToken());
+    }
+
     /**
      * Test to get all authenticated users.
      */

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerMockTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerMockTest.kt
@@ -36,6 +36,7 @@ import org.junit.Test
 private const val OLD_ACCESS_TOKEN = "old-token"
 private const val REFRESHED_ACCESS_TOKEN = "refreshed-auth-token"
 private const val REFRESH_TOKEN = "refresh-token"
+private const val ROTATED_REFRESH_TOKEN = "rotated-refresh-token"
 
 @SmallTest
 class ClientManagerMockTest {
@@ -343,6 +344,147 @@ class ClientManagerMockTest {
             mockAppContext.sendBroadcast(capture(broadcastIntentSlot))
         }
         Assert.assertEquals(ClientManager.ACCESS_TOKEN_REVOKE_INTENT, broadcastIntentSlot.captured.action)
+    }
+
+    /*
+        Server-side Refresh Token Rotation (RTR): when the token endpoint returns
+        a rotated refresh_token, the provider must update its cached refresh
+        token so subsequent calls don't reuse the now-invalidated previous one.
+     */
+    @Test
+    fun testGetNewAuthToken_RefreshTokenRotation_UpdatesCachedRefreshToken() {
+        val responseBody = """
+                {
+                    "access_token": "$REFRESHED_ACCESS_TOKEN",
+                    "refresh_token": "$ROTATED_REFRESH_TOKEN",
+                    "instance_url": "https://login.salesforce.com",
+                    "id": "https://login.salesforce.com/id/orgId/userId",
+                    "token_type": "Bearer",
+                    "issued_at": "1234567890",
+                    "signature": "mock-signature"
+                }
+            """.trimIndent().toResponseBody("application/json; charset=utf-8".toMediaType())
+        val rotatedResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { close() } just runs
+            every { body } returns responseBody
+        }
+        every { HttpAccess.DEFAULT.okHttpClient } returns mockk<OkHttpClient> {
+            every { newCall(any()) } returns mockk<Call> {
+                every { execute() } returns rotatedResponse
+            }
+        }
+
+        val userSlot = slot<UserAccount>()
+        val mockAccount = mockk<Account>(relaxed = true)
+        val mockUser = mockk<UserAccount>(relaxed = true) {
+            every { authToken } returns OLD_ACCESS_TOKEN
+            every { refreshToken } returns REFRESH_TOKEN
+            every { loginServer } returns "https://login.salesforce.com"
+        }
+        val mockClientManager = mockk<ClientManager>(relaxed = true) {
+            every { accounts } returns arrayOf(mockAccount)
+        }
+        every { mockUserAccountManager.currentUser } returns mockUser
+        every { mockUserAccountManager.buildUserAccount(mockAccount) } returns mockUser
+        every { mockUserAccountManager.updateAccount(mockAccount, any()) } returns mockk()
+
+        val authTokenProvider = ClientManager.AccMgrAuthTokenProvider(
+            mockClientManager,
+            "https://login.salesforce.com",
+            OLD_ACCESS_TOKEN,
+            REFRESH_TOKEN,
+        )
+
+        // First refresh: server rotates the refresh token.
+        Assert.assertEquals(REFRESHED_ACCESS_TOKEN, authTokenProvider.getNewAuthToken())
+
+        // The persisted account should be updated with the rotated refresh token...
+        verify(exactly = 1) {
+            mockUserAccountManager.updateAccount(mockAccount, capture(userSlot))
+        }
+        Assert.assertEquals(ROTATED_REFRESH_TOKEN, userSlot.captured.refreshTokenForPersistence)
+        // ...and so should the provider's in-memory cache, so that subsequent
+        // refreshes (and getRefreshToken consumers) use the rotated token.
+        Assert.assertEquals(ROTATED_REFRESH_TOKEN, authTokenProvider.refreshToken)
+    }
+
+    /*
+        Server-side Refresh Token Rotation (RTR): after a refresh that rotates
+        the refresh token, the provider's cached refresh token must reflect
+        the new value so that a subsequent refresh sends the current token
+        and the per-account lookup matches the rotated value persisted to
+        the account.
+     */
+    @Test
+    fun testGetNewAuthToken_RefreshTokenRotation_SubsequentRefreshSucceeds() {
+        val firstRotated = ROTATED_REFRESH_TOKEN
+        val secondRotated = "rotated-refresh-token-2"
+
+        fun rotationResponse(rt: String): Response {
+            val responseBody = """
+                {
+                    "access_token": "$REFRESHED_ACCESS_TOKEN",
+                    "refresh_token": "$rt",
+                    "instance_url": "https://login.salesforce.com",
+                    "id": "https://login.salesforce.com/id/orgId/userId",
+                    "token_type": "Bearer",
+                    "issued_at": "1234567890",
+                    "signature": "mock-signature"
+                }
+                """.trimIndent().toResponseBody("application/json; charset=utf-8".toMediaType())
+            return mockk<Response>(relaxed = true) {
+                every { isSuccessful } returns true
+                every { close() } just runs
+                every { body } returns responseBody
+            }
+        }
+
+        // Return a different rotated refresh token on each refresh.
+        every { HttpAccess.DEFAULT.okHttpClient } returns mockk<OkHttpClient> {
+            every { newCall(any()) } returnsMany listOf(
+                mockk<Call> { every { execute() } returns rotationResponse(firstRotated) },
+                mockk<Call> { every { execute() } returns rotationResponse(secondRotated) },
+            )
+        }
+
+        val mockAccount = mockk<Account>(relaxed = true)
+        // The persisted account's refresh token follows whatever updateAccount
+        // was last called with (i.e., the most recent rotated value).
+        var persistedRefreshToken = REFRESH_TOKEN
+        val mockUser = mockk<UserAccount>(relaxed = true) {
+            every { authToken } returns OLD_ACCESS_TOKEN
+            every { refreshToken } answers { persistedRefreshToken }
+            every { loginServer } returns "https://login.salesforce.com"
+        }
+        val mockClientManager = mockk<ClientManager>(relaxed = true) {
+            every { accounts } returns arrayOf(mockAccount)
+        }
+        every { mockUserAccountManager.currentUser } returns mockUser
+        every { mockUserAccountManager.buildUserAccount(mockAccount) } returns mockUser
+        every { mockUserAccountManager.updateAccount(mockAccount, any()) } answers {
+            persistedRefreshToken = secondArg<UserAccount>().refreshToken
+            mockk()
+        }
+
+        val authTokenProvider = ClientManager.AccMgrAuthTokenProvider(
+            mockClientManager,
+            "https://login.salesforce.com",
+            OLD_ACCESS_TOKEN,
+            REFRESH_TOKEN,
+        )
+
+        // First refresh succeeds, rotates to firstRotated.
+        Assert.assertEquals(REFRESHED_ACCESS_TOKEN, authTokenProvider.getNewAuthToken())
+        Assert.assertEquals(firstRotated, authTokenProvider.refreshToken)
+        Assert.assertEquals(firstRotated, persistedRefreshToken)
+
+        // Second refresh, ensure each rotation is stored.
+        Assert.assertEquals(REFRESHED_ACCESS_TOKEN, authTokenProvider.getNewAuthToken())
+        Assert.assertEquals(secondRotated, authTokenProvider.refreshToken)
+        verify(exactly = 0) {
+            mockSDKManager.logout(any(), any(), any(), any())
+        }
     }
 
     /*


### PR DESCRIPTION
* Fix Refresh Token Rotation.

* Update UserAccount.getRefreshToken to always return the latest values known to the SDK.  Add getRefreshTokenForPersistance to handle account updates and storage.