### PR TITLE
Migrate doc generation to Dokka v2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
         classpath("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.21")
         classpath("org.jacoco:org.jacoco.core:0.8.14")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.20")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:2.0.0")
     }
 }
 
@@ -36,13 +36,22 @@ allprojects {
 
 apply(plugin = "org.jetbrains.dokka")
 
-subprojects {
-    if (path.startsWith(":libs:")) {
-        apply(plugin = "org.jetbrains.dokka")
+extensions.configure<org.jetbrains.dokka.gradle.DokkaExtension> {
+    dokkaPublications.named("html") {
+        outputDirectory.set(rootDir.resolve("doc"))
     }
 }
 
-tasks.named<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>("dokkaHtmlMultiModule") {
-    moduleName.set("SalesforceSDK 14.0 API")
-    outputDirectory.set(rootDir.resolve("doc"))
+dependencies {
+    add("dokka", project(":libs:SalesforceAnalytics"))
+    add("dokka", project(":libs:SalesforceSDK"))
+    add("dokka", project(":libs:SmartStore"))
+    add("dokka", project(":libs:MobileSync"))
+    add("dokka", project(":libs:SalesforceHybrid"))
+    add("dokka", project(":libs:SalesforceReact"))
+}
+
+tasks.register<Jar>("javadocJar") {
+    from(tasks.named("dokkaGeneratePublicationHtml"))
+    archiveClassifier.set("javadoc")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.20")
         classpath("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.21")
         classpath("org.jacoco:org.jacoco.core:0.8.14")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.20")
     }
 }
 
@@ -31,4 +32,17 @@ allprojects {
             languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0)
         }
     }
+}
+
+apply(plugin = "org.jetbrains.dokka")
+
+subprojects {
+    if (path.startsWith(":libs:")) {
+        apply(plugin = "org.jetbrains.dokka")
+    }
+}
+
+tasks.named<org.jetbrains.dokka.gradle.DokkaMultiModuleTask>("dokkaHtmlMultiModule") {
+    moduleName.set("SalesforceSDK 14.0 API")
+    outputDirectory.set(rootDir.resolve("doc"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 # TODO: This should be resolved in a dedicated work item. ECJ20260423
 android.newDsl=false
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `kotlin-android`
     `publish-module`
     jacoco
+    id("org.jetbrains.dokka")
 }
 
 dependencies {

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `kotlin-android`
     `publish-module`
     jacoco
+    id("org.jetbrains.dokka")
 }
 
 dependencies {

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     `kotlin-android`
     `publish-module`
     jacoco
+    id("org.jetbrains.dokka")
 }
 
 dependencies {

--- a/libs/SalesforceReact/build.gradle.kts
+++ b/libs/SalesforceReact/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     `kotlin-android`
     `publish-module`
     jacoco
+    id("org.jetbrains.dokka")
 }
 
 dependencies {

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     kotlin("plugin.serialization") version "2.3.20"
     kotlin("plugin.parcelize")
     kotlin("plugin.compose")
+    id("org.jetbrains.dokka")
 }
 
 dependencies {

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `kotlin-android`
     `publish-module`
     jacoco
+    id("org.jetbrains.dokka")
 }
 
 dependencies {

--- a/tools/generate_doc.sh
+++ b/tools/generate_doc.sh
@@ -3,5 +3,5 @@ if [ ! -d "external" ]
 then
     echo "You must run this tool from the root directory of your repo clone"
 else
-    ./gradlew dokkaHtmlMultiModule
+    ./gradlew dokkaGeneratePublicationHtml
 fi

--- a/tools/generate_doc.sh
+++ b/tools/generate_doc.sh
@@ -3,5 +3,5 @@ if [ ! -d "external" ]
 then
     echo "You must run this tool from the root directory of your repo clone"
 else
-    javadoc -d doc -author -version -verbose -use -doctitle "SalesforceSDK 14.0 API" -sourcepath "libs/SalesforceAnalytics/src:libs/SalesforceSDK/src:libs/SmartStore/src:libs/MobileSync/src:libs/SalesforceHybrid/src:libs/SalesforceReact/src" -subpackages com
+    ./gradlew dokkaHtmlMultiModule
 fi


### PR DESCRIPTION
## Why Dokka HTML instead of Javadoc format

The old workflow ran `javadoc -subpackages com` across all six source paths, producing a single flat site. Dokka v2's `dokka-javadoc` plugin generates per-module independent Javadoc sites — there is no built-in aggregation for the Javadoc format. A `Copy`-task merge is lossy (alphabetical index files and `allclasses.html` get overwritten per-module). The HTML format is the only Dokka format with proper multi-module aggregation, so `doc/index.html` remains a complete, cross-linked API reference.