### PR TITLE
Remove remaining SalesforceReact references

### DIFF
--- a/.claude/skills/update-min-sdk.md
+++ b/.claude/skills/update-min-sdk.md
@@ -24,7 +24,6 @@ Update `minSdk` in all `build.gradle.kts` files:
 - `libs/SmartStore/build.gradle.kts`
 - `libs/MobileSync/build.gradle.kts`
 - `libs/SalesforceHybrid/build.gradle.kts`
-- `libs/SalesforceReact/build.gradle.kts`
 
 **Native Sample Apps:**
 - `native/NativeSampleApps/RestExplorer/build.gradle.kts`

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -42,13 +42,6 @@ coverage:
           - "libs/MobileSync/src/"
         flags: 
           - MobileSync
-      SalesforceReact:
-        threshold: 0%
-        paths:
-          - "libs/SalesforceReact/src/"
-        flags:
-          - SalesforceReact
-
     # Pull Request Requirements
     patch: 
       SalesforceAnalytics:
@@ -81,13 +74,6 @@ coverage:
           - "libs/MobileSync/src/"
         flags: 
           - MobileSync
-      SalesforceReact:
-        target: 80%
-        paths:
-          - "libs/SalesforceReact/src/"
-        flags:
-          - SalesforceReact
-
 ignore:
   - "hybrid"
   - "native"
@@ -122,7 +108,3 @@ component_management:
     - component_id: MobileSync
       paths: 
         - "libs/MobileSync/src/"
-    - component_id: SalesforceReact
-      name: React
-      paths: 
-        - "libs/SalesforceReact/src/"

--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -7,7 +7,7 @@ warn("Big PR, try to keep changes smaller if you can.", sticky: true) if git.lin
 fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if github.branch_for_base != "dev"
 
 # List of Android libraries for testing
-LIBS = ['SalesforceAnalytics', 'SalesforceSDK', 'SmartStore', 'MobileSync', 'SalesforceHybrid', 'SalesforceReact']
+LIBS = ['SalesforceAnalytics', 'SalesforceSDK', 'SmartStore', 'MobileSync', 'SalesforceHybrid']
 
 modified_libs = Set[]
 for file in (git.modified_files + git.added_files);

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,8 +6,8 @@ on:
   # This lets us trigger the workflow from a browser.
   workflow_dispatch:
 
-# Run the native libraries first so that the native, Hybrid and React MobileSync tests 
-# don't run simultaniously (to prevents flappers).
+# Run the native libraries first so that the native and Hybrid MobileSync tests
+# don't run simultaneously (to prevent flappers).
 jobs:
   android-nightly:
     strategy:
@@ -25,17 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         lib: [SalesforceHybrid]
-    uses: ./.github/workflows/reusable-lib-workflow.yaml
-    with:
-      lib: ${{ matrix.lib }}
-    secrets: inherit
-  android-nightly-React:
-    if: success() || failure()
-    needs: [android-nightly-Hybrid]
-    strategy:
-      fail-fast: false
-      matrix:
-        lib: [SalesforceReact]
     uses: ./.github/workflows/reusable-lib-workflow.yaml
     with:
       lib: ${{ matrix.lib }}

--- a/.github/workflows/reusable-lib-workflow.yaml
+++ b/.github/workflows/reusable-lib-workflow.yaml
@@ -34,9 +34,6 @@ jobs:
         if: ${{ inputs.lib == 'SalesforceHybrid' }}
         run: |
           npm install -g cordova
-      - name: React Native Dependencies
-        if: ${{ inputs.lib  == 'SalesforceReact' }}
-        run: npm install -g typescript
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ HTML5 is quickly emerging as dominant technology for developing cross-platform m
 | **SmartStore** | Encrypted local storage (SQLCipher) |
 | **MobileSync** | Data synchronization framework |
 | **SalesforceHybrid** | Cordova integration for hybrid apps |
-| **SalesforceReact** | React Native bridge modules |
+
+> **Note:** As of SDK 14.0, `SalesforceReact` has moved to the [SalesforceMobileSDK-ReactNative](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative) repository and is distributed via the `react-native-force` npm package.
 
 ## Getting Started
 

--- a/libs/README.md
+++ b/libs/README.md
@@ -23,13 +23,11 @@ Inside the $NATIVE_DIR, you will find several projects:
 3. **SmartStore**: Library project which provides the SmartStore functionality
 4. **MobileSync**: The MobileSync library project which provides support for Salesforce object metadata API calls, layout API calls, MRU API calls, caching
 5. **SalesforceHybrid**: The SalesforceHybrid library project which provides support for Cordova based hybrid apps
-6. **SalesforceReact**: The SalesforceReact library project which provides support for React based native apps
-7. **test/SalesforceAnalyticsTest**: Test project for SalesforceAnalytics
+6. **test/SalesforceAnalyticsTest**: Test project for SalesforceAnalytics
 8. **test/SalesforceSDKTest**: Test project for SalesforceSDK
 9. **test/SmartStoreTest**: Test project for SmartStore
 10. **test/MobileSyncTest**: Test project for MobileSync
 11. **test/SalesforceHybridTest**: Test project for SalesforceHybrid
-12. **test/SalesforceReactTest**: Test project for SalesforceReact
 
 # Running sample apps from Android Studio
 


### PR DESCRIPTION
## Summary
- Removed `android-nightly-React` job from nightly workflow
- Removed React Native Dependencies step from reusable lib workflow
- Removed `SalesforceReact` from Danger's LIBS array, codecov config, and READMEs
- Added a note in root README indicating SalesforceReact moved to SalesforceMobileSDK-ReactNative in SDK 14.0

## Test plan
- [ ] Verify nightly workflow triggers correctly without the React job
- [ ] Verify PR workflows still detect modified libs correctly
- [ ] Confirm codecov reporting works for remaining libraries