### PR TITLE
W-22917333: Rename beacon_child_consumer_{key,secret} to auto_installed_app_org_consumer_{key,secret}

### DIFF
--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/LogRedactor.kt
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/LogRedactor.kt
@@ -28,11 +28,12 @@ package com.salesforce.androidsdk.analytics.logger
 
 private const val VISIBLE_CHARS = 4
 
+// TODO: Remove beacon_child_consumer_secret from pattern once server version 264 has rolled out everywhere.
 private val SENSITIVE_JSON_PATTERN = Regex(
     pattern = """("(?:access_token|refresh_token|id_token|csrf_token|sid""" +
         """|lightning_sid|visualforce_sid|content_sid|parent_sid""" +
         """|cookie-sid_Client|cookie-clientSrc""" +
-        """|auto_installed_app_org_consumer_secret)"\s*:\s*")([^"]+)(")""",
+        """|auto_installed_app_org_consumer_secret|beacon_child_consumer_secret)"\s*:\s*")([^"]+)(")""",
     option = RegexOption.IGNORE_CASE,
 )
 

--- a/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/LogRedactor.kt
+++ b/libs/SalesforceAnalytics/src/com/salesforce/androidsdk/analytics/logger/LogRedactor.kt
@@ -32,7 +32,7 @@ private val SENSITIVE_JSON_PATTERN = Regex(
     pattern = """("(?:access_token|refresh_token|id_token|csrf_token|sid""" +
         """|lightning_sid|visualforce_sid|content_sid|parent_sid""" +
         """|cookie-sid_Client|cookie-clientSrc""" +
-        """|beacon_child_consumer_secret)"\s*:\s*")([^"]+)(")""",
+        """|auto_installed_app_org_consumer_secret)"\s*:\s*")([^"]+)(")""",
     option = RegexOption.IGNORE_CASE,
 )
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -97,8 +97,8 @@ public class UserAccount {
 	public static final String CLIENT_ID = "clientId";
 	public static final String PARENT_SID = "parentSid";
 	public static final String TOKEN_FORMAT = "tokenFormat";
-	public static final String BEACON_CHILD_CONSUMER_KEY = "beacon_child_consumer_key";
-	public static final String BEACON_CHILD_CONSUMER_SECRET = "beacon_child_consumer_secret";
+	public static final String BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
+	public static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
 	public static final String SCOPE = "scope";
 
 	private static final String TAG = "UserAccount";

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -89,8 +89,8 @@ public class AuthenticatorService extends Service {
     public static final String KEY_SID_COOKIE_NAME = "sidCookieName";
     public static final String KEY_PARENT_SID = "parentSid";
     public static final String KEY_TOKEN_FORMAT = "tokenFormat";
-    public static final String KEY_BEACON_CHILD_CONSUMER_KEY = "beacon_child_consumer_key";
-    public static final String KEY_BEACON_CHILD_CONSUMER_SECRET = "beacon_child_consumer_secret";
+    public static final String KEY_BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
+    public static final String KEY_BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
     public static final String KEY_SCOPE = "scope";
 
     private static final String TAG = "AuthenticatorService";

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -215,6 +215,9 @@ public class OAuth2 {
     private static final String TOKEN_FORMAT = "token_format";
     private static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
     private static final String BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
+    // TODO: Remove legacy fallback constants once server version 264 has rolled out everywhere.
+    private static final String LEGACY_BEACON_CHILD_CONSUMER_SECRET = "beacon_child_consumer_secret";
+    private static final String LEGACY_BEACON_CHILD_CONSUMER_KEY = "beacon_child_consumer_key";
 
     public static final DateFormat TIMESTAMP_FORMAT;
     static {
@@ -1000,11 +1003,16 @@ public class OAuth2 {
                 tokenFormat = parsedResponse.optString(TOKEN_FORMAT);
 
                 // Beacon child fields expected when using a beacon app and web server flow
+                // TODO: Remove LEGACY_BEACON_CHILD_CONSUMER_* fallback once server version 264 has rolled out everywhere.
                 if (parsedResponse.has(BEACON_CHILD_CONSUMER_KEY)) {
                     beaconChildConsumerKey = parsedResponse.getString(BEACON_CHILD_CONSUMER_KEY);
+                } else if (parsedResponse.has(LEGACY_BEACON_CHILD_CONSUMER_KEY)) {
+                    beaconChildConsumerKey = parsedResponse.getString(LEGACY_BEACON_CHILD_CONSUMER_KEY);
                 }
                 if (parsedResponse.has(BEACON_CHILD_CONSUMER_SECRET)) {
                     beaconChildConsumerSecret = parsedResponse.getString(BEACON_CHILD_CONSUMER_SECRET);
+                } else if (parsedResponse.has(LEGACY_BEACON_CHILD_CONSUMER_SECRET)) {
+                    beaconChildConsumerSecret = parsedResponse.getString(LEGACY_BEACON_CHILD_CONSUMER_SECRET);
                 }
                 scope = parsedResponse.optString(SCOPE);
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -213,8 +213,8 @@ public class OAuth2 {
     private static final String SID_COOKIE_NAME = "sidCookieName";
     private static final String PARENT_SID = "parent_sid";
     private static final String TOKEN_FORMAT = "token_format";
-    private static final String BEACON_CHILD_CONSUMER_SECRET = "beacon_child_consumer_secret";
-    private static final String BEACON_CHILD_CONSUMER_KEY = "beacon_child_consumer_key";
+    private static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
+    private static final String BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
 
     public static final DateFormat TIMESTAMP_FORMAT;
     static {

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
@@ -242,9 +242,9 @@ public class SalesforceLoggerTest {
     @Test
     public void testRedactBeaconChildConsumerSecret() {
         final String value = randomString(11);
-        final String input = "{\"beacon_child_consumer_secret\":\"" + value + "\"}";
-        final String expected = "{\"beacon_child_consumer_secret\":\"" + expectedMask(value) + "\"}";
-        Assert.assertEquals("beacon_child_consumer_secret should be redacted", expected, SalesforceLogger.redact(input));
+        final String input = "{\"auto_installed_app_org_consumer_secret\":\"" + value + "\"}";
+        final String expected = "{\"auto_installed_app_org_consumer_secret\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("auto_installed_app_org_consumer_secret should be redacted", expected, SalesforceLogger.redact(input));
     }
 
     /**

--- a/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
+++ b/libs/test/SalesforceAnalyticsTest/src/com/salesforce/androidsdk/analytics/logger/SalesforceLoggerTest.java
@@ -237,14 +237,26 @@ public class SalesforceLoggerTest {
     }
 
     /**
-     * Test that beacon_child_consumer_secret is redacted in JSON.
+     * Test that auto_installed_app_org_consumer_secret is redacted in JSON.
      */
     @Test
-    public void testRedactBeaconChildConsumerSecret() {
+    public void testRedactAutoInstalledAppOrgConsumerSecret() {
         final String value = randomString(11);
         final String input = "{\"auto_installed_app_org_consumer_secret\":\"" + value + "\"}";
         final String expected = "{\"auto_installed_app_org_consumer_secret\":\"" + expectedMask(value) + "\"}";
         Assert.assertEquals("auto_installed_app_org_consumer_secret should be redacted", expected, SalesforceLogger.redact(input));
+    }
+
+    /**
+     * Test that beacon_child_consumer_secret is redacted in JSON.
+     * TODO: Remove once server version 264 has rolled out everywhere.
+     */
+    @Test
+    public void testRedactBeaconChildConsumerSecret() {
+        final String value = randomString(11);
+        final String input = "{\"beacon_child_consumer_secret\":\"" + value + "\"}";
+        final String expected = "{\"beacon_child_consumer_secret\":\"" + expectedMask(value) + "\"}";
+        Assert.assertEquals("beacon_child_consumer_secret should be redacted", expected, SalesforceLogger.redact(input));
     }
 
     /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -655,8 +655,8 @@ public class UserAccountTest {
 
     private OAuth2.TokenEndpointResponse createTokenEndpointResponseLikeWebServerFlow() {
         Map<String, String> params = createTokenEndpointParams();
-        params.put("beacon_child_consumer_key", TEST_BEACON_CHILD_CONSUMER_KEY);
-        params.put("beacon_child_consumer_secret", TEST_BEACON_CHILD_CONSUMER_SECRET);
+        params.put("auto_installed_app_org_consumer_key", TEST_BEACON_CHILD_CONSUMER_KEY);
+        params.put("auto_installed_app_org_consumer_secret", TEST_BEACON_CHILD_CONSUMER_SECRET);
         JSONObject responseJson = new JSONObject(params);
         MediaType mediaType = MediaType.parse("application/json");
         ResponseBody responseBody = ResponseBody.create(responseJson.toString(), mediaType);


### PR DESCRIPTION
## Summary

Updates the token endpoint wire-format keys and adds a legacy fallback for servers that haven't yet rolled out version 264.

When parsing the token response, the SDK now:
1. Checks for `auto_installed_app_org_consumer_{key,secret}` (new field name)
2. Falls back to `beacon_child_consumer_{key,secret}` if the new field is absent

A `TODO` comment marks both fallback constants and the fallback logic for removal once server version 264 has rolled out everywhere.

All code symbol names (`BEACON_CHILD_CONSUMER_KEY/SECRET` constants, `beaconChildConsumerKey` field/getter, builder methods, etc.) are **unchanged**.

## Files changed
- `OAuth2.java` — new constant values + legacy fallback constants + parsing updated with new-then-old fallback
- `UserAccount.java` — `BEACON_CHILD_CONSUMER_KEY/SECRET` constant values updated
- `AuthenticatorService.java` — `KEY_BEACON_CHILD_CONSUMER_KEY/SECRET` constant values updated
- `LogRedactor.kt` — redaction regex pattern string updated
- `UserAccountTest.java` — test map key strings updated
- `SalesforceLoggerTest.java` — test JSON key strings updated

## Test plan
- [x] Android SDK and SalesforceAnalytics APKs build cleanly
- [ ] `connectedAndroidTest` passes (requires connected device)
- [ ] AuthFlowTester instrumentation tests pass (running externally)

## Related
- iOS counterpart: forcedotcom/SalesforceMobileSDK-iOS#4057
- GUS: W-22917333