### PR TITLE
Use forcedotcom-ubuntu runner for Linux CI jobs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   test-orchestrator:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/reusable-lib-workflow.yaml
+++ b/.github/workflows/reusable-lib-workflow.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   test-android:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   test-android:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:


### PR DESCRIPTION
## What
Switch all Linux GitHub Actions jobs from the public `ubuntu-latest` runner to the `forcedotcom-ubuntu` enterprise premium runner. macOS jobs are unchanged (there is no `forcedotcom-macos` runner).

## Why
`forcedotcom-ubuntu` supports much higher concurrency (~50 concurrent jobs) than the public pool, which our workflows have been hitting limits on as PR volume grew.

## Notes
- `forcedotcom-ubuntu` is scoped to the `forcedotcom` org — **personal forks cannot schedule it**. Each changed line carries an inline comment reminding fork contributors to swap back to `ubuntu-latest` for fork-based CI testing.
- Verified with a full nightly run on the org-scoped runner (in `SalesforceMobileSDK-UITests`): all Linux jobs picked up runners and ran concurrently, building apps and dispatching to Firebase Test Lab. Remaining test failures were pre-existing login/session flakes — present on the unchanged macOS jobs and the baseline `master` nightly too — and are unrelated to the runner change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
