### PR TITLE
@W-22607468: [MSDK Android] Using `application/json` Content Header For Actionable Notification Action Submission With Empty Request Body Causes Endpoint Errors

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsApiClient.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/NotificationsApiClient.kt
@@ -28,7 +28,7 @@
 package com.salesforce.androidsdk.rest
 
 import com.salesforce.androidsdk.app.SalesforceSDKManager
-import com.salesforce.androidsdk.rest.RestRequest.MEDIA_TYPE_JSON
+import com.salesforce.androidsdk.rest.RestRequest.MEDIA_TYPE_FORM_URLENCODED
 import com.salesforce.androidsdk.rest.RestRequest.RestMethod.GET
 import com.salesforce.androidsdk.rest.RestRequest.RestMethod.POST
 import com.salesforce.androidsdk.util.SalesforceSDKLogger
@@ -106,7 +106,7 @@ class NotificationsApiClient(
         val restRequest = RestRequest(
             POST,
             "https://${restClient.clientInfo.instanceUrl.host}/${ApiVersionStrings.getBasePath()}/connect/notifications/${notificationId}/actions/${actionKey}",
-            "".toRequestBody(MEDIA_TYPE_JSON),
+            ByteArray(0).toRequestBody(MEDIA_TYPE_FORM_URLENCODED),
             mutableMapOf<String, String>()
         )
         val restResponse = restClient.sendSync(restRequest)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestRequest.java
@@ -101,6 +101,11 @@ public class RestRequest {
     public static final MediaType MEDIA_TYPE_JSON = MediaType.get("application/json; charset=utf-8");
 
     /**
+     * application/x-www-form-urlencoded media type
+     */
+    public static final MediaType MEDIA_TYPE_FORM_URLENCODED = MediaType.get("application/x-www-form-urlencoded");
+
+    /**
      * utf_8 charset
      */
     public static final String UTF_8 = StandardCharsets.UTF_8.name();
@@ -386,7 +391,7 @@ public class RestRequest {
     public static RestRequest getRequestForSingleAccess(String redirectUri) throws UnsupportedEncodingException {
         RequestBody requestBody = RequestBody.create(
                 "redirect_uri=" + URLEncoder.encode(redirectUri, UTF_8),
-                MediaType.get("application/x-www-form-urlencoded")
+                MEDIA_TYPE_FORM_URLENCODED
         );
         return new RestRequest(RestMethod.POST, RestEndpoint.INSTANCE, RestAction.SINGLEACCESS.getPath(), requestBody, null);
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushMessagingTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushMessagingTest.kt
@@ -20,8 +20,11 @@ import com.salesforce.androidsdk.rest.NotificationsTypesResponseBody.Companion.f
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo
 import com.salesforce.androidsdk.rest.RestResponse
+import com.salesforce.androidsdk.rest.NotificationsApiClient
+import com.salesforce.androidsdk.rest.RestRequest
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.serialization.json.Json.Default.encodeToJsonElement
 import kotlinx.serialization.json.Json.Default.encodeToString
 import kotlinx.serialization.json.JsonArray
@@ -416,6 +419,33 @@ class PushMessagingTest {
                 restClient = restClient
             )
         }
+    }
+
+    @Test
+    fun test_givenEmptyBody_whenSubmitNotificationAction_thenUsesFormUrlencodedContentType() {
+        val restResponse = mockk<RestResponse>()
+        every { restResponse.asString() } returns encodeToString(
+            NotificationsActionsResponseBody.serializer(),
+            NotificationsActionsResponseBody(message = "ok")
+        )
+        every { restResponse.isSuccess } returns true
+
+        val requestSlot = slot<RestRequest>()
+        val restClient = mockk<RestClient>()
+        every { restClient.clientInfo } returns clientInfo
+        every { restClient.sendSync(capture(requestSlot)) } returns restResponse
+
+        val client = NotificationsApiClient(restClient)
+        client.submitNotificationAction(
+            notificationId = "test_notification_id",
+            actionKey = "test_action_key"
+        )
+
+        val capturedRequest = requestSlot.captured
+        val contentType = capturedRequest.requestBody.contentType()
+        assertEquals("application", contentType?.type)
+        assertEquals("x-www-form-urlencoded", contentType?.subtype)
+        assertEquals(0L, capturedRequest.requestBody.contentLength())
     }
 
     @Test


### PR DESCRIPTION
🎸 _*Ready For Review*_ 🥁

  This simple update changes the content type header for actionable notifications action submission requests to the one the endpoint expects.