### PR TITLE
Handle test_login_domain with or without https:// prefix

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/test/TestCredentials.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/util/test/TestCredentials.java
@@ -70,7 +70,7 @@ public class TestCredentials {
             USERNAME = json.getString("username");
             ACCOUNT_NAME = json.getString("display_name");
             USER_ID = json.getString("user_id");
-            LOGIN_URL = json.getString("test_login_domain");
+            LOGIN_URL = ensureHttpsPrefix(json.getString("test_login_domain"));
             INSTANCE_URL = json.getString("instance_url");
             API_INSTANCE_URL = JSONObjectHelper.optString(json, "api_instance_url");
             COMMUNITY_URL = json.optString("community_url", INSTANCE_URL /* in case the test_credentials.json was obtained for a user / org without community setup */);
@@ -94,7 +94,7 @@ public class TestCredentials {
             USERNAME = json.getString("username");
             ACCOUNT_NAME = json.getString("display_name");
             USER_ID = json.getString("user_id");
-            LOGIN_URL = json.getString("test_login_domain");
+            LOGIN_URL = ensureHttpsPrefix(json.getString("test_login_domain"));
             INSTANCE_URL = json.getString("instance_url");
             COMMUNITY_URL = json.optString("community_url", INSTANCE_URL /* In case the test_credentials.json was obtained for a user/org without community setup */);
             IDENTITY_URL = json.getString("identity_url");
@@ -107,5 +107,11 @@ public class TestCredentials {
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static String ensureHttpsPrefix(String url) {
+        if (url == null) return null;
+        if (url.startsWith("https://") || url.startsWith("http://")) return url;
+        return "https://" + url;
     }
 }


### PR DESCRIPTION
## Summary

`TestCredentials` now accepts `test_login_domain` as either a bare hostname (`login.salesforce.com`) or a full URL (`https://login.salesforce.com`). This allows the same `test_credentials.json` to work on both iOS and Android without platform-specific formatting.

Android adds `https://` if missing. iOS (companion PR) strips it if present.

## Test plan

- [x] Existing tests pass with current `test_credentials.json` format (with `https://`)
- [x] Tests also pass with bare hostname format (without `https://`)