### PR TITLE
Fix unit test timeouts and other failures.

### DIFF
--- a/.github/test-shards/SalesforceSDK.json
+++ b/.github/test-shards/SalesforceSDK.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "ui",
-      "comment": "Tests that exercise Activities/UI",
+      "comment": "Compose-rendering tests must NOT share a shard with classes that call mockk<...>(relaxed = true) on Activity-derived types (LoginActivity, FragmentActivity, etc.). mockk's Android dispatcher bytecode-instruments those class hierarchies for the JVM process lifetime, which slows ContextThemeWrapper.getResources() to seconds per call — hanging Compose rendering. The current polluters are LoginActivityTest, NativeLoginManagerTest, and SalesforceSDKManagerTests, all kept in the `remaining` shard.",
       "targets": [
         "class com.salesforce.androidsdk.ui.LoginViewActivityTest",
         "class com.salesforce.androidsdk.ui.PickerBottomSheetTest",
@@ -25,6 +25,15 @@
         "class com.salesforce.androidsdk.security.ScreenLockManagerTest",
         "class com.salesforce.androidsdk.security.BiometricAuthenticationManagerTest",
         "class com.salesforce.androidsdk.ui.TokenMigrationActivityTest",
+        "class com.salesforce.androidsdk.ui.TokenMigrationViewActivityTest",
+        "class com.salesforce.androidsdk.ui.ScreenLockActivityScenarioTest",
+        "class com.salesforce.androidsdk.ui.ScreenLockViewTest"
+      ]
+    },
+    {
+      "name": "webview",
+      "comment": "TokenMigrationWebViewTest is slow on the emulator (~30-60s per test) due to WebView setup, independent of the mockk pollution pathology. Keep it isolated to avoid eating budget in other shards.",
+      "targets": [
         "class com.salesforce.androidsdk.ui.TokenMigrationWebViewTest"
       ]
     },
@@ -72,7 +81,10 @@
         "notClass com.salesforce.androidsdk.rest.files.ConnectUriBuilderTest",
         "notClass com.salesforce.androidsdk.rest.files.FileRequestsTest",
         "notClass com.salesforce.androidsdk.ui.TokenMigrationActivityTest",
-        "notClass com.salesforce.androidsdk.ui.TokenMigrationWebViewTest"
+        "notClass com.salesforce.androidsdk.ui.TokenMigrationViewActivityTest",
+        "notClass com.salesforce.androidsdk.ui.TokenMigrationWebViewTest",
+        "notClass com.salesforce.androidsdk.ui.ScreenLockActivityScenarioTest",
+        "notClass com.salesforce.androidsdk.ui.ScreenLockViewTest"
       ]
     }
   ]

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/BiometricAuthenticationCallbackTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/BiometricAuthenticationCallbackTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.ui
+
+import android.content.Context.ACCESSIBILITY_SERVICE
+import android.view.accessibility.AccessibilityManager
+import androidx.biometric.BiometricPrompt
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.salesforce.androidsdk.R.string.sf__screen_lock_auth_failed
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for [ScreenLockActivity.BiometricAuthenticationCallback].
+ *
+ * Extracted from [ScreenLockActivityScenarioTest] because each test mocks the outer
+ * [ScreenLockActivity] via `mockk<ScreenLockActivity>(relaxed = true)`. mockk's Android
+ * dispatcher bytecode-instruments the entire class hierarchy of any mocked class for the
+ * JVM process lifetime — including [android.view.ContextThemeWrapper], whose `getResources`
+ * is called thousands of times per Compose frame. Once that happens, every Compose-rendering
+ * test in the same process slows from ~2s to ~27s. Keeping these mockk-of-Activity tests in
+ * a separate class lets the test runner schedule them in their own shard, isolated from the
+ * Compose-rendering tests in [ScreenLockActivityScenarioTest].
+ */
+@RunWith(AndroidJUnit4::class)
+class BiometricAuthenticationCallbackTest {
+
+    @Test
+    fun biometricAuthenticationCallback_onAuthenticationError_callsOnAuthError() {
+
+        val accessibilityManager = mockk<AccessibilityManager>(relaxed = true)
+        val activity = mockk<ScreenLockActivity>(relaxed = true)
+        every { activity.getSystemService(ACCESSIBILITY_SERVICE) } returns accessibilityManager
+        val biometricAuthenticationCallback = activity.BiometricAuthenticationCallback()
+
+        val expectedErrorString = "Expected Error String"
+
+        biometricAuthenticationCallback.onAuthenticationError(0, expectedErrorString)
+
+        verify(exactly = 1) { activity.onAuthError(accessibilityManager = any(), errString = expectedErrorString) }
+    }
+
+    @Test
+    fun biometricAuthenticationCallback_onAuthenticationSucceeded_callsFinishSuccess() {
+
+        val accessibilityManager = mockk<AccessibilityManager>(relaxed = true)
+        val activity = mockk<ScreenLockActivity>(relaxed = true)
+        every { activity.getSystemService(ACCESSIBILITY_SERVICE) } returns accessibilityManager
+        val biometricAuthenticationCallback = activity.BiometricAuthenticationCallback()
+        val biometricResult = mockk<BiometricPrompt.AuthenticationResult>(relaxed = true)
+
+        biometricAuthenticationCallback.onAuthenticationSucceeded(biometricResult)
+
+        verify(exactly = 1) {
+            activity.finishSuccess(
+                accessibilityManager = any(),
+                screenLockManager = any(),
+                sdkConfiguration = any(),
+            )
+        }
+    }
+
+    @Test
+    fun biometricAuthenticationCallback_onAuthenticationFailed_callsActivityMethods() {
+
+        val accessibilityManager = mockk<AccessibilityManager>(relaxed = true)
+        val activity = mockk<ScreenLockActivity>(relaxed = true)
+        every { activity.getSystemService(ACCESSIBILITY_SERVICE) } returns accessibilityManager
+        val sendAccessibilityCapturingSlot = slot<String>()
+        val setErrorMessageCapturingSlot = slot<String>()
+        val biometricAuthenticationCallback = activity.BiometricAuthenticationCallback()
+
+        biometricAuthenticationCallback.onAuthenticationFailed()
+
+        verify(exactly = 1) { activity.setErrorMessage(capture(setErrorMessageCapturingSlot)) }
+        assertEquals(activity.getString(sf__screen_lock_auth_failed), setErrorMessageCapturingSlot.captured)
+        verify(exactly = 1) {
+            activity.sendAccessibilityEvent(
+                accessibilityManager = any(),
+                eventText = capture(sendAccessibilityCapturingSlot),
+                sdkConfiguration = any(),
+            )
+        }
+        assertTrue(sendAccessibilityCapturingSlot.captured.contains(activity.getString(sf__screen_lock_auth_failed)))
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/ScreenLockActivityScenarioTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/ScreenLockActivityScenarioTest.kt
@@ -29,7 +29,6 @@ package com.salesforce.androidsdk.ui
 import android.R.attr.windowLightStatusBar
 import android.app.admin.DevicePolicyManager.ACTION_SET_NEW_PASSWORD
 import android.content.Context
-import android.content.Context.ACCESSIBILITY_SERVICE
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -62,7 +61,6 @@ import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.salesforce.androidsdk.R.drawable.sf__salesforce_logo
 import com.salesforce.androidsdk.R.string.sf__screen_lock_auth_error
-import com.salesforce.androidsdk.R.string.sf__screen_lock_auth_failed
 import com.salesforce.androidsdk.R.string.sf__screen_lock_auth_success
 import com.salesforce.androidsdk.R.string.sf__screen_lock_error
 import com.salesforce.androidsdk.R.string.sf__screen_lock_error_hw_unavailable
@@ -855,65 +853,6 @@ class ScreenLockActivityScenarioTest {
                 verify(exactly = 0) { userAccountManager.signoutUser(any(), null, true, USER_LOGOUT) }
             }
         }
-    }
-
-    @Test
-    fun biometricAuthenticationCallback_onAuthenticationError_callsOnAuthError() {
-
-        val accessibilityManager = mockk<AccessibilityManager>(relaxed = true)
-        val activity = mockk<ScreenLockActivity>(relaxed = true)
-        every { activity.getSystemService(ACCESSIBILITY_SERVICE) } returns accessibilityManager
-        val biometricAuthenticationCallback = activity.BiometricAuthenticationCallback()
-
-        val expectedErrorString = "Expected Error String"
-
-        biometricAuthenticationCallback.onAuthenticationError(0, expectedErrorString)
-
-        verify(exactly = 1) { activity.onAuthError(accessibilityManager = any(), errString = expectedErrorString) }
-    }
-
-    @Test
-    fun biometricAuthenticationCallback_onAuthenticationSucceeded_callsFinishSuccess() {
-
-        val accessibilityManager = mockk<AccessibilityManager>(relaxed = true)
-        val activity = mockk<ScreenLockActivity>(relaxed = true)
-        every { activity.getSystemService(ACCESSIBILITY_SERVICE) } returns accessibilityManager
-        val biometricAuthenticationCallback = activity.BiometricAuthenticationCallback()
-        val biometricResult = mockk<BiometricPrompt.AuthenticationResult>(relaxed = true)
-
-        biometricAuthenticationCallback.onAuthenticationSucceeded(biometricResult)
-
-        verify(exactly = 1) {
-            activity.finishSuccess(
-                accessibilityManager = any(),
-                screenLockManager = any(),
-                sdkConfiguration = any(),
-            )
-        }
-    }
-
-    @Test
-    fun biometricAuthenticationCallback_onAuthenticationFailed_callsActivityMethods() {
-
-        val accessibilityManager = mockk<AccessibilityManager>(relaxed = true)
-        val activity = mockk<ScreenLockActivity>(relaxed = true)
-        every { activity.getSystemService(ACCESSIBILITY_SERVICE) } returns accessibilityManager
-        val sendAccessibilityCapturingSlot = slot<String>()
-        val setErrorMessageCapturingSlot = slot<String>()
-        val biometricAuthenticationCallback = activity.BiometricAuthenticationCallback()
-
-        biometricAuthenticationCallback.onAuthenticationFailed()
-
-        verify(exactly = 1) { activity.setErrorMessage(capture(setErrorMessageCapturingSlot)) }
-        assertEquals(activity.getString(sf__screen_lock_auth_failed), setErrorMessageCapturingSlot.captured)
-        verify(exactly = 1) {
-            activity.sendAccessibilityEvent(
-                accessibilityManager = any(),
-                eventText = capture(sendAccessibilityCapturingSlot),
-                sdkConfiguration = any(),
-            )
-        }
-        assertTrue(sendAccessibilityCapturingSlot.captured.contains(activity.getString(sf__screen_lock_auth_failed)))
     }
 
     private fun Drawable.renderToBitmap(): Bitmap {

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/TokenMigrationWebViewTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/TokenMigrationWebViewTest.kt
@@ -174,35 +174,6 @@ class TokenMigrationWebViewTest {
     }
 
     @Test
-    fun shouldOverrideUrlLoading_returnsTrueForCallbackUrl_userAgentFlow() {
-        val activity = launchActivity()
-        val mockResultCallback = createMockResultCallback()
-        val clientManager = activity.TokenMigrationClientManager(mockResultCallback, "instanceServer")
-
-        every { mockViewModel.useWebServerFlow } returns false
-
-        val mockRequest = createMockWebResourceRequest("testapp://oauth/callback?code=test_code")
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            assertTrue(
-                "Callback URL should be overridden because migration is finished",
-                clientManager.shouldOverrideUrlLoading(mockWebView, mockRequest)
-            )
-            coVerify {
-                mockViewModel.onAuthFlowComplete(
-                    tr = any(),
-                    onAuthFlowSuccess = mockResultCallback.onMigrationSuccess,
-                    onAuthFlowError = mockResultCallback.onMigrationError,
-                    tokenMigration = true,
-                )
-            }
-
-            verify(exactly = 0) {
-                mockViewModel.onWebServerFlowComplete(any(), any(), any(), any(), any())
-            }
-        }
-    }
-
-    @Test
     fun shouldOverrideUrlLoading_callsErrorCallbackOnError() {
         val activity = launchActivity()
         val mockResultCallback = createMockResultCallback()

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/util/AuthConfigUtilTest.java
@@ -30,6 +30,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.HandlerThread;
 
 import androidx.core.content.ContextCompat;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -44,6 +46,8 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Tests for AuthConfigUtil.
@@ -121,25 +125,36 @@ public class AuthConfigUtilTest {
         Assert.assertNull("Auth config should be null", authConfig);
     }
 
-    @Test(timeout = 5_000)
-    public void testBroadcastSucceeds() throws ExecutionException, InterruptedException {
+    @Test(timeout = 30_000)
+    public void testBroadcastSucceeds() throws ExecutionException, InterruptedException, TimeoutException {
         testBroadcast(MY_DOMAIN_ENDPOINT, true);
     }
 
-    @Test(timeout = 5_000)
-    public void testBroadcastFails() throws ExecutionException, InterruptedException {
+    @Test(timeout = 30_000)
+    public void testBroadcastFails() throws ExecutionException, InterruptedException, TimeoutException {
         testBroadcast(SANDBOX_ENDPOINT, false);
     }
 
-    private void testBroadcast(String endpoint, Boolean expected) throws InterruptedException, ExecutionException {
+    private void testBroadcast(String endpoint, Boolean expected)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        // Receive the broadcast on a background HandlerThread rather than the main thread.
+        // Other tests in this shard launch Activities on the main thread; by the time
+        // sendBroadcast is invoked, the main looper can be backed up enough that the
+        // receiver's onReceive doesn't run before the test's timeout, even though the
+        // broadcast was dispatched. A dedicated Handler decouples broadcast delivery
+        // from main-thread saturation.
+        final HandlerThread handlerThread = new HandlerThread("AuthConfigUtilTest-receiver");
+        handlerThread.start();
+        final Handler handler = new Handler(handlerThread.getLooper());
         final TestBroadcastReceiver receiver = new TestBroadcastReceiver();
         ContextCompat.registerReceiver(SalesforceSDKManager.getInstance().getAppContext(), receiver,
-                new IntentFilter(AuthConfigUtil.AUTH_CONFIG_COMPLETE_INTENT_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED);
+                new IntentFilter(AuthConfigUtil.AUTH_CONFIG_COMPLETE_INTENT_ACTION), null,
+                handler, ContextCompat.RECEIVER_NOT_EXPORTED);
 
         try {
             AuthConfigUtil.getMyDomainAuthConfig(endpoint);
 
-            final Intent intent = receiver.getIntent().get();
+            final Intent intent = receiver.getIntent().get(20, TimeUnit.SECONDS);
             Assert.assertTrue("The intent extra should be set", intent.hasExtra(AuthConfigUtil.WAS_REQUEST_SUCCESSFUL_EXTRA));
 
             final boolean extra = intent.getBooleanExtra(AuthConfigUtil.WAS_REQUEST_SUCCESSFUL_EXTRA, !expected);
@@ -150,6 +165,7 @@ public class AuthConfigUtilTest {
             }
         } finally {
             SalesforceSDKManager.getInstance().getAppContext().unregisterReceiver(receiver);
+            handlerThread.quitSafely();
         }
     }
 }


### PR DESCRIPTION
  ## Summary

  Fix `screenLockActivity_onAuthError_sendsAccessibilityEvent` and several other  instrumentation tests that were timing out or failing on Firebase Test Lab.

  ## Root cause

  mockk's Android dispatcher uses dexmaker to bytecode-instrument any class  whose instances are mocked, including the entire ancestor chain. Once a test calls `mockk<LoginActivity>(relaxed = true)` (or any other Activity-derived type) in a given JVM process, **every subsequent `ContextThemeWrapper.getResources()` call in that process is routed through `io.mockk.proxy.android.advice.Advice.findMethod`** — even after `unmockkAll()`.

  Compose calls `getResources()` thousands of times per frame. With mockk's reflection on the hot path, single Compose frames take 8+ seconds. Tests like `screenLockActivity_onAuthError_sendsAccessibilityEvent` that launch a Compose Activity then ANR on `AuthenticatorService` bind, while others (`tokenMigrationView_*`, `screenLockView_*`) silently slow from ~2 s to ~30 s per test until the shard hits its timeout.

  Confirmed via JVM main-thread stack from a timed-out run:

  io.mockk.proxy.android.advice.Advice$Companion.findMethod(Advice.kt:171)
  io.mockk.proxy.android.AndroidMockKDispatcher.getOrigin(...)
  android.view.ContextThemeWrapper.getResources(Unknown Source:14)
  androidx.core.content.ContextCompat.getColor(...)
  com.salesforce.androidsdk.ui.theme.SFColors.primaryColor(SFColors.kt:72)
  androidx.compose.ui.platform.ComposeView.Content(...)

  The pollution is irreversible within a JVM lifetime, so the fix has to keep Activity-mocking tests and Compose-rendering tests in **separate test  processes** (separate Firebase shards).

  ## Changes

  ### Test isolation

  - `BiometricAuthenticationCallbackTest.kt` (new) — extracted three `mockk<ScreenLockActivity>(relaxed = true)` tests out of `ScreenLockActivityScenarioTest`. They tested an inner class via the outer Activity mock and were poisoning the rest of the class once they ran.
  - `ScreenLockActivityScenarioTest.kt` — removed those three tests and unused imports. The remaining 29 Compose-driven cases now run unaffected.
  - `.github/test-shards/SalesforceSDK.json`:
    - Compose-rendering classes (`ScreenLockActivityScenarioTest`, `ScreenLockViewTest`, `TokenMigrationViewActivityTest`) added to the `ui` shard.
    - `TokenMigrationWebViewTest` moved to a new `webview` shard (slow on the emulator for unrelated WebView reasons; isolating it keeps it from eating budget elsewhere).
    - The mockk-of-Activity polluters (`LoginActivityTest`, `NativeLoginManagerTest`, `SalesforceSDKManagerTests`, `BiometricAuthenticationCallbackTest`) stay in `remaining`.
    - Comment in the file documents the rule so future test authors know not to mix the two categories.

  ### Test fixes

  - `TokenMigrationWebViewTest.kt` — deleted `shouldOverrideUrlLoading_returnsTrueForCallbackUrl_userAgentFlow`. PR #2892 collapsed the `useWebServerFlow` branch in the production code; the test was verifying a path that no longer exists.
  - `AuthConfigUtilTest.java` — broadcast tests (`testBroadcastSucceeds`, `testBroadcastFails`) now register their `BroadcastReceiver` on a `HandlerThread` instead of the implicit main thread. Other tests in the same shard launch Activities, and the cumulative main-looper backlog could prevent the receiver's `onReceive` from running before the test timeout, even though the broadcast had already been dispatched. Also widened the JUnit `@Test(timeout=...)` from 5 s to 30 s and added an explicit `Future.get(20, SECONDS)` for a clearer failure mode.

  ## Test plan

  - [x] `screenLockActivity_onAuthError_sendsAccessibilityEvent` passes
  - [x] All 29 `ScreenLockActivityScenarioTest` cases pass (~2 s each)
  - [x] All 4 `ScreenLockViewTest` cases pass (~2.5 s each, down from 27 s)
  - [x] All 3 extracted `BiometricAuthenticationCallbackTest` cases pass
  - [x] `testBroadcastSucceeds` / `testBroadcastFails` pass (~2.5 s each)
  - [x] Shard config validator (`CLASSES == NOT_CLASSES`) passes

  Couple of usage notes for the PR description:
  - Untracked: run_firebase_tests.sh is a local helper — not part of the PR. Either gitignore or delete before pushing.
  - external/shared: pre-existing dirty submodule pointer, unrelated.