### PR TITLE
Update React Native to 0.81.5 in gradle dependency catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ sqlcipher-android = "4.16.0"
 
 # Hybrid / React Native
 cordova-framework = "15.0.0"
-react-android = "0.79.3"
+react-android = "0.81.5"
 
 # Analytics deps
 tape = "1.2.3"


### PR DESCRIPTION
## Summary
- Updates React Native version from 0.79.3 to 0.81.5 in `gradle/libs.versions.toml`
- Aligns with the version already specified in `libs/SalesforceReact/package.json`

## Context
The `package.json` in `libs/SalesforceReact` already declares React Native 0.81.5, but the gradle dependency catalog was still pointing to 0.79.3. This caused a version mismatch between the npm dependencies and the gradle dependencies.

## Test plan
- [x] Verified build succeeds: `./gradlew :libs:SalesforceReact:build`
- [x] Build completed successfully in 52s with all tasks passing