### PR TITLE
@W-22699717: [Android] Use web server flow when app attestation is configured

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -191,11 +191,19 @@ open class SalesforceSDKManager protected constructor(
     googleCloudProjectId: Long? = null,
 ) : DefaultLifecycleObserver {
 
+    @JvmOverloads
     constructor(
         context: Context,
         mainActivity: Class<out Activity>,
-        loginActivity: Class<out Activity>? = null
-    ) : this(context, mainActivity, loginActivity, nativeLoginActivity = null)
+        loginActivity: Class<out Activity>? = null,
+        googleCloudProjectId: Long? = null,
+    ) : this(
+        context = context,
+        mainActivity = mainActivity,
+        loginActivity = loginActivity,
+        nativeLoginActivity = null,
+        googleCloudProjectId = googleCloudProjectId
+    )
 
     /** The Android context */
     val appContext: Context = context
@@ -1879,6 +1887,28 @@ open class SalesforceSDKManager protected constructor(
             mainActivity,
             loginActivity,
             nativeLoginActivity,
+        )
+
+        /**
+         * Initializes required components with Salesforce App Attestation
+         * enabled. Native apps must call one overload of this method before
+         * using the Salesforce Mobile SDK.
+         *
+         * @param context The Android context
+         * @param mainActivity The app's main activity class
+         * @param googleCloudProjectId The Google Cloud Project ID to use with
+         * Google Play Integrity API and Salesforce App Attestation
+         */
+        @JvmStatic
+        fun initNative(
+            context: Context,
+            mainActivity: Class<out Activity>,
+            googleCloudProjectId: Long,
+        ) = init(
+            context,
+            mainActivity,
+            LoginActivity::class.java,
+            googleCloudProjectId = googleCloudProjectId,
         )
 
         /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -261,11 +261,8 @@ public class OAuth2 {
      *                                   the default OAuth scope is provided.
      * @param displayType                OAuth display type. If null, the default of 'touch' is used.
      * @param codeChallenge              Code challenge to use when using web server flow
-     * @param addlParams                 Any additional parameters that may be
-     *                                   added to the request. When using
-     *                                   Salesforce Mobile App Attestation, the
-     *                                   "attestation" parameter should be added
-     *                                   to this map.
+     * @param addlParams                 Any additional parameters to add to the
+     *                                   authorization request.
      * @return A URL to start the OAuth flow in a web browser/view.
      * @see <a href="https://help.salesforce.com/apex/HTViewHelpDoc?language=en&id=remoteaccess_oauth_scopes.htm">RemoteAccess OAuth Scopes</a>
      */
@@ -307,11 +304,8 @@ public class OAuth2 {
      * @param loginHint                  When applicable, the Salesforce Welcome Login hint
      * @param displayType                OAuth display type. If null, the default of 'touch' is used.
      * @param codeChallenge              Code challenge to use when using web server flow
-     * @param addlParams                 Any additional parameters that may be
-     *                                   added to the request. When using
-     *                                   Salesforce Mobile App Attestation, the
-     *                                   "attestation" parameter should be added
-     *                                   to this map.
+     * @param addlParams                 Any additional parameters to add to the
+     *                                   authorization request.
      * @return A URL to start the OAuth flow in a web browser/view.
      * @see <a href="https://help.salesforce.com/apex/HTViewHelpDoc?language=en&id=remoteaccess_oauth_scopes.htm">RemoteAccess OAuth Scopes</a>
      */

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -1224,7 +1224,7 @@ open class LoginActivity : FragmentActivity() {
                         viewModel.authFinished.value = true
 
                         when {
-                            viewModel.useWebServerFlow ->
+                            viewModel.useWebServerFlow() ->
                                 viewModel.onWebServerFlowComplete(
                                     params["code"],
                                     ::onAuthFlowError,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -57,7 +57,6 @@ import com.salesforce.androidsdk.app.SalesforceSDKManager.Theme.DARK
 import com.salesforce.androidsdk.app.SalesforceSDKManager.Theme.LIGHT
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.auth.OAuth2
-import com.salesforce.androidsdk.auth.OAuth2.ATTESTATION
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse
 import com.salesforce.androidsdk.auth.OAuth2.exchangeCode
 import com.salesforce.androidsdk.auth.OAuth2.getFrontdoorUrl
@@ -212,21 +211,25 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
      *
      * When no Front-Door Bridge URL is in use, Web Server Flow is
      * enabled when web server authentication or browser login are enabled.
+     * @param sdkManager The Salesforce SDK manager.  This parameter is intended
+     * for testing purposes only. Defaults to the shared instance
      * @return True if Web Server Flow is enabled, false if User-Agent Flow is
      * enabled.
      */
-    internal val useWebServerFlow: Boolean
-        get() = with(SalesforceSDKManager.getInstance()) {
-            // First, an in-use Salesforce Identity API UI Bridge front-door bridge URL takes precedence.
-            if (isUsingFrontDoorBridge) {
-                // A front-door bridge URL accompanied by a PKCE code verifier requires Web Server Flow.  Otherwise, User Agent-Flow must be used.
-                frontdoorBridgeCodeVerifier != null
-            }
-            // Second, when not using a front-door bridge URL, the app's preferences can be used.
-            else {
-                useWebServerAuthentication || isBrowserLoginEnabled || singleServerCustomTabActivity
-            }
+    internal fun useWebServerFlow(
+        sdkManager: SalesforceSDKManager = SalesforceSDKManager.getInstance(),
+    ): Boolean = with(sdkManager) {
+        // First, an in-use Salesforce Identity API UI Bridge front-door bridge URL takes precedence.
+        if (isUsingFrontDoorBridge) {
+            // A front-door bridge URL accompanied by a PKCE code verifier requires Web Server Flow.  Otherwise, User Agent-Flow must be used.
+            frontdoorBridgeCodeVerifier != null
         }
+        // Second, when not using a front-door bridge URL, the app's preferences can be used.
+        // App attestation always requires Web Server Flow because attestation is only supported at the token endpoint.
+        else {
+            useWebServerAuthentication || isBrowserLoginEnabled || singleServerCustomTabActivity || appAttestationClient != null
+        }
+    }
 
     /**
      * Setting this option to true will enable a mode where only a custom tab will be shown.  The first server will be
@@ -459,13 +462,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
         val codeVerifier = getRandom128ByteKey().also { codeVerifier = it }
         val codeChallenge = getSHA256Hash(codeVerifier)
 
-        // Populate the additional parameter map with app attestation, if applicable.
         val additionalParameters = mutableMapOf<String, String>()
-        sdkManager.appAttestationClient?.run {
-            val challenge = fetchMobileAppAttestationChallenge() ?: return@run
-            val attestation = createAppAttestation(challenge) ?: return@run
-            additionalParameters[ATTESTATION] = attestation
-        }
 
         val authorizationUrl = OAuth2.getAuthorizationUrl(
             /* useWebServerAuthentication = */ true,
@@ -512,14 +509,6 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
             val codeVerifier = getRandom128ByteKey().also { codeVerifier = it }
             val codeChallenge = getSHA256Hash(codeVerifier)
 
-            // Populate the additional parameter map with app attestation, if applicable.
-            sdkManager.appAttestationClient?.run {
-                val challenge = fetchMobileAppAttestationChallenge() ?: return@run
-                val attestation = createAppAttestation(challenge) ?: return@run
-                additionalParams[ATTESTATION] = attestation
-            }
-
-
             val webServerAuthorizationUrl = OAuth2.getAuthorizationUrl(
                 /* useWebServerAuthentication = */ true,
                 sdkManager.useHybridAuthentication,
@@ -544,7 +533,7 @@ open class LoginViewModel(val bootConfig: BootConfig) : ViewModel() {
                 else -> webServerAuthorizationUrl.toString()
             }.toString()
 
-            val webViewUrlValue = if (useWebServerFlow) {
+            val webViewUrlValue = if (useWebServerFlow(sdkManager)) {
                 browserTabUrlValue
             } else {
                 val userAgentAuthorizationUrl = OAuth2.getAuthorizationUrl(

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
@@ -459,6 +459,39 @@ class SalesforceSDKManagerTests {
     }
 
 
+    @Test
+    fun initNative_WithGoogleCloudProjectId_CreatesInstanceWithAppAttestationClient() {
+        val instanceField = SalesforceSDKManager::class.java.getDeclaredField("INSTANCE")
+        instanceField.isAccessible = true
+        val originalInstance = instanceField.get(null)
+
+        try {
+            instanceField.set(null, null)
+
+            SalesforceSDKManager.initNative(
+                getInstrumentation().targetContext,
+                LoginActivity::class.java,
+                762473690072L,
+            )
+
+            assertNotNull(SalesforceSDKManager.getInstance().appAttestationClient)
+        } finally {
+            instanceField.set(null, originalInstance)
+        }
+    }
+
+    @Test
+    fun initNative_WithoutGoogleCloudProjectId_CreatesInstanceWithoutAppAttestationClient() {
+        val sdkManager = TestSalesforceSDKManagerWithAttestation(
+            context = getInstrumentation().targetContext,
+            mainActivity = LoginActivity::class.java,
+            loginActivity = LoginActivity::class.java,
+            googleCloudProjectId = null,
+        )
+
+        assertNull(sdkManager.appAttestationClient)
+    }
+
     /**
      * Helper to create a test [SalesforceSDKManager] instance with optional
      * [googleCloudProjectId] for app attestation tests.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -965,6 +965,12 @@ class LoginViewModelTest {
         assertFalse(freshViewModel.useWebServerFlow(sdkManager))
     }
 
+    @Test
+    fun useWebServerFlow_UsesDefaultSdkManager_WhenNoParameterProvided() {
+        val freshViewModel = LoginViewModel(bootConfig)
+        assertTrue(freshViewModel.useWebServerFlow())
+    }
+
     // endregion
 
     @Test

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -70,10 +70,6 @@ import java.net.URI
 private const val FAKE_SERVER_URL = "shouldMatchNothing.salesforce.com"
 private const val FAKE_JWT = "1234"
 private const val FAKE_JWT_FLOW_AUTH = "5678"
-private const val TEST_ATTESTATION_SERVER = "test.salesforce.com"
-private const val TEST_CHALLENGE_VALUE = "__TEST_CHALLENGE_VALUE__"
-private const val TEST_APP_ATTESTATION = "__TEST_APP_ATTESTATION__"
-private const val ATTESTATION_QUERY_PARAM_PREFIX = "attestation="
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -567,6 +563,7 @@ class LoginViewModelTest {
         val appConfigRedirectUri = "appconfig://should_not_be_used"
         every { sdkManagerMock.isDebugBuild } returns false
         every { sdkManagerMock.useHybridAuthentication } returns false
+        every { sdkManagerMock.useWebServerAuthentication } returns true
         // generateAuthorizationUrl reads isBrowserLoginEnabled to decide whether to invoke
         // the onBrowserCustomTabReady callback; not relevant to this assertion but must be stubbed.
         every { sdkManagerMock.isBrowserLoginEnabled } returns false
@@ -885,110 +882,90 @@ class LoginViewModelTest {
         }
     }
 
+    // region useWebServerFlow Tests
+
     @Test
-    fun getAuthorizationUrl_WithNullAppAttestationClient_OmitsAttestationParam() = runBlocking {
+    fun useWebServerFlow_ReturnsTrue_WhenAppAttestationClientIsNotNull() {
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.appAttestationClient } returns mockk()
+        every { sdkManager.useWebServerAuthentication } returns false
+        every { sdkManager.isBrowserLoginEnabled } returns false
+
         val freshViewModel = LoginViewModel(bootConfig)
-
-        val migrationConsumerKey = "migration_override_key_789"
-        val migrationRedirectUri = "migration://redirect"
-        val migrationScopes = listOf("api", "migration_scope")
-
-        val loginUrl = freshViewModel.generateMigrationAuthorizationPath(
-            server = TEST_ATTESTATION_SERVER,
-            migrationOAuthConfig = OAuthConfig(
-                migrationConsumerKey,
-                migrationRedirectUri,
-                migrationScopes,
-            ),
-        )
-
-        assertFalse(
-            "URL should NOT contain an attestation parameter but was '$loginUrl'.",
-            loginUrl.contains(ATTESTATION_QUERY_PARAM_PREFIX),
-        )
+        assertTrue(freshViewModel.useWebServerFlow(sdkManager))
     }
 
     @Test
-    fun getAuthorizationUrl_WithAppAttestationClient_IncludesAttestationParam() = runBlocking {
-        val appAttestationClient = createMockAppAttestationClient(attestation = TEST_APP_ATTESTATION)
-        val sdkManagerMock = createSdkManagerMockForAttestation(appAttestationClient = appAttestationClient)
+    fun useWebServerFlow_ReturnsFalse_WhenNoAttestationAndWebServerAuthDisabled() {
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.appAttestationClient } returns null
+        every { sdkManager.useWebServerAuthentication } returns false
+        every { sdkManager.isBrowserLoginEnabled } returns false
+
         val freshViewModel = LoginViewModel(bootConfig)
+        assertFalse(freshViewModel.useWebServerFlow(sdkManager))
+    }
 
-        val migrationConsumerKey = "migration_override_key_789"
-        val migrationRedirectUri = "migration://redirect"
-        val migrationScopes = listOf("api", "migration_scope")
+    @Test
+    fun useWebServerFlow_ReturnsTrue_WhenUseWebServerAuthenticationIsTrue() {
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.useWebServerAuthentication } returns true
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        every { sdkManager.appAttestationClient } returns null
 
-        val loginUrl = freshViewModel.generateMigrationAuthorizationPath(
-            server = TEST_ATTESTATION_SERVER,
-            migrationOAuthConfig = OAuthConfig(
-                migrationConsumerKey,
-                migrationRedirectUri,
-                migrationScopes,
-            ),
-            sdkManager = sdkManagerMock,
-        )
+        val freshViewModel = LoginViewModel(bootConfig)
+        assertTrue(freshViewModel.useWebServerFlow(sdkManager))
+    }
 
-        assertTrue(
-            "URL should contain '$ATTESTATION_QUERY_PARAM_PREFIX$TEST_APP_ATTESTATION' but was '$loginUrl'.",
-            loginUrl.contains("$ATTESTATION_QUERY_PARAM_PREFIX$TEST_APP_ATTESTATION"),
-        )
-        coVerify(exactly = 1) {
-            appAttestationClient.fetchMobileAppAttestationChallenge()
-            appAttestationClient.createAppAttestation(appAttestationChallenge = TEST_CHALLENGE_VALUE)
+    @Test
+    fun useWebServerFlow_ReturnsTrue_WhenBrowserLoginIsEnabled() {
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.useWebServerAuthentication } returns false
+        every { sdkManager.isBrowserLoginEnabled } returns true
+        every { sdkManager.appAttestationClient } returns null
+
+        val freshViewModel = LoginViewModel(bootConfig)
+        assertTrue(freshViewModel.useWebServerFlow(sdkManager))
+    }
+
+    @Test
+    fun useWebServerFlow_ReturnsTrue_WhenSingleServerCustomTabActivity() {
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.useWebServerAuthentication } returns false
+        every { sdkManager.isBrowserLoginEnabled } returns false
+        every { sdkManager.appAttestationClient } returns null
+
+        val freshViewModel = object : LoginViewModel(bootConfig) {
+            override val singleServerCustomTabActivity = true
         }
+        assertTrue(freshViewModel.useWebServerFlow(sdkManager))
     }
 
     @Test
-    fun generateAuthorizationUrl_WhenCreateAppAttestationReturnsNull_OmitsAttestationParam() = runBlocking {
-        val appAttestationClient = createMockAppAttestationClient(attestation = null)
-        val sdkManagerMock = createSdkManagerMockForAttestation(appAttestationClient = appAttestationClient)
+    fun useWebServerFlow_ReturnsTrue_WhenUsingFrontDoorBridgeWithCodeVerifier() {
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
         val freshViewModel = LoginViewModel(bootConfig)
-
-        freshViewModel.generateAuthorizationUrl(
-            server = TEST_ATTESTATION_SERVER,
-            sdkManager = sdkManagerMock,
+        freshViewModel.loginWithFrontDoorBridgeUrl(
+            "https://test.salesforce.com/frontdoor.jsp?sid=test_session",
+            pkceCodeVerifier = "__VERIFIER__",
         )
 
-        val loginUrl = freshViewModel.loginUrl.value!!
-        assertFalse(
-            "URL should NOT contain an attestation parameter but was '$loginUrl'.",
-            loginUrl.contains(ATTESTATION_QUERY_PARAM_PREFIX),
-        )
-        coVerify(exactly = 1) {
-            appAttestationClient.fetchMobileAppAttestationChallenge()
-            appAttestationClient.createAppAttestation(appAttestationChallenge = TEST_CHALLENGE_VALUE)
-        }
+        assertTrue(freshViewModel.useWebServerFlow(sdkManager))
     }
 
     @Test
-    fun getAuthorizationUrl_WhenCreateAppAttestationReturnsNull_OmitsAttestationParam() = runBlocking {
-        val appAttestationClient = createMockAppAttestationClient(attestation = null)
-        val sdkManagerMock = createSdkManagerMockForAttestation(appAttestationClient = appAttestationClient)
+    fun useWebServerFlow_ReturnsFalse_WhenUsingFrontDoorBridgeWithoutCodeVerifier() {
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
         val freshViewModel = LoginViewModel(bootConfig)
-
-        val migrationConsumerKey = "migration_override_key_789"
-        val migrationRedirectUri = "migration://redirect"
-        val migrationScopes = listOf("api", "migration_scope")
-
-        val loginUrl = freshViewModel.generateMigrationAuthorizationPath(
-            server = TEST_ATTESTATION_SERVER,
-            migrationOAuthConfig = OAuthConfig(
-                migrationConsumerKey,
-                migrationRedirectUri,
-                migrationScopes,
-            ),
-            sdkManager = sdkManagerMock,
+        freshViewModel.loginWithFrontDoorBridgeUrl(
+            "https://test.salesforce.com/frontdoor.jsp?sid=test_session",
+            pkceCodeVerifier = null,
         )
 
-        assertFalse(
-            "URL should NOT contain an attestation parameter but was '$loginUrl'.",
-            loginUrl.contains(ATTESTATION_QUERY_PARAM_PREFIX),
-        )
-        coVerify(exactly = 1) {
-            appAttestationClient.fetchMobileAppAttestationChallenge()
-            appAttestationClient.createAppAttestation(appAttestationChallenge = TEST_CHALLENGE_VALUE)
-        }
+        assertFalse(freshViewModel.useWebServerFlow(sdkManager))
     }
+
+    // endregion
 
     @Test
     fun generateAuthorizationUrl_WithJwtFlow_IgnoresAdditionalParameters() = runBlocking {
@@ -1023,107 +1000,6 @@ class LoginViewModelTest {
             "URL should NOT contain custom_param from additionalParameters when JWT flow is active but was '$loginUrl'.",
             loginUrl.contains("custom_param"),
         )
-    }
-
-    @Test
-    fun generateAuthorizationUrl_WithJwtFlowAndAppAttestation_IncludesAttestationParam() = runBlocking {
-        val appAttestationClient = createMockAppAttestationClient(attestation = TEST_APP_ATTESTATION)
-        val sdkManagerMock = createSdkManagerMockForAttestation(appAttestationClient = appAttestationClient)
-
-        val freshViewModel = LoginViewModel(bootConfig)
-
-        // Set up JWT flow - even with JWT flow active, attestation should still be added
-        freshViewModel.jwt = FAKE_JWT
-        freshViewModel.authCodeForJwtFlow = FAKE_JWT_FLOW_AUTH
-
-        // Set additional parameters that should be ignored in JWT flow
-        freshViewModel.additionalParameters["custom_param"] = "should_not_appear"
-
-        freshViewModel.generateAuthorizationUrl(
-            server = TEST_ATTESTATION_SERVER,
-            sdkManager = sdkManagerMock,
-        )
-
-        val loginUrl = freshViewModel.loginUrl.value!!
-
-        // Verify attestation IS in the URL (even with JWT flow, app attestation adds to additionalParams)
-        assertTrue(
-            "URL should contain attestation parameter but was '$loginUrl'.",
-            loginUrl.contains(ATTESTATION_QUERY_PARAM_PREFIX),
-        )
-
-        // Verify custom_param is NOT in URL (JWT flow ignores viewModel.additionalParameters)
-        // This covers lines 511 and 514
-        assertFalse(
-            "URL should NOT contain custom_param when JWT flow is active but was '$loginUrl'.",
-            loginUrl.contains("custom_param"),
-        )
-
-        // App attestation client should be called (covering the code path)
-        coVerify(exactly = 1) {
-            appAttestationClient.fetchMobileAppAttestationChallenge()
-            appAttestationClient.createAppAttestation(appAttestationChallenge = TEST_CHALLENGE_VALUE)
-        }
-    }
-
-    @Test
-    fun generateMigrationAuthorizationPath_WhenCreateAppAttestationReturnsNull_OmitsAttestationParam() = runBlocking {
-        val appAttestationClient = createMockAppAttestationClient(attestation = null)
-        val sdkManagerMock = createSdkManagerMockForAttestation(appAttestationClient = appAttestationClient)
-        val freshViewModel = LoginViewModel(bootConfig)
-
-        val migrationConsumerKey = "migration_override_key_789"
-        val migrationRedirectUri = "migration://redirect"
-        val migrationScopes = listOf("api", "migration_scope")
-
-        val loginUrl = freshViewModel.generateMigrationAuthorizationPath(
-            server = TEST_ATTESTATION_SERVER,
-            migrationOAuthConfig = OAuthConfig(
-                migrationConsumerKey,
-                migrationRedirectUri,
-                migrationScopes,
-            ),
-            sdkManager = sdkManagerMock,
-        )
-
-        assertFalse(
-            "URL should NOT contain an attestation parameter but was '$loginUrl'.",
-            loginUrl.contains(ATTESTATION_QUERY_PARAM_PREFIX),
-        )
-        coVerify(exactly = 1) {
-            appAttestationClient.fetchMobileAppAttestationChallenge()
-            appAttestationClient.createAppAttestation(appAttestationChallenge = TEST_CHALLENGE_VALUE)
-        }
-    }
-
-    @Test
-    fun generateAuthorizationUrl_WhenFetchChallengeReturnsNull_OmitsAttestationParam() = runBlocking {
-        verifyAttestationOmittedWhenChallengeIsNull { viewModel, sdkManager ->
-            viewModel.generateAuthorizationUrl(
-                server = TEST_ATTESTATION_SERVER,
-                sdkManager = sdkManager,
-            )
-            viewModel.loginUrl.value!!
-        }
-    }
-
-    @Test
-    fun generateMigrationAuthorizationPath_WhenFetchChallengeReturnsNull_OmitsAttestationParam() = runBlocking {
-        verifyAttestationOmittedWhenChallengeIsNull { viewModel, sdkManager ->
-            val migrationConsumerKey = "migration_override_key_789"
-            val migrationRedirectUri = "migration://redirect"
-            val migrationScopes = listOf("api", "migration_scope")
-
-            viewModel.generateMigrationAuthorizationPath(
-                server = TEST_ATTESTATION_SERVER,
-                migrationOAuthConfig = OAuthConfig(
-                    migrationConsumerKey,
-                    migrationRedirectUri,
-                    migrationScopes,
-                ),
-                sdkManager = sdkManager,
-            )
-        }
     }
 
     @Test
@@ -1581,59 +1457,6 @@ class LoginViewModelTest {
         val result = "https://www.example.com" // IETF-Reserved Test Domain
 
         assertEquals(result, viewModel.getValidServerUrl(value))
-    }
-
-    private fun createSdkManagerMockForAttestation(
-        appAttestationClient: AppAttestationClient?,
-    ): SalesforceSDKManager = mockk<SalesforceSDKManager>(relaxed = true).also { mock ->
-        every { mock.useHybridAuthentication } returns false
-        every { mock.isDebugBuild } returns false
-        every { mock.debugOverrideAppConfig } returns null
-        every { mock.appConfigForLoginHost } returns { _ -> null }
-        every { mock.appAttestationClient } returns appAttestationClient
-    }
-
-    private fun createMockAppAttestationClient(
-        attestation: String?,
-    ): AppAttestationClient = mockk<AppAttestationClient>(relaxed = true).also { client ->
-        coEvery { client.fetchMobileAppAttestationChallenge() } returns TEST_CHALLENGE_VALUE
-        coEvery {
-            client.createAppAttestation(appAttestationChallenge = TEST_CHALLENGE_VALUE)
-        } returns attestation
-    }
-
-    /**
-     * Creates a mock [AppAttestationClient] where
-     * [AppAttestationClient.fetchMobileAppAttestationChallenge] returns null,
-     * simulating the case where [AppAttestationClient.apiHostName] is null
-     * (Salesforce App Attestation is disabled for the current login server).
-     */
-    private fun createMockAppAttestationClientWithNullChallenge(): AppAttestationClient =
-        mockk<AppAttestationClient>(relaxed = true).also { client ->
-            coEvery { client.fetchMobileAppAttestationChallenge() } returns null
-        }
-
-    /**
-     * Helper to verify that attestation is omitted when fetchMobileAppAttestationChallenge returns null.
-     *
-     * @param urlGenerator Function that generates a URL string given a view model and SDK manager
-     */
-    private suspend fun verifyAttestationOmittedWhenChallengeIsNull(
-        urlGenerator: suspend (LoginViewModel, SalesforceSDKManager) -> String
-    ) {
-        val appAttestationClient = createMockAppAttestationClientWithNullChallenge()
-        val sdkManagerMock = createSdkManagerMockForAttestation(appAttestationClient = appAttestationClient)
-        val freshViewModel = LoginViewModel(bootConfig)
-
-        val url = urlGenerator(freshViewModel, sdkManagerMock)
-
-        assertFalse(
-            "URL should NOT contain an attestation parameter when challenge fetch returns null, but was '$url'.",
-            url.contains(ATTESTATION_QUERY_PARAM_PREFIX),
-        )
-        coVerify(exactly = 0) {
-            appAttestationClient.createAppAttestation(any())
-        }
     }
 
     private fun generateExpectedAuthorizationUrl(

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/TokenMigrationWebViewTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/TokenMigrationWebViewTest.kt
@@ -65,7 +65,7 @@ class TokenMigrationWebViewTest {
             every { authFinished } returns mutableStateOf(false)
             every { loadingIndicator } returns null
             every { oAuthConfig } returns mockOAuthConfig
-            every { useWebServerFlow } returns true
+            every { useWebServerFlow(any()) } returns true
         }
 
         // Wire up the factory so the activity's `by viewModels` delegate returns mockViewModel
@@ -148,7 +148,7 @@ class TokenMigrationWebViewTest {
         val mockResultCallback = createMockResultCallback()
         val clientManager = activity.TokenMigrationClientManager(mockResultCallback, "instanceServer")
 
-        every { mockViewModel.useWebServerFlow } returns true
+        every { mockViewModel.useWebServerFlow(any()) } returns true
 
         val mockRequest = createMockWebResourceRequest("testapp://oauth/callback?code=test_code")
         InstrumentationRegistry.getInstrumentation().runOnMainSync {


### PR DESCRIPTION
## Summary

- Enforce web server flow (PKCE + code exchange) when app attestation is configured (`appAttestationClient != null`), preventing the user-agent flow from being used with attestation
- Remove attestation parameter from the authorize URL in both `generateAuthorizationUrl()` and `generateMigrationAuthorizationPath()` — attestation is now only sent at the token endpoint
- Add new public `initNative(context, mainActivity, googleCloudProjectId)` overload so apps can enable attestation without subclassing `SalesforceSDKManager`

## Motivation

Supporting attestation on the authorize URL is problematic (e.g., if the instance URL was not configured/discovered, or first login for a beacon app). The server is removing attestation validation on the authorize call and replacing it with a check that denies entry if app attestation is required and the user-agent flow is being used. This client-side change enforces web server flow and removes attestation from the authorize URL to align with the new server behavior.

## Changes

| File | Change |
|------|--------|
| `LoginViewModel.kt` | Refactored `useWebServerFlow` from property to function with `sdkManager` param; added `appAttestationClient != null` condition; removed attestation code from both URL generation methods; removed `ATTESTATION` import |
| `LoginActivity.kt` | Updated call site to `useWebServerFlow()` |
| `OAuth2.java` | Updated Javadoc on `getAuthorizationUrl()` to remove attestation references from `addlParams` docs |
| `SalesforceSDKManager.kt` | Added `initNative` overload with `googleCloudProjectId`; added `@JvmOverloads` to secondary constructor for Java compatibility |
| `LoginViewModelTest.kt` | Removed 9 obsolete attestation-on-authorize-URL tests; added 7 `useWebServerFlow` condition-coverage tests; added `useWebServerAuthentication` stub to pre-existing non-relaxed mock test |
| `SalesforceSDKManagerTests.kt` | Added 2 tests for `initNative` with/without `googleCloudProjectId` |
| `TokenMigrationWebViewTest.kt` | Updated mocks for property→function change |

## Test plan

- [x] All 70 `LoginViewModelTest` tests pass
- [x] Both new `initNative` tests in `SalesforceSDKManagerTests` pass
- [x] Full branch coverage of `useWebServerFlow` (all 12 branches covered)
- [x] Full line coverage of new `initNative` overload
- [x] `TokenMigrationWebViewTest` compiles and mocks updated
- [ ] End-to-end login flow testing with attestation-enabled org (requires server-side rollout coordination)