### PR TITLE
[auto-generated] Fix CI: MockK kotlin-reflect alignment for API 28-32

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,4 +29,10 @@ allprojects {
             languageVersion = "1.6"
         }
     }
+
+    configurations.matching { it.name.contains("androidTest") }.configureEach {
+        resolutionStrategy {
+            force("org.jetbrains.kotlin:kotlin-reflect:1.9.24")
+        }
+    }
 }

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.arch.core:core-testing:2.2.0")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:$composeVersion")
-    androidTestImplementation("io.mockk:mockk-android:1.14.0") // Update requires Kotlin 2
+    androidTestImplementation("io.mockk:mockk-android:1.14.2")
 }
 
 android {


### PR DESCRIPTION
## Summary
- Bumps `mockk-android` from 1.14.0 to 1.14.2 for improved Android framework reflection handling
- Adds resolution strategy forcing `kotlin-reflect:1.9.24` (matching the Kotlin compiler version) for androidTest configurations only
- Fixes `ArrayIndexOutOfBoundsException` in `kotlin.reflect.jvm.internal.impl.descriptors.runtime` on API 31-32 and `NoClassDefFoundError: PictureInPictureUiState` on API 28-30 affecting 12+ test classes

## Root Cause
MockK 1.14.0's `JvmMockFactoryHelper.isKotlinInline()` scans method annotations via kotlin-reflect. On API 31-32, Android framework method stubs have stripped parameter annotation metadata (empty arrays from `getParameterAnnotations()`), causing the ArrayIndexOutOfBoundsException. On API 28-30, reflection encounters `Activity.onPictureInPictureUiStateChanged()` (added in API 31), causing NoClassDefFoundError.

## Test plan
- [ ] Verify Nightly Tests pass on API 28, 29, 30, 31, 32
- [ ] Verify no production behavior changes (resolution strategy scoped to androidTest only)
- [ ] Verify LoginServerManagerMockTest, ClientManagerMockTest, LoginActivityTest pass