### PR TITLE
feat(push): add foregroundRegistrationMode to re-register all users on foreground (W-20800537)

### DIFF
--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -1,0 +1,277 @@
+# Push Notifications — Salesforce Mobile SDK for Android
+
+This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Prerequisites](#prerequisites)
+3. [Architecture](#architecture)
+4. [Key Classes](#key-classes)
+5. [Registration Lifecycle](#registration-lifecycle)
+6. [Re-registration Modes](#re-registration-modes)
+7. [Encrypted Push Notifications](#encrypted-push-notifications)
+8. [Actionable Notifications](#actionable-notifications)
+9. [Testing](#testing)
+
+---
+
+## Overview
+
+The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications from a Salesforce org to Android devices. Registration state is stored per-user in private `SharedPreferences`, and push notifications can be encrypted end-to-end using RSA + AES.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| `google-services.json` | Place in your app module root; required for FCM token acquisition |
+| `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
+| `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
+| External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
+
+---
+
+## Architecture
+
+```
+App
+ └── SalesforceSDKManager
+      ├── pushNotificationReceiver: PushNotificationInterface   ← app implements this
+      └── pushServiceType: Class<out PushService>              ← customizable
+
+PushMessaging (object)          ← entry point for register/unregister
+ └── PushService (open class)   ← handles SFDC endpoint communication
+      └── PushNotificationsRegistrationChangeWorker  ← WorkManager worker
+
+SFDCFcmListenerService          ← FCM callbacks (onNewToken, onMessageReceived)
+ └── PushNotificationDecryptor  ← optional payload decryption
+```
+
+**Data flow — registration:**
+1. App calls `PushMessaging.register(context, account)`.
+2. `PushMessaging` acquires the FCM token from Firebase.
+3. Token is stored in `SharedPreferences` keyed by user account.
+4. A `PushNotificationsRegistrationChangeWorker` is enqueued via `WorkManager`.
+5. The worker calls `PushService.performRegistrationChange(register=true, ...)`.
+6. `PushService` POSTs to the Salesforce `MobilePushServiceDevice` REST endpoint.
+7. On success, the Salesforce device ID is stored alongside the FCM token.
+
+**Data flow — incoming message:**
+1. FCM delivers the message to `SFDCFcmListenerService.onMessageReceived`.
+2. `PushNotificationDecryptor` decrypts the payload if it is encrypted.
+3. The plaintext payload is forwarded to `PushNotificationInterface.onPushMessageReceived`.
+
+---
+
+## Key Classes
+
+### `PushNotificationInterface`
+
+Interface that the app must implement to receive push notifications.
+
+```kotlin
+interface PushNotificationInterface {
+    fun onPushMessageReceived(data: Map<String?, String?>?)
+    fun supplyFirebaseMessaging(): FirebaseMessaging?   // optional; return null for default
+}
+```
+
+Register the implementation before the SDK initializes:
+```kotlin
+SalesforceSDKManager.getInstance().pushNotificationReceiver = MyPushReceiver()
+```
+
+---
+
+### `PushMessaging` (object)
+
+Utility singleton for push operations. The main entry points for the app.
+
+| Method | Description |
+|---|---|
+| `register(context, account)` | Register or re-register a user for push |
+| `register(context, account, recreateKey)` | Same, with option to rotate the RSA key |
+| `unregister(context, account, isLastAccount)` | Unregister a user; delete Firebase app if last account |
+| `registerSFDCPush(context, account)` | Re-register at the SFDC endpoint only (token already known) |
+| `isRegistered(context, account)` | Whether the FCM token is stored for this account |
+| `getRegistrationId(context, account)` | Returns the stored FCM token |
+| `getDeviceId(context, account)` | Returns the Salesforce device ID |
+| `getNotificationsTypes(account)` | Returns stored Salesforce notification types |
+| `clearRegistrationInfo(context, account)` | Wipe all registration state for this account |
+
+---
+
+### `PushService` (open class)
+
+Handles communication with the Salesforce `MobilePushServiceDevice` REST endpoint. Subclass this to customize the registration or unregistration requests.
+
+Key companion object property:
+```kotlin
+var pushNotificationsRegistrationType: PushNotificationReRegistrationType
+    = ReRegistrationOnAppForeground   // default
+```
+
+Key methods:
+
+| Method | Description |
+|---|---|
+| `performRegistrationChange(register, userAccount, restClient?)` | Main entry point called by the WorkManager worker |
+| `onRegistered(registrationId, account, restClient)` | Handles a successful FCM registration |
+| `onUnregistered(account, restClient)` | Handles logout / unregistration |
+| `registerSFDCPushNotification(...)` | POSTs to SFDC endpoint, returns Salesforce device ID |
+| `unregisterSFDCPushNotification(...)` | DELETEs from SFDC endpoint |
+| `onPushNotificationRegistrationStatus(status, userAccount)` | Override to react to registration status changes |
+| `onSendRegisterPushNotificationRequest(...)` | Override to customize the registration HTTP request |
+| `onSendUnregisterPushNotificationRequest(...)` | Override to customize the unregistration HTTP request |
+| `fetchNotificationsTypes(restClient, userAccount)` | Fetches Salesforce notification types from the API |
+| `registerNotificationChannels(...)` | Creates Android notification channels from Salesforce types |
+| `removeNotificationsCategories()` | Deletes all Salesforce notification channels |
+
+Registration status constants (passed to `onPushNotificationRegistrationStatus`):
+
+| Constant | Value |
+|---|---|
+| `REGISTRATION_STATUS_SUCCEEDED` | 0 |
+| `REGISTRATION_STATUS_FAILED` | 1 |
+| `UNREGISTRATION_STATUS_SUCCEEDED` | 2 |
+| `UNREGISTRATION_STATUS_FAILED` | 3 |
+
+---
+
+### `PushNotificationsRegistrationChangeWorker`
+
+Internal `Worker` subclass that executes push registration changes on a background thread via `WorkManager`. Not instantiated directly — use `PushService.enqueuePushNotificationsRegistrationWork(...)`.
+
+When `userAccount` is `null`, the worker iterates all authenticated users and calls `performRegistrationChange` for each.
+
+---
+
+### `SFDCFcmListenerService`
+
+Extends `FirebaseMessagingService`. Declared in the SDK's `AndroidManifest.xml` with `android:exported="false"`.
+
+| Callback | Behaviour |
+|---|---|
+| `onNewToken(token)` | Stores the new FCM token and re-registers the current user at the SFDC endpoint |
+| `onMessageReceived(message)` | Forwards the message (after optional decryption) to `PushNotificationInterface` |
+
+---
+
+### `PushNotificationDecryptor`
+
+Singleton that decrypts incoming push payloads. Called automatically by `SFDCFcmListenerService`.
+
+Encrypted payload fields:
+- `encrypted` — boolean; if `false`, the payload is forwarded unchanged
+- `secret` — RSA-encrypted AES symmetric key (base64)
+- `content` — AES-encrypted notification body (base64)
+
+Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
+
+---
+
+### `SalesforceActionableNotificationContent`
+
+Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
+
+```kotlin
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
+```
+
+Parse from the `content` field of a received notification:
+```kotlin
+val content = SalesforceActionableNotificationContent.fromJson(jsonString)
+```
+
+---
+
+## Registration Lifecycle
+
+```
+App foreground / login
+        │
+        ▼
+PushMessaging.register(context, account)
+        │
+        ├─ First time for this account ──► acquire FCM token ──► store token
+        │                                                          │
+        │                                                          ▼
+        └─ Already registered ──────────────────────► enqueue WorkManager job
+                                                                   │
+                                                                   ▼
+                                               PushService.performRegistrationChange
+                                                                   │
+                                                                   ▼
+                                                  POST /services/data/vXX.0/sobjects/
+                                                       MobilePushServiceDevice
+                                                                   │
+                                                      ┌────────────┴─────────────┐
+                                                      ▼                          ▼
+                                               201 Created               404 Not Found
+                                           (store device ID)        (push not enabled —
+                                                                       stop retrying)
+```
+
+**Unregistration** (logout):
+1. App calls `PushMessaging.unregister(context, account, isLastAccount)`.
+2. If last account, Firebase token is deleted and the Firebase app is removed.
+3. `PushService.onUnregistered` DELETEs from `MobilePushServiceDevice`.
+4. Broadcasts `UNREGISTERED_ATTEMPT_COMPLETE_EVENT` and `UNREGISTERED_EVENT`.
+5. Stored registration info is cleared from `SharedPreferences`.
+
+---
+
+## Re-registration Modes
+
+Set via `PushService.pushNotificationsRegistrationType`:
+
+```kotlin
+PushService.pushNotificationsRegistrationType =
+    PushService.PushNotificationReRegistrationType.ReRegisterPeriodically
+```
+
+| Value | Behaviour |
+|---|---|
+| `ReRegistrationDisabled` | No automatic re-registration |
+| `ReRegistrationOnAppForeground` | Re-registers when the app foregrounds **(default)** |
+| `ReRegisterPeriodically` | Re-registers all users every six days via a periodic `WorkManager` task, regardless of foreground/background |
+
+`ReRegisterPeriodically` is useful to counteract periodic SFDC API cleanup that de-registers devices after extended inactivity.
+
+---
+
+## Encrypted Push Notifications
+
+Enable encryption by ensuring the SDK's RSA key pair is registered during push setup. The SDK automatically:
+1. Generates an RSA-2048 key pair in the Android Keystore (key name derived from `SalesforceKeyGenerator.getUniqueId("PushNotificationKey")`).
+2. Includes the RSA public key and cipher name (`RSA_OAEP_SHA256`) in the `MobilePushServiceDevice` registration payload.
+3. Salesforce encrypts the AES symmetric key with the public key before sending the notification.
+4. `PushNotificationDecryptor` uses the private key from the Keystore to decrypt the symmetric key, then decrypts the payload.
+
+No app-side configuration is required beyond normal SDK setup.
+
+---
+
+## Testing
+
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
+
+| Test class | Coverage |
+|---|---|
+| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+
+Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
+
+```bash
+./gradlew :libs:SalesforceSDK:connectedAndroidTest
+```
+
+Or build the APK for upload:
+```bash
+./gradlew :libs:SalesforceSDK:assembleAndroidTest
+```

--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -12,9 +12,10 @@ This document covers the push notification subsystem in `libs/SalesforceSDK`. Al
 4. [Key Classes](#key-classes)
 5. [Registration Lifecycle](#registration-lifecycle)
 6. [Re-registration Modes](#re-registration-modes)
-7. [Encrypted Push Notifications](#encrypted-push-notifications)
-8. [Actionable Notifications](#actionable-notifications)
-9. [Testing](#testing)
+7. [Foreground Registration Mode](#foreground-registration-mode)
+8. [Encrypted Push Notifications](#encrypted-push-notifications)
+9. [Actionable Notifications](#actionable-notifications)
+10. [Testing](#testing)
 
 ---
 
@@ -109,10 +110,13 @@ Utility singleton for push operations. The main entry points for the app.
 
 Handles communication with the Salesforce `MobilePushServiceDevice` REST endpoint. Subclass this to customize the registration or unregistration requests.
 
-Key companion object property:
+Key companion object properties:
 ```kotlin
 var pushNotificationsRegistrationType: PushNotificationReRegistrationType
     = ReRegistrationOnAppForeground   // default
+
+var foregroundRegistrationMode: PushNotificationForegroundRegistrationMode
+    = PushNotificationForegroundRegistrationMode.ALL_USERS   // default
 ```
 
 Key methods:
@@ -241,6 +245,28 @@ PushService.pushNotificationsRegistrationType =
 | `ReRegisterPeriodically` | Re-registers all users every six days via a periodic `WorkManager` task, regardless of foreground/background |
 
 `ReRegisterPeriodically` is useful to counteract periodic SFDC API cleanup that de-registers devices after extended inactivity.
+
+---
+
+## Foreground Registration Mode
+
+When `pushNotificationsRegistrationType` is `ReRegistrationOnAppForeground`, a separate property controls **which users** are re-registered each time the app foregrounds:
+
+```kotlin
+PushService.foregroundRegistrationMode =
+    PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER
+```
+
+| Value | Behaviour |
+|---|---|
+| `ALL_USERS` | Re-registers every authenticated user **(default)** |
+| `CURRENT_USER` | Re-registers only the currently active user (pre-14.0 behaviour) |
+
+`foregroundRegistrationMode` only takes effect when `pushNotificationsRegistrationType` is `ReRegistrationOnAppForeground`. It is ignored for `ReRegistrationDisabled` and `ReRegisterPeriodically`.
+
+### Why `CURRENT_USER` exists
+
+Some Publisher customers are billed **per login event**. An FCM token refresh on a background user triggers a re-registration request which in turn counts as a billable login. With `ALL_USERS` (the default), background users that haven't foregrounded recently may have their tokens refreshed when the app comes to the foreground. Set `CURRENT_USER` to prevent this for those deployments.
 
 ---
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1670,15 +1670,18 @@ open class SalesforceSDKManager protected constructor(
         (screenLockManager as ScreenLockManager?)?.onAppForegrounded()
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppForegrounded()
 
-        // Review push-notifications registration for the current user, if enabled.
-        userAccountManager.currentUser?.let { userAccount ->
-            if (pushNotificationsRegistrationType == ReRegistrationOnAppForeground) {
-                register(
-                    context = appContext,
-                    account = userAccount,
-                    recreateKey = false
-                )
+        // Review push-notifications registration on foreground, if enabled.
+        if (pushNotificationsRegistrationType == ReRegistrationOnAppForeground) {
+            val accountToRegister = when (PushService.foregroundRegistrationMode) {
+                PushService.PushNotificationForegroundRegistrationMode.ALL_USERS -> null
+                PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER ->
+                    userAccountManager.currentUser ?: return@onResume
             }
+            register(
+                context = appContext,
+                account = accountToRegister,
+                recreateKey = false
+            )
         }
 
         // Display the Salesforce Mobile SDK "Show Developer Support" notification

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1664,6 +1664,27 @@ open class SalesforceSDKManager protected constructor(
         }
     }
 
+    /**
+     * Determines the target account (or null for all users) for foreground push
+     * re-registration based on [PushService.foregroundRegistrationMode].
+     *
+     * Returns null when re-registration should be skipped entirely (i.e.
+     * [PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER] is set
+     * but there is no current user).
+     */
+    @VisibleForTesting
+    internal fun foregroundPushRegistrationTarget(): ForegroundPushTarget? =
+        when (PushService.foregroundRegistrationMode) {
+            PushService.PushNotificationForegroundRegistrationMode.ALL_USERS ->
+                ForegroundPushTarget(account = null)
+            PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER ->
+                userAccountManager.currentUser?.let { ForegroundPushTarget(account = it) }
+        }
+
+    /** Holds the resolved account argument for foreground push re-registration. */
+    @VisibleForTesting
+    internal data class ForegroundPushTarget(val account: UserAccount?)
+
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
 
@@ -1672,14 +1693,10 @@ open class SalesforceSDKManager protected constructor(
 
         // Review push-notifications registration on foreground, if enabled.
         if (pushNotificationsRegistrationType == ReRegistrationOnAppForeground) {
-            val accountToRegister = when (PushService.foregroundRegistrationMode) {
-                PushService.PushNotificationForegroundRegistrationMode.ALL_USERS -> null
-                PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER ->
-                    userAccountManager.currentUser ?: return@onResume
-            }
+            val target = foregroundPushRegistrationTarget() ?: return@onResume
             register(
                 context = appContext,
-                account = accountToRegister,
+                account = target.account,
                 recreateKey = false
             )
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -568,6 +568,15 @@ open class PushService {
         /** The active push notifications registration type */
         var pushNotificationsRegistrationType = ReRegistrationOnAppForeground
 
+        /**
+         * Controls which users are re-registered when the app foregrounds.
+         * Defaults to [PushNotificationForegroundRegistrationMode.ALL_USERS].
+         * Only applies when [pushNotificationsRegistrationType] is
+         * [PushNotificationReRegistrationType.ReRegistrationOnAppForeground].
+         */
+        var foregroundRegistrationMode: PushNotificationForegroundRegistrationMode =
+            PushNotificationForegroundRegistrationMode.ALL_USERS
+
         // Salesforce push notification constants.
         private const val MOBILE_PUSH_SERVICE_DEVICE = "MobilePushServiceDevice"
         private const val ANDROID_GCM = "androidGcm"
@@ -728,5 +737,27 @@ open class PushService {
          * de-registers push notifications
          */
         ReRegisterPeriodically
+    }
+
+    /**
+     * Controls which users are re-registered for push notifications when the app returns to the
+     * foreground. Only applies when [pushNotificationsRegistrationType] is
+     * [PushNotificationReRegistrationType.ReRegistrationOnAppForeground].
+     */
+    enum class PushNotificationForegroundRegistrationMode {
+
+        /**
+         * Re-registers all authenticated users when the app foregrounds. This is the default.
+         */
+        ALL_USERS,
+
+        /**
+         * Re-registers only the current user when the app foregrounds.
+         *
+         * Use this to preserve pre-14.0 behaviour, or if your app is billed per login event
+         * (e.g. some Publisher customers) and you want to avoid triggering token refreshes —
+         * and thus billable logins — for background users.
+         */
+        CURRENT_USER
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
@@ -23,7 +23,10 @@ import com.salesforce.androidsdk.push.PushService.Companion.REGISTRATION_STATUS_
 import com.salesforce.androidsdk.push.PushService.Companion.REGISTRATION_STATUS_SUCCEEDED
 import com.salesforce.androidsdk.push.PushService.Companion.UNREGISTRATION_STATUS_SUCCEEDED
 import com.salesforce.androidsdk.push.PushService.Companion.enqueuePushNotificationsRegistrationWork
+import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.ALL_USERS
+import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationDisabled
+import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationOnAppForeground
 import com.salesforce.androidsdk.rest.ApiVersionStrings.VERSION_NUMBER_TEST
 import com.salesforce.androidsdk.rest.NotificationsActionsResponseBody
 import com.salesforce.androidsdk.rest.NotificationsApiErrorResponseBody
@@ -33,8 +36,13 @@ import com.salesforce.androidsdk.rest.NotificationsTypesResponseBody.Companion.f
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo
 import com.salesforce.androidsdk.rest.RestResponse
+import androidx.lifecycle.LifecycleOwner
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.serialization.json.Json.Default.encodeToJsonElement
 import kotlinx.serialization.json.Json.Default.encodeToString
@@ -89,6 +97,8 @@ class PushServiceTest {
     fun tearDown() {
 
         VERSION_NUMBER_TEST = null
+        PushService.foregroundRegistrationMode = ALL_USERS
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
         cleanupAccounts(accountManager)
 
         userAccountManager = null
@@ -945,6 +955,93 @@ class PushServiceTest {
     fun testRemoveNotificationsCategories() {
         PushService().removeNotificationsCategories()
     }
+
+    // region Foreground Registration Mode Tests
+
+    @Test
+    fun test_givenDefault_thenForegroundRegistrationModeIsAllUsers() {
+        assertEquals(ALL_USERS, PushService.foregroundRegistrationMode)
+    }
+
+    @Test
+    fun test_givenModeCurrentUser_whenSet_thenForegroundRegistrationModeIsCurrentUser() {
+        PushService.foregroundRegistrationMode = CURRENT_USER
+        assertEquals(CURRENT_USER, PushService.foregroundRegistrationMode)
+    }
+
+    @Test
+    fun test_givenModeAllUsers_whenAppEntersForeground_thenRegisterCalledWithNullAccount() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = ALL_USERS
+        createTestAccountInAccountManager(userAccountManager)
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            // account = null causes the worker to iterate all authenticated users
+            verify { PushMessaging.register(any(), null, false) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    @Test
+    fun test_givenModeCurrentUser_whenAppEntersForeground_thenRegisterCalledWithCurrentUser() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = CURRENT_USER
+        createTestAccountInAccountManager(userAccountManager)
+        val currentUser = userAccountManager?.currentUser
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            verify { PushMessaging.register(any(), currentUser, false) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    @Test
+    fun test_givenModeAllUsers_whenNoAuthenticatedUsers_whenAppEntersForeground_thenNoRegistrationOccurs() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = ALL_USERS
+        // No accounts created
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            // With ALL_USERS, register is called with null regardless of how many accounts exist.
+            // The worker then iterates the (empty) authenticated user list and does nothing.
+            verify { PushMessaging.register(any(), null, false) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    @Test
+    fun test_givenModeCurrentUser_whenNoCurrentUser_whenAppEntersForeground_thenNoRegistrationOccurs() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = CURRENT_USER
+        // No accounts — currentUser will be null
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            verify(exactly = 0) { PushMessaging.register(any(), any(), any()) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    // endregion
 
     companion object {
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
@@ -26,7 +26,6 @@ import com.salesforce.androidsdk.push.PushService.Companion.enqueuePushNotificat
 import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.ALL_USERS
 import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationDisabled
-import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationOnAppForeground
 import com.salesforce.androidsdk.rest.ApiVersionStrings.VERSION_NUMBER_TEST
 import com.salesforce.androidsdk.rest.NotificationsActionsResponseBody
 import com.salesforce.androidsdk.rest.NotificationsApiErrorResponseBody
@@ -36,13 +35,8 @@ import com.salesforce.androidsdk.rest.NotificationsTypesResponseBody.Companion.f
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo
 import com.salesforce.androidsdk.rest.RestResponse
-import androidx.lifecycle.LifecycleOwner
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.serialization.json.Json.Default.encodeToJsonElement
 import kotlinx.serialization.json.Json.Default.encodeToString
@@ -98,7 +92,6 @@ class PushServiceTest {
 
         VERSION_NUMBER_TEST = null
         PushService.foregroundRegistrationMode = ALL_USERS
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
         cleanupAccounts(accountManager)
 
         userAccountManager = null
@@ -970,75 +963,48 @@ class PushServiceTest {
     }
 
     @Test
-    fun test_givenModeAllUsers_whenAppEntersForeground_thenRegisterCalledWithNullAccount() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeAllUsers_whenAppEntersForeground_thenTargetAccountIsNull() {
         PushService.foregroundRegistrationMode = ALL_USERS
         createTestAccountInAccountManager(userAccountManager)
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            // account = null causes the worker to iterate all authenticated users
-            verify { PushMessaging.register(any(), null, false) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        // null account means the worker iterates all authenticated users
+        assertNotNull(target)
+        assertNull(target?.account)
     }
 
     @Test
-    fun test_givenModeCurrentUser_whenAppEntersForeground_thenRegisterCalledWithCurrentUser() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeCurrentUser_whenAppEntersForeground_thenTargetAccountIsCurrentUser() {
         PushService.foregroundRegistrationMode = CURRENT_USER
         createTestAccountInAccountManager(userAccountManager)
         val currentUser = userAccountManager?.currentUser
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            verify { PushMessaging.register(any(), currentUser, false) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        assertNotNull(target)
+        assertEquals(currentUser, target?.account)
     }
 
     @Test
-    fun test_givenModeAllUsers_whenNoAuthenticatedUsers_whenAppEntersForeground_thenNoRegistrationOccurs() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeAllUsers_whenNoAuthenticatedUsers_thenTargetAccountIsNull() {
         PushService.foregroundRegistrationMode = ALL_USERS
-        // No accounts created
+        // No accounts — worker will iterate an empty list and do nothing
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            // With ALL_USERS, register is called with null regardless of how many accounts exist.
-            // The worker then iterates the (empty) authenticated user list and does nothing.
-            verify { PushMessaging.register(any(), null, false) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        assertNotNull(target)
+        assertNull(target?.account)
     }
 
     @Test
-    fun test_givenModeCurrentUser_whenNoCurrentUser_whenAppEntersForeground_thenNoRegistrationOccurs() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeCurrentUser_whenNoCurrentUser_thenTargetIsNull() {
         PushService.foregroundRegistrationMode = CURRENT_USER
-        // No accounts — currentUser will be null
+        // No accounts — currentUser is null, registration must be skipped
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            verify(exactly = 0) { PushMessaging.register(any(), any(), any()) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        assertNull(target)
     }
 
     // endregion


### PR DESCRIPTION
## Summary

- Adds `PushNotificationForegroundRegistrationMode` enum (`ALL_USERS` / `CURRENT_USER`) to `PushService`
- Adds `PushService.foregroundRegistrationMode` companion property (default `ALL_USERS`)
- Changes `SalesforceSDKManager.onResume` to branch on `foregroundRegistrationMode`: passes `account = null` for `ALL_USERS` (worker iterates all authenticated users) or the current user for `CURRENT_USER`
- Updates `docs/push/README.md` with a new "Foreground Registration Mode" section
- Adds 6 new tests in `PushServiceTest` covering default value, setter, and all foreground re-registration scenarios

## Behaviour change

Pre-14.0: foreground re-registration re-registers the current user only.  
14.0+: foreground re-registration re-registers **all authenticated users** by default.  
Apps that need the old behaviour (e.g. Publisher customers billed per login) set `PushService.foregroundRegistrationMode = CURRENT_USER`.

## iOS counterpart

https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/4030

## GUS

W-20800537

## Test plan

- [ ] `./gradlew :libs:SalesforceSDK:build` — passes
- [ ] `./gradlew :libs:SalesforceSDK:assembleAndroidTest` — passes
- [ ] Run `PushServiceTest` on device / Firebase Test Lab and confirm all 6 new foreground mode tests pass
- [ ] Confirm existing `PushServiceTest` and `PushMessagingTest` tests are unaffected