### PR TITLE
Fix crash: use postValue in resetFrontDoorBridgeUrl

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -412,7 +412,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
      * its default inactive state.
      */
     internal fun resetFrontDoorBridgeUrl() {
-        frontDoorBridgeUrl.value = null
+        frontDoorBridgeUrl.postValue(null)
         frontdoorBridgeServer = null
         frontdoorBridgeCodeVerifier = null
     }


### PR DESCRIPTION
## Summary

`resetFrontDoorBridgeUrl()` calls `LiveData.setValue()` but can be invoked from a background coroutine dispatcher (via `onAuthFlowError` → `doCodeExchange` error path). This throws `IllegalStateException: Cannot invoke setValue on a background thread`.

Fix: use `postValue(null)` instead of `value = null`.

## Context

The bug was introduced in "Modern Login Architecture (#2653)" on 2025-01-24. It only manifests when the OAuth code exchange fails (e.g., invalid consumer key, network error during exchange) — the happy path never hits this code.

## Test Plan

- [x] Reproduced crash with invalid consumer key on React Native template app
- [x] Verified fix resolves crash — auth error is handled gracefully