### PR TITLE
W-22974697: Remove deprecated adjustResize from native Android activities

### DIFF
--- a/libs/SalesforceSDK/AndroidManifest.xml
+++ b/libs/SalesforceSDK/AndroidManifest.xml
@@ -40,7 +40,6 @@
         <activity android:name="com.salesforce.androidsdk.ui.LoginActivity"
             android:theme="@style/SalesforceSDK"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
             android:exported="true" />
 
@@ -53,7 +52,7 @@
         <!-- Screen Lock Activity-->
         <activity android:name="com.salesforce.androidsdk.ui.ScreenLockActivity"
             android:exported="false"
-            android:windowSoftInputMode="adjustResize|stateAlwaysVisible"
+            android:windowSoftInputMode="stateAlwaysVisible"
             android:theme="@style/SalesforceSDK.ScreenLock" />
 
         <!-- Manage space activity -->


### PR DESCRIPTION
## Summary

Remove `android:windowSoftInputMode="adjustResize"` from `LoginActivity` and `ScreenLockActivity` in `libs/SalesforceSDK/AndroidManifest.xml`.

`adjustResize` is deprecated on Android API 35+ in edge-to-edge windows and does not work correctly when the window is in edge-to-edge mode (mandatory on API 36 / Android 16). For `ScreenLockActivity`, `stateAlwaysVisible` is preserved.

## GUS

W-22974697

## Test plan

- [ ] Verify keyboard behavior on login screen (LoginActivity)
- [ ] Verify keyboard behavior on screen lock screen (ScreenLockActivity)
- [ ] Test on API 35+ device/emulator and API 31-34