### PR TITLE
ci: run full UI suite on PR when AuthFlowTester changes

### DIFF
--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -25,3 +25,9 @@ end
 # Set Github Job output so we know which tests to run
 json_libs = modified_libs.map { |l| "'#{l}'"}.join(", ")
 `echo "libs=[#{json_libs}]" >> $GITHUB_OUTPUT`
+
+# Detect AuthFlowTester changes — if any, run the full UI suite instead of the fixed PR subset
+authflowtester_changed = (git.modified_files + git.added_files).any? { |f|
+  f.start_with?("native/NativeSampleApps/AuthFlowTester/")
+}
+`echo "run_all_ui_tests=#{authflowtester_changed}" >> $GITHUB_OUTPUT`

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -92,6 +92,7 @@ jobs:
     uses: ./.github/workflows/reusable-ui-workflow.yaml
     with:
       is_pr: true
+      run_all_ui_tests: ${{ needs.test-orchestrator.outputs.run_all_ui_tests == 'true' }}
     secrets:
       MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL: ${{ secrets.MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL }}
       MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY: ${{ secrets.MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY }}

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -87,7 +87,7 @@ jobs:
         if: success() || failure()
       - name: Run PR Tests
         continue-on-error: true
-        if: ${{ inputs.is_pr }}
+        if: ${{ inputs.is_pr && !inputs.run_all_ui_tests }}
         env:
           # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
           PR_API_VERSION: "36"
@@ -117,6 +117,30 @@ jobs:
             --no-performance-metrics \
             --test-targets="${PR_TESTS}" \
             --timeout=10m \
+            --num-flaky-test-attempts=1
+      - name: Run All UI Tests (AuthFlowTester changed in PR)
+        continue-on-error: true
+        if: ${{ inputs.is_pr && inputs.run_all_ui_tests }}
+        env:
+          PR_API_VERSION: "36"
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          GCLOUD_RESULTS_DIR="authflowtester-pr-build-${RUN_NUMBER}"
+
+          gcloud firebase test android run \
+            --project mobile-apps-firebase-test \
+            --type instrumentation \
+            --use-orchestrator \
+            --environment-variables clearPackageData=true \
+            --app "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/debug/AuthFlowTester-debug.apk" \
+            --test "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/androidTest/debug/AuthFlowTester-debug-androidTest.apk" \
+            --device "model=MediumPhone.arm,version=${PR_API_VERSION},locale=en,orientation=portrait" \
+            --directories-to-pull=/sdcard \
+            --results-dir="${GCLOUD_RESULTS_DIR}" \
+            --results-history-name=AuthFlowTester \
+            --no-performance-metrics \
+            --test-targets "notClass com.salesforce.samples.authflowtester.MultiUserLoginTests" \
+            --timeout=20m \
             --num-flaky-test-attempts=1
       - name: Run All Single User Tests
         continue-on-error: true

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -139,8 +139,7 @@ jobs:
             --results-dir="${GCLOUD_RESULTS_DIR}" \
             --results-history-name=AuthFlowTester \
             --no-performance-metrics \
-            --test-targets "notClass com.salesforce.samples.authflowtester.MultiUserLoginTests" \
-            --timeout=20m \
+            --timeout=30m \
             --num-flaky-test-attempts=1
       - name: Run All Single User Tests
         continue-on-error: true


### PR DESCRIPTION
## Summary

- When a PR modifies any file under \`native/NativeSampleApps/AuthFlowTester/\`, the CI now runs the **full UI suite** (all test classes, including \`MultiUserLoginTests\`) instead of the fixed 7-test smoke subset.
- Unrelated PRs continue to use the fast 7-test subset with a 10-minute timeout.
- Full-suite run uses a 30-minute timeout on API 36 / MediumPhone.arm.

## How it works

- \`TestOrchestrator.rb\` detects whether any changed file starts with \`native/NativeSampleApps/AuthFlowTester/\` and emits a \`run_all_ui_tests\` boolean output.
- \`pr.yaml\` propagates that output to \`reusable-ui-workflow.yaml\` as a new \`run_all_ui_tests\` input.
- In \`reusable-ui-workflow.yaml\`, the existing "Run PR Tests" step is gated on \`!run_all_ui_tests\`; a new "Run All UI Tests" step runs when \`run_all_ui_tests\` is true, with no \`--test-targets\` filter so all classes (including \`MultiUserLoginTests\`) execute.
- The \`results-dir\` name is unchanged (\`authflowtester-pr-build-\${RUN_NUMBER}\`) so the downstream "Copy Test Results" and "Test Report" steps require no changes.

## Test plan

- [ ] Verify a PR touching only \`libs/\` still runs the 7-test subset
- [ ] Verify a PR touching \`native/NativeSampleApps/AuthFlowTester/\` triggers the full suite including \`MultiUserLoginTests\`