### PR TITLE
Bump Android minSdk to 31

### DIFF
--- a/.github/workflows/reusable-lib-workflow.yaml
+++ b/.github/workflows/reusable-lib-workflow.yaml
@@ -127,8 +127,8 @@ jobs:
         if: success() || failure()
         env:
           # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          PR_API_VERSION: "35"
-          FULL_API_RANGE: "28 29 30 31 32 33 34 35 36"
+          PR_API_VERSION: "36"
+          FULL_API_RANGE: "31 32 33 34 35 36"
           IS_PR: ${{ inputs.is_pr }}
           LIB: ${{ inputs.lib }}
           RUN_NUMBER: ${{ github.run_number }}
@@ -180,8 +180,8 @@ jobs:
         if: success() || failure()
         env:
           # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          PR_API_VERSION: "35"
-          FULL_API_RANGE: "28 29 30 31 32 33 34 35 36"
+          PR_API_VERSION: "36"
+          FULL_API_RANGE: "31 32 33 34 35 36"
           IS_PR: ${{ inputs.is_pr }}
           LIB: ${{ inputs.lib }}
           RUN_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ inputs.is_pr }}
         env:
           # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          PR_API_VERSION: "35"
+          PR_API_VERSION: "36"
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           GCLOUD_RESULTS_DIR="authflowtester-pr-build-${RUN_NUMBER}"
@@ -122,7 +122,7 @@ jobs:
         continue-on-error: true
         if: ${{ ! inputs.is_pr }}
         env:
-          FULL_API_RANGE: "28 29 30 31 32 33 34 35 36"
+          FULL_API_RANGE: "31 32 33 34 35 36"
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           GCLOUD_RESULTS_DIR="authflowtester-single-user-build-${RUN_NUMBER}"
@@ -150,7 +150,7 @@ jobs:
         continue-on-error: true
         if: ${{ ! inputs.is_pr }}
         env:
-          FULL_API_RANGE: "28 29 30 31 32 33 34 35 36"
+          FULL_API_RANGE: "31 32 33 34 35 36"
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           GCLOUD_RESULTS_DIR="authflowtester-multi-user-build-${RUN_NUMBER}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ SalesforceHybrid
 - [Android Javadoc](https://forcedotcom.github.io/SalesforceMobileSDK-Android/index.html)
 
 ### Android Build Details
-- **Minimum SDK**: 28 (Android 9.0)
+- **Minimum SDK**: 31 (Android 12)
 - **Compile SDK**: 35 (Android 15.0)
 - **Target SDK**: Follows compileSdk
 - **Build system**: Gradle 8.14.3 with Kotlin DSL (`.gradle.kts` files)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 cdvCompileSdkVersion=35
-cdvMinSdkVersion=28
+cdvMinSdkVersion=31
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false

--- a/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
+++ b/hybrid/HybridSampleApps/AccountEditor/build.gradle.kts
@@ -15,7 +15,7 @@ android { // TODO: This cannot be resolved until newDSL=true
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     sourceSets {

--- a/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
+++ b/hybrid/HybridSampleApps/MobileSyncExplorerHybrid/build.gradle.kts
@@ -15,7 +15,7 @@ android { // TODO: This cannot be resolved until newDSL=true
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     sourceSets {

--- a/libs/MobileSync/build.gradle.kts
+++ b/libs/MobileSync/build.gradle.kts
@@ -28,7 +28,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/libs/SalesforceAnalytics/build.gradle.kts
+++ b/libs/SalesforceAnalytics/build.gradle.kts
@@ -27,7 +27,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
     }
 
     buildTypes {

--- a/libs/SalesforceHybrid/build.gradle.kts
+++ b/libs/SalesforceHybrid/build.gradle.kts
@@ -33,7 +33,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
     }
 
     buildTypes {

--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -6,7 +6,6 @@
 	android:versionName="14.0.0.dev">
 
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 

--- a/libs/SalesforceSDK/build.gradle.kts
+++ b/libs/SalesforceSDK/build.gradle.kts
@@ -65,7 +65,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -42,9 +42,7 @@ import android.content.res.Configuration.UI_MODE_NIGHT_MASK
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.os.Build.MODEL
 import android.os.Build.VERSION.RELEASE
-import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION.SECURITY_PATCH
-import android.os.Build.VERSION_CODES.R
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper.getMainLooper
@@ -52,8 +50,6 @@ import android.provider.Settings.Secure.ANDROID_ID
 import android.provider.Settings.Secure.getString
 import android.text.TextUtils.isEmpty
 import android.text.TextUtils.join
-import android.view.View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-import android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
 import android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
 import android.webkit.CookieManager
 import android.webkit.URLUtil.isHttpsUrl
@@ -1624,16 +1620,11 @@ open class SalesforceSDKManager protected constructor(
              * This covers the case where OS dark theme is true, but app has
              * disabled.
              */
-            if (SDK_INT > R) {
-                runCatching {
-                    activity.window?.insetsController?.setSystemBarsAppearance(
-                        APPEARANCE_LIGHT_STATUS_BARS,
-                        APPEARANCE_LIGHT_STATUS_BARS
-                    )
-                }
-            } else {
-                // TODO: Remove with minimum API >= 30
-                activity.window?.decorView?.systemUiVisibility = SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR or SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            runCatching {
+                activity.window?.insetsController?.setSystemBarsAppearance(
+                    APPEARANCE_LIGHT_STATUS_BARS,
+                    APPEARANCE_LIGHT_STATUS_BARS
+                )
             }
         }
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -32,9 +32,6 @@ import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
 import android.content.pm.PackageManager.FEATURE_FACE
 import android.content.pm.PackageManager.FEATURE_IRIS
 import android.net.Uri
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.Q
-import android.os.Build.VERSION_CODES.R
 import android.os.Bundle
 import android.util.Base64.NO_PADDING
 import android.util.Base64.NO_WRAP
@@ -43,7 +40,6 @@ import android.util.Base64.encodeToString
 import android.util.Patterns.EMAIL_ADDRESS
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS
 import androidx.biometric.BiometricPrompt
@@ -954,22 +950,15 @@ internal class NativeLoginManager(
             return false
         }
 
-        // TODO: Remove when min API > 29.
-        val authenticators = when {
-            SDK_INT >= R -> BIOMETRIC_STRONG or DEVICE_CREDENTIAL
-            else -> BIOMETRIC_WEAK or DEVICE_CREDENTIAL
-        }
+        val authenticators = BIOMETRIC_STRONG or DEVICE_CREDENTIAL
 
         if (biometricManager.canAuthenticate(authenticators) != BIOMETRIC_SUCCESS) {
             return false
         }
 
         val username = accountManager.currentUser?.username ?: ""
-        var hasFaceUnlock = false
-        if (SDK_INT >= Q) {
-            hasFaceUnlock = activity.packageManager.hasSystemFeature(FEATURE_FACE)
-                    || activity.packageManager.hasSystemFeature(FEATURE_IRIS)
-        }
+        val hasFaceUnlock = activity.packageManager.hasSystemFeature(FEATURE_FACE)
+                || activity.packageManager.hasSystemFeature(FEATURE_IRIS)
 
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle(activity.resources.getString(sf__biometric_opt_in_title))

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -32,7 +32,6 @@ import android.accounts.AccountAuthenticatorResponse
 import android.accounts.AccountManager.ERROR_CODE_CANCELED
 import android.accounts.AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE
 import android.annotation.SuppressLint
-import android.app.admin.DevicePolicyManager.ACTION_SET_NEW_PASSWORD
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
@@ -47,8 +46,6 @@ import android.net.http.SslError.SSL_IDMISMATCH
 import android.net.http.SslError.SSL_NOTYETVALID
 import android.net.http.SslError.SSL_UNTRUSTED
 import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.Q
-import android.os.Build.VERSION_CODES.R
 import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Bundle
 import android.provider.Settings.ACTION_BIOMETRIC_ENROLL
@@ -81,7 +78,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.Companion.PROTECTED
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.biometric.BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
 import androidx.biometric.BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
@@ -673,31 +669,17 @@ open class LoginActivity : FragmentActivity() {
             }
 
             BIOMETRIC_ERROR_HW_UNAVAILABLE, BIOMETRIC_ERROR_NONE_ENROLLED -> {
-                /*
-                 * Prompts the user to setup OS screen lock and biometric
-                 * TODO: Remove when min API > 29
-                 */
-                when {
-                    SDK_INT >= R -> viewModel.biometricAuthenticationButtonAction.value = {
-                        startActivityForResult(
-                            Intent(
-                                ACTION_BIOMETRIC_ENROLL
-                            ).apply {
-                                putExtra(
-                                    EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
-                                    authenticators
-                                )
-                            },
-                            SETUP_REQUEST_CODE
-                        )
-                    }
-
-                    else -> viewModel.biometricAuthenticationButtonAction.value = {
-                        startActivityForResult(
-                            Intent(ACTION_SET_NEW_PASSWORD),
-                            SETUP_REQUEST_CODE
-                        )
-                    }
+                // Prompts the user to setup OS screen lock and biometric
+                viewModel.biometricAuthenticationButtonAction.value = {
+                    startActivityForResult(
+                        Intent(ACTION_BIOMETRIC_ENROLL).apply {
+                            putExtra(
+                                EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED,
+                                authenticators
+                            )
+                        },
+                        SETUP_REQUEST_CODE
+                    )
                 }
                 viewModel.biometricAuthenticationButtonText.intValue = sf__setup_biometric_unlock
             }
@@ -740,22 +722,15 @@ open class LoginActivity : FragmentActivity() {
     }
 
     private val authenticators
-        get() = // TODO: Remove when min API > 29.
-            when {
-                SDK_INT >= R -> BIOMETRIC_STRONG or DEVICE_CREDENTIAL
-                else -> BIOMETRIC_WEAK or DEVICE_CREDENTIAL
-            }
+        get() = BIOMETRIC_STRONG or DEVICE_CREDENTIAL
 
     private val promptInfo: PromptInfo
         get() {
-            var hasFaceUnlock = false
-            if (SDK_INT >= Q) {
-                hasFaceUnlock = packageManager.hasSystemFeature(
-                    FEATURE_FACE
-                ) || packageManager.hasSystemFeature(
-                    FEATURE_IRIS
-                )
-            }
+            val hasFaceUnlock = packageManager.hasSystemFeature(
+                FEATURE_FACE
+            ) || packageManager.hasSystemFeature(
+                FEATURE_IRIS
+            )
             val subtitle = SalesforceSDKManager.getInstance().userAccountManager.currentUser?.username ?: ""
 
             return PromptInfo.Builder()

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockActivity.kt
@@ -26,7 +26,6 @@
  */
 package com.salesforce.androidsdk.ui
 
-import android.app.admin.DevicePolicyManager.ACTION_SET_NEW_PASSWORD
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -221,16 +220,12 @@ class ScreenLockActivity : FragmentActivity() {
      * @param biometricSetupActivityResultLauncher The activity result launcher
      * to use for biometric setup. This parameter is intended for testing
      * purposes only.  Defaults to the biometric setup activity result launcher
-     * @param sdkConfiguration The Android SDK configuration. This parameter is
-     * intended for testing purposes only. Defaults to the current Android SDK
-     * build
      */
     @VisibleForTesting
     internal fun presentBiometricAuthentication(
         biometricManager: BiometricManager = BiometricManager.from(this),
         biometricPrompt: BiometricPrompt = getBiometricPrompt(),
         biometricSetupActivityResultLauncher: ActivityResultLauncher<Intent> = this.biometricSetupActivityResultLauncher,
-        sdkConfiguration: AndroidSdkConfiguration = AndroidSdkConfiguration,
     ) {
         when (biometricManager.canAuthenticate(viewModel.biometricAuthenticators())) {
             BIOMETRIC_ERROR_NO_HARDWARE, BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED, BIOMETRIC_ERROR_UNSUPPORTED, BIOMETRIC_STATUS_UNKNOWN -> {
@@ -245,16 +240,10 @@ class ScreenLockActivity : FragmentActivity() {
                 setErrorMessage(getString(sf__screen_lock_setup_required, viewModel.appName()))
 
                 // Prompts the user to set up the operating system screen lock and biometrics.
-                if (sdkConfiguration.isR) { // TODO: Remove when min API > 29.
-                    viewModel.setupButtonAction.value = {
-                        biometricSetupActivityResultLauncher.launch(Intent(ACTION_BIOMETRIC_ENROLL).apply {
-                            putExtra(EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED, viewModel.biometricAuthenticators())
-                        })
-                    }
-                } else {
-                    viewModel.setupButtonAction.value = {
-                        biometricSetupActivityResultLauncher.launch(Intent(ACTION_SET_NEW_PASSWORD))
-                    }
+                viewModel.setupButtonAction.value = {
+                    biometricSetupActivityResultLauncher.launch(Intent(ACTION_BIOMETRIC_ENROLL).apply {
+                        putExtra(EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED, viewModel.biometricAuthenticators())
+                    })
                 }
                 viewModel.setupButtonLabel.value = getString(sf__screen_lock_setup_button)
                 viewModel.setupButtonVisible.value = true
@@ -272,20 +261,13 @@ class ScreenLockActivity : FragmentActivity() {
      * @param packageManager The package manager to use for authentication.
      * This parameter is intended for testing purposes only. Defaults to the
      * current package manager
-     * @param sdkConfiguration The Android SDK configuration. This parameter is
-     * intended for testing purposes only. Defaults to the current Android SDK
-     * build
      */
     @VisibleForTesting
     internal fun getBiometricPromptInfo(
         packageManager: PackageManager = this.packageManager,
-        sdkConfiguration: AndroidSdkConfiguration = AndroidSdkConfiguration,
     ): PromptInfo {
-        val hasFaceUnlock = if (sdkConfiguration.isQ) { // TODO: Remove when min API > 28.
-            packageManager.hasSystemFeature(FEATURE_FACE) || (packageManager.hasSystemFeature(FEATURE_IRIS))
-        } else {
-            false
-        }
+        val hasFaceUnlock = packageManager.hasSystemFeature(FEATURE_FACE)
+                || packageManager.hasSystemFeature(FEATURE_IRIS)
 
         return PromptInfo.Builder()
             .setTitle(getString(sf__screen_lock_title, viewModel.appName()))
@@ -341,21 +323,16 @@ class ScreenLockActivity : FragmentActivity() {
      * @param screenLockManager The screen lock manager to use for
      * authentication. This parameter is intended for testing purposes only.
      * Defaults to the current screen lock manager
-     * @param sdkConfiguration The Android SDK configuration. This parameter is
-     * intended for testing purposes only. Defaults to the current Android SDK
-     * build
      */
     @VisibleForTesting
     internal fun finishSuccess(
         accessibilityManager: AccessibilityManager = getSystemService(ACCESSIBILITY_SERVICE) as AccessibilityManager,
         screenLockManager: ScreenLockManager? = getInstance().screenLockManager as ScreenLockManager?,
-        sdkConfiguration: AndroidSdkConfiguration = AndroidSdkConfiguration,
     ) {
         resetUI()
         sendAccessibilityEvent(
             accessibilityManager = accessibilityManager,
             eventText = getString(sf__screen_lock_auth_success),
-            sdkConfiguration = sdkConfiguration,
         )
         screenLockManager?.onUnlock()
         finish()
@@ -417,30 +394,18 @@ class ScreenLockActivity : FragmentActivity() {
      * the event. This parameter is intended for testing purposes only. Defaults
      * to the current accessibility manager
      * @param eventText The event text
-     * @param sdkConfiguration The Android SDK configuration. This parameter is
-     * intended for testing purposes only. Defaults to the current Android SDK
-     * build
      */
     @VisibleForTesting
     internal fun sendAccessibilityEvent(
         accessibilityManager: AccessibilityManager = getSystemService(ACCESSIBILITY_SERVICE) as AccessibilityManager,
         eventText: String?,
-        sdkConfiguration: AndroidSdkConfiguration = AndroidSdkConfiguration,
     ) {
         if (accessibilityManager.isEnabled) {
             accessibilityManager.sendAccessibilityEvent(
-                if (sdkConfiguration.isR) {
-                    AccessibilityEvent()
-                } else {
-                    // TODO: Remove when min API > 29.
-                    @Suppress("DEPRECATION")
-                    AccessibilityEvent.obtain()
-                }.apply {
+                AccessibilityEvent().apply {
                     setEventType(TYPE_WINDOW_STATE_CHANGED)
                     setClassName(this@ScreenLockActivity.javaClass.getName())
-                    if (sdkConfiguration.isS) {
-                        setPackageName(this@ScreenLockActivity::javaClass.get().packageName)
-                    }
+                    setPackageName(this@ScreenLockActivity::javaClass.get().packageName)
                     text.add(eventText)
                 })
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ScreenLockViewModel.kt
@@ -26,10 +26,7 @@
  */
 package com.salesforce.androidsdk.ui
 
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.R
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -83,16 +80,8 @@ internal class ScreenLockViewModel() : ViewModel() {
 
     /**
      * Returns the biometric authenticators to use.
-     * @param build The Android SDK build. This parameter is intended for
-     * testing purposes only. Defaults to the current Android SDK build
      */
-    fun biometricAuthenticators(
-        build: Int = SDK_INT,
-    ) = if (build >= R) {
-        BIOMETRIC_STRONG or DEVICE_CREDENTIAL
-    } else {
-        BIOMETRIC_WEAK or DEVICE_CREDENTIAL
-    }
+    fun biometricAuthenticators() = BIOMETRIC_STRONG or DEVICE_CREDENTIAL
 
     // endregion
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/UserInterfaceConstants.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/UserInterfaceConstants.kt
@@ -27,10 +27,6 @@
 package com.salesforce.androidsdk.ui
 
 import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.P
-import android.os.Build.VERSION_CODES.Q
-import android.os.Build.VERSION_CODES.R
-import android.os.Build.VERSION_CODES.S
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.annotation.ChecksSdkIntAtLeast
 
@@ -46,21 +42,6 @@ internal fun noOp() {}
  * The Android SDK configuration.
  */
 object AndroidSdkConfiguration {
-
-    @get:ChecksSdkIntAtLeast(api = P)
-    val isP = true
-
-    @get:ChecksSdkIntAtLeast(api = Q)
-    val isQ
-        get() = SDK_INT >= Q
-
-    @get:ChecksSdkIntAtLeast(api = R)
-    val isR
-        get() = SDK_INT >= R
-
-    @get:ChecksSdkIntAtLeast(api = S)
-    val isS
-        get() = SDK_INT >= S
 
     @get:ChecksSdkIntAtLeast(api = TIRAMISU)
     val isTiramisu

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -29,7 +29,6 @@ package com.salesforce.androidsdk.ui.components
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.res.Configuration
-import android.os.Build
 import android.webkit.WebView
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
@@ -517,12 +516,7 @@ private tailrec fun Context.getActivity(): FragmentActivity? = when (this) {
 
 @Composable
 internal fun Modifier.applyImePaddingConditionally() : Modifier =
-    // TODO:  Remove when min API is > 29
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        windowInsetsPadding(WindowInsets.ime)
-    } else {
-        this
-    }
+    windowInsetsPadding(WindowInsets.ime)
 
 @ExcludeFromJacocoGeneratedReport
 @Preview // Note: the light and dark previews should look the same.

--- a/libs/SmartStore/build.gradle.kts
+++ b/libs/SmartStore/build.gradle.kts
@@ -31,7 +31,7 @@ android { // TODO: This cannot be resolved until newDSL=true
     compileSdk = 36 // TODO: MSDK 14 will remain on 36.  The next increment will be in MSDK 15.
 
     defaultConfig {
-        minSdk = 28
+        minSdk = 31
         consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/libs/test/MobileSyncTest/AndroidManifest.xml
+++ b/libs/test/MobileSyncTest/AndroidManifest.xml
@@ -17,6 +17,4 @@
             </intent-filter>
         </activity>
 	</application>
-
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
+++ b/libs/test/SalesforceAnalyticsTest/AndroidManifest.xml
@@ -2,5 +2,4 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<application />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/libs/test/SalesforceHybridTest/AndroidManifest.xml
+++ b/libs/test/SalesforceHybridTest/AndroidManifest.xml
@@ -20,6 +20,4 @@
             </intent-filter>
         </activity>
     </application>
-
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/libs/test/SalesforceSDKTest/AndroidManifest.xml
+++ b/libs/test/SalesforceSDKTest/AndroidManifest.xml
@@ -32,6 +32,4 @@
             </intent-filter>
         </activity>
 	</application>
-
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/ScreenLockViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/ScreenLockViewModelTest.kt
@@ -26,10 +26,7 @@
  */
 package com.salesforce.androidsdk.auth
 
-import android.os.Build.VERSION_CODES.Q
-import android.os.Build.VERSION_CODES.R
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.salesforce.androidsdk.app.SalesforceSDKManager
@@ -59,14 +56,8 @@ class ScreenLockViewModelTest {
     }
 
     @Test
-    fun viewModel_biometricAuthenticators_updatesOn_api30Plus() {
-        val biometricAuthenticators = viewModel.biometricAuthenticators(R)
+    fun viewModel_biometricAuthenticators_returnsStrongOrDeviceCredential() {
+        val biometricAuthenticators = viewModel.biometricAuthenticators()
         assertEquals(BIOMETRIC_STRONG or DEVICE_CREDENTIAL, biometricAuthenticators)
-    }
-
-    @Test
-    fun viewModel_biometricAuthenticators_updatesOn_api29Minus() {
-        val biometricAuthenticators = viewModel.biometricAuthenticators(Q)
-        assertEquals(BIOMETRIC_WEAK or DEVICE_CREDENTIAL, biometricAuthenticators)
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/BiometricAuthenticationCallbackTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/BiometricAuthenticationCallbackTest.kt
@@ -85,7 +85,6 @@ class BiometricAuthenticationCallbackTest {
             activity.finishSuccess(
                 accessibilityManager = any(),
                 screenLockManager = any(),
-                sdkConfiguration = any(),
             )
         }
     }
@@ -108,7 +107,6 @@ class BiometricAuthenticationCallbackTest {
             activity.sendAccessibilityEvent(
                 accessibilityManager = any(),
                 eventText = capture(sendAccessibilityCapturingSlot),
-                sdkConfiguration = any(),
             )
         }
         assertTrue(sendAccessibilityCapturingSlot.captured.contains(activity.getString(sf__screen_lock_auth_failed)))

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/ScreenLockActivityScenarioTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/ScreenLockActivityScenarioTest.kt
@@ -27,7 +27,6 @@
 package com.salesforce.androidsdk.ui
 
 import android.R.attr.windowLightStatusBar
-import android.app.admin.DevicePolicyManager.ACTION_SET_NEW_PASSWORD
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
@@ -133,7 +132,7 @@ class ScreenLockActivityScenarioTest {
                 val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
                 every { sdkManager.isDarkTheme } returns false
 
-                activity.create(sdkConfiguration = AndroidSdkConfigurationS, sdkManager = sdkManager)
+                activity.create(sdkConfiguration = AndroidSdkConfigurationPreTiramisu, sdkManager = sdkManager)
 
                 assertTrue(activity.window.attributes.flags and FLAG_SECURE != 0)
 
@@ -386,7 +385,7 @@ class ScreenLockActivityScenarioTest {
     }
 
     @Test
-    fun screenLockActivity_presentsEnrollment_whenBiometricManagerCannotAuthenticateNoneEnrolled_api30Plus() {
+    fun screenLockActivity_presentsEnrollment_whenBiometricManagerCannotAuthenticateNoneEnrolled() {
         launch<ScreenLockActivity>(
             Intent(
                 getApplicationContext(),
@@ -406,7 +405,6 @@ class ScreenLockActivityScenarioTest {
                     biometricManager = biometricManager,
                     biometricPrompt = biometricPrompt,
                     biometricSetupActivityResultLauncher = biometricSetupActivityResultLauncher,
-                    sdkConfiguration = AndroidSdkConfigurationR,
                 )
                 activity.viewModel.setupButtonAction.value()
 
@@ -420,43 +418,7 @@ class ScreenLockActivityScenarioTest {
     }
 
     @Test
-    fun screenLockActivity_presentsEnrollment_whenBiometricManagerCannotAuthenticateNoneEnrolled_api29Minus() {
-        launch<ScreenLockActivity>(
-            Intent(
-                getApplicationContext(),
-                ScreenLockActivity::class.java,
-            )
-        ).use { activityScenario ->
-
-            activityScenario.onActivity { activity ->
-
-                val biometricManager = mockk<BiometricManager>(relaxed = true)
-                every { biometricManager.canAuthenticate(any()) } returns BIOMETRIC_ERROR_NONE_ENROLLED
-                val biometricPrompt = mockk<BiometricPrompt>(relaxed = true)
-                val biometricSetupActivityResultLauncher = mockk<ActivityResultLauncher<Intent>>(relaxed = true)
-                val intent = slot<Intent>()
-
-                activity.presentBiometricAuthentication(
-                    biometricManager = biometricManager,
-                    biometricPrompt = biometricPrompt,
-                    biometricSetupActivityResultLauncher = biometricSetupActivityResultLauncher,
-                    sdkConfiguration = AndroidSdkConfigurationQ,
-                )
-                activity.viewModel.setupButtonAction.value()
-
-                assertEquals(activity.getString(sf__screen_lock_setup_required, activity.viewModel.appName()), activity.viewModel.setupMessageText.value)
-                verify(exactly = 1) { biometricSetupActivityResultLauncher.launch(capture(intent)) }
-                assertEquals(ACTION_SET_NEW_PASSWORD, intent.captured.action)
-                assertEquals(-1, intent.captured.getIntExtra(EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED, -1))
-                assertEquals(activity.getString(sf__screen_lock_setup_button), activity.viewModel.setupButtonLabel.value)
-                assertTrue(activity.viewModel.setupButtonVisible.value)
-                verify(exactly = 0) { biometricPrompt.authenticate(any()) }
-            }
-        }
-    }
-
-    @Test
-    fun screenLockActivity_getBiometricPromptInfoWithoutFeatures_returnsBiometricPromptInfoWithoutConfirmation_api29Plus() {
+    fun screenLockActivity_getBiometricPromptInfoWithoutFeatures_returnsBiometricPromptInfoWithoutConfirmation() {
         launch<ScreenLockActivity>(
             Intent(
                 getApplicationContext(),
@@ -471,7 +433,6 @@ class ScreenLockActivityScenarioTest {
                 every { packageManager.hasSystemFeature(FEATURE_IRIS) } returns false
                 val result = activity.getBiometricPromptInfo(
                     packageManager = packageManager,
-                    sdkConfiguration = AndroidSdkConfigurationQ,
                 )
                 assertEquals(activity.getString(sf__screen_lock_title, activity.viewModel.appName()), result.title)
                 assertEquals(activity.getString(sf__screen_lock_subtitle, activity.viewModel.appName()), result.subtitle)
@@ -482,7 +443,7 @@ class ScreenLockActivityScenarioTest {
     }
 
     @Test
-    fun screenLockActivity_getBiometricPromptInfoWithoutFaceFeature_returnsBiometricPromptInfoWithConfirmation_api29Plus() {
+    fun screenLockActivity_getBiometricPromptInfoWithoutFaceFeature_returnsBiometricPromptInfoWithConfirmation() {
         launch<ScreenLockActivity>(
             Intent(
                 getApplicationContext(),
@@ -497,7 +458,6 @@ class ScreenLockActivityScenarioTest {
                 every { packageManager.hasSystemFeature(FEATURE_IRIS) } returns false
                 val result = activity.getBiometricPromptInfo(
                     packageManager = packageManager,
-                    sdkConfiguration = AndroidSdkConfigurationQ,
                 )
                 assertEquals(activity.getString(sf__screen_lock_title, activity.viewModel.appName()), result.title)
                 assertEquals(activity.getString(sf__screen_lock_subtitle, activity.viewModel.appName()), result.subtitle)
@@ -508,7 +468,7 @@ class ScreenLockActivityScenarioTest {
     }
 
     @Test
-    fun screenLockActivity_getBiometricPromptInfoWithoutIrisFeature_returnsBiometricPromptInfoWithConfirmation_api29Plus() {
+    fun screenLockActivity_getBiometricPromptInfoWithoutIrisFeature_returnsBiometricPromptInfoWithConfirmation() {
         launch<ScreenLockActivity>(
             Intent(
                 getApplicationContext(),
@@ -523,7 +483,6 @@ class ScreenLockActivityScenarioTest {
                 every { packageManager.hasSystemFeature(FEATURE_IRIS) } returns true
                 val result = activity.getBiometricPromptInfo(
                     packageManager = packageManager,
-                    sdkConfiguration = AndroidSdkConfigurationQ,
                 )
                 assertEquals(activity.getString(sf__screen_lock_title, activity.viewModel.appName()), result.title)
                 assertEquals(activity.getString(sf__screen_lock_subtitle, activity.viewModel.appName()), result.subtitle)
@@ -534,7 +493,7 @@ class ScreenLockActivityScenarioTest {
     }
 
     @Test
-    fun screenLockActivity_getBiometricPromptInfoWithFeatures_returnsBiometricPromptInfoWithConfirmation_api29Plus() {
+    fun screenLockActivity_getBiometricPromptInfoWithFeatures_returnsBiometricPromptInfoWithConfirmation() {
         launch<ScreenLockActivity>(
             Intent(
                 getApplicationContext(),
@@ -549,39 +508,11 @@ class ScreenLockActivityScenarioTest {
                 every { packageManager.hasSystemFeature(FEATURE_IRIS) } returns true
                 val result = activity.getBiometricPromptInfo(
                     packageManager = packageManager,
-                    sdkConfiguration = AndroidSdkConfigurationQ,
                 )
                 assertEquals(activity.getString(sf__screen_lock_title, activity.viewModel.appName()), result.title)
                 assertEquals(activity.getString(sf__screen_lock_subtitle, activity.viewModel.appName()), result.subtitle)
                 assertEquals(activity.viewModel.biometricAuthenticators(), result.allowedAuthenticators)
                 assertTrue(result.isConfirmationRequired)
-            }
-        }
-    }
-
-    @Test
-    fun screenLockActivity_getBiometricPromptInfo_returnsBiometricPromptInfoWithoutConfirmation_api28Minus() {
-
-        launch<ScreenLockActivity>(
-            Intent(
-                getApplicationContext(),
-                ScreenLockActivity::class.java,
-            )
-        ).use { activityScenario ->
-
-            activityScenario.onActivity { activity ->
-
-                val packageManager = mockk<PackageManager>(relaxed = true)
-                every { packageManager.hasSystemFeature(FEATURE_FACE) } returns true
-                every { packageManager.hasSystemFeature(FEATURE_IRIS) } returns true
-                val result = activity.getBiometricPromptInfo(
-                    packageManager = packageManager,
-                    sdkConfiguration = AndroidSdkConfigurationP,
-                )
-                assertEquals(activity.getString(sf__screen_lock_title, activity.viewModel.appName()), result.title)
-                assertEquals(activity.getString(sf__screen_lock_subtitle, activity.viewModel.appName()), result.subtitle)
-                assertEquals(activity.viewModel.biometricAuthenticators(), result.allowedAuthenticators)
-                assertFalse(result.isConfirmationRequired)
             }
         }
     }
@@ -714,42 +645,6 @@ class ScreenLockActivityScenarioTest {
     }
 
     @Test
-    fun screenLockActivity_finishSuccess_sendsAccessibilityEvent_api29Minus() {
-        launch<ScreenLockActivity>(
-            Intent(
-                getApplicationContext(),
-                ScreenLockActivity::class.java,
-            )
-        ).use { activityScenario ->
-
-            activityScenario.onActivity { activity ->
-
-                val accessibilityManager = mockk<AccessibilityManager>(relaxed = true)
-                every { accessibilityManager.isEnabled } returns true
-                val capturingSlot = slot<AccessibilityEvent>()
-                val screenLockManager = mockk<ScreenLockManager>(relaxed = true)
-                activity.finishSuccess(
-                    accessibilityManager = accessibilityManager,
-                    screenLockManager = screenLockManager,
-                    sdkConfiguration = AndroidSdkConfigurationQ
-                )
-
-                verify(exactly = 1) { accessibilityManager.sendAccessibilityEvent(capture(capturingSlot)) }
-                assertTrue(capturingSlot.captured.text.toString().contains(activity.getString(sf__screen_lock_auth_success)))
-                assertEquals(TYPE_WINDOW_STATE_CHANGED, capturingSlot.captured.eventType)
-                assertEquals(ScreenLockActivity::class.java.name, capturingSlot.captured.className)
-                assertEquals(null, capturingSlot.captured.packageName)
-
-                verify(exactly = 1) { screenLockManager.onUnlock() }
-
-                assertFalse(activity.viewModel.logoutButtonVisible.value)
-                assertFalse(activity.viewModel.setupButtonVisible.value)
-                assertFalse(activity.viewModel.setupMessageVisible.value)
-            }
-        }
-    }
-
-    @Test
     fun screenLockActivity_logoutScreenLockUsers_logsOutUsers() {
         launch<ScreenLockActivity>(
             Intent(
@@ -869,34 +764,6 @@ class ScreenLockActivityScenarioTest {
     }
 }
 
-val AndroidSdkConfigurationP = mockk<AndroidSdkConfiguration>().apply {
-    every { isP } returns true
-    every { isQ } returns false
-    every { isR } returns false
-    every { isS } returns false
-    every { isTiramisu } returns false
-}
-
-val AndroidSdkConfigurationQ = mockk<AndroidSdkConfiguration>().apply {
-    every { isP } returns true
-    every { isQ } returns true
-    every { isR } returns false
-    every { isS } returns false
-    every { isTiramisu } returns false
-}
-
-val AndroidSdkConfigurationR = mockk<AndroidSdkConfiguration>().apply {
-    every { isP } returns true
-    every { isQ } returns true
-    every { isR } returns true
-    every { isS } returns false
-    every { isTiramisu } returns false
-}
-
-val AndroidSdkConfigurationS = mockk<AndroidSdkConfiguration>().apply {
-    every { isP } returns true
-    every { isQ } returns true
-    every { isR } returns true
-    every { isS } returns true
+val AndroidSdkConfigurationPreTiramisu = mockk<AndroidSdkConfiguration>().apply {
     every { isTiramisu } returns false
 }

--- a/libs/test/SmartStoreTest/AndroidManifest.xml
+++ b/libs/test/SmartStoreTest/AndroidManifest.xml
@@ -17,6 +17,4 @@
             </intent-filter>
         </activity>
 	</application>
-
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/native/NativeSampleApps/AppConfigurator/build.gradle.kts
+++ b/native/NativeSampleApps/AppConfigurator/build.gradle.kts
@@ -15,7 +15,7 @@ android { // TODO: This cannot be resolved until newDSL=true
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     sourceSets {

--- a/native/NativeSampleApps/AuthFlowTester/build.gradle.kts
+++ b/native/NativeSampleApps/AuthFlowTester/build.gradle.kts
@@ -51,7 +51,7 @@ android { // TODO: This cannot be resolved until newDSL=true
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
@@ -32,7 +32,6 @@ import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.IntentFilter
 import android.content.res.Configuration
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.ScrollView
@@ -40,7 +39,6 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -874,22 +872,14 @@ class AuthFlowTesterActivity : SalesforceActivity() {
     @Composable
     fun getColorScheme(): ColorScheme {
         return with(SalesforceSDKManager.getInstance()) {
-            when {
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-                    if (isDarkTheme) {
-                        dynamicDarkColorScheme(this@AuthFlowTesterActivity)
-                    } else {
-                        dynamicLightColorScheme(this@AuthFlowTesterActivity)
-                    }
-                }
-                else -> {
-                    if (isDarkTheme) sfDarkColors() else sfLightColors()
-                }
+            if (isDarkTheme) {
+                dynamicDarkColorScheme(this@AuthFlowTesterActivity)
+            } else {
+                dynamicLightColorScheme(this@AuthFlowTesterActivity)
             }
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
     @ExcludeFromJacocoGeneratedReport
     @Preview
     @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
@@ -905,7 +895,6 @@ class AuthFlowTesterActivity : SalesforceActivity() {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
     @ExcludeFromJacocoGeneratedReport
     @Preview
     @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
@@ -928,7 +917,6 @@ class AuthFlowTesterActivity : SalesforceActivity() {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
     @ExcludeFromJacocoGeneratedReport
     @Preview
     @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
@@ -996,7 +984,6 @@ class AuthFlowTesterActivity : SalesforceActivity() {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.S)
     @ExcludeFromJacocoGeneratedReport
     @Preview
     @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/BaseComponents.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/BaseComponents.kt
@@ -30,8 +30,6 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.res.Configuration
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.foundation.clickable
@@ -354,7 +352,6 @@ private fun copyToClipboard(context: Context, title: String, text: String) {
     clipboard.setPrimaryClip(clip)
 }
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)
@@ -370,7 +367,6 @@ private fun InfoRowViewPreview() {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)
@@ -386,7 +382,6 @@ private fun InfoRowViewSensitivePreview() {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)
@@ -421,7 +416,6 @@ private fun InfoRowSectionFallbackThemePreview() {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)
@@ -460,7 +454,6 @@ private fun UserCredentialsViewFallbackThemePreview() {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/JwtTokenView.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/JwtTokenView.kt
@@ -28,8 +28,6 @@
 package com.salesforce.samples.authflowtester.components
 
 import android.content.res.Configuration
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -131,7 +129,6 @@ private fun generateJwtJSON(jwtToken: JwtAccessToken?): String {
 }
 
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/OAuthConfigurationView.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/OAuthConfigurationView.kt
@@ -28,8 +28,6 @@
 package com.salesforce.samples.authflowtester.components
 
 import android.content.res.Configuration
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -96,7 +94,6 @@ private fun generateConfigJSON(
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/UserCredentialsView.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/UserCredentialsView.kt
@@ -28,8 +28,6 @@
 package com.salesforce.samples.authflowtester.components
 
 import android.content.res.Configuration
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -257,7 +255,6 @@ private fun generateCredentialsJSON(user: UserAccount?): String {
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.S)
 @ExcludeFromJacocoGeneratedReport
 @Preview(showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true, backgroundColor = 0xFF181818)

--- a/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
+++ b/native/NativeSampleApps/ConfiguredApp/build.gradle.kts
@@ -17,7 +17,7 @@ android { // TODO: This cannot be resolved until newDSL=true
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     sourceSets {

--- a/native/NativeSampleApps/RestExplorer/build.gradle.kts
+++ b/native/NativeSampleApps/RestExplorer/build.gradle.kts
@@ -33,7 +33,7 @@ android { // TODO: This cannot be resolved until newDSL=true
 
     defaultConfig {
         targetSdk = 37
-        minSdk = 28
+        minSdk = 31
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- Bumps Android `minSdk` from 28 to 31 across all libraries and sample apps.
- Updates CI: nightly `FULL_API_RANGE` to `31 32 33 34 35 36`; default PR API to 36.
- Removes dead API < 31 branches in auth, login, screen-lock, and SDK manager code.
- Drops obsolete `USE_CREDENTIALS` permission and unused `WRITE_EXTERNAL_STORAGE` from test manifests.

## Test plan
- [x] CI: lib workflow runs against API 31 → 36
- [x] CI: UI workflow (AuthFlowTester) runs against API 31 → 36
- [x] Manual: verify biometric setup / screen-lock flows still work on API 31 device
- [x] Manual: verify login UI theming still correct on API 31 device

🤖 Generated with [Claude Code](https://claude.com/claude-code)