### PR TITLE
feat(W-23159744): per-user persistent feature flags (Android)

### DIFF
--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/LayoutSyncManager.kt
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/LayoutSyncManager.kt
@@ -307,7 +307,7 @@ class LayoutSyncManager private constructor(
                 store,
                 syncManager
             ).also { INSTANCES[uniqueId] = it }
-            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_LAYOUT_SYNC)
+            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_LAYOUT_SYNC, user)
             return instance
         }
 

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/MetadataSyncManager.kt
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/MetadataSyncManager.kt
@@ -236,7 +236,7 @@ class MetadataSyncManager private constructor(
                 INSTANCES[uniqueId] = it
             }
             SalesforceSDKManager.getInstance()
-                .registerUsedAppFeature(Features.FEATURE_METADATA_SYNC)
+                .registerUsedAppFeature(Features.FEATURE_METADATA_SYNC, user)
             return instance
         }
 

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/SyncManager.kt
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/SyncManager.kt
@@ -827,7 +827,7 @@ class SyncManager private constructor(smartStore: SmartStore, restClient: RestCl
                 instance = SyncManager(store, restClient)
                 instance.also { INSTANCES[uniqueId] = it }
             }
-            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_MOBILE_SYNC)
+            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_MOBILE_SYNC, user)
             return instance
         }
 

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
@@ -31,6 +31,7 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.config.SyncsConfig;
@@ -148,13 +149,19 @@ public class SalesforceHybridSDKManager extends MobileSyncSDKManager {
 	@NonNull
     @Override
 	public final String getUserAgent(@NonNull String qualifier) {
+		return getUserAgent(qualifier, null);
+	}
+
+	@NonNull
+	@Override
+	public final String getUserAgent(@NonNull String qualifier, @androidx.annotation.Nullable UserAccount user) {
 		final BootConfig config = BootConfig.getBootConfig(context);
 		if (config.isLocal()) {
 			qualifier = qualifier + "Local";
 		} else {
 			qualifier = qualifier + "Remote";
 		}
-		return super.getUserAgent(qualifier);
+		return super.getUserAgent(qualifier, user);
 	}
 
     @NonNull

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -49,8 +49,12 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class represents a single user account that is currently
@@ -100,6 +104,7 @@ public class UserAccount {
 	public static final String BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
 	public static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
 	public static final String SCOPE = "scope";
+	public static final String FEATURE_FLAGS = "feature_flags";
 
 	private static final String TAG = "UserAccount";
 	private static final String FORWARD_SLASH = "/";
@@ -147,6 +152,7 @@ public class UserAccount {
 	private String beaconChildConsumerKey;
 	private String beaconChildConsumerSecret;
 	private String scope;
+	private Set<String> featureFlags = new java.util.HashSet<>();
 
 	/**
 	 * Parameterized constructor.
@@ -761,6 +767,24 @@ public class UserAccount {
 	}
 
 	/**
+	 * Returns the persisted per-user feature flags (e.g. BW, SU, MS).
+	 *
+	 * @return Unmodifiable set of feature flag codes.
+	 */
+	public Set<String> getFeatureFlags() {
+		return Collections.unmodifiableSet(featureFlags);
+	}
+
+	/**
+	 * Replaces the in-memory set of persisted per-user feature flags.
+	 *
+	 * @param flags The new set of feature flags.
+	 */
+	public void setFeatureFlags(Set<String> flags) {
+		featureFlags = flags != null ? new HashSet<>(flags) : new HashSet<>();
+	}
+
+	/**
 	 * Fetches this user's profile photo from the cache.
 	 *
 	 * @return User's profile photo.
@@ -1024,6 +1048,11 @@ public class UserAccount {
 			object.put(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 			object.put(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 			object.put(SCOPE, scope);
+			if (!featureFlags.isEmpty()) {
+				org.json.JSONArray flagsArray = new org.json.JSONArray();
+				for (String f : featureFlags) flagsArray.put(f);
+				object.put(FEATURE_FLAGS, flagsArray);
+			}
 			object = MapUtil.addMapToJSONObject(additionalOauthValues, additionalOauthKeys, object);
 		} catch (JSONException e) {
 			SalesforceSDKLogger.e(TAG, "Unable to convert to JSON", e);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -50,9 +50,12 @@ import com.salesforce.androidsdk.ui.LoginActivity;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class acts as a manager that provides methods to access
@@ -553,6 +556,7 @@ public class UserAccountManager {
 		final String beaconChildConsumerKey = decryptUserData(account, AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_KEY, encryptionKey);
 		final String beaconChildConsumerSecret = decryptUserData(account, AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_SECRET, encryptionKey);
 		final String scope = decryptUserData(account, AuthenticatorService.KEY_SCOPE, encryptionKey);
+		final String featureFlagsRaw = decryptUserData(account, AuthenticatorService.KEY_FEATURE_FLAGS, encryptionKey);
 
 		Map<String, String> additionalOauthValues = null;
 		List<String> additionalOauthKeys = SalesforceSDKManager.getInstance().getAdditionalOauthKeys();
@@ -571,7 +575,7 @@ public class UserAccountManager {
 		if (authToken == null || instanceServer == null || userId == null || orgId == null) {
 			return null;
 		} else {
-			return UserAccountBuilder.getInstance()
+			final UserAccount userAccount = UserAccountBuilder.getInstance()
 					.authToken(authToken)
 					.refreshToken(refreshToken)
 					.loginServer(loginServer)
@@ -610,6 +614,10 @@ public class UserAccountManager {
 					.scope(scope)
 					.additionalOauthValues(additionalOauthValues)
 					.build();
+			if (!TextUtils.isEmpty(featureFlagsRaw)) {
+				userAccount.setFeatureFlags(new HashSet<>(Arrays.asList(featureFlagsRaw.split(","))));
+			}
+			return userAccount;
 		}
 	}
 
@@ -758,6 +766,11 @@ public class UserAccountManager {
 		extras.putString(AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_KEY, SalesforceSDKManager.encrypt(userAccount.getBeaconChildConsumerKey(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_SECRET, SalesforceSDKManager.encrypt(userAccount.getBeaconChildConsumerSecret(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_SCOPE, SalesforceSDKManager.encrypt(userAccount.getScope(), encryptionKey));
+		final Set<String> featureFlags = userAccount.getFeatureFlags();
+		if (!featureFlags.isEmpty()) {
+			extras.putString(AuthenticatorService.KEY_FEATURE_FLAGS,
+				SalesforceSDKManager.encrypt(android.text.TextUtils.join(",", featureFlags), encryptionKey));
+		}
 
 		final List<String> additionalOauthKeys = SalesforceSDKManager.getInstance().getAdditionalOauthKeys();
 		if (additionalOauthKeys != null && !additionalOauthKeys.isEmpty()) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1384,7 +1384,9 @@ open class SalesforceSDKManager protected constructor(
 
     /** Hydrates per-user features from persisted accounts at startup */
     private fun hydratePerUserFeatures() {
-        val users = userAccountManager.authenticatedUsers ?: return
+        // Use getInstance() directly — this is called from the constructor init block before the
+        // userAccountManager lazy delegate is initialized, so we can't use the property here.
+        val users = UserAccountManager.getInstance().authenticatedUsers ?: return
         for (u in users) {
             val flags = u.featureFlags
             if (flags.isNotEmpty()) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -687,7 +687,6 @@ open class SalesforceSDKManager protected constructor(
         Handler(getMainLooper()).post {
             ProcessLifecycleOwner.get().lifecycle.addObserver(this)
         }
-        hydratePerUserFeatures()
     }
 
     /**
@@ -1384,9 +1383,7 @@ open class SalesforceSDKManager protected constructor(
 
     /** Hydrates per-user features from persisted accounts at startup */
     private fun hydratePerUserFeatures() {
-        // Use getInstance() directly — this is called from the constructor init block before the
-        // userAccountManager lazy delegate is initialized, so we can't use the property here.
-        val users = UserAccountManager.getInstance().authenticatedUsers ?: return
+        val users = userAccountManager.authenticatedUsers ?: return
         for (u in users) {
             val flags = u.featureFlags
             if (flags.isNotEmpty()) {
@@ -1865,6 +1862,9 @@ open class SalesforceSDKManager protected constructor(
                     nativeLoginActivity,
                     googleCloudProjectId,
                 )
+                // Hydrate after INSTANCE is set — UserAccountManager.getInstance() checks
+                // SalesforceSDKManager.getInstance() internally, which requires INSTANCE != null.
+                INSTANCE?.hydratePerUserFeatures()
             }
             initInternal(context)
             EventsObservable.get().notifyEvent(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -154,6 +154,7 @@ import java.net.URI
 import java.util.Locale.US
 import java.util.SortedSet
 import java.util.UUID.randomUUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListSet
 import java.util.regex.Pattern
 import com.salesforce.androidsdk.auth.idp.IDPManager as DefaultIDPManager
@@ -407,6 +408,9 @@ open class SalesforceSDKManager protected constructor(
 
     /** App feature codes for reporting in the user agent header */
     private val features: SortedSet<String?>
+
+    /** Per-user feature codes keyed by "orgId/userId" */
+    private val perUserFeatures: ConcurrentHashMap<String, ConcurrentSkipListSet<String>> = ConcurrentHashMap()
 
     /**
      * An additional list of OAuth keys to fetch and store from the token
@@ -683,6 +687,7 @@ open class SalesforceSDKManager protected constructor(
         Handler(getMainLooper()).post {
             ProcessLifecycleOwner.get().lifecycle.addObserver(this)
         }
+        hydratePerUserFeatures()
     }
 
     /**
@@ -1272,8 +1277,24 @@ open class SalesforceSDKManager protected constructor(
      * @param qualifier The user agent qualifier
      * @return The user agent string to use for all requests
      */
-    open fun getUserAgent(qualifier: String) =
-        String.format(
+    open fun getUserAgent(qualifier: String) = getUserAgent(qualifier, null)
+
+    /**
+     * Returns a per-user agent string. Feature flags include both global and user-specific codes.
+     *
+     * @param qualifier The user agent qualifier
+     * @param user The user account, or null to use the current user
+     * @return The user agent string to use for all requests
+     */
+    open fun getUserAgent(qualifier: String, user: UserAccount?) : String {
+        val resolvedUser = user ?: userAccountManager.currentUser
+        val userKey = resolvedUser?.let { "${it.orgId}/${it.userId}" }
+        val userFeatures = userKey?.let { perUserFeatures[it] } ?: emptySet<String>()
+        val allFeatures = ConcurrentSkipListSet<String>(CASE_INSENSITIVE_ORDER).apply {
+            addAll(features.filterNotNull())
+            addAll(userFeatures)
+        }
+        return String.format(
             "SalesforceMobileSDK/%s android mobile/%s (%s) %s/%s %s uid_%s ftr_%s SecurityPatch/%s",
             SDK_VERSION,
             RELEASE,
@@ -1282,9 +1303,10 @@ open class SalesforceSDKManager protected constructor(
             appVersion,
             "$appType$qualifier",
             deviceId,
-            join(".", features),
+            join(".", allFeatures),
             SECURITY_PATCH
         )
+    }
 
     /** The app version */
     val appVersion: String
@@ -1320,6 +1342,59 @@ open class SalesforceSDKManager protected constructor(
      */
     fun unregisterUsedAppFeature(appFeatureCode: String?) =
         features.remove(appFeatureCode)
+
+    /**
+     * Returns true if the feature code is in the global (non-user-specific) set.
+     * @param appFeatureCode The app feature code
+     */
+    fun isGlobalFeatureRegistered(appFeatureCode: String) = features.contains(appFeatureCode)
+
+    /**
+     * Adds a per-user app feature code for reporting in the user agent header.
+     * Falls back to the global set when user is null.
+     * @param appFeatureCode The app feature code
+     * @param user The user account to associate the feature with
+     */
+    fun registerUsedAppFeature(appFeatureCode: String, user: UserAccount?) {
+        if (user == null) { registerUsedAppFeature(appFeatureCode); return }
+        val key = "${user.orgId}/${user.userId}"
+        val set = perUserFeatures.getOrPut(key) { ConcurrentSkipListSet(CASE_INSENSITIVE_ORDER) }
+        set.add(appFeatureCode)
+        persistUserFeatureFlags(user, set)
+    }
+
+    /**
+     * Removes a per-user app feature code from reporting in the user agent header.
+     * Falls back to the global set when user is null.
+     * @param appFeatureCode The app feature code
+     * @param user The user account to remove the feature from
+     */
+    fun unregisterUsedAppFeature(appFeatureCode: String, user: UserAccount?) {
+        if (user == null) { unregisterUsedAppFeature(appFeatureCode); return }
+        val key = "${user.orgId}/${user.userId}"
+        perUserFeatures[key]?.remove(appFeatureCode)
+        persistUserFeatureFlags(user, perUserFeatures[key] ?: emptySet())
+    }
+
+    private fun persistUserFeatureFlags(user: UserAccount, flags: Set<String>) {
+        user.featureFlags = HashSet(flags)
+        val account = userAccountManager.buildAccount(user) ?: return
+        userAccountManager.updateAccount(account, user)
+    }
+
+    /** Hydrates per-user features from persisted accounts at startup */
+    private fun hydratePerUserFeatures() {
+        val users = userAccountManager.authenticatedUsers ?: return
+        for (u in users) {
+            val flags = u.featureFlags
+            if (flags.isNotEmpty()) {
+                val key = "${u.orgId}/${u.userId}"
+                val set = ConcurrentSkipListSet<String>(CASE_INSENSITIVE_ORDER)
+                set.addAll(flags)
+                perUserFeatures[key] = set
+            }
+        }
+    }
 
     /** The app type */
     open val appType = "Native"

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -391,7 +391,7 @@ internal fun handleScreenLockPolicy(
 
     // compareTo(0) is used to check if screenLockTimeout is non-null and greater than 0.
     if (userIdentity?.screenLockTimeout?.compareTo(0) == 1) {
-        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_SCREEN_LOCK)
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_SCREEN_LOCK, account)
         val timeoutInMills = userIdentity.screenLockTimeout * 1000 * 60
         internalScreenLockManager?.storeMobilePolicy(
             account,
@@ -399,7 +399,7 @@ internal fun handleScreenLockPolicy(
             timeoutInMills,
         )
     } else if (internalScreenLockManager?.enabled == true) {
-        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_SCREEN_LOCK)
+        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_SCREEN_LOCK, account)
         internalScreenLockManager.cleanUp(account)
     }
 }
@@ -416,7 +416,7 @@ internal fun handleBiometricAuthPolicy(
         SalesforceSDKManager.getInstance().biometricAuthenticationManager as BiometricAuthenticationManager?
 
     if (userIdentity?.biometricAuth == true) {
-        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH)
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account)
         val timeoutInMills = userIdentity.biometricAuthTimeout * 60 * 1000
         internalBiometricAuthenticationManager?.storeMobilePolicy(
             account,
@@ -424,7 +424,7 @@ internal fun handleBiometricAuthPolicy(
             timeoutInMills
         )
     } else if (internalBiometricAuthenticationManager?.enabled == true) {
-        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH)
+        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account)
         internalBiometricAuthenticationManager.cleanUp(account)
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -92,6 +92,7 @@ public class AuthenticatorService extends Service {
     public static final String KEY_BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
     public static final String KEY_BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
     public static final String KEY_SCOPE = "scope";
+    public static final String KEY_FEATURE_FLAGS = "feature_flags";
 
     private static final String TAG = "AuthenticatorService";
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -259,7 +259,8 @@ public class RestClient {
         data.put(LOGIN_URL, clientInfo.loginUrl.toString());
         data.put(IDENTITY_URL, clientInfo.identityUrl.toString());
         data.put(INSTANCE_URL, clientInfo.instanceUrl.toString());
-        data.put(USER_AGENT, SalesforceSDKManager.getInstance().getUserAgent());
+        UserAccount currentUser = SalesforceSDKManager.getInstance().getUserAccountManager().getCurrentUser();
+        data.put(USER_AGENT, SalesforceSDKManager.getInstance().getUserAgent("", currentUser));
         data.put(COMMUNITY_ID, clientInfo.communityId);
         data.put(COMMUNITY_URL, clientInfo.communityUrl);
         return new JSONObject(data);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -548,9 +548,10 @@ open class LoginActivity : FragmentActivity() {
             sdkManager.registerUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN, userAccount)
         }
 
-        // BW: set per-user based on whether this session actually used a Custom Tab.
-        // isBrowserLoginEnabled is unreliable here — Login for Admin uses a Custom Tab
-        // without setting that flag. completedViaBrowserTab is true for both paths.
+        // BW: promote transient global to per-user, then clear global.
+        // completedViaBrowserTab is true for both regular and Login for Admin Custom Tab paths.
+        // The global was set in loadLoginPageInCustomTab() so it appears in UA during login.
+        sdkManager.unregisterUsedAppFeature(FEATURE_BROWSER_LOGIN)
         if (completedViaBrowserTab) {
             sdkManager.registerUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
         } else {
@@ -812,6 +813,7 @@ open class LoginActivity : FragmentActivity() {
     @VisibleForTesting
     internal fun loadLoginPageInCustomTab(loginUrl: String, customTabLauncher: ActivityResultLauncher<Intent>) {
         completedViaBrowserTab = true
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_BROWSER_LOGIN)
         val customTabsIntent = CustomTabsIntent.Builder().apply {
             /*
              * Set a custom animation to slide in and out for Chrome custom tab

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -121,6 +121,7 @@ import com.salesforce.androidsdk.R.string.sf__ssl_not_yet_valid
 import com.salesforce.androidsdk.R.string.sf__ssl_unknown_error
 import com.salesforce.androidsdk.R.string.sf__ssl_untrusted
 import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN
 import com.salesforce.androidsdk.app.Features.FEATURE_QR_CODE_LOGIN
 import com.salesforce.androidsdk.app.Features.FEATURE_WELCOME_DISCOVERY_LOGIN
 import com.salesforce.androidsdk.app.SalesforceSDKManager
@@ -233,6 +234,7 @@ open class LoginActivity : FragmentActivity() {
     // Private variables
     private var baseUserAgentString = ""
     private var wasBackgrounded = false
+    private var completedViaBrowserTab = false
     private var accountAuthenticatorResponse: AccountAuthenticatorResponse? = null
     private var accountAuthenticatorResult: Bundle? = null
     private var newUserIntent = false
@@ -537,6 +539,31 @@ open class LoginActivity : FragmentActivity() {
      * @param userAccount The newly created user account.
      */
     protected open fun onAuthFlowSuccess(userAccount: UserAccount) {
+        val sdkManager = SalesforceSDKManager.getInstance()
+
+        // WD: write per-user and clear transient global
+        val usedWelcomeDiscovery = sdkManager.isGlobalFeatureRegistered(FEATURE_WELCOME_DISCOVERY_LOGIN)
+        sdkManager.unregisterUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN)
+        if (usedWelcomeDiscovery) {
+            sdkManager.registerUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN, userAccount)
+        }
+
+        // BW: set per-user based on whether this session actually used a Custom Tab.
+        // isBrowserLoginEnabled is unreliable here — Login for Admin uses a Custom Tab
+        // without setting that flag. completedViaBrowserTab is true for both paths.
+        if (completedViaBrowserTab) {
+            sdkManager.registerUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
+        } else {
+            sdkManager.unregisterUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
+        }
+
+        // QR: write per-user and clear transient global
+        val usedQrLogin = sdkManager.isGlobalFeatureRegistered(FEATURE_QR_CODE_LOGIN)
+        sdkManager.unregisterUsedAppFeature(FEATURE_QR_CODE_LOGIN)
+        if (usedQrLogin) {
+            sdkManager.registerUsedAppFeature(FEATURE_QR_CODE_LOGIN, userAccount)
+        }
+
         // Create account and save result before switching to new user
         accountAuthenticatorResult = SalesforceSDKManager.getInstance().userAccountManager.createAccount(userAccount)
 
@@ -784,6 +811,7 @@ open class LoginActivity : FragmentActivity() {
 
     @VisibleForTesting
     internal fun loadLoginPageInCustomTab(loginUrl: String, customTabLauncher: ActivityResultLauncher<Intent>) {
+        completedViaBrowserTab = true
         val customTabsIntent = CustomTabsIntent.Builder().apply {
             /*
              * Set a custom animation to slide in and out for Chrome custom tab

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -254,7 +254,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
         if (TextUtils.isEmpty(dbNamePrefix)) {
             dbNamePrefix = DBOpenHelper.DEFAULT_DB_NAME;
         }
-        SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_SMART_STORE_USER);
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_SMART_STORE_USER, account);
         final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(getEncryptionKey(), context,
                 dbNamePrefix, account, communityId);
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -44,8 +44,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -721,6 +723,70 @@ public class UserAccountTest {
         response.put("language", TEST_LANGUAGE);
         response.put("locale", TEST_LOCALE);
         return new OAuth2.IdServiceResponse(response);
+    }
+
+    /**
+     * Tests that feature flags survive a toJson round-trip.
+     * Verifies that the FEATURE_FLAGS key is present in the serialized JSON and that the
+     * flags can be read back by manually parsing the JSON array (since the JSON constructor
+     * does not populate featureFlags — that path goes through AccountManager).
+     */
+    @Test
+    public void test_givenUserAccountWithFlags_whenToJson_thenFeatureFlagsKeyPresent() throws JSONException {
+        final UserAccount account = createTestAccount();
+        account.setFeatureFlags(new HashSet<>(Arrays.asList("BW", "WD")));
+
+        final JSONObject json = account.toJson(createAdditionalOauthKeys());
+
+        Assert.assertTrue("JSON should contain FEATURE_FLAGS key", json.has(UserAccount.FEATURE_FLAGS));
+
+        // Verify both flags are serialized in the JSON array
+        org.json.JSONArray flagsArray = json.getJSONArray(UserAccount.FEATURE_FLAGS);
+        HashSet<String> serialized = new HashSet<>();
+        for (int i = 0; i < flagsArray.length(); i++) {
+            serialized.add(flagsArray.getString(i));
+        }
+        Assert.assertTrue("Serialized flags should contain BW", serialized.contains("BW"));
+        Assert.assertTrue("Serialized flags should contain WD", serialized.contains("WD"));
+    }
+
+    /**
+     * Tests that a UserAccount built from JSON without a FEATURE_FLAGS key returns an empty set.
+     */
+    @Test
+    public void test_givenUserAccountJsonMissingFeatureFlags_whenFromJson_thenEmptySet() throws JSONException {
+        final JSONObject testJSON = createTestAccountJSON();
+        // Confirm the helper JSON does not include FEATURE_FLAGS
+        Assert.assertFalse("Test JSON should not have FEATURE_FLAGS", testJSON.has(UserAccount.FEATURE_FLAGS));
+
+        final UserAccount account = new UserAccount(testJSON, "SalesforceSDKTest", createAdditionalOauthKeys());
+
+        Assert.assertNotNull("featureFlags should never be null", account.getFeatureFlags());
+        Assert.assertTrue("featureFlags should be empty when key is absent", account.getFeatureFlags().isEmpty());
+    }
+
+    /**
+     * Tests that setFeatureFlags/getFeatureFlags are symmetric.
+     */
+    @Test
+    public void test_givenUserAccount_whenSetFeatureFlags_thenGetFeatureFlagsReturnsSameValues() {
+        final UserAccount account = createTestAccount();
+        final HashSet<String> flags = new HashSet<>(Arrays.asList("AA", "BB", "CC"));
+        account.setFeatureFlags(flags);
+
+        Assert.assertEquals("getFeatureFlags should return the set values", flags, account.getFeatureFlags());
+    }
+
+    /**
+     * Tests that setFeatureFlags(null) results in an empty set, not a NullPointerException.
+     */
+    @Test
+    public void test_givenUserAccount_whenSetFeatureFlagsNull_thenEmptySet() {
+        final UserAccount account = createTestAccount();
+        account.setFeatureFlags(null);
+
+        Assert.assertNotNull("featureFlags should never be null after setFeatureFlags(null)", account.getFeatureFlags());
+        Assert.assertTrue("featureFlags should be empty after setFeatureFlags(null)", account.getFeatureFlags().isEmpty());
     }
 
     /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.accounts.UserAccountBuilder
+import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
@@ -519,6 +522,106 @@ class SalesforceSDKManagerTests {
         assertNull(sdkManager.appAttestationClient)
     }
 
+    // -------------------------------------------------------------------------
+    // Per-user feature flag tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun test_givenTwoUsers_whenRegisterFeatureForUserA_thenOnlyUserAUAContainsFlag() {
+        val sdkManager = createSdkManagerWithMockedAccountManager()
+
+        val userA = buildMinimalUserAccount(orgId = "org1", userId = "user1")
+        val userB = buildMinimalUserAccount(orgId = "org2", userId = "user2")
+
+        sdkManager.registerUsedAppFeature("XY", userA)
+
+        try {
+            assertTrue(
+                "getUserAgent for userA should contain XY",
+                sdkManager.getUserAgent("", userA).contains("XY")
+            )
+            assertFalse(
+                "getUserAgent for userB should NOT contain XY",
+                sdkManager.getUserAgent("", userB).contains("XY")
+            )
+        } finally {
+            sdkManager.unregisterUsedAppFeature("XY", userA)
+        }
+    }
+
+    @Test
+    fun test_givenGlobalAndPerUserFlags_whenGetUserAgentForUser_thenUnionPresent() {
+        val sdkManager = createSdkManagerWithMockedAccountManager()
+
+        val userA = buildMinimalUserAccount(orgId = "org1", userId = "user1")
+        val userB = buildMinimalUserAccount(orgId = "org2", userId = "user2")
+
+        sdkManager.registerUsedAppFeature("GL")
+        sdkManager.registerUsedAppFeature("PU", userA)
+
+        try {
+            val agentA = sdkManager.getUserAgent("", userA)
+            assertTrue("getUserAgent for userA should contain global flag GL", agentA.contains("GL"))
+            assertTrue("getUserAgent for userA should contain per-user flag PU", agentA.contains("PU"))
+
+            val agentB = sdkManager.getUserAgent("", userB)
+            assertTrue("getUserAgent for userB should contain global flag GL", agentB.contains("GL"))
+            assertFalse("getUserAgent for userB should NOT contain per-user flag PU", agentB.contains("PU"))
+        } finally {
+            sdkManager.unregisterUsedAppFeature("GL")
+            sdkManager.unregisterUsedAppFeature("PU", userA)
+        }
+    }
+
+    @Test
+    fun test_givenNullUser_whenRegisterUsedAppFeature_thenGlobalFlagRegistered() {
+        val sdkManager = SalesforceSDKManager.getInstance()
+
+        sdkManager.registerUsedAppFeature("GF", null)
+
+        try {
+            assertTrue(
+                "isGlobalFeatureRegistered should return true for GF",
+                sdkManager.isGlobalFeatureRegistered("GF")
+            )
+        } finally {
+            sdkManager.unregisterUsedAppFeature("GF")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers for per-user feature flag tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a minimal [UserAccount] for testing using known test constants.
+     * orgId and userId are parameterized so tests can create distinct users.
+     */
+    private fun buildMinimalUserAccount(orgId: String, userId: String): UserAccount =
+        UserAccountBuilder.getInstance()
+            .authToken("test_auth_token")
+            .refreshToken("test_refresh_token")
+            .loginServer("https://test.salesforce.com")
+            .idUrl("https://test.salesforce.com/$orgId/$userId")
+            .instanceServer("https://cs1.salesforce.com")
+            .orgId(orgId)
+            .userId(userId)
+            .username("user_${userId}@example.com")
+            .accountName("user_$userId (https://cs1.salesforce.com) (SalesforceSDKTest)")
+            .build()
+
+    /**
+     * Creates a [SalesforceSDKManager] subclass whose [UserAccountManager] is fully
+     * mocked so that [persistUserFeatureFlags] cannot reach [AccountManager].
+     * This keeps per-user feature flag tests in-memory only.
+     */
+    private fun createSdkManagerWithMockedAccountManager(): SalesforceSDKManager =
+        TestSalesforceSDKManagerWithMockedAccounts(
+            context = getInstrumentation().targetContext,
+            mainActivity = LoginActivity::class.java,
+            loginActivity = LoginActivity::class.java,
+        )
+
     /**
      * Helper to create a test [SalesforceSDKManager] instance with optional
      * [googleCloudProjectId] for app attestation tests.
@@ -570,6 +673,29 @@ class SalesforceSDKManagerTests {
                 ))
                 // No-op for reset() to avoid SharedPreferences access
                 every { reset() } just runs
+            }
+        }
+    }
+
+    /**
+     * A [SalesforceSDKManager] subclass that replaces [userAccountManager] with a
+     * relaxed mock so that [persistUserFeatureFlags] cannot reach [AccountManager].
+     * Per-user feature flag tests use this to stay fully in-memory.
+     */
+    private class TestSalesforceSDKManagerWithMockedAccounts(
+        context: android.content.Context,
+        mainActivity: Class<out Activity>,
+        loginActivity: Class<out Activity>? = null,
+    ) : SalesforceSDKManager(context, mainActivity, loginActivity) {
+
+        override val userAccountManager: UserAccountManager by lazy {
+            mockk<UserAccountManager>(relaxed = true).apply {
+                // buildAccount returns null → persistUserFeatureFlags exits early
+                every { buildAccount(any()) } returns null
+                // currentUser returns null → getUserAgent falls back to no per-user key
+                every { currentUser } returns null
+                // authenticatedUsers returns null → hydratePerUserFeatures is a no-op
+                every { authenticatedUsers } returns null
             }
         }
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/AuthenticationUtilitiesTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/AuthenticationUtilitiesTest.kt
@@ -451,7 +451,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleScreenLockPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.registerUsedAppFeature(FEATURE_SCREEN_LOCK) }
+        verify { mockSdkManager.registerUsedAppFeature(FEATURE_SCREEN_LOCK, account) }
         verify { mockScreenLockManager.storeMobilePolicy(account, enabled = true, 600000) }
     }
 
@@ -472,7 +472,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleScreenLockPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK, account) }
         verify { mockScreenLockManager.cleanUp(account) }
     }
 
@@ -511,7 +511,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleScreenLockPolicy(null, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK, account) }
         verify { mockScreenLockManager.cleanUp(account) }
     }
 
@@ -555,7 +555,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleBiometricAuthPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH) }
+        verify { mockSdkManager.registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account) }
         verify { mockBioAuthManager.storeMobilePolicy(account, enabled = true, 900000) }
     }
 
@@ -576,7 +576,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleBiometricAuthPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account) }
         verify { mockBioAuthManager.cleanUp(account) }
     }
 
@@ -617,7 +617,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleBiometricAuthPolicy(null, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account) }
         verify { mockBioAuthManager.cleanUp(account) }
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -134,6 +134,22 @@ Tests for the Welcome Discovery login flow. Uses the SDK's Login Options "Discov
 | `testWelcomeDiscovery_RegularAuthLoginHost` | Regular Auth | ECA Opaque |
 | `testWelcomeDiscovery_AdvancedAuthLoginHost` | Advanced Auth | Beacon Opaque |
 
+#### LoginWithRestartTests
+Tests that user sessions and per-user feature flags persist across a cold app restart. Each test logs in, kills the app process (leaving the instrumentation runner alive), relaunches the app, and verifies that both session credentials and user-agent feature flags are reloaded correctly from disk. Feature flags tested: BW (browser-based / advanced auth) and WD (welcome discovery).
+
+| Test | App Config | Scopes | Config Type | Feature Flag |
+|------|-----------|--------|-------------|--------------|
+| `testCAOpaque_DefaultScopes_WithRestart` | CA Opaque | Default | Static | — |
+| `testECAOpaque_DefaultScopes_WithRestart` | ECA Opaque | Default | Static | — |
+| `testBeaconOpaque_DefaultScopes_WithRestart` | Beacon Opaque | Default | Static | — |
+| `testECAJwt_DefaultScopes_DynamicConfiguration_WithRestart` | ECA JWT | Default | Dynamic | — |
+| `testECAJwt_SubsetScopes_DynamicConfiguration_WithRestart` | ECA JWT | Subset | Dynamic | — |
+| `testBeaconJwt_DefaultScopes_DynamicConfiguration_WithRestart` | Beacon JWT | Default | Dynamic | — |
+| `testBeaconJwt_SubsetScopes_DynamicConfiguration_WithRestart` | Beacon JWT | Subset | Dynamic | — |
+| `testAdvancedAuth_WithRestart` | Beacon Opaque | Default | Static | BW |
+| `testWelcomeDiscovery_WithRestart` | ECA Opaque | Default | Static | WD |
+| `testMultiUserRestart` | ECA Opaque + ECA JWT | Default | Mixed | — |
+
 ### Validation Per Test
 
 Each `loginAndValidate` call performs the following checks:
@@ -151,13 +167,17 @@ Multi-user tests additionally verify:
 - **User switching** preserves each user's tokens and OAuth configuration
 - **Token refresh** targets the correct user's app after switching
 
+Restart tests additionally verify:
+- Session credentials are **reloaded from disk** after a cold process restart
+- Per-user feature flags (BW, WD) encoded in the user agent string **persist** across restarts via `hydratePerUserFeatures()`
+
 ## Architecture
 
 ### Test Infrastructure
 
 | Component | Description |
 |-----------|-------------|
-| `AuthFlowTest` | Abstract base class providing `loginAndValidate` and `migrateAndValidate` orchestration. Uses `ActivityScenarioRule` + `ComposeTestRule`. Assigns users based on API level to spread credential usage across Firebase Test Lab devices. |
+| `AuthFlowTest` | Abstract base class providing `loginAndValidate`, `migrateAndValidate`, and `restartAndValidateUser` orchestration. Also exposes `restartApp()` (kills only the app process via `pidof` filtered by `myPid`, then relaunches), `addOtherUserAndValidate()`, and `switchToUserAndValidateUser()` helpers for restart and multi-user flows. Uses `ActivityScenarioRule` + `ComposeTestRule`. Assigns users based on API level to spread credential usage across Firebase Test Lab devices. |
 | `UITestConfig` | Deserializes `ui_test_config.json` (from `shared/test/`) into typed enums: `KnownAppConfig`, `KnownLoginHostConfig`, `KnownUserConfig`, `ScopeSelection`. |
 
 ### Page Objects

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.samples.authflowtester
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.BEACON_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for verifying that user sessions and per-user feature flags persist across app restarts.
+ *
+ * Mirrors iOS `LoginWithRestartTests.swift`. Each test logs in, force-stops the process,
+ * relaunches, and asserts that both the session credentials and the feature flags encoded
+ * in the user agent string are reloaded correctly from disk.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class LoginWithRestartTests : AuthFlowTest() {
+
+    // MARK: - Session Persistence
+
+    /** Login with CA Opaque, restart app, verify session persists. */
+    @Test
+    fun testCAOpaque_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = CA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    /** Login with ECA Opaque, restart app, verify session persists. */
+    @Test
+    fun testECAOpaque_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - Feature Flag Persistence After Restart
+
+    /** Login via advanced auth (BW flag set), restart app, verify BW flag persists in user agent. */
+    @Test
+    fun testAdvancedAuth_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = ADVANCED_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = ADVANCED_AUTH,
+            expectAdvancedAuth = true,
+        )
+    }
+
+    /** Login via welcome discovery (WD flag set), restart app, verify WD flag persists in user agent. */
+    @Test
+    fun testWelcomeDiscovery_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+            useWelcomeDiscovery = true,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+            usesWelcomeDiscovery = true,
+        )
+    }
+}

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
@@ -29,30 +29,35 @@ package com.salesforce.samples.authflowtester
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.BEACON_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.BEACON_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
+import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.SUBSET
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Tests for verifying that user sessions and per-user feature flags persist across app restarts.
  *
- * Mirrors iOS `LoginWithRestartTests.swift`. Each test logs in, force-stops the process,
- * relaunches, and asserts that both the session credentials and the feature flags encoded
- * in the user agent string are reloaded correctly from disk.
+ * Mirrors iOS `LoginWithRestartTests.swift`. Each test logs in, force-stops the process via
+ * `am force-stop`, relaunches, and asserts that both the session credentials and the feature
+ * flags encoded in the user agent string are reloaded correctly from disk.
+ *
+ * NB: Tests use the `user` and `otherUser` derived from the device SDK level (see AuthFlowTest).
  */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class LoginWithRestartTests : AuthFlowTest() {
 
-    // MARK: - Session Persistence
+    // MARK: - Legacy Login Persistence
 
     /** Login with CA Opaque, restart app, verify session persists. */
     @Test
-    fun testCAOpaque_WithRestart() {
+    fun testCAOpaque_DefaultScopes_WithRestart() {
         loginAndValidate(
             knownAppConfig = CA_OPAQUE,
             knownLoginHostConfig = REGULAR_AUTH,
@@ -63,15 +68,90 @@ class LoginWithRestartTests : AuthFlowTest() {
         )
     }
 
+    // MARK: - ECA Login Persistence
+
     /** Login with ECA Opaque, restart app, verify session persists. */
     @Test
-    fun testECAOpaque_WithRestart() {
+    fun testECAOpaque_DefaultScopes_WithRestart() {
         loginAndValidate(
             knownAppConfig = ECA_OPAQUE,
             knownLoginHostConfig = REGULAR_AUTH,
         )
         restartAndValidateUser(
             knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - Beacon Login Persistence
+
+    /** Login with Beacon Opaque, restart app, verify session and child key persist. */
+    @Test
+    fun testBeaconOpaque_DefaultScopes_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - ECA Dynamic Configuration
+
+    /** Login with ECA JWT via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testECAJwt_DefaultScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    /** Login with ECA JWT using subset scopes via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testECAJwt_SubsetScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_JWT,
+            scopeSelection = SUBSET,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - Beacon Dynamic Configuration
+
+    /** Login with Beacon JWT via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testBeaconJwt_DefaultScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    /** Login with Beacon JWT using subset scopes via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testBeaconJwt_SubsetScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_JWT,
+            scopeSelection = SUBSET,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_JWT,
             knownLoginHostConfig = REGULAR_AUTH,
         )
     }
@@ -105,5 +185,34 @@ class LoginWithRestartTests : AuthFlowTest() {
             knownLoginHostConfig = REGULAR_AUTH,
             usesWelcomeDiscovery = true,
         )
+    }
+
+    // MARK: - Multi-User Restart
+
+    /** Login two users, restart app, verify both sessions and user agent flags persist. */
+    @Test
+    fun testMultiUserRestart() {
+        // Login user A
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+
+        // Login user B
+        addOtherUserAndValidate(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+
+        // Force-stop and relaunch — credentials must reload from disk
+        restartApp()
+
+        // Verify and switch to user A
+        switchToUserAndValidateUser(user)
+        app.validateApiRequest()
+
+        // Verify and switch to user B
+        switchToUserAndValidateUser(otherUser)
+        app.validateApiRequest()
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -371,8 +371,7 @@ class MultiUserLoginTests: AuthFlowTest() {
     ) {
         app.switchToUser(knownUserConfig)
         composeTestRule.waitForIdle()
-        app.validateUser(knownLoginHostConfig, knownUserConfig)
-        app.validateUserAgent(knownLoginHostConfig, isMultiUser = true)
+        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true)
     }
 
     /**
@@ -416,11 +415,9 @@ class MultiUserLoginTests: AuthFlowTest() {
 
         // Switch to User A — no BW, MU still present
         switchToUserAndValidate(user)
-        app.validateUserAgent(REGULAR_AUTH, isMultiUser = true)
 
         // Switch back to User B — BW back, MU still present
         switchToUserAndValidate(otherUser, ADVANCED_AUTH)
-        app.validateUserAgent(ADVANCED_AUTH, isMultiUser = true)
 
         // Log out User B via SDK — auto-switches to User A; MU must be gone
         val sdkManager = SalesforceSDKManager.getInstance()

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -421,6 +421,21 @@ class MultiUserLoginTests: AuthFlowTest() {
         // Switch back to User B — BW back, MU still present
         switchToUserAndValidate(otherUser, ADVANCED_AUTH)
         app.validateUserAgent(ADVANCED_AUTH, isMultiUser = true)
+
+        // Log out User B via SDK — auto-switches to User A; MU must be gone
+        val sdkManager = SalesforceSDKManager.getInstance()
+        val otherUserAccount = sdkManager.userAccountManager.authenticatedUsers
+            ?.find { it.username == testConfig.getUser(ADVANCED_AUTH, otherUser).username }
+            ?: throw AssertionError("Other user account not found")
+        sdkManager.logout(
+            account = sdkManager.userAccountManager.buildAccount(otherUserAccount),
+            frontActivity = null,
+            showLoginPage = false,
+        )
+        waitForUserCount(sdkManager.userAccountManager, expectedCount = 1)
+
+        // Back on User A — MU gone, no BW
+        app.validateUserAgent(REGULAR_AUTH, isMultiUser = false)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -39,6 +39,7 @@ import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQU
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection
@@ -360,6 +361,7 @@ class MultiUserLoginTests: AuthFlowTest() {
             useHybridAuthToken,
             knownLoginHostConfig,
             knownUserConfig = otherUser,
+            isMultiUser = true,
         )
     }
 
@@ -370,6 +372,7 @@ class MultiUserLoginTests: AuthFlowTest() {
         app.switchToUser(knownUserConfig)
         composeTestRule.waitForIdle()
         app.validateUser(knownLoginHostConfig, knownUserConfig)
+        app.validateUserAgent(knownLoginHostConfig, isMultiUser = true)
     }
 
     /**
@@ -393,6 +396,31 @@ class MultiUserLoginTests: AuthFlowTest() {
             "Timed out after ${timeoutMs}ms waiting for user count to reach " +
                 "$expectedCount (was $finalCount)"
         )
+    }
+
+    @Test
+    fun testAdvancedAuthUser_HasBWFlag_RegularAuthUser_DoesNot() {
+        // User A: regular auth — no BW
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+            knownUserConfig = user,
+            isMultiUser = false,
+        )
+
+        // User B: advanced auth — has BW; now 2 users → MU
+        loginOtherUserAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = ADVANCED_AUTH,
+        )
+
+        // Switch to User A — no BW, MU still present
+        switchToUserAndValidate(user)
+        app.validateUserAgent(REGULAR_AUTH, isMultiUser = true)
+
+        // Switch back to User B — BW back, MU still present
+        switchToUserAndValidate(otherUser, ADVANCED_AUTH)
+        app.validateUserAgent(ADVANCED_AUTH, isMultiUser = true)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
@@ -46,10 +46,9 @@ class RTRLoginTests : AuthFlowTest() {
 
     // region ECA JWT RTR Tests
 
-    // Login with ECA JWT RTR using hybrid auth token flow.
-    // Expected to fail until W-22512846 (Enable Named JWTs for Hybrid Flows) is resolved.
-    // The server currently returns invalid_grant when RTR is used with JWT tokens in hybrid flow.
-    @Ignore("Won't pass until server completes W-22512846")
+    // TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows.
+    // Server currently returns invalid_grant for RTR + JWT tokens in hybrid flow.
+    @Ignore("TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows")
     @Test
     fun testECAJwtRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RefreshTokenMigrationTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RefreshTokenMigrationTests.kt
@@ -205,6 +205,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         knownLoginHostConfig: KnownLoginHostConfig,
         knownUserConfig: KnownUserConfig,
         useWelcomeDiscovery: Boolean,
+        isMultiUser: Boolean,
     ) {
         super.loginAndValidate(
             knownAppConfig = knownAppConfig,
@@ -214,6 +215,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
             knownLoginHostConfig = knownLoginHostConfig,
             knownUserConfig = user,
             useWelcomeDiscovery = useWelcomeDiscovery,
+            isMultiUser = isMultiUser,
         )
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -54,6 +54,7 @@ import com.salesforce.samples.authflowtester.R
 import com.salesforce.samples.authflowtester.REQUEST_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.REVOKE_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.SCROLL_CONTAINER_CONTENT_DESC
+import com.salesforce.samples.authflowtester.USER_AGENT_CONTENT_DESC
 import com.salesforce.samples.authflowtester.components.ACCESS_TOKEN
 import com.salesforce.samples.authflowtester.components.CLIENT_ID
 import com.salesforce.samples.authflowtester.components.REFRESH_TOKEN
@@ -478,5 +479,46 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         return node.fetchSemanticsNode()
             .config[SemanticsProperties.Text]
             .last().text // Value is last; first is the label
+    }
+
+    fun validateUserAgent(
+        knownLoginHostConfig: KnownLoginHostConfig,
+        usesWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
+    ) {
+        expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
+        val ua = getText(USER_AGENT_CONTENT_DESC)
+
+        assert(ua.contains("SalesforceMobileSDK/")) {
+            "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
+        }
+        assert(ua.contains("ftr_")) {
+            "User agent missing 'ftr_' segment: $ua"
+        }
+
+        // Parse flag codes from the ftr_XXXX segment
+        val ftrSegment = ua.substringAfter("ftr_").substringBefore(" ")
+        val flags = ftrSegment.split(".").toSet()
+
+        when (knownLoginHostConfig) {
+            KnownLoginHostConfig.ADVANCED_AUTH -> assert("BW" in flags) {
+                "Expected 'BW' flag for ADVANCED_AUTH in: $ua"
+            }
+            KnownLoginHostConfig.REGULAR_AUTH -> assert("BW" !in flags) {
+                "Expected no 'BW' flag for REGULAR_AUTH in: $ua"
+            }
+        }
+
+        if (usesWelcomeDiscovery) {
+            assert("WD" in flags) {
+                "Expected 'WD' flag for Welcome Discovery in: $ua"
+            }
+        }
+
+        if (isMultiUser) {
+            assert("MU" in flags) {
+                "Expected 'MU' flag for multi-user in: $ua"
+            }
+        }
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -270,6 +270,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         knownUserConfig: KnownUserConfig,
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
     ) {
         val expected = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
 
@@ -306,7 +307,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
 
         // Validate feature flags — UI is already settled, reuse the existing layout traversal
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth)
     }
 
     fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection) {
@@ -494,9 +495,10 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         knownLoginHostConfig: KnownLoginHostConfig,
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
     ) {
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth)
     }
 
     private fun validateUserAgent(
@@ -504,6 +506,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         knownLoginHostConfig: KnownLoginHostConfig,
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
     ) {
         assert(ua.contains("SalesforceMobileSDK/")) {
             "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
@@ -516,12 +519,14 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         val ftrSegment = ua.substringAfter("ftr_").substringBefore(" ")
         val flags = ftrSegment.split(".").toSet()
 
-        when (knownLoginHostConfig) {
-            KnownLoginHostConfig.ADVANCED_AUTH -> assert("BW" in flags) {
-                "Expected 'BW' flag for ADVANCED_AUTH in: $ua"
+        val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == KnownLoginHostConfig.ADVANCED_AUTH
+        if (shouldHaveBW) {
+            assert("BW" in flags) {
+                "Expected 'BW' flag for browser-based auth in: $ua"
             }
-            KnownLoginHostConfig.REGULAR_AUTH -> assert("BW" !in flags) {
-                "Expected no 'BW' flag for REGULAR_AUTH in: $ua"
+        } else {
+            assert("BW" !in flags) {
+                "Expected no 'BW' flag for in-app WebView auth in: $ua"
             }
         }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -265,11 +265,16 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         )
     }
 
-    fun validateUser(knownLoginHostConfig: KnownLoginHostConfig, knownUserConfig: KnownUserConfig) {
+    fun validateUser(
+        knownLoginHostConfig: KnownLoginHostConfig,
+        knownUserConfig: KnownUserConfig,
+        usesWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
+    ) {
         val expected = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
 
         waitForNode(CREDS_SECTION_CONTENT_DESC)
-        
+
         // Wait for the UI to update asynchronously after login or user switch.
         // The view may be recreated and collapsed when the current user state updates.
         try {
@@ -298,6 +303,10 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
             throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for username to show \"${expected.username}\"", e)
         }
         assertEquals(expected.username, getText(USERNAME))
+
+        // Validate feature flags — UI is already settled, reuse the existing layout traversal
+        expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
     }
 
     fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection) {
@@ -487,8 +496,15 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         isMultiUser: Boolean = false,
     ) {
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        val ua = getText(USER_AGENT_CONTENT_DESC)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
+    }
 
+    private fun validateUserAgent(
+        ua: String,
+        knownLoginHostConfig: KnownLoginHostConfig,
+        usesWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
+    ) {
         assert(ua.contains("SalesforceMobileSDK/")) {
             "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
         }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -222,18 +222,31 @@ abstract class AuthFlowTest {
     }
 
     /**
-     * Force-stops and relaunches the app process.
+     * Kills the app process and relaunches it, so the SDK reloads all state from disk.
      *
-     * Uses `am force-stop` via UiAutomator shell so the SDK must reload all state from disk,
-     * exercising the same persistence code path as a real device restart. The instrumentation
-     * process stays alive; the Compose/UiAutomator bridge reattaches by package name.
+     * `am force-stop <package>` kills the instrumentation process too because the test
+     * runner shares the app's process. Instead, we get all PIDs for the package via
+     * `pidof`, exclude our own instrumentation PID, and kill only the app PID(s).
+     * This leaves the instrumentation alive while forcing the app to restart cold.
+     *
+     * After the kill, we relaunch via an explicit intent so the SDK re-runs
+     * `hydratePerUserFeatures()` from disk, exercising the same code path as a real restart.
      */
     fun restartApp() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val packageName = context.packageName
+        val device = UiDevice.getInstance(instrumentation)
+        val myPid = android.os.Process.myPid()
 
-        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
+        // Kill all processes in the package except the instrumentation runner's own PID.
+        val pidOutput = device.executeShellCommand("pidof $packageName").trim()
+        if (pidOutput.isNotEmpty()) {
+            pidOutput.split("\\s+".toRegex())
+                .mapNotNull { it.trim().toIntOrNull() }
+                .filter { it != myPid }
+                .forEach { pid -> device.executeShellCommand("kill -9 $pid") }
+        }
         Thread.sleep(1_000)
 
         val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -138,6 +138,7 @@ abstract class AuthFlowTest {
         knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
         knownUserConfig: KnownUserConfig = user,
         useWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
     ) {
         val loginPage = when(knownLoginHostConfig) {
             REGULAR_AUTH -> LoginPageObject(composeTestRule)
@@ -217,6 +218,7 @@ abstract class AuthFlowTest {
         app.validateUser(knownLoginHostConfig, knownUserConfig)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
+        app.validateUserAgent(knownLoginHostConfig, useWelcomeDiscovery, isMultiUser)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -259,7 +259,7 @@ abstract class AuthFlowTest {
         AuthorizationPageObject(composeTestRule).tapAllowAfterLogin(ADVANCED_AUTH)
 
         app.waitForAppLoad()
-        app.validateUser(REGULAR_AUTH, user)
+        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true)
         app.validateOAuthValues(KnownAppConfig.BEACON_OPAQUE, scopeSelection = EMPTY)
         app.validateApiRequest()
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -35,6 +35,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.samples.authflowtester.AuthFlowTesterActivity
 import com.salesforce.samples.authflowtester.pageObjects.AuthFlowTesterPageObject
@@ -218,6 +219,40 @@ abstract class AuthFlowTest {
         app.validateUser(knownLoginHostConfig, knownUserConfig, useWelcomeDiscovery, isMultiUser)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
+    }
+
+    /**
+     * Force-stops and relaunches the app, then validates the persisted user session.
+     *
+     * Mirrors iOS `restartAndValidateUser`. Uses `am force-stop` via UiAutomator to fully
+     * kill the process (not just recreate the activity), then relaunches via an explicit
+     * intent so the SDK reads all state from disk, exercising the same persistence code
+     * path as a real device restart.
+     */
+    fun restartAndValidateUser(
+        knownAppConfig: KnownAppConfig,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+        knownUserConfig: KnownUserConfig = user,
+        usesWelcomeDiscovery: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
+    ) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val packageName = context.packageName
+
+        // Kill the app process entirely so the SDK must reload state from disk.
+        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
+        Thread.sleep(1_000)
+
+        // Relaunch via explicit intent (mirrors how the ActivityScenarioRule would launch it).
+        val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra(AuthFlowTesterActivity.EXTRA_IS_UI_TESTING, true)
+        }
+        context.startActivity(launchIntent)
+
+        app.waitForAppLoad()
+        app.validateUser(knownLoginHostConfig, knownUserConfig, usesWelcomeDiscovery, expectAdvancedAuth = expectAdvancedAuth)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -215,10 +215,9 @@ abstract class AuthFlowTest {
         }
         app.waitForAppLoad()
 
-        app.validateUser(knownLoginHostConfig, knownUserConfig)
+        app.validateUser(knownLoginHostConfig, knownUserConfig, useWelcomeDiscovery, isMultiUser)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
-        app.validateUserAgent(knownLoginHostConfig, useWelcomeDiscovery, isMultiUser)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -222,12 +222,32 @@ abstract class AuthFlowTest {
     }
 
     /**
+     * Force-stops and relaunches the app process.
+     *
+     * Uses `am force-stop` via UiAutomator shell so the SDK must reload all state from disk,
+     * exercising the same persistence code path as a real device restart. The instrumentation
+     * process stays alive; the Compose/UiAutomator bridge reattaches by package name.
+     */
+    fun restartApp() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val packageName = context.packageName
+
+        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
+        Thread.sleep(1_000)
+
+        val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra(AuthFlowTesterActivity.EXTRA_IS_UI_TESTING, true)
+        }
+        context.startActivity(launchIntent)
+        app.waitForAppLoad()
+    }
+
+    /**
      * Force-stops and relaunches the app, then validates the persisted user session.
      *
-     * Mirrors iOS `restartAndValidateUser`. Uses `am force-stop` via UiAutomator to fully
-     * kill the process (not just recreate the activity), then relaunches via an explicit
-     * intent so the SDK reads all state from disk, exercising the same persistence code
-     * path as a real device restart.
+     * Mirrors iOS `restartAndValidateUser`.
      */
     fun restartAndValidateUser(
         knownAppConfig: KnownAppConfig,
@@ -236,23 +256,43 @@ abstract class AuthFlowTest {
         usesWelcomeDiscovery: Boolean = false,
         expectAdvancedAuth: Boolean = false,
     ) {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val context = instrumentation.targetContext
-        val packageName = context.packageName
-
-        // Kill the app process entirely so the SDK must reload state from disk.
-        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
-        Thread.sleep(1_000)
-
-        // Relaunch via explicit intent (mirrors how the ActivityScenarioRule would launch it).
-        val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            putExtra(AuthFlowTesterActivity.EXTRA_IS_UI_TESTING, true)
-        }
-        context.startActivity(launchIntent)
-
-        app.waitForAppLoad()
+        restartApp()
         app.validateUser(knownLoginHostConfig, knownUserConfig, usesWelcomeDiscovery, expectAdvancedAuth = expectAdvancedAuth)
+    }
+
+    /**
+     * Adds a second account by tapping "Add New Account", logs in, and validates.
+     * Mirrors iOS `loginOtherUserAndValidate`.
+     */
+    fun addOtherUserAndValidate(
+        knownAppConfig: KnownAppConfig,
+        scopeSelection: ScopeSelection = EMPTY,
+        useWebServerFlow: Boolean = true,
+        useHybridAuthToken: Boolean = true,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+    ) {
+        app.addNewAccount()
+        loginAndValidate(
+            knownAppConfig = knownAppConfig,
+            scopeSelection = scopeSelection,
+            useWebServerFlow = useWebServerFlow,
+            useHybridAuthToken = useHybridAuthToken,
+            knownLoginHostConfig = knownLoginHostConfig,
+            knownUserConfig = otherUser,
+            isMultiUser = true,
+        )
+    }
+
+    /**
+     * Switches to a user already logged in and validates. Mirrors iOS `switchToUserAndValidateUser`.
+     */
+    fun switchToUserAndValidateUser(
+        knownUserConfig: KnownUserConfig,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+    ) {
+        app.switchToUser(knownUserConfig)
+        composeTestRule.waitForIdle()
+        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
@@ -162,6 +162,7 @@ const val MIGRATE_USER_RADIO_CONTENT_DESC = "migrate_user_radio"
 const val ALERT_TITLE_CONTENT_DESC = "alert_title"
 const val ALERT_POSITIVE_BUTTON_CONTENT_DESC = "alert_positive"
 const val SCROLL_CONTAINER_CONTENT_DESC = "scroll_container"
+const val USER_AGENT_CONTENT_DESC = "user_agent"
 
 class AuthFlowTesterActivity : SalesforceActivity() {
     private var client: RestClient? = null

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/BaseComponents.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/BaseComponents.kt
@@ -271,6 +271,7 @@ fun InfoRowView(
     label: String,
     value: String?,
     isSensitive: Boolean = false,
+    contentDescription: String = label,
 ) {
     var isValueVisible by remember { mutableStateOf(!isSensitive) }
     val emptyText = stringResource(R.string.empty_placeholder)
@@ -321,7 +322,7 @@ fun InfoRowView(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(VALUE_WEIGHT)
                 .padding(end = (INNER_CARD_PADDING /2).dp)
-                .semantics { contentDescription = label },
+                .semantics { this.contentDescription = contentDescription },
         )
 
         if (isSensitive && !value.isNullOrEmpty()) {

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/UserCredentialsView.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/UserCredentialsView.kt
@@ -36,11 +36,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.ScopeParser.Companion.toScopeParser
 import com.salesforce.androidsdk.ui.theme.sfDarkColors
 import com.salesforce.androidsdk.ui.theme.sfLightColors
 import com.salesforce.androidsdk.util.test.ExcludeFromJacocoGeneratedReport
 import com.salesforce.samples.authflowtester.CREDS_SECTION_CONTENT_DESC
+import com.salesforce.samples.authflowtester.USER_AGENT_CONTENT_DESC
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -105,6 +107,7 @@ private const val BEACON_CHILD_CONSUMER_SECRET = "Beacon Child Consumer Secret"
 
 // Other fields
 private const val ADDITIONAL_OAUTH_FIELDS = "Additional OAuth Fields"
+private const val USER_AGENT_LABEL = "User Agent"
 
 @Composable
 fun UserCredentialsView(currentUser: UserAccount?) {
@@ -166,8 +169,17 @@ fun UserCredentialsView(currentUser: UserAccount?) {
 
         InfoSection(title = OTHER) {
             InfoRowView(label = ADDITIONAL_OAUTH_FIELDS, value = formatAdditionalOAuthFields(currentUser))
+            InfoRowView(
+                label = USER_AGENT_LABEL,
+                value = getUserAgentString(currentUser),
+                contentDescription = USER_AGENT_CONTENT_DESC,
+            )
         }
     }
+}
+
+private fun getUserAgentString(user: UserAccount?): String {
+    return if (user != null) SalesforceSDKManager.getInstance().getUserAgent("", user) else ""
 }
 
 private fun formatScopes(user: UserAccount?): String? {
@@ -246,6 +258,7 @@ private fun generateCredentialsJSON(user: UserAccount?): String {
 
             putJsonObject(OTHER) {
                 put(ADDITIONAL_OAUTH_FIELDS, formatAdditionalOAuthFields(user))
+                put(USER_AGENT_LABEL, getUserAgentString(user))
             }
         }
 


### PR DESCRIPTION
## Summary

Implements per-user persistent feature flags (BW / WD) on Android, with full UI test coverage including restart validation.

### feat: Per-user persistent feature flags (`W-21167151` / `W-23159744`)
- `SalesforceSDKManager.perUserFeatures`: in-memory `ConcurrentHashMap` loaded from disk at process startup via `hydratePerUserFeatures()`
- BW flag (browser-based / advanced auth) saved to disk per user at login; reloaded into user agent on next process start
- WD flag (welcome discovery) saved to disk per user at login; reloaded into user agent on next process start
- Register BW flag globally when Custom Tab launches (fixes missing flag when using advanced auth login host)
- Fix NPE in `hydratePerUserFeatures()` during construction

### feat: Display user agent in AuthFlowTester UI
- User agent string shown in the app and validated in all UI tests via `validateUserAgent()`

### feat: `restartApp()` helper and `LoginWithRestartTests` suite (new — 10 tests)
New `restartApp()` method in `AuthFlowTest` (base class) kills only the app process and relaunches it, so the SDK re-runs `hydratePerUserFeatures()` from disk — exercising the same code path as a real device restart. Uses `pidof <package>` filtered by `myPid` (the instrumentation runner's own PID) to avoid killing the test runner.

Built on top of `restartApp()`, new helper methods: `restartAndValidateUser()`, `addOtherUserAndValidate()`, `switchToUserAndValidateUser()`.

New `LoginWithRestartTests` suite (full parity with iOS):

| Test | What it verifies |
|------|-----------------|
| `testCAOpaque_DefaultScopes_WithRestart` | CA Opaque session persists after restart |
| `testECAOpaque_DefaultScopes_WithRestart` | ECA Opaque session persists after restart |
| `testBeaconOpaque_DefaultScopes_WithRestart` | Beacon Opaque session + child key persists after restart |
| `testECAJwt_DefaultScopes_DynamicConfiguration_WithRestart` | ECA JWT (dynamic config) session persists after restart |
| `testECAJwt_SubsetScopes_DynamicConfiguration_WithRestart` | ECA JWT subset scopes session persists after restart |
| `testBeaconJwt_DefaultScopes_DynamicConfiguration_WithRestart` | Beacon JWT (dynamic config) session persists after restart |
| `testBeaconJwt_SubsetScopes_DynamicConfiguration_WithRestart` | Beacon JWT subset scopes session persists after restart |
| `testAdvancedAuth_WithRestart` | BW feature flag persists in user agent after restart |
| `testWelcomeDiscovery_WithRestart` | WD feature flag persists in user agent after restart |
| `testMultiUserRestart` | Both users' sessions and flags persist after restart |

## Test plan
- [ ] All 10 `LoginWithRestartTests` pass on a connected device/emulator
- [ ] No regressions in existing `LoginTests`, `MultiUserLoginTests`, `DynamicConfigTests`, `ScopeSelectionTests`