### PR TITLE
Fix Login for Admin and Welcome Discovery incompatibility

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -772,7 +772,14 @@ open class LoginActivity : FragmentActivity() {
      */
     @Deprecated(message = "This function will be replaced by a permanent solution in 14.0.")
     fun launchLoginForAdminsAction() {
-        val selectedServer = SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer?.url?.toUri()
+        // Guard against launching a Custom Tab on the Welcome Discovery Phase 1 page, whose
+        // callback (sfdc://discocallback) is not app-unique.  This MUST use the same signal as the
+        // menu-item visibility gating in LoginView (viewModel.selectedServer), NOT
+        // LoginServerManager.selectedLoginServer: the latter stays welcome.salesforce.com through
+        // BOTH phases, while selectedServer is the discovered My Domain in Phase 2 — where LFA is
+        // valid and the menu item is shown.  Keying off LoginServerManager here would no-op the
+        // action in Phase 2 even though the menu offers it.
+        val selectedServer = viewModel.selectedServer.value?.toUri()
         if (selectedServer?.let { isSalesforceWelcomeDiscoveryUrlPath(it) } == true) {
             w(TAG, "launchLoginForAdminsAction is a no-op for Welcome Discovery; " +
                     "LFA requires an app-unique OAuth callback")
@@ -1234,8 +1241,15 @@ open class LoginActivity : FragmentActivity() {
                     return@evaluateJavascript
                 }
 
-                viewModel.dynamicBackgroundColor.value = validateAndExtractBackgroundColor(result)
-                    ?: return@evaluateJavascript
+                viewModel.dynamicBackgroundColor.value =
+                    if (url?.toUri()?.let { isSalesforceWelcomeDiscoveryUrlPath(it) } == true) {
+                        // The Welcome Discovery Phase 1 page (welcome.salesforce.com/discovery)
+                        // reports a dark computed background in some states (e.g. after logout),
+                        // which would tint the top and bottom app bars black.
+                        Color.White
+                    } else {
+                        validateAndExtractBackgroundColor(result) ?: return@evaluateJavascript
+                    }
 
                 // Ensure Status Bar Icons are readable no matter which OS theme is used.
                 val titleTextColorLight = viewModel.titleTextColor?.luminance()?.let { it < 0.5 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -150,7 +150,6 @@ import org.json.JSONObject
 import java.lang.String.format
 import java.net.URI
 import java.net.URLDecoder
-import java.net.URLEncoder
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 
@@ -768,9 +767,17 @@ open class LoginActivity : FragmentActivity() {
      *  Launches the current login server in a Custom Tab. This allows Admins
      *  to authenticate with a Passkey or by other methods that require
      *  Advanced/Browser Authentication.
+     *
+     *  This function is a no-op for Welcome Discovery.
      */
     @Deprecated(message = "This function will be replaced by a permanent solution in 14.0.")
     fun launchLoginForAdminsAction() {
+        val selectedServer = SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer?.url?.toUri()
+        if (selectedServer?.let { isSalesforceWelcomeDiscoveryUrlPath(it) } == true) {
+            w(TAG, "launchLoginForAdminsAction is a no-op for Welcome Discovery; " +
+                    "LFA requires an app-unique OAuth callback")
+            return
+        }
         val loginUrl = viewModel.browserCustomTabUrl.value ?: return
         loadLoginPageInCustomTab(loginUrl, adminLoginCustomTabLauncher)
     }
@@ -1035,31 +1042,6 @@ open class LoginActivity : FragmentActivity() {
     }
 
     /**
-     * Creates a Salesforce Welcome Discovery mobile URL using the provided
-     * Salesforce Welcome Discovery host and path URL.
-     * @param salesforceWelcomeDiscoveryHostAndPathUrl The Salesforce Welcome
-     * Discovery host and path URL
-     * @return A Salesforce Welcome Discovery mobile URL with all required
-     * parameters
-     */
-    private fun generateSalesforceWelcomeDiscoveryMobileUrl(
-        salesforceWelcomeDiscoveryHostAndPathUrl: Uri
-    ) = salesforceWelcomeDiscoveryHostAndPathUrl.buildUpon()
-        .appendQueryParameter(
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID,
-            viewModel.oAuthConfig.consumerKey,
-        )
-        .appendQueryParameter(
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION,
-            URLEncoder.encode(SalesforceSDKManager.getInstance().appVersion, "utf8")
-        )
-        .appendQueryParameter(
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CALLBACK_URL,
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL
-        )
-        .build()
-
-    /**
      * Switches between default or Salesforce Welcome Discovery log in as needed
      * using the provided pending login server URL.
      * @param pendingLoginServerUri The pending login server URL
@@ -1084,7 +1066,7 @@ open class LoginActivity : FragmentActivity() {
                         this,
                         SalesforceSDKManager.getInstance().webViewLoginActivityClass
                     ).apply {
-                        data = generateSalesforceWelcomeDiscoveryMobileUrl(pendingLoginServerUri)
+                        data = viewModel.generateSalesforceWelcomeDiscoveryMobileUrl(pendingLoginServerUri)
                         flags = FLAG_ACTIVITY_SINGLE_TOP
                     })
                 true
@@ -1496,7 +1478,7 @@ open class LoginActivity : FragmentActivity() {
         // region Salesforce Welcome Login Private Implementation
 
         /** The default Salesforce Welcome Discovery mobile callback URL.  This value is fixed until future Salesforce Welcome updates */
-        private const val SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL = "sfdc://discocallback"
+        internal const val SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL = "sfdc://discocallback"
 
         /** The Salesforce Welcome Discovery mobile callback URL's "login hint" parameter key */
         private const val SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL_QUERY_PARAMETER_KEY_LOGIN_HINT = "login_hint"

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -344,17 +344,10 @@ open class LoginViewModel(
                     // onPageFinished, which runs after the new page loads — the gap leaves the
                     // Phase-2 color visible on the bar even though the WebView URL has changed.
                     dynamicBackgroundColor.value = White
-                    // Set loginUrl first so LoginUrlSource's same-host short-circuit (host of new
-                    // selectedServer == host of current loginUrl) suppresses an auth-URL regen
-                    // when we reset selectedServer below.
+                    // Must precede selectedServer reset — LoginUrlSource same-host short-circuit.
                     loginUrl.value =
                         generateSalesforceWelcomeDiscoveryMobileUrl(selectedLoginServerUri).toString()
-                    // Reset VM-level selectedServer back to the Welcome URL so the top app bar
-                    // title (via defaultTitleText), menu gating in Compose (LoginView reads
-                    // viewModel.selectedServer to hide "Login for Admin" on Phase 1), and any
-                    // other observers of selectedServer realign with Phase 1.  In Phase 2 this
-                    // value had been overwritten with the discovered My Domain by
-                    // applySalesforceWelcomeLoginHintAndHost → applyPendingServer.
+                    // Must follow loginUrl — depends on same-host short-circuit seeing new loginUrl.
                     val welcomeUrl = selectedLoginServerUri.toString()
                     if (selectedServer.value != welcomeUrl) {
                         selectedServer.value = welcomeUrl

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.net.URI
+import java.net.URLEncoder
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -299,8 +300,69 @@ open class LoginViewModel(
         loginUrl.addSource(selectedServer, LoginUrlSource())
     }
 
+    /**
+     * Creates a Salesforce Welcome Discovery mobile URL using the provided
+     * Salesforce Welcome Discovery host and path URL.
+     * @param salesforceWelcomeDiscoveryHostAndPathUrl The Salesforce Welcome
+     * Discovery host and path URL
+     * @return A Salesforce Welcome Discovery mobile URL with all required
+     * parameters
+     */
+    internal fun generateSalesforceWelcomeDiscoveryMobileUrl(
+        salesforceWelcomeDiscoveryHostAndPathUrl: Uri
+    ) = salesforceWelcomeDiscoveryHostAndPathUrl.buildUpon()
+        .appendQueryParameter(
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID,
+            oAuthConfig.consumerKey,
+        )
+        .appendQueryParameter(
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION,
+            URLEncoder.encode(SalesforceSDKManager.getInstance().appVersion, "utf8")
+        )
+        .appendQueryParameter(
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CALLBACK_URL,
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL
+        )
+        .build()
+
     /** Reloads the WebView with a newly generated authorization URL. */
     open fun reloadWebView() {
+        // If the user-selected login server (per LoginServerManager) is Salesforce Welcome
+        // Discovery, load the Phase 1 discovery mobile URL directly instead of regenerating a
+        // Phase-2-style auth URL.  We intentionally do NOT key off `selectedServer.value` here:
+        // during Phase 2, the VM's selectedServer is the discovered My Domain, while the
+        // LoginServerManager retains Welcome Discovery as the user's actual server selection.
+        // This branch runs BEFORE the isUsingFrontDoorBridge short-circuit by design — Welcome
+        // Discovery and frontdoor bridge are mutually exclusive in practice, but defense-in-depth
+        // ordering ensures a stray frontdoor URL cannot suppress the discovery reload.
+        SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer?.url
+            ?.toUri()?.let { selectedLoginServerUri ->
+                if (isSalesforceWelcomeDiscoveryUrlPath(selectedLoginServerUri)) {
+                    // Reset the top app bar background to White synchronously so the bar flips
+                    // immediately when the user reloads/re-selects Welcome Discovery from Phase 2.
+                    // dynamicBackgroundColor is otherwise only updated by AuthWebViewClient.
+                    // onPageFinished, which runs after the new page loads — the gap leaves the
+                    // Phase-2 color visible on the bar even though the WebView URL has changed.
+                    dynamicBackgroundColor.value = White
+                    // Set loginUrl first so LoginUrlSource's same-host short-circuit (host of new
+                    // selectedServer == host of current loginUrl) suppresses an auth-URL regen
+                    // when we reset selectedServer below.
+                    loginUrl.value =
+                        generateSalesforceWelcomeDiscoveryMobileUrl(selectedLoginServerUri).toString()
+                    // Reset VM-level selectedServer back to the Welcome URL so the top app bar
+                    // title (via defaultTitleText), menu gating in Compose (LoginView reads
+                    // viewModel.selectedServer to hide "Login for Admin" on Phase 1), and any
+                    // other observers of selectedServer realign with Phase 1.  In Phase 2 this
+                    // value had been overwritten with the discovered My Domain by
+                    // applySalesforceWelcomeLoginHintAndHost → applyPendingServer.
+                    val welcomeUrl = selectedLoginServerUri.toString()
+                    if (selectedServer.value != welcomeUrl) {
+                        selectedServer.value = welcomeUrl
+                    }
+                    return
+                }
+            }
+
         if (!isUsingFrontDoorBridge) {
             selectedServer.value?.let { server ->
                 // The Web Server Flow code challenge makes the authorization url unique each time,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -167,6 +167,8 @@ fun LoginView() {
         }
     }
 
+    // During WD phase 2, selectedServer is the My Domain, so this is false and LFA is shown.
+    // See LoginActivity guard for the programmatic defense-in-depth check.
     val isWelcomeDiscoveryServer = selectedServer.value
         ?.let { LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(it.toUri()) } == true
     val topAppBar = viewModel.topAppBar ?: {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -90,6 +90,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.core.net.toUri
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
@@ -147,10 +148,16 @@ fun LoginView() {
     val viewModel: LoginViewModel =
         viewModel(factory = SalesforceSDKManager.getInstance().loginViewModelFactory)
     val frontDoorBridgeUrl = viewModel.frontDoorBridgeUrl.observeAsState()
+    // Observe selectedServer and loginUrl AS COMPOSE STATE so that recomposition triggers when
+    // either changes — and so titleText is read inside Compose's snapshot system, not via the
+    // non-reactive `defaultTitleText` getter chain (which reads LiveData.getValue() directly and
+    // is invisible to Compose).
+    val selectedServer = viewModel.selectedServer.observeAsState()
+    val loginUrl = viewModel.loginUrl.observeAsState()
     val titleText = if (frontDoorBridgeUrl.value != null) {
         viewModel.frontdoorBridgeServer ?: ""
     } else {
-        viewModel.titleText ?: viewModel.defaultTitleText
+        viewModel.titleText ?: if (loginUrl.value == LoginActivity.ABOUT_BLANK) "" else selectedServer.value ?: ""
     }
     val showDevSupport = with(SalesforceSDKManager.getInstance()) {
         return@with if (isDebugBuild && isDevSupportEnabled()) {
@@ -160,6 +167,8 @@ fun LoginView() {
         }
     }
 
+    val isWelcomeDiscoveryServer = selectedServer.value
+        ?.let { LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(it.toUri()) } == true
     val topAppBar = viewModel.topAppBar ?: {
         DefaultTopAppBar(
             backgroundColor = viewModel.topBarColor ?: viewModel.dynamicBackgroundColor.value,
@@ -172,7 +181,9 @@ fun LoginView() {
             shouldShowBackButton = viewModel.shouldShowBackButton,
             showDevSupport = showDevSupport,
             finish = { activity.handleBackBehavior() },
-            onLoginForAdmins = { activity.launchLoginForAdminsAction() },
+            onLoginForAdmins = if (isWelcomeDiscoveryServer) null else {
+                { activity.launchLoginForAdminsAction() }
+            },
         )
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -131,9 +131,11 @@ import com.salesforce.androidsdk.R.string.sf__server_url_save
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.app.SalesforceSDKManager
+import androidx.core.net.toUri
 import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
 import com.salesforce.androidsdk.ui.CORNER_RADIUS
+import com.salesforce.androidsdk.ui.LoginActivity
 import com.salesforce.androidsdk.ui.LoginViewModel
 import com.salesforce.androidsdk.ui.PADDING_SIZE
 import com.salesforce.androidsdk.ui.theme.hintTextColor
@@ -177,6 +179,12 @@ internal fun TestablePickerBottomSheet(
             if (newSelectedServer != SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer) {
                 viewModel.loading.value = true
                 SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer = newSelectedServer
+            } else if (LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(newSelectedServer.url.toUri())) {
+                // Re-selecting Welcome Discovery while it is already the selected server should
+                // return the WebView to Phase 1 (welcome.salesforce.com/discovery), even though
+                // LoginServerManager's selection didn't change.  This mirrors the reload-button
+                // behavior the user expects when stuck on a discovered My Domain in Phase 2.
+                viewModel.reloadWebView()
             }
         }
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -39,6 +39,7 @@ import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
 import com.salesforce.androidsdk.config.LoginServerManager.WELCOME_LOGIN_URL
 import com.salesforce.androidsdk.config.OAuthConfig
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getSHA256Hash
+import com.salesforce.androidsdk.ui.LoginActivity
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.ABOUT_BLANK
 import com.salesforce.androidsdk.ui.LoginViewModel
 import io.mockk.coEvery
@@ -69,6 +70,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.net.URI
+import java.net.URLEncoder
 
 private const val FAKE_SERVER_URL = "shouldMatchNothing.salesforce.com"
 private const val FAKE_JWT = "1234"
@@ -778,12 +780,119 @@ class LoginViewModelTest {
         assertTrue("isUsingFrontDoorBridge should be true", viewModel.isUsingFrontDoorBridge)
         assertEquals("frontDoorBridgeUrl should be front door URL", frontDoorUrl, viewModel.frontDoorBridgeUrl.value)
 
+        // Precondition: invariant ("frontdoor wins over reload") only holds when the
+        // LoginServerManager-selected server is NOT a Welcome Discovery URL.  The Welcome Discovery
+        // branch in reloadWebView intentionally runs before the frontdoor short-circuit.
+        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(
+            (SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer?.url ?: "").toUri()))
+
         // Call reloadWebView
         viewModel.reloadWebView()
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Verify URL did not change
         assertEquals("frontDoorBridgeUrl should still be front door URL", frontDoorUrl, viewModel.frontDoorBridgeUrl.value)
+    }
+
+    @Test
+    fun test_givenLoginServerManagerSelectedServerIsWelcomeDiscovery_whenReloadWebView_thenLoginUrlIsDiscoveryMobileUrl() {
+        val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        loginServerManager.addCustomLoginServer("Welcome", WELCOME_LOGIN_URL)
+        // Simulate Phase 2: VM's selectedServer is the discovered My Domain even though
+        // LoginServerManager still has Welcome Discovery selected.
+        viewModel.selectedServer.value = "https://acme.my.salesforce.com"
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val resultUri = viewModel.loginUrl.value?.toUri()
+        assertNotNull(resultUri)
+        assertTrue(LoginActivity.isSalesforceWelcomeDiscoveryMobileUrl(resultUri!!))
+        assertEquals(viewModel.oAuthConfig.consumerKey,
+            resultUri.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID))
+        assertFalse(viewModel.loginUrl.value!!.contains("/services/oauth2/authorize"))
+    }
+
+    @Test
+    fun test_givenLoginServerManagerSelectedServerIsNotWelcomeDiscovery_whenReloadWebView_thenLoginUrlIsAuthUrl() {
+        // LoginServerManager defaults to Production (login.salesforce.com).
+        viewModel.selectedServer.value = "https://login.salesforce.com"
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val url = viewModel.loginUrl.value
+        assertNotNull(url)
+        assertTrue(url!!.contains("/services/oauth2/authorize"))
+        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(url.toUri()))
+    }
+
+    @Test
+    fun test_givenLoginServerManagerSelectedServerIsWelcomeDiscovery_whenIsUsingFrontDoorBridge_andReloadWebView_thenLoginUrlIsDiscoveryMobileUrl() {
+        val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        loginServerManager.addCustomLoginServer("Welcome", WELCOME_LOGIN_URL)
+        val frontdoorUrl = "https://example.my.salesforce.com/secur/frontdoor.jsp?sid=fake"
+        viewModel.loginWithFrontDoorBridgeUrl(frontdoorUrl, pkceCodeVerifier = null)
+        assertTrue(viewModel.isUsingFrontDoorBridge)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val resultUri = viewModel.loginUrl.value?.toUri()
+        assertNotNull(resultUri)
+        assertTrue(LoginActivity.isSalesforceWelcomeDiscoveryMobileUrl(resultUri!!))
+        assertNotEquals(frontdoorUrl, viewModel.loginUrl.value)
+    }
+
+    /**
+     * Regression guard for the Phase-2 reload bug: when the user is in Phase 2 of the Welcome
+     * Discovery flow, viewModel.selectedServer is the discovered My Domain (NOT the Welcome URL),
+     * but LoginServerManager retains Welcome as the user's actual server selection.  Reload must
+     * return the WebView to Phase 1.
+     */
+    @Test
+    fun test_givenInPhase2OfWelcomeDiscovery_whenReloadWebView_thenLoginUrlReturnsToPhase1() {
+        val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        loginServerManager.addCustomLoginServer("Welcome", WELCOME_LOGIN_URL)
+        // Phase 2 state: VM mirrors the My Domain from applySalesforceWelcomeLoginHintAndHost.
+        val myDomainUrl = "https://acme.my.salesforce.com"
+        viewModel.selectedServer.value = myDomainUrl
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val resultUri = viewModel.loginUrl.value?.toUri()
+        assertNotNull(resultUri)
+        assertEquals("welcome.salesforce.com", resultUri!!.host)
+        assertEquals(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_URL_PATH, resultUri.path)
+        assertFalse(viewModel.loginUrl.value!!.contains(myDomainUrl))
+        assertFalse(viewModel.loginUrl.value!!.contains("/services/oauth2/authorize"))
+
+        // Reload must also realign VM-level selectedServer back to the Welcome URL so the top
+        // app bar title (defaultTitleText reads selectedServer.value) and the Compose menu
+        // gating ("Login for Admin" hidden when selectedServer is the discovery URL) follow.
+        assertEquals(WELCOME_LOGIN_URL, viewModel.selectedServer.value)
+    }
+
+    @Test
+    fun test_givenConsumerKeyAndAppVersion_whenGenerateSalesforceWelcomeDiscoveryMobileUrl_thenReturnsExpectedUrl() {
+        val input = "https://welcome.salesforce.com/discovery".toUri()
+        val result = viewModel.generateSalesforceWelcomeDiscoveryMobileUrl(input)
+
+        assertEquals("welcome.salesforce.com", result.host)
+        assertEquals("/discovery", result.path)
+        assertEquals(viewModel.oAuthConfig.consumerKey,
+            result.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID))
+        assertEquals(URLEncoder.encode(SalesforceSDKManager.getInstance().appVersion, "utf8"),
+            result.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION))
+        assertEquals("sfdc://discocallback",
+            result.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CALLBACK_URL))
+        // Companion validator round-trip:
+        assertTrue(LoginActivity.isSalesforceWelcomeDiscoveryMobileUrl(result))
     }
 
     @Test

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
@@ -143,8 +143,11 @@ class LoginActivityTest {
     fun onLoginForAdminsClick_withNullBrowserCustomTabUrl_doesNotLaunchCustomTab() {
         val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
         every { browserCustomTabUrl.value } returns null
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        every { selectedServer.value } returns "https://example.com"
         val viewModel = mockk<LoginViewModel>(relaxed = true)
         every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
 
         val activity = mockk<LoginActivity>(relaxed = true)
         every { activity.viewModel } returns viewModel
@@ -160,8 +163,11 @@ class LoginActivityTest {
         val testUrl = "https://example.com/services/oauth2/authorize"
         val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
         every { browserCustomTabUrl.value } returns testUrl
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        every { selectedServer.value } returns "https://example.com"
         val viewModel = mockk<LoginViewModel>(relaxed = true)
         every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
 
         val activity = mockk<LoginActivity>(relaxed = true)
         every { activity.viewModel } returns viewModel
@@ -175,6 +181,56 @@ class LoginActivityTest {
         // getter for `adminLoginCustomTabLauncher`. The admin-vs-regular launcher routing is
         // enforced structurally by the 2-line body of `onLoginForAdminsClick`.
         verify(exactly = 1) { activity.loadLoginPageInCustomTab(eq(testUrl), any()) }
+    }
+
+    /**
+     * Phase 2 of Welcome Discovery: viewModel.selectedServer is the discovered My Domain (even
+     * though LoginServerManager still has the Welcome URL selected).  Login for Admin is valid
+     * here and MUST launch the Custom Tab.  Regression guard: keying the no-op off
+     * LoginServerManager.selectedLoginServer instead of viewModel.selectedServer broke this.
+     */
+    @Test
+    fun onLoginForAdminsClick_inWelcomeDiscoveryPhase2_launchesCustomTabAgainstMyDomain() {
+        val testUrl = "https://acme.my.salesforce.com/services/oauth2/authorize"
+        val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
+        every { browserCustomTabUrl.value } returns testUrl
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        // Phase 2: selectedServer is the discovered My Domain, NOT the Welcome URL.
+        every { selectedServer.value } returns "https://acme.my.salesforce.com"
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
+
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.viewModel } returns viewModel
+        every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
+
+        activity.launchLoginForAdminsAction()
+
+        verify(exactly = 1) { activity.loadLoginPageInCustomTab(eq(testUrl), any()) }
+    }
+
+    /**
+     * Phase 1 of Welcome Discovery: viewModel.selectedServer is the Welcome Discovery URL, whose
+     * callback (sfdc://discocallback) is not app-unique.  Login for Admin MUST be a no-op here.
+     */
+    @Test
+    fun onLoginForAdminsClick_inWelcomeDiscoveryPhase1_doesNotLaunchCustomTab() {
+        val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
+        every { browserCustomTabUrl.value } returns "https://welcome.salesforce.com/discovery"
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        every { selectedServer.value } returns "https://welcome.salesforce.com/discovery"
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
+
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.viewModel } returns viewModel
+        every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
+
+        activity.launchLoginForAdminsAction()
+
+        verify(exactly = 0) { activity.loadLoginPageInCustomTab(any(), any()) }
     }
 
     // endregion

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
@@ -43,6 +43,7 @@ import com.salesforce.androidsdk.ui.LoginActivity.Companion.SALESFORCE_WELCOME_D
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.SALESFORCE_WELCOME_DISCOVERY_URL_PATH
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.isSalesforceWelcomeDiscoveryMobileUrl
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.isSalesforceWelcomeDiscoveryUrlPath
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.SimulatedDiscoveryResult
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.startDefaultLoginWithHintAndHost
 import com.salesforce.androidsdk.app.SalesforceSDKManager
@@ -150,6 +151,12 @@ class LoginActivityTest {
         every { activity.viewModel } returns viewModel
         every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
 
+        // Contract guard: launchLoginForAdminsAction is the non-Welcome-Discovery path.  Gating is at
+        // the Compose call site (LoginView).  This pins the contract so a future in-function
+        // short-circuit cannot silently hide gating logic.
+        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(
+            (viewModel.selectedServer.value ?: "").toUri()))
+
         activity.launchLoginForAdminsAction()
 
         verify(exactly = 0) { activity.loadLoginPageInCustomTab(any(), any()) }
@@ -166,6 +173,12 @@ class LoginActivityTest {
         val activity = mockk<LoginActivity>(relaxed = true)
         every { activity.viewModel } returns viewModel
         every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
+
+        // Contract guard: launchLoginForAdminsAction is the non-Welcome-Discovery path.  Gating is at
+        // the Compose call site (LoginView).  This pins the contract so a future in-function
+        // short-circuit cannot silently hide gating logic.
+        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(
+            (viewModel.selectedServer.value ?: "").toUri()))
 
         activity.launchLoginForAdminsAction()
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
@@ -43,7 +43,6 @@ import com.salesforce.androidsdk.ui.LoginActivity.Companion.SALESFORCE_WELCOME_D
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.SALESFORCE_WELCOME_DISCOVERY_URL_PATH
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.isSalesforceWelcomeDiscoveryMobileUrl
-import com.salesforce.androidsdk.ui.LoginActivity.Companion.isSalesforceWelcomeDiscoveryUrlPath
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.SimulatedDiscoveryResult
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.startDefaultLoginWithHintAndHost
 import com.salesforce.androidsdk.app.SalesforceSDKManager
@@ -151,12 +150,6 @@ class LoginActivityTest {
         every { activity.viewModel } returns viewModel
         every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
 
-        // Contract guard: launchLoginForAdminsAction is the non-Welcome-Discovery path.  Gating is at
-        // the Compose call site (LoginView).  This pins the contract so a future in-function
-        // short-circuit cannot silently hide gating logic.
-        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(
-            (viewModel.selectedServer.value ?: "").toUri()))
-
         activity.launchLoginForAdminsAction()
 
         verify(exactly = 0) { activity.loadLoginPageInCustomTab(any(), any()) }
@@ -173,12 +166,6 @@ class LoginActivityTest {
         val activity = mockk<LoginActivity>(relaxed = true)
         every { activity.viewModel } returns viewModel
         every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
-
-        // Contract guard: launchLoginForAdminsAction is the non-Welcome-Discovery path.  Gating is at
-        // the Compose call site (LoginView).  This pins the contract so a future in-function
-        // short-circuit cannot silently hide gating logic.
-        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(
-            (viewModel.selectedServer.value ?: "").toUri()))
 
         activity.launchLoginForAdminsAction()
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
@@ -353,6 +353,26 @@ class LoginViewActivityTest {
     }
 
     @Test
+    fun test_givenOnLoginForAdminsIsNull_whenDropdownMenuOpened_thenLoginForAdminsItemIsAbsent() {
+        androidComposeTestRule.setContent {
+            DefaultTopAppBarTestWrapper(
+                onLoginForAdmins = null,
+            )
+        }
+
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+        val loginForAdminsButton = androidComposeTestRule.onNodeWithText(
+            androidComposeTestRule.activity.getString(R.string.sf__login_for_admins)
+        )
+
+        menu.assertIsDisplayed()
+        menu.performClick()
+        loginForAdminsButton.assertDoesNotExist()
+    }
+
+    @Test
     fun bottomAppBar_WithNoButton_DisplaysCorrectly() {
         androidComposeTestRule.setContent {
             DefaultBottomAppBarTestWrapper()
@@ -540,7 +560,7 @@ class LoginViewActivityTest {
         shouldShowBackButton: Boolean = false,
         showDevSupport: (() -> Unit)? = { },
         finish: () -> Unit = { },
-        onLoginForAdmins: (() -> Unit) = { },
+        onLoginForAdmins: (() -> Unit)? = { },
     ) {
         DefaultTopAppBar(
             backgroundColor, titleText, titleTextColor, showServerPicker, clearCookies,


### PR DESCRIPTION
## Summary

Fixes the interaction between **Login for Admin (LFA)** and the **Welcome Discovery** 2-phase login flow. Previously the LFA menu item was offered even on the Welcome Discovery Phase 1 page (welcome.salesforce.com/discovery), where the registered OAuth callback (`sfdc://discocallback`) is **not app-unique** — any app on the device that registers the `sfdc://` scheme could intercept the response. This change hides LFA in Phase 1, keeps it available in Phase 2 (the discovered My Domain), guards `LoginActivity.launchLoginForAdminsAction` so a programmatic invocation is also a no-op for Welcome Discovery, and fixes a related reload bug.

## Behavior changes

### 1. LFA hidden on Welcome Discovery Phase 1
- `LoginView` (Compose) now passes `onLoginForAdmins = null` to `DefaultTopAppBar` when the VM-level `selectedServer` LiveData matches `LoginActivity.isSalesforceWelcomeDiscoveryUrlPath`.
- `DefaultTopAppBar` already conditionally renders the menu item when `onLoginForAdmins != null` — the test wrapper signature was widened to nullable to mirror that contract.

### 2. LFA action is also a no-op for Welcome Discovery (defense-in-depth)
- `LoginActivity.launchLoginForAdminsAction()` now short-circuits with a single `w(TAG, ...)` log when `LoginServerManager.selectedLoginServer.url` matches the discovery path. Even if a host app calls the (deprecated) public method directly, it cannot launch a Custom Tab against welcome.salesforce.com.
- The `@Deprecated` annotation, KDoc, and visibility are unchanged. KDoc gains one line noting the no-op.

### 3. Reload / Clear Cookies / Clear Cache / re-select Welcome → returns the WebView to Phase 1
- `LoginViewModel.reloadWebView()` checks `LoginServerManager.selectedLoginServer` (the source of truth — distinct from `viewModel.selectedServer`, which during Phase 2 holds the discovered My Domain). When it is Welcome Discovery, the function:
  - resets `dynamicBackgroundColor` to white synchronously (so the top app bar background flips immediately, not after `onPageFinished`),
  - rebuilds the Phase-1 mobile URL via the relocated `generateSalesforceWelcomeDiscoveryMobileUrl`,
  - realigns `viewModel.selectedServer.value` back to the Welcome URL so the title and the menu gating recompose,
  - returns early so the Phase-2 auth-URL regen path is skipped.
- `PickerBottomSheet` adds an equality-branch handler: re-selecting Welcome Discovery while it is already the selected server now calls `viewModel.reloadWebView()` (otherwise the picker would dismiss with no observable change).

### 4. Top app bar title is now reactive
- `LoginView` previously read `viewModel.defaultTitleText` (a plain Kotlin getter that calls `LiveData.getValue()`), which is invisible to Compose's snapshot system, so the title never recomposed when `selectedServer` changed. The composable now `observeAsState()`s `selectedServer` and `loginUrl` and reads them directly inside the title computation, so the bar updates in lock-step with reload/re-select.

### 5. Structural-only relocation
- `generateSalesforceWelcomeDiscoveryMobileUrl` moved from a `private fun` on `LoginActivity` to an `internal fun` on `LoginViewModel` so both the activity (intent dispatch) and the VM (reload) can share one implementation. Bytes-identical Phase-1 URL — verified by S19 in the manual test plan.
- `SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL` widened from `private` to `internal` to support the relocation. No public API surface change.

## Test plan — manual verification checklist

A full manual test plan with 20 numbered scenarios was authored alongside this work (kept locally; not committed). Reviewers should walk through the following scenarios on **at least Android API 31 and API 36**, running the AuthFlowTester sample app unless noted otherwise.

### Menu gating
- [x] **S1** — Welcome Discovery selected, Phase 1 loaded → ⋮ menu does NOT contain \"Login for Admin\".
- [x] **S2** — Production / Sandbox / custom My Domain selected → ⋮ menu DOES contain \"Login for Admin\".
- [x] **S3** — Phase-2 (post-discovery) My Domain → ⋮ menu DOES contain \"Login for Admin\".

### Reload bug fix (the WebView returns to Phase 1 on each of these)
- [x] **S4** — Phase 2 → tap Reload → WebView navigates to `https://welcome.salesforce.com/discovery?client_id=...&client_version=...&callback_url=sfdc%3A%2F%2Fdiscocallback`.
- [x] **S5** — Phase 2 → server picker → re-select \"Welcome\" → same end state as S4.
- [x] **S6** — Phase 2 → Clear Cookies → Phase 1 reloads, cookies cleared.
- [x] **S7** — Phase 2 → Clear cache → Phase 1 reloads, cache cleared.

### Phase-1 → Phase-2 transition (regression guard)
- [x] **S8** — Welcome → enter email → land in Phase 2 → ⋮ menu now CONTAINS \"Login for Admin\" (no menu reopen needed).

### LFA still works in Phase 2
- [x] **S10** — Verify across all variations: a Custom Tab is NEVER launched against welcome.salesforce.com. Logcat audit shows zero hits on `welcome.salesforce.com` in the `loadLoginPageInCustomTab` path.

### Multi-user
- [x] **S11** — User A logged in via Welcome Discovery → add User B via Production → ⋮ menu reflects User B's server (LFA visible).
- [x] **S12** — User A logged in via Welcome Discovery → add User B also via Welcome Discovery → Phase 1 is fresh, no auto-advance to a stale Phase 2.

### Configuration changes
- [x] **S13** — Phase 1 → rotate device → menu still hides LFA in both orientations; WebView preserves Phase 1.
- [x] **S14** — Phase 2 → rotate → menu still shows LFA → tap Reload → returns to Phase 1; rotate back → menu now hides LFA.
- [x] **S15** — Toggle dark/light theme in either phase → URL unchanged, menu list unchanged, top-bar colors update.

### Backward compatibility (apps without Welcome Discovery)
- [x] **S18** — `RestExplorer` (no Welcome in `servers.xml`) → menu list unchanged from prior release; Reload, Clear Cookies, Clear cache, Login for Admin all behave identically to the pre-change build.

### URL-builder relocation regression guard
- [x] **S19** — Capture the Phase-1 URL via WebView client log → bytes-identical to a `dev`-baseline capture: same scheme/host/path, same query parameters in the same order (`client_id`, `client_version`, `callback_url`), `client_version` UTF-8 encoded with `%2F` for slashes, `callback_url=sfdc%3A%2F%2Fdiscocallback`.

### Cross-platform parity
- [x] **S25 Ultra** — Re-run S1, S4, S9 on the iOS twin once it lands; mark as deferred with a linked iOS PR if it has not yet merged.