### PR TITLE
Add UI tests for refresh token rotation

### DIFF
--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -47,6 +47,16 @@ External Client App (ECA) login tests for both opaque and JWT token formats with
 | `testECAJwt_SubsetScopes_NotHybrid` | ECA JWT | Subset |
 | `testECAJwt_AllScopes` | ECA JWT | All |
 
+#### RTRLoginTests
+Tests for ECA configurations with Refresh Token Rotation (RTR) enabled. Verifies that the refresh token rotates on each token refresh cycle. The `assertRevokeAndRefreshWorks` check asserts the refresh token **changes** after a revoke/refresh cycle for RTR apps.
+
+| Test | App Config | Hybrid |
+|------|-----------|--------|
+| `testECAJwtRtr_Hybrid` | ECA JWT RTR | Yes |
+| `testECAJwtRtr_NoHybrid` | ECA JWT RTR | No |
+| `testECAOpaqueRtr_Hybrid` | ECA Opaque RTR | Yes |
+| `testECAOpaqueRtr_NoHybrid` | ECA Opaque RTR | No |
+
 #### BeaconLoginTests
 Beacon app login tests for lightweight authentication use cases, covering both opaque and JWT token formats.
 
@@ -148,7 +158,7 @@ Multi-user tests additionally verify:
 
 ### Configuration
 
-- **App configs** (`KnownAppConfig`): `ECA_OPAQUE`, `ECA_JWT`, `BEACON_OPAQUE`, `BEACON_JWT`, `CA_OPAQUE`, `CA_JWT`
+- **App configs** (`KnownAppConfig`): `ECA_OPAQUE`, `ECA_JWT`, `ECA_OPAQUE_RTR`, `ECA_JWT_RTR`, `BEACON_OPAQUE`, `BEACON_JWT`, `CA_OPAQUE`, `CA_JWT`
 - **Login hosts** (`KnownLoginHostConfig`): `REGULAR_AUTH` (in-app WebView), `ADVANCED_AUTH` (Chrome Custom Tab)
 - **Scope options** (`ScopeSelection`): `EMPTY` (default/boot config scopes), `SUBSET` (all minus `sfap_api`), `ALL`
 - **Users** (`KnownUserConfig`): `FIRST` through `FIFTH`, assigned per API level

--- a/native/NativeSampleApps/AuthFlowTester/build.gradle.kts
+++ b/native/NativeSampleApps/AuthFlowTester/build.gradle.kts
@@ -96,10 +96,10 @@ android { // TODO: This cannot be resolved until newDSL=true
 
 configurations.all {
     resolutionStrategy {
-        force("org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3")
-        force("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.6.3")
-        force("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-        force("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.6.3")
+        force("org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0")
+        force("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.11.0")
+        force("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+        force("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0")
         force("androidx.test:runner:1.7.0")
         force("androidx.test:rules:1.6.1")
         force("androidx.test.espresso:espresso-core:3.7.0")

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
@@ -31,6 +31,7 @@ import androidx.test.filters.LargeTest
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT_RTR
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE_RTR
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -48,9 +49,11 @@ class RTRLoginTests : AuthFlowTest() {
     // Login with ECA JWT RTR using hybrid auth token flow.
     // Expected to fail until W-22512846 (Enable Named JWTs for Hybrid Flows) is resolved.
     // The server currently returns invalid_grant when RTR is used with JWT tokens in hybrid flow.
+    @Ignore("Won't pass until server completes W-22512846")
     @Test
     fun testECAJwtRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR)
+        assertRevokeAndRefreshWorks(isRtr = true)
         assertRevokeAndRefreshWorks(isRtr = true)
     }
 
@@ -58,6 +61,7 @@ class RTRLoginTests : AuthFlowTest() {
     @Test
     fun testECAJwtRtr_NoHybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR, useHybridAuthToken = false)
+        assertRevokeAndRefreshWorks(isRtr = true)
         assertRevokeAndRefreshWorks(isRtr = true)
     }
 
@@ -70,12 +74,14 @@ class RTRLoginTests : AuthFlowTest() {
     fun testECAOpaqueRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_OPAQUE_RTR)
         assertRevokeAndRefreshWorks(isRtr = true)
+        assertRevokeAndRefreshWorks(isRtr = true)
     }
 
     // Login with ECA Opaque RTR without hybrid auth token.
     @Test
     fun testECAOpaqueRtr_NoHybrid() {
         loginAndValidate(knownAppConfig = ECA_OPAQUE_RTR, useHybridAuthToken = false)
+        assertRevokeAndRefreshWorks(isRtr = true)
         assertRevokeAndRefreshWorks(isRtr = true)
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
@@ -46,6 +46,8 @@ class RTRLoginTests : AuthFlowTest() {
     // region ECA JWT RTR Tests
 
     // Login with ECA JWT RTR using hybrid auth token flow.
+    // Expected to fail until W-22512846 (Enable Named JWTs for Hybrid Flows) is resolved.
+    // The server currently returns invalid_grant when RTR is used with JWT tokens in hybrid flow.
     @Test
     fun testECAJwtRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.samples.authflowtester
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT_RTR
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE_RTR
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for login flows using External Client App (ECA) configurations with Refresh Token Rotation (RTR).
+ *
+ * NB: Tests use the first user from ui_test_config.json
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class RTRLoginTests : AuthFlowTest() {
+
+    // region ECA JWT RTR Tests
+
+    // Login with ECA JWT RTR using hybrid auth token flow.
+    @Test
+    fun testECAJwtRtr_Hybrid() {
+        loginAndValidate(knownAppConfig = ECA_JWT_RTR)
+        assertRevokeAndRefreshWorks(isRtr = true)
+    }
+
+    // Login with ECA JWT RTR without hybrid auth token.
+    @Test
+    fun testECAJwtRtr_NoHybrid() {
+        loginAndValidate(knownAppConfig = ECA_JWT_RTR, useHybridAuthToken = false)
+        assertRevokeAndRefreshWorks(isRtr = true)
+    }
+
+    // endregion
+
+    // region ECA Opaque RTR Tests
+
+    // Login with ECA Opaque RTR using hybrid auth token flow.
+    @Test
+    fun testECAOpaqueRtr_Hybrid() {
+        loginAndValidate(knownAppConfig = ECA_OPAQUE_RTR)
+        assertRevokeAndRefreshWorks(isRtr = true)
+    }
+
+    // Login with ECA Opaque RTR without hybrid auth token.
+    @Test
+    fun testECAOpaqueRtr_NoHybrid() {
+        loginAndValidate(knownAppConfig = ECA_OPAQUE_RTR, useHybridAuthToken = false)
+        assertRevokeAndRefreshWorks(isRtr = true)
+    }
+
+    // endregion
+}

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -218,4 +218,19 @@ abstract class AuthFlowTest {
         app.revokeAccessToken()
         app.validateApiRequest()
     }
+
+    fun assertRevokeAndRefreshWorks(isRtr: Boolean) {
+        val (preAccessToken, preRefreshToken) = app.getTokens()
+        app.revokeAccessToken()
+        app.validateApiRequest()
+        val (postAccessToken, postRefreshToken) = app.getTokens()
+
+        assert(preAccessToken != postAccessToken) { "Access token should have been refreshed" }
+
+        if (isRtr) {
+            assert(preRefreshToken != postRefreshToken) { "Refresh token should have rotated (RTR app)" }
+        } else {
+            assert(preRefreshToken == postRefreshToken) { "Refresh token should not have changed (non-RTR app)" }
+        }
+    }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
@@ -55,6 +55,8 @@ enum class KnownLoginHostConfig {
 enum class KnownAppConfig {
     ECA_OPAQUE,
     ECA_JWT,
+    ECA_OPAQUE_RTR,
+    ECA_JWT_RTR,
     BEACON_OPAQUE,
     BEACON_JWT,
     CA_OPAQUE,
@@ -109,6 +111,7 @@ data class AppConfig(
     val scopes: String,
 ) {
     val issuesJwt = name.contains("_jwt")
+    val isRtr = name.contains("_rtr")
     val expectedTokenFormat = if (issuesJwt) "jwt" else "Opaque"
     val scopeList = scopes.split(" ")
 

--- a/shared/test/ui_test_config.json.sample
+++ b/shared/test/ui_test_config.json.sample
@@ -89,6 +89,18 @@
       "consumerKey": "your_consumer_key_here",
       "redirectUri": "beaconadvancedjwt://success/done",
       "scopes": "api content id lightning refresh_token sfap_api web"
+    },
+    {
+      "name": "eca_jwt_rtr",
+      "consumerKey": "your_consumer_key_here",
+      "redirectUri": "ecajwtrtr://success/done",
+      "scopes": "api content id lightning refresh_token sfap_api web"
+    },
+    {
+      "name": "eca_opaque_rtr",
+      "consumerKey": "your_consumer_key_here",
+      "redirectUri": "ecaopaquertr://success/done",
+      "scopes": "api content id lightning refresh_token sfap_api web"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds \`RTRLoginTests\` — 4 UI tests covering ECA apps with Refresh Token Rotation (RTR) enabled, across hybrid/non-hybrid flows
- \`assertRevokeAndRefreshWorks(isRtr)\` added to \`AuthFlowTest\` base class: asserts the refresh token **rotates** after a revoke/refresh cycle for RTR apps, and **stays stable** for non-RTR apps
- Adds \`ECA_OPAQUE_RTR\` and \`ECA_JWT_RTR\` to \`KnownAppConfig\` and \`AppConfig.isRtr\` property in \`UITestConfig\`
- Updates \`ui_test_config.json.sample\` with the two new RTR app entries
- Updates \`README.md\` to document the new test class and app configs

## Known failures — W-22512846

\`testECAJwtRtr_Hybrid\` is **expected to fail** until [W-22512846](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002a74cTYAQ/view) (_Enable Named JWTs for Hybrid Flows_) is resolved on the server side.

The server currently returns \`invalid_grant\` when RTR is used with JWT-based access tokens in hybrid flow. The three remaining tests (opaque hybrid, jwt no-hybrid, opaque no-hybrid) are expected to pass.

## Notes

This is the Android equivalent of [iOS PR #4035](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/4035). The restart variants (\`_WithRestart\`) are omitted — Android does not currently have an equivalent of iOS's \`restartAndValidateUser\` infrastructure.