### PR TITLE
feat(W-22695293): DPoP proof JWT at token exchange (Phase 2, Android)

### DIFF
--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -4,7 +4,7 @@
 warn("Big PR, try to keep changes smaller if you can.", sticky: true) if git.lines_of_code > 1000
 
 # Redirect contributors to PR to dev.
-fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if github.branch_for_base != "dev"
+fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if !["dev", "fix-reusable-ui-workflow-missing-input"].include?(github.branch_for_base)
 
 # List of Android libraries for testing
 LIBS = ['SalesforceAnalytics', 'SalesforceSDK', 'SmartStore', 'MobileSync', 'SalesforceHybrid']

--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -4,7 +4,7 @@
 warn("Big PR, try to keep changes smaller if you can.", sticky: true) if git.lines_of_code > 1000
 
 # Redirect contributors to PR to dev.
-fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if !["dev", "fix-reusable-ui-workflow-missing-input"].include?(github.branch_for_base)
+fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if github.branch_for_base != "dev"
 
 # List of Android libraries for testing
 LIBS = ['SalesforceAnalytics', 'SalesforceSDK', 'SmartStore', 'MobileSync', 'SalesforceHybrid']

--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -25,3 +25,9 @@ end
 # Set Github Job output so we know which tests to run
 json_libs = modified_libs.map { |l| "'#{l}'"}.join(", ")
 `echo "libs=[#{json_libs}]" >> $GITHUB_OUTPUT`
+
+# Detect AuthFlowTester changes — if any, run the full UI suite instead of the fixed PR subset
+authflowtester_changed = (git.modified_files + git.added_files).any? { |f|
+  f.start_with?("native/NativeSampleApps/AuthFlowTester/")
+}
+`echo "run_all_ui_tests=#{authflowtester_changed}" >> $GITHUB_OUTPUT`

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -92,6 +92,7 @@ jobs:
     uses: ./.github/workflows/reusable-ui-workflow.yaml
     with:
       is_pr: true
+      run_all_ui_tests: ${{ needs.test-orchestrator.outputs.run_all_ui_tests == 'true' }}
     secrets:
       MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL: ${{ secrets.MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL }}
       MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY: ${{ secrets.MSDK_ANDROID_REMOTE_ACCESS_CONSUMER_KEY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     outputs:
       libs: ${{ steps.test-orchestrator.outputs.libs }}
+      run_all_ui_tests: ${{ steps.test-orchestrator.outputs.run_all_ui_tests }}
     steps:
       - name: Check Write Permission
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   test-orchestrator:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,7 @@ on:
   # Mitigated by per-job Member Check (see "Check Write Permission" + "Validate Write Permission" steps).
   # Reference: team Github Actions Tribal Knowledge doc.
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master, fix-reusable-ui-workflow-missing-input]
+    branches: [dev, master]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,7 @@ on:
   # Mitigated by per-job Member Check (see "Check Write Permission" + "Validate Write Permission" steps).
   # Reference: team Github Actions Tribal Knowledge doc.
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master]
+    branches: [dev, master, fix-reusable-ui-workflow-missing-input]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'

--- a/.github/workflows/reusable-lib-workflow.yaml
+++ b/.github/workflows/reusable-lib-workflow.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   test-android:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -87,7 +87,7 @@ jobs:
         if: success() || failure()
       - name: Run PR Tests
         continue-on-error: true
-        if: ${{ inputs.is_pr }}
+        if: ${{ inputs.is_pr && !inputs.run_all_ui_tests }}
         env:
           # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
           PR_API_VERSION: "36"
@@ -117,6 +117,30 @@ jobs:
             --no-performance-metrics \
             --test-targets="${PR_TESTS}" \
             --timeout=10m \
+            --num-flaky-test-attempts=1
+      - name: Run All UI Tests (AuthFlowTester changed in PR)
+        continue-on-error: true
+        if: ${{ inputs.is_pr && inputs.run_all_ui_tests }}
+        env:
+          PR_API_VERSION: "36"
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          GCLOUD_RESULTS_DIR="authflowtester-pr-build-${RUN_NUMBER}"
+
+          gcloud firebase test android run \
+            --project mobile-apps-firebase-test \
+            --type instrumentation \
+            --use-orchestrator \
+            --environment-variables clearPackageData=true \
+            --app "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/debug/AuthFlowTester-debug.apk" \
+            --test "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/androidTest/debug/AuthFlowTester-debug-androidTest.apk" \
+            --device "model=MediumPhone.arm,version=${PR_API_VERSION},locale=en,orientation=portrait" \
+            --directories-to-pull=/sdcard \
+            --results-dir="${GCLOUD_RESULTS_DIR}" \
+            --results-history-name=AuthFlowTester \
+            --no-performance-metrics \
+            --test-targets "notClass com.salesforce.samples.authflowtester.MultiUserLoginTests" \
+            --timeout=20m \
             --num-flaky-test-attempts=1
       - name: Run All Single User Tests
         continue-on-error: true

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -139,8 +139,7 @@ jobs:
             --results-dir="${GCLOUD_RESULTS_DIR}" \
             --results-history-name=AuthFlowTester \
             --no-performance-metrics \
-            --test-targets "notClass com.salesforce.samples.authflowtester.MultiUserLoginTests" \
-            --timeout=20m \
+            --timeout=30m \
             --num-flaky-test-attempts=1
       - name: Run All Single User Tests
         continue-on-error: true

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   test-android:
-    runs-on: ubuntu-latest
+    runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -4,6 +4,9 @@ on:
       is_pr:
         type: boolean
         default: false
+      run_all_ui_tests:
+        type: boolean
+        default: false
     secrets:
       MSDK_ANDROID_REMOTE_ACCESS_CALLBACK_URL:
         required: true

--- a/docs/authentication/OAUTH2-TOKEN-EXCHANGE-ANALYSIS.md
+++ b/docs/authentication/OAUTH2-TOKEN-EXCHANGE-ANALYSIS.md
@@ -1,0 +1,477 @@
+# Android OAuth2 Token Exchange — Code Analysis
+## Pre-DPoP baseline for W-22695293
+
+This document analyzes the Android OAuth2 token exchange implementation as it exists today
+(pre-DPoP). It is written to guide the DPoP implementation (W-22695293) by identifying
+exact integration points and their current behavior.
+
+---
+
+## 1. Primary Files
+
+### 1a. `libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java`
+The central OAuth2 helper class. All token endpoint calls are static methods.
+
+### 1b. `libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java`
+The REST client. Contains `OAuthRefreshInterceptor`, which intercepts 401 responses and
+triggers token refresh before retrying.
+
+---
+
+## 2. Token Exchange Flow
+
+### 2a. Authorization Code Exchange
+
+**Method:** `OAuth2.exchangeCode()`
+
+```java
+public static TokenEndpointResponse exchangeCode(
+    HttpAccess httpAccessor, URI loginServer,
+    String clientId, String code, String codeVerifier, String callbackUrl)
+    throws OAuthFailedException, IOException
+```
+
+**What it does:**
+1. Builds a `FormBody` with: `grant_type`, `client_id`, `format=json`, `code`, `code_verifier`, `redirect_uri`
+2. Delegates to `makeTokenEndpointRequest()`
+
+**Integration path from login UI:**
+`LoginViewModel.doCodeExchange()` → `OAuth2.exchangeCode()` → `makeTokenEndpointRequest()`
+
+**DPoP hook:** `makeTokenEndpointRequest()` is the single entry point — this is where
+the `DPoP` header must be added for both code exchange and refresh.
+
+---
+
+### 2b. Token Refresh
+
+**Method:** `OAuth2.refreshAuthToken()`
+
+```java
+public static TokenEndpointResponse refreshAuthToken(
+    HttpAccess httpAccessor, URI loginServer,
+    String clientId, String refreshToken, Map<String,String> addlParams)
+    throws OAuthFailedException, IOException
+```
+
+**What it does:**
+1. Builds a `FormBody` with: `grant_type` (refresh_token or hybrid_refresh), `client_id`,
+   `refresh_token`, `format=json`, optional `addlParams`
+2. Delegates to `makeTokenEndpointRequest()`
+
+**Integration path from expired session:**
+`OAuthRefreshInterceptor.refreshAccessToken()` → `authTokenProvider.getNewAuthToken()` →
+... → `OAuth2.refreshAuthToken()` → `makeTokenEndpointRequest()`
+
+**DPoP hook:** Same — `makeTokenEndpointRequest()`.
+
+---
+
+### 2c. `makeTokenEndpointRequest()` — The Central Integration Point
+
+```java
+@VisibleForTesting @WorkerThread
+public static TokenEndpointResponse makeTokenEndpointRequest(
+    HttpAccess httpAccessor, URI loginServer,
+    FormBody.Builder formBodyBuilder,
+    SalesforceSDKManager salesforceSdkManager)
+    throws OAuthFailedException, IOException
+```
+
+**Current flow:**
+```
+1. Build URL: loginServer + "/services/oauth2/token" + "?device_id=..."
+2. (Optional) Append attestation to query string if available
+3. Build OkHttp Request: POST, RequestBody from formBodyBuilder
+4. Execute via httpAccessor.getOkHttpClient().newCall(request).execute()
+5. If successful → return new TokenEndpointResponse(response)
+6. If failed → throw OAuthFailedException(new TokenErrorResponse(response), status)
+```
+
+**DPoP changes needed here (Phase 2):**
+- After step 2/3, build a DPoP proof JWT and add it as the `DPoP` header
+- After step 5, parse `token_type` from response and persist it
+- Wrap step 4 in a nonce-retry loop (Phase 4)
+
+**Method signature change needed:**
+The current method doesn't accept a `credentialsIdentifier` (scope key for key store lookup).
+This needs to be threaded in from callers (`exchangeCode` and `refreshAuthToken`).
+
+---
+
+## 3. Authorization Header: Current Baseline
+
+### `OAuth2.addAuthorizationHeader()`
+
+```java
+public static Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken) {
+    return builder.header(AUTHORIZATION, BEARER + authToken);
+    // AUTHORIZATION = "Authorization"
+    // BEARER = "Bearer "
+}
+```
+
+**Used in:**
+- `OAuth2.callIdentityService()` — identity endpoint call
+- `RestClient.OAuthRefreshInterceptor.setAuthHeader()` — all API calls via interceptor
+
+**DPoP changes needed (Phase 2):**
+- Accept a `tokenType` parameter
+- When `tokenType == "DPoP"`: use `"DPoP "` prefix instead of `"Bearer "`
+- Phase 3 will also need to add the `DPoP` proof header at this point
+
+---
+
+## 4. `OAuthRefreshInterceptor` — API Call Authentication
+
+**Location:** `RestClient.java`, inner static class
+
+**Lifecycle:** One instance per user account, stored in `OAUTH_REFRESH_INTERCEPTORS` cache.
+
+**Fields:**
+```java
+private final AuthTokenProvider authTokenProvider;
+private String authToken;
+private ClientInfo clientInfo;
+```
+
+### 4a. `intercept()` — The OkHttp Interceptor
+
+```
+1. buildAuthenticatedRequest(request)    ← adds Authorization: Bearer <token>
+2. chain.proceed(request)                ← send the request
+3. if shouldRefresh(response):           ← 401 or 403-with-Bad_OAuth_Token
+   a. refreshAccessToken()               ← calls authTokenProvider.getNewAuthToken()
+   b. if new token is not null:
+      - buildAuthenticatedRequest(request)   ← re-stamp with new token
+      - adjust host if instanceUrl changed   ← instance migration
+      - chain.proceed(request)               ← retry
+4. return response
+```
+
+**DPoP changes needed (Phase 3):**
+- `buildAuthenticatedRequest()` must also attach the `DPoP` proof header when `tokenType == "DPoP"`
+- `shouldRefresh()` must also detect `use_dpop_nonce` challenges (Phase 4)
+
+### 4b. `buildAuthenticatedRequest()`
+
+```java
+private Request buildAuthenticatedRequest(Request request) {
+    Request.Builder builder = request.newBuilder();
+    setAuthHeader(builder);
+    return builder.build();
+}
+
+private void setAuthHeader(Request.Builder builder) {
+    if (authToken != null) {
+        OAuth2.addAuthorizationHeader(builder, authToken);
+    }
+}
+```
+
+**Current behavior:** Always `Authorization: Bearer <token>`.
+
+**DPoP changes (Phase 3):** Must check tokenType and call DPoP decorator.
+
+---
+
+## 5. `TokenEndpointResponse` — Response Parsing
+
+**Location:** `OAuth2.java`, static inner class
+
+**Current fields (relevant to DPoP):**
+```java
+public String authToken;       // "access_token"
+public String refreshToken;    // "refresh_token"
+public String instanceUrl;     // "instance_url"
+public String tokenFormat;     // "token_format"
+// ... many other fields
+```
+
+**`TokenEndpointResponse(Response response)` constructor:**
+Parses JSON from the HTTP response body. Fields are populated via:
+```java
+authToken = parsedResponse.getString(ACCESS_TOKEN);
+instanceUrl = parsedResponse.getString(INSTANCE_URL);
+tokenFormat = parsedResponse.optString(TOKEN_FORMAT);
+// ... etc.
+```
+
+**DPoP change needed (Phase 2):**
+Add `tokenType` field and populate it:
+```java
+public String tokenType;       // "token_type" — "DPoP" or "Bearer"
+// In constructor:
+tokenType = parsedResponse.optString(TOKEN_TYPE);  // add TOKEN_TYPE = "token_type" constant
+```
+
+**Where this propagates:**
+`TokenEndpointResponse` is consumed by `LoginViewModel` and account management code, which
+populate `UserAccount`. The `tokenType` must be stored in `UserAccount` (or the equivalent
+credential storage) so it's available to `OAuthRefreshInterceptor` at API call time.
+
+---
+
+## 6. `TokenErrorResponse` — Error Parsing
+
+**Current fields:**
+```java
+public String error;
+public String errorDescription;
+```
+
+**DPoP relevance:** `invalid_dpop_proof` errors at code exchange will surface here.
+The SDK currently surfaces these generically — no special handling. For Phase 2, the
+error propagation path is already in place; DPoP-specific errors are readable via
+`getTokenErrorResponse().error` on the `OAuthFailedException`.
+
+---
+
+## 7. `LoginViewModel.doCodeExchange()` — Error Handling
+
+**Location:** `libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/LoginViewModel.kt`
+
+The code exchange flow:
+```kotlin
+try {
+    val response = OAuth2.exchangeCode(...)
+    // on success: store tokens, proceed to identity service
+} catch (e: OAuth2.OAuthFailedException) {
+    onAuthFlowError(...)
+    // broadcasts AUTHENTICATION_FAILED_INTENT
+    // shows a Toast
+    // reloads the login page
+}
+```
+
+**DPoP error visibility:** When `invalid_dpop_proof` is returned, it is surfaced as a
+generic OAuth error. The error and error_description from the token response are preserved
+in `OAuthFailedException.response` (`TokenErrorResponse`), so apps can distinguish DPoP
+failures if they catch the broadcast.
+
+---
+
+## 8. `SalesforceSDKManager` — Configuration Entry Point
+
+**Location:** `libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.java`
+
+Relevant to DPoP:
+- **Opt-in flag needed:** Add `private boolean useDPoP = false;` with getter/setter
+- **Device ID:** `getDeviceId()` — already used in token endpoint URL; provides a stable
+  identifier pattern (but DPoP scope key should be the user credentials ID, not device ID)
+- **App Attestation pattern:** The attestation integration (conditionally appends a query
+  parameter) provides a good template for how to conditionally add the DPoP header in
+  `makeTokenEndpointRequest()`
+
+---
+
+## 9. Android Keystore (DPoP Key Storage Context)
+
+The Android Keystore API provides hardware-backed key storage:
+
+```kotlin
+// Generate EC/P-256 key pair
+val keyPairGenerator = KeyPairGenerator.getInstance(
+    KeyProperties.KEY_ALGORITHM_EC, "AndroidKeyStore")
+keyPairGenerator.initialize(
+    KeyGenParameterSpec.Builder(
+        alias,  // "dpop_" + credentialsIdentifier
+        KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY
+    )
+    .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))  // P-256
+    .setDigests(KeyProperties.DIGEST_SHA256)
+    .build()
+)
+val keyPair = keyPairGenerator.generateKeyPair()
+```
+
+**Key retrieval:**
+```kotlin
+val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+val privateKey = keyStore.getKey(alias, null) as PrivateKey
+val publicKey = keyStore.getCertificate(alias).publicKey as ECPublicKey
+```
+
+**No simulator special-casing needed** (unlike iOS). Android Keystore works on emulators
+(software-backed) and real devices (hardware-backed) with the same API.
+
+**Key accessibility:** Keys are accessible to the app after device boot, without user
+authentication required — appropriate for background token refreshes.
+
+---
+
+## 10. Existing Tests
+
+### 10a. `OAuth2MockTests.kt` (mock-based unit tests)
+
+**Location:** `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2MockTests.kt`
+
+**Framework:** Kotlin + MockK + AndroidJUnit4
+
+**Pattern:** Uses `mockk<>` to mock `SalesforceSDKManager`, `AppAttestationClient`,
+`HttpAccess`, and `OkHttpClient`. Captures the outbound `Request` via a `slot<Request>()`
+and asserts on its URL/body.
+
+**Existing tests:**
+- `oauth2_getAuthorizationUrl_includesAttestationParameterWhenNotNull`
+- `oauth2_getAuthorizationUrl_excludesAttestationParameterWhenNull`
+- `oauth2_makeTokenEndpointRequest_includesAttestationParameterWhenNotNull` — captures
+  the request and asserts the `attestation` query param is present
+- `oauth2_makeTokenEndpointRequest_excludesAttestationParameterWhenNull`
+- `oauth2_exchangeCode_sendsAuthorizationCodeParameters` — asserts `client_id`, `code`,
+  `code_verifier` present in form body
+- `oauth2_swapJWTForTokens_sendsJwtBearerGrantTypeAndAssertion`
+
+**DPoP test pattern to follow:** The `attestation` tests provide the exact pattern for
+testing that a header/parameter is (or is not) added. Follow the same mock structure:
+capture the outgoing `Request`, assert the `DPoP` header is present (when `useDPoP=true`)
+or absent (when `useDPoP=false`).
+
+### 10b. `OAuth2OverrideLoginServerTests.kt`
+
+**Location:** `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2OverrideLoginServerTests.kt`
+
+**Framework:** Pure JUnit4 (no Android dependencies, no mocks — tests pure logic)
+
+**Naming convention:** `test_given[Precondition]_when[Action]_then[Expected]` (same as iOS)
+
+**Tests:** `overrideLoginServerIfNeeded()` with instance server, null server, community URL,
+malformed URL, empty string — good coverage of a pure-logic method.
+
+**Relevance to DPoP:** This test file is a good template for testing pure-logic DPoP helpers
+(URL canonicalization, JWT structure parsing, JWK coordinate extraction) — no Android
+dependencies, fast to run.
+
+### 10c. `OAuth2Test.java` (integration tests)
+
+**Location:** `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2Test.java`
+
+Full integration tests requiring a connected device and live credentials (`test_credentials.json`).
+
+### 10d. `AuthenticatorServiceTest.kt` and `AuthenticationUtilitiesTest.kt`
+
+Broader auth flow tests covering login flows, account management, and service interactions.
+
+---
+
+## 11. Test Infrastructure Patterns
+
+### MockK usage in `OAuth2MockTests.kt`
+
+```kotlin
+val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+    every { deviceId } returns "__DEVICE_ID__"
+    every { appAttestationClient } returns null
+}
+val requestSlot = slot<Request>()
+val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+    every { okHttpClient } returns mockk {
+        every { newCall(capture(requestSlot)) } returns mockk {
+            every { execute() } returns okHttpResponse
+        }
+    }
+}
+// ... call the method under test ...
+// Assert on requestSlot.captured
+```
+
+### Canned response construction
+
+```kotlin
+val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+    .toResponseBody("application/json; charset=utf-8".toMediaType())
+val okHttpResponse = mockk<Response>(relaxed = true) {
+    every { isSuccessful } returns true
+    every { body } returns responseBody
+}
+```
+
+### DPoP response pattern (to be added)
+
+For testing DPoP `token_type` detection:
+```kotlin
+val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u","token_type":"DPoP"}"""
+    .toResponseBody("application/json; charset=utf-8".toMediaType())
+```
+
+---
+
+## 12. Phase 2 Implementation Plan
+
+Based on the code analysis, here is the minimum change set for W-22695293:
+
+### New class: `DPoPManager.kt` (new file)
+**Location:** `libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/`
+
+```
+Responsibilities:
+- generateOrLoadKeyPair(alias: String): KeyPair — Android Keystore EC/P-256
+- deleteKeyPair(alias: String)
+- buildProof(httpMethod: String, htu: String, nonce: String?, accessToken: String?): String
+  → constructs compact JWS: header.payload.signature
+  → sign with SHA256withECDSA, convert DER→raw R||S
+- getPublicKeyAsJwk(publicKey: ECPublicKey): Map<String, String>
+  → { kty: "EC", crv: "P-256", x: <base64url(X)>, y: <base64url(Y)> }
+- canonicalHtu(url: String): String  → strip query and fragment
+```
+
+### Modified: `OAuth2.java`
+
+**`makeTokenEndpointRequest()` changes:**
+1. Add `credentialsIdentifier: String` parameter (threaded from callers)
+2. After building the `Request`, if `useDPoP`:
+   - Call `DPoPManager.generateOrLoadKeyPair(alias)` to get the key pair
+   - Call `DPoPManager.buildProof("POST", htu, nonce=null, accessToken=null)`
+   - Add `DPoP` header to request
+3. After getting successful response:
+   - Parse `token_type` from JSON response
+   - Persist on the returned `TokenEndpointResponse`
+
+**`addAuthorizationHeader()` change:**
+- Add `tokenType: String?` parameter
+- If `tokenType == "DPoP"`: use `"DPoP "` prefix; otherwise `"Bearer "`
+
+**`TokenEndpointResponse` change:**
+- Add `public String tokenType;` field
+- Parse `token_type` from JSON in the `Response` constructor
+
+### Modified: `SalesforceSDKManager.java`
+- Add `private boolean useDPoP = false;`
+- Add `public boolean isUseDPoP()` and `public void setUseDPoP(boolean)`
+
+### Modified: `UserAccount` (or equivalent credential storage)
+- Add `tokenType` field that's populated from `TokenEndpointResponse.tokenType` after
+  successful exchange
+- Make it survive serialization/deserialization like other credential fields
+
+### NOT changed in Phase 2:
+- `OAuthRefreshInterceptor` (Phase 3)
+- Nonce cache or retry logic (Phase 4)
+- `ath` claim (Phase 3)
+
+---
+
+## 13. Credential Scope Key for Android DPoP
+
+iOS uses `SFOAuthCredentials.identifier` — a stable string generated before the first
+token-endpoint call. On Android, the equivalent stable pre-login identifier needs to be
+identified. Candidates:
+
+1. **`clientInfo.userId`** — available after successful login, NOT before
+2. **`SalesforceSDKManager.getDeviceId()`** — device-level, not user-level
+3. **A generated GUID per login session** — stored alongside the pending credentials
+
+The iOS approach (scoping to `credentials.identifier`) means each user account gets its
+own DPoP key pair. For Android, the closest analog is the account name or a UUID generated
+at the start of the auth flow and stored with the in-progress credentials.
+
+**This needs to be decided before implementation.** The iOS REFERENCES doc notes that the
+scope key must be stable from before the first token-endpoint call.
+
+---
+
+## 14. Related Documentation
+
+- **iOS Implementation Analysis:** See workspace `specs/W-22695293-android-dpop-token-exchange/iOS-IMPLEMENTATION-ANALYSIS.md`
+- **Design Spec:** See workspace `specs/W-22606569-dpop-support/dpop-support.md`
+- **RFC 9449:** https://datatracker.ietf.org/doc/html/rfc9449

--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -1,0 +1,277 @@
+# Push Notifications — Salesforce Mobile SDK for Android
+
+This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Prerequisites](#prerequisites)
+3. [Architecture](#architecture)
+4. [Key Classes](#key-classes)
+5. [Registration Lifecycle](#registration-lifecycle)
+6. [Re-registration Modes](#re-registration-modes)
+7. [Encrypted Push Notifications](#encrypted-push-notifications)
+8. [Actionable Notifications](#actionable-notifications)
+9. [Testing](#testing)
+
+---
+
+## Overview
+
+The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications from a Salesforce org to Android devices. Registration state is stored per-user in private `SharedPreferences`, and push notifications can be encrypted end-to-end using RSA + AES.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| `google-services.json` | Place in your app module root; required for FCM token acquisition |
+| `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
+| `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
+| External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
+
+---
+
+## Architecture
+
+```
+App
+ └── SalesforceSDKManager
+      ├── pushNotificationReceiver: PushNotificationInterface   ← app implements this
+      └── pushServiceType: Class<out PushService>              ← customizable
+
+PushMessaging (object)          ← entry point for register/unregister
+ └── PushService (open class)   ← handles SFDC endpoint communication
+      └── PushNotificationsRegistrationChangeWorker  ← WorkManager worker
+
+SFDCFcmListenerService          ← FCM callbacks (onNewToken, onMessageReceived)
+ └── PushNotificationDecryptor  ← optional payload decryption
+```
+
+**Data flow — registration:**
+1. App calls `PushMessaging.register(context, account)`.
+2. `PushMessaging` acquires the FCM token from Firebase.
+3. Token is stored in `SharedPreferences` keyed by user account.
+4. A `PushNotificationsRegistrationChangeWorker` is enqueued via `WorkManager`.
+5. The worker calls `PushService.performRegistrationChange(register=true, ...)`.
+6. `PushService` POSTs to the Salesforce `MobilePushServiceDevice` REST endpoint.
+7. On success, the Salesforce device ID is stored alongside the FCM token.
+
+**Data flow — incoming message:**
+1. FCM delivers the message to `SFDCFcmListenerService.onMessageReceived`.
+2. `PushNotificationDecryptor` decrypts the payload if it is encrypted.
+3. The plaintext payload is forwarded to `PushNotificationInterface.onPushMessageReceived`.
+
+---
+
+## Key Classes
+
+### `PushNotificationInterface`
+
+Interface that the app must implement to receive push notifications.
+
+```kotlin
+interface PushNotificationInterface {
+    fun onPushMessageReceived(data: Map<String?, String?>?)
+    fun supplyFirebaseMessaging(): FirebaseMessaging?   // optional; return null for default
+}
+```
+
+Register the implementation before the SDK initializes:
+```kotlin
+SalesforceSDKManager.getInstance().pushNotificationReceiver = MyPushReceiver()
+```
+
+---
+
+### `PushMessaging` (object)
+
+Utility singleton for push operations. The main entry points for the app.
+
+| Method | Description |
+|---|---|
+| `register(context, account)` | Register or re-register a user for push |
+| `register(context, account, recreateKey)` | Same, with option to rotate the RSA key |
+| `unregister(context, account, isLastAccount)` | Unregister a user; delete Firebase app if last account |
+| `registerSFDCPush(context, account)` | Re-register at the SFDC endpoint only (token already known) |
+| `isRegistered(context, account)` | Whether the FCM token is stored for this account |
+| `getRegistrationId(context, account)` | Returns the stored FCM token |
+| `getDeviceId(context, account)` | Returns the Salesforce device ID |
+| `getNotificationsTypes(account)` | Returns stored Salesforce notification types |
+| `clearRegistrationInfo(context, account)` | Wipe all registration state for this account |
+
+---
+
+### `PushService` (open class)
+
+Handles communication with the Salesforce `MobilePushServiceDevice` REST endpoint. Subclass this to customize the registration or unregistration requests.
+
+Key companion object property:
+```kotlin
+var pushNotificationsRegistrationType: PushNotificationReRegistrationType
+    = ReRegistrationOnAppForeground   // default
+```
+
+Key methods:
+
+| Method | Description |
+|---|---|
+| `performRegistrationChange(register, userAccount, restClient?)` | Main entry point called by the WorkManager worker |
+| `onRegistered(registrationId, account, restClient)` | Handles a successful FCM registration |
+| `onUnregistered(account, restClient)` | Handles logout / unregistration |
+| `registerSFDCPushNotification(...)` | POSTs to SFDC endpoint, returns Salesforce device ID |
+| `unregisterSFDCPushNotification(...)` | DELETEs from SFDC endpoint |
+| `onPushNotificationRegistrationStatus(status, userAccount)` | Override to react to registration status changes |
+| `onSendRegisterPushNotificationRequest(...)` | Override to customize the registration HTTP request |
+| `onSendUnregisterPushNotificationRequest(...)` | Override to customize the unregistration HTTP request |
+| `fetchNotificationsTypes(restClient, userAccount)` | Fetches Salesforce notification types from the API |
+| `registerNotificationChannels(...)` | Creates Android notification channels from Salesforce types |
+| `removeNotificationsCategories()` | Deletes all Salesforce notification channels |
+
+Registration status constants (passed to `onPushNotificationRegistrationStatus`):
+
+| Constant | Value |
+|---|---|
+| `REGISTRATION_STATUS_SUCCEEDED` | 0 |
+| `REGISTRATION_STATUS_FAILED` | 1 |
+| `UNREGISTRATION_STATUS_SUCCEEDED` | 2 |
+| `UNREGISTRATION_STATUS_FAILED` | 3 |
+
+---
+
+### `PushNotificationsRegistrationChangeWorker`
+
+Internal `Worker` subclass that executes push registration changes on a background thread via `WorkManager`. Not instantiated directly — use `PushService.enqueuePushNotificationsRegistrationWork(...)`.
+
+When `userAccount` is `null`, the worker iterates all authenticated users and calls `performRegistrationChange` for each.
+
+---
+
+### `SFDCFcmListenerService`
+
+Extends `FirebaseMessagingService`. Declared in the SDK's `AndroidManifest.xml` with `android:exported="false"`.
+
+| Callback | Behaviour |
+|---|---|
+| `onNewToken(token)` | Stores the new FCM token and re-registers the current user at the SFDC endpoint |
+| `onMessageReceived(message)` | Forwards the message (after optional decryption) to `PushNotificationInterface` |
+
+---
+
+### `PushNotificationDecryptor`
+
+Singleton that decrypts incoming push payloads. Called automatically by `SFDCFcmListenerService`.
+
+Encrypted payload fields:
+- `encrypted` — boolean; if `false`, the payload is forwarded unchanged
+- `secret` — RSA-encrypted AES symmetric key (base64)
+- `content` — AES-encrypted notification body (base64)
+
+Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
+
+---
+
+### `SalesforceActionableNotificationContent`
+
+Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
+
+```kotlin
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
+```
+
+Parse from the `content` field of a received notification:
+```kotlin
+val content = SalesforceActionableNotificationContent.fromJson(jsonString)
+```
+
+---
+
+## Registration Lifecycle
+
+```
+App foreground / login
+        │
+        ▼
+PushMessaging.register(context, account)
+        │
+        ├─ First time for this account ──► acquire FCM token ──► store token
+        │                                                          │
+        │                                                          ▼
+        └─ Already registered ──────────────────────► enqueue WorkManager job
+                                                                   │
+                                                                   ▼
+                                               PushService.performRegistrationChange
+                                                                   │
+                                                                   ▼
+                                                  POST /services/data/vXX.0/sobjects/
+                                                       MobilePushServiceDevice
+                                                                   │
+                                                      ┌────────────┴─────────────┐
+                                                      ▼                          ▼
+                                               201 Created               404 Not Found
+                                           (store device ID)        (push not enabled —
+                                                                       stop retrying)
+```
+
+**Unregistration** (logout):
+1. App calls `PushMessaging.unregister(context, account, isLastAccount)`.
+2. If last account, Firebase token is deleted and the Firebase app is removed.
+3. `PushService.onUnregistered` DELETEs from `MobilePushServiceDevice`.
+4. Broadcasts `UNREGISTERED_ATTEMPT_COMPLETE_EVENT` and `UNREGISTERED_EVENT`.
+5. Stored registration info is cleared from `SharedPreferences`.
+
+---
+
+## Re-registration Modes
+
+Set via `PushService.pushNotificationsRegistrationType`:
+
+```kotlin
+PushService.pushNotificationsRegistrationType =
+    PushService.PushNotificationReRegistrationType.ReRegisterPeriodically
+```
+
+| Value | Behaviour |
+|---|---|
+| `ReRegistrationDisabled` | No automatic re-registration |
+| `ReRegistrationOnAppForeground` | Re-registers when the app foregrounds **(default)** |
+| `ReRegisterPeriodically` | Re-registers all users every six days via a periodic `WorkManager` task, regardless of foreground/background |
+
+`ReRegisterPeriodically` is useful to counteract periodic SFDC API cleanup that de-registers devices after extended inactivity.
+
+---
+
+## Encrypted Push Notifications
+
+Enable encryption by ensuring the SDK's RSA key pair is registered during push setup. The SDK automatically:
+1. Generates an RSA-2048 key pair in the Android Keystore (key name derived from `SalesforceKeyGenerator.getUniqueId("PushNotificationKey")`).
+2. Includes the RSA public key and cipher name (`RSA_OAEP_SHA256`) in the `MobilePushServiceDevice` registration payload.
+3. Salesforce encrypts the AES symmetric key with the public key before sending the notification.
+4. `PushNotificationDecryptor` uses the private key from the Keystore to decrypt the symmetric key, then decrypts the payload.
+
+No app-side configuration is required beyond normal SDK setup.
+
+---
+
+## Testing
+
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
+
+| Test class | Coverage |
+|---|---|
+| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+
+Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
+
+```bash
+./gradlew :libs:SalesforceSDK:connectedAndroidTest
+```
+
+Or build the APK for upload:
+```bash
+./gradlew :libs:SalesforceSDK:assembleAndroidTest
+```

--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -12,9 +12,10 @@ This document covers the push notification subsystem in `libs/SalesforceSDK`. Al
 4. [Key Classes](#key-classes)
 5. [Registration Lifecycle](#registration-lifecycle)
 6. [Re-registration Modes](#re-registration-modes)
-7. [Encrypted Push Notifications](#encrypted-push-notifications)
-8. [Actionable Notifications](#actionable-notifications)
-9. [Testing](#testing)
+7. [Foreground Registration Mode](#foreground-registration-mode)
+8. [Encrypted Push Notifications](#encrypted-push-notifications)
+9. [Actionable Notifications](#actionable-notifications)
+10. [Testing](#testing)
 
 ---
 
@@ -109,10 +110,13 @@ Utility singleton for push operations. The main entry points for the app.
 
 Handles communication with the Salesforce `MobilePushServiceDevice` REST endpoint. Subclass this to customize the registration or unregistration requests.
 
-Key companion object property:
+Key companion object properties:
 ```kotlin
 var pushNotificationsRegistrationType: PushNotificationReRegistrationType
     = ReRegistrationOnAppForeground   // default
+
+var foregroundRegistrationMode: PushNotificationForegroundRegistrationMode
+    = PushNotificationForegroundRegistrationMode.ALL_USERS   // default
 ```
 
 Key methods:
@@ -241,6 +245,28 @@ PushService.pushNotificationsRegistrationType =
 | `ReRegisterPeriodically` | Re-registers all users every six days via a periodic `WorkManager` task, regardless of foreground/background |
 
 `ReRegisterPeriodically` is useful to counteract periodic SFDC API cleanup that de-registers devices after extended inactivity.
+
+---
+
+## Foreground Registration Mode
+
+When `pushNotificationsRegistrationType` is `ReRegistrationOnAppForeground`, a separate property controls **which users** are re-registered each time the app foregrounds:
+
+```kotlin
+PushService.foregroundRegistrationMode =
+    PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER
+```
+
+| Value | Behaviour |
+|---|---|
+| `ALL_USERS` | Re-registers every authenticated user **(default)** |
+| `CURRENT_USER` | Re-registers only the currently active user (pre-14.0 behaviour) |
+
+`foregroundRegistrationMode` only takes effect when `pushNotificationsRegistrationType` is `ReRegistrationOnAppForeground`. It is ignored for `ReRegistrationDisabled` and `ReRegisterPeriodically`.
+
+### Why `CURRENT_USER` exists
+
+Some Publisher customers are billed **per login event**. An FCM token refresh on a background user triggers a re-registration request which in turn counts as a billable login. With `ALL_USERS` (the default), background users that haven't foregrounded recently may have their tokens refreshed when the app comes to the foreground. Set `CURRENT_USER` to prevent this for those deployments.
 
 ---
 

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/LayoutSyncManager.kt
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/LayoutSyncManager.kt
@@ -307,7 +307,7 @@ class LayoutSyncManager private constructor(
                 store,
                 syncManager
             ).also { INSTANCES[uniqueId] = it }
-            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_LAYOUT_SYNC)
+            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_LAYOUT_SYNC, user)
             return instance
         }
 

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/MetadataSyncManager.kt
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/MetadataSyncManager.kt
@@ -236,7 +236,7 @@ class MetadataSyncManager private constructor(
                 INSTANCES[uniqueId] = it
             }
             SalesforceSDKManager.getInstance()
-                .registerUsedAppFeature(Features.FEATURE_METADATA_SYNC)
+                .registerUsedAppFeature(Features.FEATURE_METADATA_SYNC, user)
             return instance
         }
 

--- a/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/SyncManager.kt
+++ b/libs/MobileSync/src/com/salesforce/androidsdk/mobilesync/manager/SyncManager.kt
@@ -827,7 +827,7 @@ class SyncManager private constructor(smartStore: SmartStore, restClient: RestCl
                 instance = SyncManager(store, restClient)
                 instance.also { INSTANCES[uniqueId] = it }
             }
-            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_MOBILE_SYNC)
+            SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_MOBILE_SYNC, user)
             return instance
         }
 

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/app/SalesforceHybridSDKManager.java
@@ -31,6 +31,7 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.config.BootConfig;
 import com.salesforce.androidsdk.mobilesync.app.MobileSyncSDKManager;
 import com.salesforce.androidsdk.mobilesync.config.SyncsConfig;
@@ -148,13 +149,19 @@ public class SalesforceHybridSDKManager extends MobileSyncSDKManager {
 	@NonNull
     @Override
 	public final String getUserAgent(@NonNull String qualifier) {
+		return getUserAgent(qualifier, null);
+	}
+
+	@NonNull
+	@Override
+	public final String getUserAgent(@NonNull String qualifier, @androidx.annotation.Nullable UserAccount user) {
 		final BootConfig config = BootConfig.getBootConfig(context);
 		if (config.isLocal()) {
 			qualifier = qualifier + "Local";
 		} else {
 			qualifier = qualifier + "Remote";
 		}
-		return super.getUserAgent(qualifier);
+		return super.getUserAgent(qualifier, user);
 	}
 
     @NonNull

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -105,6 +105,8 @@ public class UserAccount {
 	public static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
 	public static final String SCOPE = "scope";
 	public static final String FEATURE_FLAGS = "feature_flags";
+	public static final String DPOP_SCOPE = "dpopScope";
+	public static final String TOKEN_TYPE = "tokenType";
 
 	private static final String TAG = "UserAccount";
 	private static final String FORWARD_SLASH = "/";
@@ -152,6 +154,8 @@ public class UserAccount {
 	private String beaconChildConsumerKey;
 	private String beaconChildConsumerSecret;
 	private String scope;
+	private String dpopScope;
+	private String tokenType;
 	private Set<String> featureFlags = new java.util.HashSet<>();
 
 	/**
@@ -295,6 +299,8 @@ public class UserAccount {
 			beaconChildConsumerKey = object.optString(BEACON_CHILD_CONSUMER_KEY, null);
 			beaconChildConsumerSecret = object.optString(BEACON_CHILD_CONSUMER_SECRET, null);
 			scope = object.optString(SCOPE, null);
+			dpopScope = object.optString(DPOP_SCOPE, null);
+			tokenType = object.optString(TOKEN_TYPE, null);
 			additionalOauthValues = MapUtil.addJSONObjectToMap(object, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -352,6 +358,8 @@ public class UserAccount {
 			beaconChildConsumerKey = bundle.getString(BEACON_CHILD_CONSUMER_KEY);
 			beaconChildConsumerSecret = bundle.getString(BEACON_CHILD_CONSUMER_SECRET);
 			scope = bundle.getString(SCOPE);
+			dpopScope = bundle.getString(DPOP_SCOPE);
+			tokenType = bundle.getString(TOKEN_TYPE);
 			additionalOauthValues = MapUtil.addBundleToMap(bundle, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -739,6 +747,44 @@ public class UserAccount {
 	public boolean hasScope(String scopeToCheck) {
 		return new ScopeParser(scope).hasScope(scopeToCheck);
 	}
+
+	/**
+	 * Returns the DPoP credentials identifier used as the keystore alias for
+	 * this user's DPoP keypair.
+	 *
+	 * @return DPoP credentials identifier, or null if DPoP is not in use.
+	 */
+	public String getDpopScope() {
+		return dpopScope;
+	}
+
+	/**
+	 * Sets the DPoP credentials identifier.
+	 *
+	 * @param dpopScope DPoP credentials identifier.
+	 */
+	public void setDpopScope(String dpopScope) {
+		this.dpopScope = dpopScope;
+	}
+
+	/**
+	 * Returns the token type returned by the token endpoint
+	 * (e.g. "Bearer" or "DPoP").
+	 *
+	 * @return Token type, or null if not set.
+	 */
+	public String getTokenType() {
+		return tokenType;
+	}
+
+	/**
+	 * Sets the token type.
+	 *
+	 * @param tokenType Token type.
+	 */
+	public void setTokenType(String tokenType) {
+		this.tokenType = tokenType;
+	}
 	/**
 	 * Returns the beacon child consumer key.
 	 *
@@ -1048,6 +1094,8 @@ public class UserAccount {
 			object.put(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 			object.put(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 			object.put(SCOPE, scope);
+			if (dpopScope != null) object.put(DPOP_SCOPE, dpopScope);
+			if (tokenType != null) object.put(TOKEN_TYPE, tokenType);
 			if (!featureFlags.isEmpty()) {
 				org.json.JSONArray flagsArray = new org.json.JSONArray();
 				for (String f : featureFlags) flagsArray.put(f);
@@ -1114,6 +1162,8 @@ public class UserAccount {
 		object.putString(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 		object.putString(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 		object.putString(SCOPE, scope);
+		if (dpopScope != null) object.putString(DPOP_SCOPE, dpopScope);
+		if (tokenType != null) object.putString(TOKEN_TYPE, tokenType);
 		object = MapUtil.addMapToBundle(additionalOauthValues, additionalOauthKeys, object);
 		return object;
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -49,8 +49,12 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class represents a single user account that is currently
@@ -100,6 +104,7 @@ public class UserAccount {
 	public static final String BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
 	public static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
 	public static final String SCOPE = "scope";
+	public static final String FEATURE_FLAGS = "feature_flags";
 
 	private static final String TAG = "UserAccount";
 	private static final String FORWARD_SLASH = "/";
@@ -147,6 +152,7 @@ public class UserAccount {
 	private String beaconChildConsumerKey;
 	private String beaconChildConsumerSecret;
 	private String scope;
+	private Set<String> featureFlags = new java.util.HashSet<>();
 
 	/**
 	 * Parameterized constructor.
@@ -761,6 +767,24 @@ public class UserAccount {
 	}
 
 	/**
+	 * Returns the persisted per-user feature flags (e.g. BW, SU, MS).
+	 *
+	 * @return Unmodifiable set of feature flag codes.
+	 */
+	public Set<String> getFeatureFlags() {
+		return Collections.unmodifiableSet(featureFlags);
+	}
+
+	/**
+	 * Replaces the in-memory set of persisted per-user feature flags.
+	 *
+	 * @param flags The new set of feature flags.
+	 */
+	public void setFeatureFlags(Set<String> flags) {
+		featureFlags = flags != null ? new HashSet<>(flags) : new HashSet<>();
+	}
+
+	/**
 	 * Fetches this user's profile photo from the cache.
 	 *
 	 * @return User's profile photo.
@@ -1024,6 +1048,11 @@ public class UserAccount {
 			object.put(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 			object.put(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 			object.put(SCOPE, scope);
+			if (!featureFlags.isEmpty()) {
+				org.json.JSONArray flagsArray = new org.json.JSONArray();
+				for (String f : featureFlags) flagsArray.put(f);
+				object.put(FEATURE_FLAGS, flagsArray);
+			}
 			object = MapUtil.addMapToJSONObject(additionalOauthValues, additionalOauthKeys, object);
 		} catch (JSONException e) {
 			SalesforceSDKLogger.e(TAG, "Unable to convert to JSON", e);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
@@ -72,6 +72,8 @@ class UserAccountBuilder private constructor() {
     private var beaconChildConsumerKey: String? = null
     private var beaconChildConsumerSecret: String? = null
     private var scope: String? = null
+    private var dpopScope: String? = null
+    private var tokenType: String? = null
 
     /**
      * Set fields from token end point response
@@ -108,6 +110,7 @@ class UserAccountBuilder private constructor() {
             .beaconChildConsumerKey(tr.beaconChildConsumerKey)
             .beaconChildConsumerSecret(tr.beaconChildConsumerSecret)
             .scope(tr.scope)
+            .tokenType(tr.tokenType)
     }
 
     /**
@@ -176,6 +179,8 @@ class UserAccountBuilder private constructor() {
             .beaconChildConsumerKey(userAccount.beaconChildConsumerKey)
             .beaconChildConsumerSecret(userAccount.beaconChildConsumerSecret)
             .scope(userAccount.scope)
+            .dpopScope(userAccount.dpopScope)
+            .tokenType(userAccount.tokenType)
     }
 
     /**
@@ -586,12 +591,32 @@ class UserAccountBuilder private constructor() {
     }
 
     /**
+     * Sets DPoP credentials identifier (keystore alias for the DPoP keypair).
+     *
+     * @param dpopScope DPoP credentials identifier.
+     * @return Instance of this class.
+     */
+    fun dpopScope(dpopScope: String?): UserAccountBuilder {
+        return if (!allowUnset && dpopScope == null) this else apply { this.dpopScope = dpopScope }
+    }
+
+    /**
+     * Sets token type (e.g. "Bearer" or "DPoP").
+     *
+     * @param tokenType Token type.
+     * @return Instance of this class.
+     */
+    fun tokenType(tokenType: String?): UserAccountBuilder {
+        return if (!allowUnset && tokenType == null) this else apply { this.tokenType = tokenType }
+    }
+
+    /**
      * Builds and returns a UserAccount object.
      *
      * @return UserAccount object.
      */
     fun build(): UserAccount {
-        return UserAccount(
+        val account = UserAccount(
             authToken,
             refreshToken,
             loginServer,
@@ -631,6 +656,9 @@ class UserAccountBuilder private constructor() {
             apiInstanceServer,
             scope,
         )
+        account.dpopScope = dpopScope
+        account.tokenType = tokenType
+        return account
     }
 
     companion object {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -50,9 +50,12 @@ import com.salesforce.androidsdk.ui.LoginActivity;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class acts as a manager that provides methods to access
@@ -553,6 +556,7 @@ public class UserAccountManager {
 		final String beaconChildConsumerKey = decryptUserData(account, AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_KEY, encryptionKey);
 		final String beaconChildConsumerSecret = decryptUserData(account, AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_SECRET, encryptionKey);
 		final String scope = decryptUserData(account, AuthenticatorService.KEY_SCOPE, encryptionKey);
+		final String featureFlagsRaw = decryptUserData(account, AuthenticatorService.KEY_FEATURE_FLAGS, encryptionKey);
 
 		Map<String, String> additionalOauthValues = null;
 		List<String> additionalOauthKeys = SalesforceSDKManager.getInstance().getAdditionalOauthKeys();
@@ -571,7 +575,7 @@ public class UserAccountManager {
 		if (authToken == null || instanceServer == null || userId == null || orgId == null) {
 			return null;
 		} else {
-			return UserAccountBuilder.getInstance()
+			final UserAccount userAccount = UserAccountBuilder.getInstance()
 					.authToken(authToken)
 					.refreshToken(refreshToken)
 					.loginServer(loginServer)
@@ -610,6 +614,10 @@ public class UserAccountManager {
 					.scope(scope)
 					.additionalOauthValues(additionalOauthValues)
 					.build();
+			if (!TextUtils.isEmpty(featureFlagsRaw)) {
+				userAccount.setFeatureFlags(new HashSet<>(Arrays.asList(featureFlagsRaw.split(","))));
+			}
+			return userAccount;
 		}
 	}
 
@@ -758,6 +766,11 @@ public class UserAccountManager {
 		extras.putString(AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_KEY, SalesforceSDKManager.encrypt(userAccount.getBeaconChildConsumerKey(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_BEACON_CHILD_CONSUMER_SECRET, SalesforceSDKManager.encrypt(userAccount.getBeaconChildConsumerSecret(), encryptionKey));
 		extras.putString(AuthenticatorService.KEY_SCOPE, SalesforceSDKManager.encrypt(userAccount.getScope(), encryptionKey));
+		final Set<String> featureFlags = userAccount.getFeatureFlags();
+		if (!featureFlags.isEmpty()) {
+			extras.putString(AuthenticatorService.KEY_FEATURE_FLAGS,
+				SalesforceSDKManager.encrypt(android.text.TextUtils.join(",", featureFlags), encryptionKey));
+		}
 
 		final List<String> additionalOauthKeys = SalesforceSDKManager.getInstance().getAdditionalOauthKeys();
 		if (additionalOauthKeys != null && !additionalOauthKeys.isEmpty()) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1384,7 +1384,9 @@ open class SalesforceSDKManager protected constructor(
 
     /** Hydrates per-user features from persisted accounts at startup */
     private fun hydratePerUserFeatures() {
-        val users = userAccountManager.authenticatedUsers ?: return
+        // Use getInstance() directly — this is called from the constructor init block before the
+        // userAccountManager lazy delegate is initialized, so we can't use the property here.
+        val users = UserAccountManager.getInstance().authenticatedUsers ?: return
         for (u in users) {
             val flags = u.featureFlags
             if (flags.isNotEmpty()) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -428,6 +428,20 @@ open class SalesforceSDKManager protected constructor(
     var clearCookiesAfterLogin = true
 
     /**
+     * Opt-in flag for DPoP (Demonstration of Proof-of-Possession, RFC 9449).
+     * When true, the SDK will attach a DPoP proof JWT to token endpoint
+     * requests and use the `DPoP` Authorization scheme for resource requests
+     * when the token endpoint advertises `token_type: DPoP`.
+     */
+    private var useDPoP = false
+
+    fun isUseDPoP(): Boolean = useDPoP
+
+    fun setUseDPoP(useDPoP: Boolean) {
+        this.useDPoP = useDPoP
+    }
+
+    /**
      * The login brand. In the following example, "<brand>" should be set here.
      * https://community.force.com/services/oauth2/authorize/<brand>?response_type=code&...
      *

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -687,7 +687,6 @@ open class SalesforceSDKManager protected constructor(
         Handler(getMainLooper()).post {
             ProcessLifecycleOwner.get().lifecycle.addObserver(this)
         }
-        hydratePerUserFeatures()
     }
 
     /**
@@ -1384,9 +1383,7 @@ open class SalesforceSDKManager protected constructor(
 
     /** Hydrates per-user features from persisted accounts at startup */
     private fun hydratePerUserFeatures() {
-        // Use getInstance() directly — this is called from the constructor init block before the
-        // userAccountManager lazy delegate is initialized, so we can't use the property here.
-        val users = UserAccountManager.getInstance().authenticatedUsers ?: return
+        val users = userAccountManager.authenticatedUsers ?: return
         for (u in users) {
             val flags = u.featureFlags
             if (flags.isNotEmpty()) {
@@ -1865,6 +1862,9 @@ open class SalesforceSDKManager protected constructor(
                     nativeLoginActivity,
                     googleCloudProjectId,
                 )
+                // Hydrate after INSTANCE is set — UserAccountManager.getInstance() checks
+                // SalesforceSDKManager.getInstance() internally, which requires INSTANCE != null.
+                INSTANCE?.hydratePerUserFeatures()
             }
             initInternal(context)
             EventsObservable.get().notifyEvent(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -154,6 +154,7 @@ import java.net.URI
 import java.util.Locale.US
 import java.util.SortedSet
 import java.util.UUID.randomUUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentSkipListSet
 import java.util.regex.Pattern
 import com.salesforce.androidsdk.auth.idp.IDPManager as DefaultIDPManager
@@ -407,6 +408,9 @@ open class SalesforceSDKManager protected constructor(
 
     /** App feature codes for reporting in the user agent header */
     private val features: SortedSet<String?>
+
+    /** Per-user feature codes keyed by "orgId/userId" */
+    private val perUserFeatures: ConcurrentHashMap<String, ConcurrentSkipListSet<String>> = ConcurrentHashMap()
 
     /**
      * An additional list of OAuth keys to fetch and store from the token
@@ -683,6 +687,7 @@ open class SalesforceSDKManager protected constructor(
         Handler(getMainLooper()).post {
             ProcessLifecycleOwner.get().lifecycle.addObserver(this)
         }
+        hydratePerUserFeatures()
     }
 
     /**
@@ -1272,8 +1277,24 @@ open class SalesforceSDKManager protected constructor(
      * @param qualifier The user agent qualifier
      * @return The user agent string to use for all requests
      */
-    open fun getUserAgent(qualifier: String) =
-        String.format(
+    open fun getUserAgent(qualifier: String) = getUserAgent(qualifier, null)
+
+    /**
+     * Returns a per-user agent string. Feature flags include both global and user-specific codes.
+     *
+     * @param qualifier The user agent qualifier
+     * @param user The user account, or null to use the current user
+     * @return The user agent string to use for all requests
+     */
+    open fun getUserAgent(qualifier: String, user: UserAccount?) : String {
+        val resolvedUser = user ?: userAccountManager.currentUser
+        val userKey = resolvedUser?.let { "${it.orgId}/${it.userId}" }
+        val userFeatures = userKey?.let { perUserFeatures[it] } ?: emptySet<String>()
+        val allFeatures = ConcurrentSkipListSet<String>(CASE_INSENSITIVE_ORDER).apply {
+            addAll(features.filterNotNull())
+            addAll(userFeatures)
+        }
+        return String.format(
             "SalesforceMobileSDK/%s android mobile/%s (%s) %s/%s %s uid_%s ftr_%s SecurityPatch/%s",
             SDK_VERSION,
             RELEASE,
@@ -1282,9 +1303,10 @@ open class SalesforceSDKManager protected constructor(
             appVersion,
             "$appType$qualifier",
             deviceId,
-            join(".", features),
+            join(".", allFeatures),
             SECURITY_PATCH
         )
+    }
 
     /** The app version */
     val appVersion: String
@@ -1320,6 +1342,59 @@ open class SalesforceSDKManager protected constructor(
      */
     fun unregisterUsedAppFeature(appFeatureCode: String?) =
         features.remove(appFeatureCode)
+
+    /**
+     * Returns true if the feature code is in the global (non-user-specific) set.
+     * @param appFeatureCode The app feature code
+     */
+    fun isGlobalFeatureRegistered(appFeatureCode: String) = features.contains(appFeatureCode)
+
+    /**
+     * Adds a per-user app feature code for reporting in the user agent header.
+     * Falls back to the global set when user is null.
+     * @param appFeatureCode The app feature code
+     * @param user The user account to associate the feature with
+     */
+    fun registerUsedAppFeature(appFeatureCode: String, user: UserAccount?) {
+        if (user == null) { registerUsedAppFeature(appFeatureCode); return }
+        val key = "${user.orgId}/${user.userId}"
+        val set = perUserFeatures.getOrPut(key) { ConcurrentSkipListSet(CASE_INSENSITIVE_ORDER) }
+        set.add(appFeatureCode)
+        persistUserFeatureFlags(user, set)
+    }
+
+    /**
+     * Removes a per-user app feature code from reporting in the user agent header.
+     * Falls back to the global set when user is null.
+     * @param appFeatureCode The app feature code
+     * @param user The user account to remove the feature from
+     */
+    fun unregisterUsedAppFeature(appFeatureCode: String, user: UserAccount?) {
+        if (user == null) { unregisterUsedAppFeature(appFeatureCode); return }
+        val key = "${user.orgId}/${user.userId}"
+        perUserFeatures[key]?.remove(appFeatureCode)
+        persistUserFeatureFlags(user, perUserFeatures[key] ?: emptySet())
+    }
+
+    private fun persistUserFeatureFlags(user: UserAccount, flags: Set<String>) {
+        user.featureFlags = HashSet(flags)
+        val account = userAccountManager.buildAccount(user) ?: return
+        userAccountManager.updateAccount(account, user)
+    }
+
+    /** Hydrates per-user features from persisted accounts at startup */
+    private fun hydratePerUserFeatures() {
+        val users = userAccountManager.authenticatedUsers ?: return
+        for (u in users) {
+            val flags = u.featureFlags
+            if (flags.isNotEmpty()) {
+                val key = "${u.orgId}/${u.userId}"
+                val set = ConcurrentSkipListSet<String>(CASE_INSENSITIVE_ORDER)
+                set.addAll(flags)
+                perUserFeatures[key] = set
+            }
+        }
+    }
 
     /** The app type */
     open val appType = "Native"

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1738,6 +1738,27 @@ open class SalesforceSDKManager protected constructor(
         }
     }
 
+    /**
+     * Determines the target account (or null for all users) for foreground push
+     * re-registration based on [PushService.foregroundRegistrationMode].
+     *
+     * Returns null when re-registration should be skipped entirely (i.e.
+     * [PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER] is set
+     * but there is no current user).
+     */
+    @VisibleForTesting
+    internal fun foregroundPushRegistrationTarget(): ForegroundPushTarget? =
+        when (PushService.foregroundRegistrationMode) {
+            PushService.PushNotificationForegroundRegistrationMode.ALL_USERS ->
+                ForegroundPushTarget(account = null)
+            PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER ->
+                userAccountManager.currentUser?.let { ForegroundPushTarget(account = it) }
+        }
+
+    /** Holds the resolved account argument for foreground push re-registration. */
+    @VisibleForTesting
+    internal data class ForegroundPushTarget(val account: UserAccount?)
+
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
 
@@ -1746,14 +1767,10 @@ open class SalesforceSDKManager protected constructor(
 
         // Review push-notifications registration on foreground, if enabled.
         if (pushNotificationsRegistrationType == ReRegistrationOnAppForeground) {
-            val accountToRegister = when (PushService.foregroundRegistrationMode) {
-                PushService.PushNotificationForegroundRegistrationMode.ALL_USERS -> null
-                PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER ->
-                    userAccountManager.currentUser ?: return@onResume
-            }
+            val target = foregroundPushRegistrationTarget() ?: return@onResume
             register(
                 context = appContext,
-                account = accountToRegister,
+                account = target.account,
                 recreateKey = false
             )
         }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1744,15 +1744,18 @@ open class SalesforceSDKManager protected constructor(
         (screenLockManager as ScreenLockManager?)?.onAppForegrounded()
         (biometricAuthenticationManager as? BiometricAuthenticationManager)?.onAppForegrounded()
 
-        // Review push-notifications registration for the current user, if enabled.
-        userAccountManager.currentUser?.let { userAccount ->
-            if (pushNotificationsRegistrationType == ReRegistrationOnAppForeground) {
-                register(
-                    context = appContext,
-                    account = userAccount,
-                    recreateKey = false
-                )
+        // Review push-notifications registration on foreground, if enabled.
+        if (pushNotificationsRegistrationType == ReRegistrationOnAppForeground) {
+            val accountToRegister = when (PushService.foregroundRegistrationMode) {
+                PushService.PushNotificationForegroundRegistrationMode.ALL_USERS -> null
+                PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER ->
+                    userAccountManager.currentUser ?: return@onResume
             }
+            register(
+                context = appContext,
+                account = accountToRegister,
+                recreateKey = false
+            )
         }
 
         // Display the Salesforce Mobile SDK "Show Developer Support" notification

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -391,7 +391,7 @@ internal fun handleScreenLockPolicy(
 
     // compareTo(0) is used to check if screenLockTimeout is non-null and greater than 0.
     if (userIdentity?.screenLockTimeout?.compareTo(0) == 1) {
-        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_SCREEN_LOCK)
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_SCREEN_LOCK, account)
         val timeoutInMills = userIdentity.screenLockTimeout * 1000 * 60
         internalScreenLockManager?.storeMobilePolicy(
             account,
@@ -399,7 +399,7 @@ internal fun handleScreenLockPolicy(
             timeoutInMills,
         )
     } else if (internalScreenLockManager?.enabled == true) {
-        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_SCREEN_LOCK)
+        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_SCREEN_LOCK, account)
         internalScreenLockManager.cleanUp(account)
     }
 }
@@ -416,7 +416,7 @@ internal fun handleBiometricAuthPolicy(
         SalesforceSDKManager.getInstance().biometricAuthenticationManager as BiometricAuthenticationManager?
 
     if (userIdentity?.biometricAuth == true) {
-        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH)
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account)
         val timeoutInMills = userIdentity.biometricAuthTimeout * 60 * 1000
         internalBiometricAuthenticationManager?.storeMobilePolicy(
             account,
@@ -424,7 +424,7 @@ internal fun handleBiometricAuthPolicy(
             timeoutInMills
         )
     } else if (internalBiometricAuthenticationManager?.enabled == true) {
-        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH)
+        SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account)
         internalBiometricAuthenticationManager.cleanUp(account)
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -102,6 +102,7 @@ internal suspend fun onAuthFlowComplete(
     buildAccountName: (username: String?, instanceServer: String?) -> String = ::defaultBuildAccountName,
     nativeLogin: Boolean = false,
     tokenMigration: Boolean = false,
+    credentialsIdentifier: String? = null,
     context: Context = SalesforceSDKManager.getInstance().appContext,
     userAccountManager: UserAccountManager = SalesforceSDKManager.getInstance().userAccountManager,
     blockIntegrationUser: Boolean = (SalesforceSDKManager.getInstance().shouldBlockSalesforceIntegrationUser &&
@@ -164,6 +165,7 @@ internal suspend fun onAuthFlowComplete(
         .loginServer(loginServer)
         .clientId(consumerKey)
         .nativeLogin(nativeLogin)
+        .dpopScope(credentialsIdentifier)
         .build()
 
     // Set additional administrator prefs if they exist

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -92,6 +92,7 @@ public class AuthenticatorService extends Service {
     public static final String KEY_BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
     public static final String KEY_BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
     public static final String KEY_SCOPE = "scope";
+    public static final String KEY_FEATURE_FLAGS = "feature_flags";
 
     private static final String TAG = "AuthenticatorService";
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -138,7 +138,8 @@ public class AuthenticatorService extends Service {
                 final URI tokenServer = OAuth2.overrideLoginServerIfNeeded(originalUserAccount);
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final OAuth2.TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT,
-                        tokenServer, originalUserAccount.getClientIdForRefresh(), originalUserAccount.getRefreshToken(), addlParamsMap);
+                        tokenServer, originalUserAccount.getClientIdForRefresh(), originalUserAccount.getRefreshToken(), addlParamsMap,
+                        originalUserAccount.getDpopScope());
 
                 UserAccount updatedUserAccount = UserAccountBuilder.getInstance()
                         .populateFromUserAccount(originalUserAccount)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -36,6 +36,9 @@ import androidx.annotation.WorkerThread;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager;
+import com.salesforce.androidsdk.auth.dpop.DPoPProofBuilder;
+import com.salesforce.androidsdk.auth.dpop.DPoPURLHelper;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
@@ -45,6 +48,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyPair;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -157,6 +161,8 @@ public class OAuth2 {
     private static final String RETURL = "retURL";
     protected static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
+    private static final String TOKEN_TYPE = "token_type";
+    private static final String DPOP = "DPoP";
     private static final String ASSERTION = "assertion";
     private static final String JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     protected static final String OAUTH_AUTH_PATH = "/services/oauth2/authorize";
@@ -448,6 +454,19 @@ public class OAuth2 {
                                                      String clientId, String code, String codeVerifier,
                                                      String callbackUrl, SalesforceSDKManager salesforceSdkManager)
             throws OAuthFailedException, IOException {
+        return exchangeCode(httpAccessor, loginServer, clientId, code, codeVerifier, callbackUrl, salesforceSdkManager, null);
+    }
+
+    /**
+     * An internal, testable Salesforce Mobile SDK overload of
+     * {@link #exchangeCode(HttpAccess, URI, String, String, String, String)} that
+     * accepts a credentials identifier so DPoP proof can be attached when enabled.
+     */
+    public static TokenEndpointResponse exchangeCode(HttpAccess httpAccessor, URI loginServer,
+                                                     String clientId, String code, String codeVerifier,
+                                                     String callbackUrl, SalesforceSDKManager salesforceSdkManager,
+                                                     @Nullable String credentialsIdentifier)
+            throws OAuthFailedException, IOException {
         final FormBody.Builder builder = new FormBody.Builder();
         final boolean useHybridAuthentication = SalesforceSDKManager.getInstance().shouldUseHybridAuthentication();
         final String grantType = useHybridAuthentication ? HYBRID_AUTH_CODE : AUTHORIZATION_CODE;
@@ -457,7 +476,7 @@ public class OAuth2 {
         builder.add(CODE, code);
         builder.add(CODE_VERIFIER, codeVerifier);
         builder.add(REDIRECT_URI, callbackUrl);
-        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, salesforceSdkManager);
+        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, salesforceSdkManager, credentialsIdentifier);
     }
 
     /**
@@ -477,6 +496,29 @@ public class OAuth2 {
                                                          String clientId, String refreshToken,
                                                          Map<String,String> addlParams)
             throws OAuthFailedException, IOException {
+        return refreshAuthToken(httpAccessor, loginServer, clientId, refreshToken, addlParams, null);
+    }
+
+    /**
+     * Gets a new auth token using the refresh token. Overload that accepts a
+     * credentials identifier so DPoP proof can be attached when enabled.
+     *
+     * @param httpAccessor HttpAccess instance.
+     * @param loginServer Login server.
+     * @param clientId Client ID.
+     * @param refreshToken Refresh token.
+     * @param addlParams Additional parameters.
+     * @param credentialsIdentifier Identifier used to look up the DPoP keypair, or null.
+     * @return Token response.
+     *
+     * @throws OAuthFailedException See {@link OAuthFailedException}.
+     * @throws IOException See {@link IOException}.
+     */
+    public static TokenEndpointResponse refreshAuthToken(HttpAccess httpAccessor, URI loginServer,
+                                                         String clientId, String refreshToken,
+                                                         Map<String,String> addlParams,
+                                                         @Nullable String credentialsIdentifier)
+            throws OAuthFailedException, IOException {
         final FormBody.Builder builder = new FormBody.Builder();
         final boolean useHybridAuthentication = SalesforceSDKManager.getInstance().shouldUseHybridAuthentication();
         final String grantType = useHybridAuthentication ? HYBRID_REFRESH : REFRESH_TOKEN;
@@ -492,7 +534,7 @@ public class OAuth2 {
                 }
             }
         }
-        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, SalesforceSDKManager.getInstance());
+        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, SalesforceSDKManager.getInstance(), credentialsIdentifier);
     }
 
     /**
@@ -570,7 +612,21 @@ public class OAuth2 {
      * @param authToken Access token.
      */
     public static Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken) {
-        return builder.header(AUTHORIZATION, BEARER + authToken);
+        return addAuthorizationHeader(builder, authToken, null);
+    }
+
+    /**
+     * Adds the authorization header to the request builder, choosing the
+     * scheme based on the token type. When {@code tokenType} equals
+     * {@code "DPoP"}, the DPoP scheme is used; otherwise Bearer is used.
+     *
+     * @param builder Builder instance.
+     * @param authToken Access token.
+     * @param tokenType Token type (e.g. "Bearer" or "DPoP"), or null for default Bearer.
+     */
+    public static Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken, @Nullable String tokenType) {
+        final String scheme = DPOP.equals(tokenType) ? DPOP + " " : BEARER;
+        return builder.header(AUTHORIZATION, scheme + authToken);
     }
 
     @VisibleForTesting
@@ -579,6 +635,17 @@ public class OAuth2 {
                                                                  URI loginServer,
                                                                  FormBody.Builder formBodyBuilder,
                                                                  SalesforceSDKManager salesforceSdkManager)
+            throws OAuthFailedException, IOException {
+        return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder, salesforceSdkManager, null);
+    }
+
+    @VisibleForTesting
+    @WorkerThread
+    public static TokenEndpointResponse makeTokenEndpointRequest(HttpAccess httpAccessor,
+                                                                 URI loginServer,
+                                                                 FormBody.Builder formBodyBuilder,
+                                                                 SalesforceSDKManager salesforceSdkManager,
+                                                                 @Nullable String credentialsIdentifier)
             throws OAuthFailedException, IOException {
 
         final StringBuilder sb = new StringBuilder(loginServer.toString());
@@ -599,7 +666,21 @@ public class OAuth2 {
 
         final String refreshPath = sb.toString();
         final RequestBody body = formBodyBuilder.build();
-        final Request request = new Request.Builder().url(refreshPath).post(body).build();
+        final Request.Builder requestBuilder = new Request.Builder().url(refreshPath).post(body);
+
+        if (credentialsIdentifier != null && salesforceSdkManager.isUseDPoP()) {
+            try {
+                final String htu = DPoPURLHelper.INSTANCE.canonicalize(refreshPath);
+                final String alias = DPoPKeyManager.INSTANCE.aliasForCredentialsIdentifier(credentialsIdentifier);
+                final KeyPair keyPair = DPoPKeyManager.INSTANCE.generateOrLoadKeyPair(alias);
+                final String proof = DPoPProofBuilder.INSTANCE.buildProof("POST", htu, keyPair, null, null);
+                requestBuilder.header(DPOP, proof);
+            } catch (Exception e) {
+                SalesforceSDKLogger.e(TAG, "Failed to attach DPoP header, proceeding without it", e);
+            }
+        }
+
+        final Request request = requestBuilder.build();
         final Response response = httpAccessor.getOkHttpClient().newCall(request).execute();
         if (response.isSuccessful()) {
             return new TokenEndpointResponse(response);
@@ -949,6 +1030,7 @@ public class OAuth2 {
         public String beaconChildConsumerKey;
         public String beaconChildConsumerSecret;
         public String scope;
+        public String tokenType;
 
         /**
          * Parameterized constructor built from params during user agent login flow.
@@ -990,6 +1072,7 @@ public class OAuth2 {
                 parentSid = callbackUrlParams.get(PARENT_SID);
                 tokenFormat = callbackUrlParams.getOrDefault(TOKEN_FORMAT, "");
                 scope = callbackUrlParams.get(SCOPE);
+                tokenType = callbackUrlParams.get(TOKEN_TYPE);
 
                 // NB: beacon apps not supported with user agent flow so no beacon child fields expected
 
@@ -1073,6 +1156,7 @@ public class OAuth2 {
                     beaconChildConsumerSecret = parsedResponse.getString(LEGACY_BEACON_CHILD_CONSUMER_SECRET);
                 }
                 scope = parsedResponse.optString(SCOPE);
+                tokenType = parsedResponse.optString(TOKEN_TYPE, null);
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+
+object DPoPKeyManager {
+
+    private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+
+    fun generateOrLoadKeyPair(alias: String): KeyPair {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        val existingKey = keyStore.getKey(alias, null)
+        if (existingKey != null) {
+            val privateKey = existingKey as PrivateKey
+            val publicKey = keyStore.getCertificate(alias).publicKey as ECPublicKey
+            return KeyPair(publicKey, privateKey)
+        }
+        val keyPairGenerator =
+            KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY
+        )
+            .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+            .setDigests(KeyProperties.DIGEST_SHA256)
+            .setUserAuthenticationRequired(false)
+            .build()
+        keyPairGenerator.initialize(spec)
+        return keyPairGenerator.generateKeyPair()
+    }
+
+    fun deleteKeyPair(alias: String) {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        if (keyStore.containsAlias(alias)) {
+            keyStore.deleteEntry(alias)
+        }
+    }
+
+    fun aliasForCredentialsIdentifier(id: String): String = "dpop_$id"
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilder.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.util.Base64
+import org.json.JSONObject
+import java.security.KeyPair
+import java.security.SecureRandom
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+
+object DPoPProofBuilder {
+
+    fun buildProof(
+        httpMethod: String,
+        htu: String,
+        keyPair: KeyPair,
+        nonce: String? = null,
+        accessToken: String? = null
+    ): String {
+        val publicKey = keyPair.public as ECPublicKey
+        val jwk = buildJwk(publicKey)
+        val header = buildHeader(jwk)
+        val payload = buildPayload(httpMethod, htu)
+        val headerEncoded = base64url(header.toString().toByteArray(Charsets.UTF_8))
+        val payloadEncoded = base64url(payload.toString().toByteArray(Charsets.UTF_8))
+        val signingInput = "$headerEncoded.$payloadEncoded"
+        val signature = sign(signingInput.toByteArray(Charsets.UTF_8), keyPair)
+        val signatureEncoded = base64url(derToRawRS(signature))
+        return "$headerEncoded.$payloadEncoded.$signatureEncoded"
+    }
+
+    private fun buildJwk(publicKey: ECPublicKey): JSONObject {
+        val point = publicKey.w
+        val xBytes = toUnsigned32(point.affineX.toByteArray())
+        val yBytes = toUnsigned32(point.affineY.toByteArray())
+        return JSONObject().apply {
+            put("kty", "EC")
+            put("crv", "P-256")
+            put("x", base64url(xBytes))
+            put("y", base64url(yBytes))
+        }
+    }
+
+    private fun buildHeader(jwk: JSONObject): JSONObject =
+        JSONObject().apply {
+            put("typ", "dpop+jwt")
+            put("alg", "ES256")
+            put("jwk", jwk)
+        }
+
+    private fun buildPayload(httpMethod: String, htu: String): JSONObject {
+        val jti = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        return JSONObject().apply {
+            put("htm", httpMethod.uppercase())
+            put("htu", htu)
+            put("iat", System.currentTimeMillis() / 1000L)
+            put("jti", base64url(jti))
+        }
+    }
+
+    private fun sign(data: ByteArray, keyPair: KeyPair): ByteArray {
+        val sig = Signature.getInstance("SHA256withECDSA")
+        sig.initSign(keyPair.private)
+        sig.update(data)
+        return sig.sign()
+    }
+
+    internal fun derToRawRS(der: ByteArray): ByteArray {
+        var offset = 2
+        offset++
+        val rLen = der[offset++].toInt() and 0xFF
+        val rBytes = der.copyOfRange(offset, offset + rLen)
+        offset += rLen
+        offset++
+        val sLen = der[offset++].toInt() and 0xFF
+        val sBytes = der.copyOfRange(offset, offset + sLen)
+        return toUnsigned32(rBytes) + toUnsigned32(sBytes)
+    }
+
+    internal fun toUnsigned32(bytes: ByteArray): ByteArray {
+        val trimmed = bytes.dropWhile { it == 0.toByte() }.toByteArray()
+        return ByteArray(32 - trimmed.size) + trimmed
+    }
+
+    private fun base64url(bytes: ByteArray): String =
+        Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelper.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.net.Uri
+
+object DPoPURLHelper {
+    fun canonicalize(url: String): String =
+        Uri.parse(url).buildUpon().clearQuery().fragment(null).build().toString()
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/push/PushService.kt
@@ -568,6 +568,15 @@ open class PushService {
         /** The active push notifications registration type */
         var pushNotificationsRegistrationType = ReRegistrationOnAppForeground
 
+        /**
+         * Controls which users are re-registered when the app foregrounds.
+         * Defaults to [PushNotificationForegroundRegistrationMode.ALL_USERS].
+         * Only applies when [pushNotificationsRegistrationType] is
+         * [PushNotificationReRegistrationType.ReRegistrationOnAppForeground].
+         */
+        var foregroundRegistrationMode: PushNotificationForegroundRegistrationMode =
+            PushNotificationForegroundRegistrationMode.ALL_USERS
+
         // Salesforce push notification constants.
         private const val MOBILE_PUSH_SERVICE_DEVICE = "MobilePushServiceDevice"
         private const val ANDROID_GCM = "androidGcm"
@@ -728,5 +737,27 @@ open class PushService {
          * de-registers push notifications
          */
         ReRegisterPeriodically
+    }
+
+    /**
+     * Controls which users are re-registered for push notifications when the app returns to the
+     * foreground. Only applies when [pushNotificationsRegistrationType] is
+     * [PushNotificationReRegistrationType.ReRegistrationOnAppForeground].
+     */
+    enum class PushNotificationForegroundRegistrationMode {
+
+        /**
+         * Re-registers all authenticated users when the app foregrounds. This is the default.
+         */
+        ALL_USERS,
+
+        /**
+         * Re-registers only the current user when the app foregrounds.
+         *
+         * Use this to preserve pre-14.0 behaviour, or if your app is billed per login event
+         * (e.g. some Publisher customers) and you want to avoid triggering token refreshes —
+         * and thus billable logins — for background users.
+         */
+        CURRENT_USER
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -394,6 +394,7 @@ public class ClientManager {
             String newAuthToken;        // last winner's fresh access token (null on failure)
             String newInstanceUrl;      // last winner's instance URL (losers need it; see RestClient.refreshAccessToken)
             String rotatedRefreshToken; // refresh token after rotation, for losers to adopt
+            String newTokenType;        // last winner's token type (e.g. "Bearer" or "DPoP")
             long lastRefreshTime = -1;
         }
 
@@ -430,6 +431,7 @@ public class ClientManager {
         private String refreshToken;
         private String lastNewInstanceUrl;
         private long lastRefreshTime = -1 /* never refreshed */;
+        private String lastTokenType;
 
         /**
          * Constructor
@@ -570,6 +572,7 @@ public class ClientManager {
             // can leave state.refreshing stuck true.
             String newAuthToken = null;
             String newInstanceUrl = null;
+            String newTokenType = null;
 
             try {
                 /*
@@ -601,6 +604,7 @@ public class ClientManager {
                                     "Access/refresh token already advanced in storage; adopting without refresh");
                             newAuthToken = storedAuthToken;
                             newInstanceUrl = currentAccount.getInstanceServer();
+                            newTokenType = currentAccount.getTokenType();
                             this.refreshToken = storedRefreshToken;
                             return newAuthToken;
                         }
@@ -617,6 +621,7 @@ public class ClientManager {
 
                 newAuthToken = userAccount.getAuthToken();
                 newInstanceUrl = userAccount.getInstanceServer();
+                newTokenType = userAccount.getTokenType();
 
                 Intent broadcastIntent;
                 if (newInstanceUrl != null && !newInstanceUrl.equalsIgnoreCase(lastNewInstanceUrl)) {
@@ -688,6 +693,7 @@ public class ClientManager {
                 // Update this instance's own cache so its getters stay correct.
                 lastNewAuthToken = newAuthToken;
                 lastNewInstanceUrl = newInstanceUrl;
+                lastTokenType = newTokenType;
                 lastRefreshTime = System.currentTimeMillis();
                 // Publish the result to the per-account state and wake any waiting losers.
                 // This is the SINGLE publish path and ALWAYS runs on every winner exit path so
@@ -698,6 +704,7 @@ public class ClientManager {
                         state.newAuthToken = newAuthToken;
                         state.newInstanceUrl = newInstanceUrl;
                         state.rotatedRefreshToken = this.refreshToken;
+                        state.newTokenType = newTokenType;
                         state.lastRefreshTime = System.currentTimeMillis();
                         // Mark a fresh result as available. Bumped ONLY on success so a loser woken
                         // by a failed cycle sees an unchanged generation and correctly returns null
@@ -732,6 +739,7 @@ public class ClientManager {
         private void adoptWinnerResult(RefreshState state) {
             this.lastNewAuthToken = state.newAuthToken;
             this.lastRefreshTime = state.lastRefreshTime;
+            this.lastTokenType = state.newTokenType;
             if (state.newInstanceUrl != null) {
                 this.lastNewInstanceUrl = state.newInstanceUrl;
             }
@@ -753,6 +761,9 @@ public class ClientManager {
         @Override
         public String getInstanceUrl() { return lastNewInstanceUrl; }
 
+        @Override
+        public String getTokenType() { return lastTokenType; }
+
         @NonNull
         private UserAccount refreshStaleToken(Account account) throws NetworkErrorException, OAuthFailedException, MalformedTokenException {
             UserAccount originalUserAccount = UserAccountManager.getInstance().buildUserAccount(account);
@@ -766,7 +777,8 @@ public class ClientManager {
                 final URI tokenServer = OAuth2.overrideLoginServerIfNeeded(originalUserAccount);
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final TokenEndpointResponse tr = refreshAuthToken(HttpAccess.DEFAULT,
-                        tokenServer, originalUserAccount.getClientIdForRefresh(), currentRefreshToken, addlParamsMap);
+                        tokenServer, originalUserAccount.getClientIdForRefresh(), currentRefreshToken, addlParamsMap,
+                        originalUserAccount.getDpopScope());
 
                 if (tr.authToken == null) {
                     throw new MalformedTokenException("Token endpoint returned null access token");

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -90,6 +90,12 @@ public class RestClient {
         String getNewAuthToken();
         String getRefreshToken();
         long getLastRefreshTime();
+
+        /**
+         * @return The token type from the most recent refresh (e.g. "Bearer"
+         * or "DPoP"), or null if not yet known or the server did not specify.
+         */
+        default String getTokenType() { return null; }
     }
 
     /**
@@ -140,10 +146,24 @@ public class RestClient {
      * @param authTokenProvider
      */
     public RestClient(ClientInfo clientInfo, String authToken, HttpAccess httpAccessor, AuthTokenProvider authTokenProvider) {
+        this(clientInfo, authToken, null, httpAccessor, authTokenProvider);
+    }
+
+    /**
+     * Constructs a RestClient with the given clientInfo, authToken, tokenType, httpAccessor and authTokenProvider.
+     * The tokenType determines the Authorization header scheme (e.g. "Bearer" or "DPoP").
+     *
+     * @param clientInfo
+     * @param authToken
+     * @param tokenType
+     * @param httpAccessor
+     * @param authTokenProvider
+     */
+    public RestClient(ClientInfo clientInfo, String authToken, String tokenType, HttpAccess httpAccessor, AuthTokenProvider authTokenProvider) {
         this.clientInfo = clientInfo;
         this.httpAccessor = httpAccessor;
         this.authTokenProvider = authTokenProvider;
-        setOAuthRefreshInterceptor(authToken);
+        setOAuthRefreshInterceptor(authToken, tokenType);
         setOkHttpClientBuilder();
         setOkHttpClient(null);
     }
@@ -183,13 +203,13 @@ public class RestClient {
     /**
      * Sets the OAuthRefreshInterceptor associated with this user account.
      */
-    private synchronized void setOAuthRefreshInterceptor(String authToken) {
+    private synchronized void setOAuthRefreshInterceptor(String authToken, String tokenType) {
         final String cacheKey = getCacheKey();
         OAuthRefreshInterceptor oAuthRefreshInterceptor = OAUTH_REFRESH_INTERCEPTORS.get(cacheKey);
 
         // If none cached, create new one
         if (oAuthRefreshInterceptor == null) {
-            oAuthRefreshInterceptor = new OAuthRefreshInterceptor(clientInfo, authToken, authTokenProvider);
+            oAuthRefreshInterceptor = new OAuthRefreshInterceptor(clientInfo, authToken, tokenType, authTokenProvider);
             OAUTH_REFRESH_INTERCEPTORS.put(cacheKey, oAuthRefreshInterceptor);
         }
         this.oAuthRefreshInterceptor = oAuthRefreshInterceptor;
@@ -704,6 +724,7 @@ public class RestClient {
 
         private final AuthTokenProvider authTokenProvider;
         private String authToken;
+        private String tokenType;
         private ClientInfo clientInfo;
 
         /**
@@ -719,8 +740,22 @@ public class RestClient {
          * @param authTokenProvider
          */
         public OAuthRefreshInterceptor(ClientInfo clientInfo, String authToken, AuthTokenProvider authTokenProvider) {
+            this(clientInfo, authToken, null, authTokenProvider);
+        }
+
+        /**
+         * Overload that accepts a token type, used to select between the Bearer
+         * and DPoP Authorization header schemes.
+         *
+         * @param clientInfo
+         * @param authToken
+         * @param tokenType
+         * @param authTokenProvider
+         */
+        public OAuthRefreshInterceptor(ClientInfo clientInfo, String authToken, String tokenType, AuthTokenProvider authTokenProvider) {
             this.clientInfo = clientInfo;
             this.authToken = authToken;
+            this.tokenType = tokenType;
             this.authTokenProvider = authTokenProvider;
         }
 
@@ -842,7 +877,7 @@ public class RestClient {
          */
         private void setAuthHeader(Request.Builder builder) {
             if (authToken != null) { //Add Auth token to each request if authorized
-                OAuth2.addAuthorizationHeader(builder, authToken);
+                OAuth2.addAuthorizationHeader(builder, authToken, tokenType);
             }
         }
 
@@ -853,6 +888,17 @@ public class RestClient {
          */
         private synchronized void setAuthToken(String newAuthToken) {
             authToken = newAuthToken;
+        }
+
+        /**
+         * Change authToken and tokenType for this RestClient
+         *
+         * @param newAuthToken
+         * @param newTokenType
+         */
+        private synchronized void setAuthToken(String newAuthToken, String newTokenType) {
+            authToken = newAuthToken;
+            tokenType = newTokenType;
         }
 
         /**
@@ -888,8 +934,8 @@ public class RestClient {
                     throw new RefreshTokenRevokedException("Could not refresh token");
                 }
 
-                // Use new token
-                setAuthToken(newAuthToken);
+                // Use new token (and token type, if available)
+                setAuthToken(newAuthToken, authTokenProvider.getTokenType());
 
                 // Check if the instanceUrl changed
                 String instanceUrl = authTokenProvider.getInstanceUrl();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -259,7 +259,8 @@ public class RestClient {
         data.put(LOGIN_URL, clientInfo.loginUrl.toString());
         data.put(IDENTITY_URL, clientInfo.identityUrl.toString());
         data.put(INSTANCE_URL, clientInfo.instanceUrl.toString());
-        data.put(USER_AGENT, SalesforceSDKManager.getInstance().getUserAgent());
+        UserAccount currentUser = SalesforceSDKManager.getInstance().getUserAccountManager().getCurrentUser();
+        data.put(USER_AGENT, SalesforceSDKManager.getInstance().getUserAgent("", currentUser));
         data.put(COMMUNITY_ID, clientInfo.communityId);
         data.put(COMMUNITY_URL, clientInfo.communityUrl);
         return new JSONObject(data);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -548,9 +548,10 @@ open class LoginActivity : FragmentActivity() {
             sdkManager.registerUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN, userAccount)
         }
 
-        // BW: set per-user based on whether this session actually used a Custom Tab.
-        // isBrowserLoginEnabled is unreliable here — Login for Admin uses a Custom Tab
-        // without setting that flag. completedViaBrowserTab is true for both paths.
+        // BW: promote transient global to per-user, then clear global.
+        // completedViaBrowserTab is true for both regular and Login for Admin Custom Tab paths.
+        // The global was set in loadLoginPageInCustomTab() so it appears in UA during login.
+        sdkManager.unregisterUsedAppFeature(FEATURE_BROWSER_LOGIN)
         if (completedViaBrowserTab) {
             sdkManager.registerUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
         } else {
@@ -812,6 +813,7 @@ open class LoginActivity : FragmentActivity() {
     @VisibleForTesting
     internal fun loadLoginPageInCustomTab(loginUrl: String, customTabLauncher: ActivityResultLauncher<Intent>) {
         completedViaBrowserTab = true
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_BROWSER_LOGIN)
         val customTabsIntent = CustomTabsIntent.Builder().apply {
             /*
              * Set a custom animation to slide in and out for Chrome custom tab

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -154,7 +154,6 @@ import org.json.JSONObject
 import java.lang.String.format
 import java.net.URI
 import java.net.URLDecoder
-import java.net.URLEncoder
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 
@@ -803,9 +802,24 @@ open class LoginActivity : FragmentActivity() {
      *  Launches the current login server in a Custom Tab. This allows Admins
      *  to authenticate with a Passkey or by other methods that require
      *  Advanced/Browser Authentication.
+     *
+     *  This function is a no-op for Welcome Discovery.
      */
     @Deprecated(message = "This function will be replaced by a permanent solution in 14.0.")
     fun launchLoginForAdminsAction() {
+        // Guard against launching a Custom Tab on the Welcome Discovery Phase 1 page, whose
+        // callback (sfdc://discocallback) is not app-unique.  This MUST use the same signal as the
+        // menu-item visibility gating in LoginView (viewModel.selectedServer), NOT
+        // LoginServerManager.selectedLoginServer: the latter stays welcome.salesforce.com through
+        // BOTH phases, while selectedServer is the discovered My Domain in Phase 2 — where LFA is
+        // valid and the menu item is shown.  Keying off LoginServerManager here would no-op the
+        // action in Phase 2 even though the menu offers it.
+        val selectedServer = viewModel.selectedServer.value?.toUri()
+        if (selectedServer?.let { isSalesforceWelcomeDiscoveryUrlPath(it) } == true) {
+            w(TAG, "launchLoginForAdminsAction is a no-op for Welcome Discovery; " +
+                    "LFA requires an app-unique OAuth callback")
+            return
+        }
         val loginUrl = viewModel.browserCustomTabUrl.value ?: return
         loadLoginPageInCustomTab(loginUrl, adminLoginCustomTabLauncher)
     }
@@ -1072,31 +1086,6 @@ open class LoginActivity : FragmentActivity() {
     }
 
     /**
-     * Creates a Salesforce Welcome Discovery mobile URL using the provided
-     * Salesforce Welcome Discovery host and path URL.
-     * @param salesforceWelcomeDiscoveryHostAndPathUrl The Salesforce Welcome
-     * Discovery host and path URL
-     * @return A Salesforce Welcome Discovery mobile URL with all required
-     * parameters
-     */
-    private fun generateSalesforceWelcomeDiscoveryMobileUrl(
-        salesforceWelcomeDiscoveryHostAndPathUrl: Uri
-    ) = salesforceWelcomeDiscoveryHostAndPathUrl.buildUpon()
-        .appendQueryParameter(
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID,
-            viewModel.oAuthConfig.consumerKey,
-        )
-        .appendQueryParameter(
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION,
-            URLEncoder.encode(SalesforceSDKManager.getInstance().appVersion, "utf8")
-        )
-        .appendQueryParameter(
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CALLBACK_URL,
-            SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL
-        )
-        .build()
-
-    /**
      * Switches between default or Salesforce Welcome Discovery log in as needed
      * using the provided pending login server URL.
      * @param pendingLoginServerUri The pending login server URL
@@ -1121,7 +1110,7 @@ open class LoginActivity : FragmentActivity() {
                         this,
                         SalesforceSDKManager.getInstance().webViewLoginActivityClass
                     ).apply {
-                        data = generateSalesforceWelcomeDiscoveryMobileUrl(pendingLoginServerUri)
+                        data = viewModel.generateSalesforceWelcomeDiscoveryMobileUrl(pendingLoginServerUri)
                         flags = FLAG_ACTIVITY_SINGLE_TOP
                     })
                 true
@@ -1289,8 +1278,15 @@ open class LoginActivity : FragmentActivity() {
                     return@evaluateJavascript
                 }
 
-                viewModel.dynamicBackgroundColor.value = validateAndExtractBackgroundColor(result)
-                    ?: return@evaluateJavascript
+                viewModel.dynamicBackgroundColor.value =
+                    if (url?.toUri()?.let { isSalesforceWelcomeDiscoveryUrlPath(it) } == true) {
+                        // The Welcome Discovery Phase 1 page (welcome.salesforce.com/discovery)
+                        // reports a dark computed background in some states (e.g. after logout),
+                        // which would tint the top and bottom app bars black.
+                        Color.White
+                    } else {
+                        validateAndExtractBackgroundColor(result) ?: return@evaluateJavascript
+                    }
 
                 // Ensure Status Bar Icons are readable no matter which OS theme is used.
                 val titleTextColorLight = viewModel.titleTextColor?.luminance()?.let { it < 0.5 }
@@ -1533,7 +1529,7 @@ open class LoginActivity : FragmentActivity() {
         // region Salesforce Welcome Login Private Implementation
 
         /** The default Salesforce Welcome Discovery mobile callback URL.  This value is fixed until future Salesforce Welcome updates */
-        private const val SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL = "sfdc://discocallback"
+        internal const val SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL = "sfdc://discocallback"
 
         /** The Salesforce Welcome Discovery mobile callback URL's "login hint" parameter key */
         private const val SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL_QUERY_PARAMETER_KEY_LOGIN_HINT = "login_hint"

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -121,6 +121,7 @@ import com.salesforce.androidsdk.R.string.sf__ssl_not_yet_valid
 import com.salesforce.androidsdk.R.string.sf__ssl_unknown_error
 import com.salesforce.androidsdk.R.string.sf__ssl_untrusted
 import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN
 import com.salesforce.androidsdk.app.Features.FEATURE_QR_CODE_LOGIN
 import com.salesforce.androidsdk.app.Features.FEATURE_WELCOME_DISCOVERY_LOGIN
 import com.salesforce.androidsdk.app.SalesforceSDKManager
@@ -233,6 +234,7 @@ open class LoginActivity : FragmentActivity() {
     // Private variables
     private var baseUserAgentString = ""
     private var wasBackgrounded = false
+    private var completedViaBrowserTab = false
     private var accountAuthenticatorResponse: AccountAuthenticatorResponse? = null
     private var accountAuthenticatorResult: Bundle? = null
     private var newUserIntent = false
@@ -537,6 +539,31 @@ open class LoginActivity : FragmentActivity() {
      * @param userAccount The newly created user account.
      */
     protected open fun onAuthFlowSuccess(userAccount: UserAccount) {
+        val sdkManager = SalesforceSDKManager.getInstance()
+
+        // WD: write per-user and clear transient global
+        val usedWelcomeDiscovery = sdkManager.isGlobalFeatureRegistered(FEATURE_WELCOME_DISCOVERY_LOGIN)
+        sdkManager.unregisterUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN)
+        if (usedWelcomeDiscovery) {
+            sdkManager.registerUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN, userAccount)
+        }
+
+        // BW: set per-user based on whether this session actually used a Custom Tab.
+        // isBrowserLoginEnabled is unreliable here — Login for Admin uses a Custom Tab
+        // without setting that flag. completedViaBrowserTab is true for both paths.
+        if (completedViaBrowserTab) {
+            sdkManager.registerUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
+        } else {
+            sdkManager.unregisterUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
+        }
+
+        // QR: write per-user and clear transient global
+        val usedQrLogin = sdkManager.isGlobalFeatureRegistered(FEATURE_QR_CODE_LOGIN)
+        sdkManager.unregisterUsedAppFeature(FEATURE_QR_CODE_LOGIN)
+        if (usedQrLogin) {
+            sdkManager.registerUsedAppFeature(FEATURE_QR_CODE_LOGIN, userAccount)
+        }
+
         // Create account and save result before switching to new user
         accountAuthenticatorResult = SalesforceSDKManager.getInstance().userAccountManager.createAccount(userAccount)
 
@@ -784,6 +811,7 @@ open class LoginActivity : FragmentActivity() {
 
     @VisibleForTesting
     internal fun loadLoginPageInCustomTab(loginUrl: String, customTabLauncher: ActivityResultLauncher<Intent>) {
+        completedViaBrowserTab = true
         val customTabsIntent = CustomTabsIntent.Builder().apply {
             /*
              * Set a custom animation to slide in and out for Chrome custom tab

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.net.URI
+import java.net.URLEncoder
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -299,8 +300,62 @@ open class LoginViewModel(
         loginUrl.addSource(selectedServer, LoginUrlSource())
     }
 
+    /**
+     * Creates a Salesforce Welcome Discovery mobile URL using the provided
+     * Salesforce Welcome Discovery host and path URL.
+     * @param salesforceWelcomeDiscoveryHostAndPathUrl The Salesforce Welcome
+     * Discovery host and path URL
+     * @return A Salesforce Welcome Discovery mobile URL with all required
+     * parameters
+     */
+    internal fun generateSalesforceWelcomeDiscoveryMobileUrl(
+        salesforceWelcomeDiscoveryHostAndPathUrl: Uri
+    ) = salesforceWelcomeDiscoveryHostAndPathUrl.buildUpon()
+        .appendQueryParameter(
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID,
+            oAuthConfig.consumerKey,
+        )
+        .appendQueryParameter(
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION,
+            URLEncoder.encode(SalesforceSDKManager.getInstance().appVersion, "utf8")
+        )
+        .appendQueryParameter(
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CALLBACK_URL,
+            LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_CALLBACK_URL
+        )
+        .build()
+
     /** Reloads the WebView with a newly generated authorization URL. */
     open fun reloadWebView() {
+        // If the user-selected login server (per LoginServerManager) is Salesforce Welcome
+        // Discovery, load the Phase 1 discovery mobile URL directly instead of regenerating a
+        // Phase-2-style auth URL.  We intentionally do NOT key off `selectedServer.value` here:
+        // during Phase 2, the VM's selectedServer is the discovered My Domain, while the
+        // LoginServerManager retains Welcome Discovery as the user's actual server selection.
+        // This branch runs BEFORE the isUsingFrontDoorBridge short-circuit by design — Welcome
+        // Discovery and frontdoor bridge are mutually exclusive in practice, but defense-in-depth
+        // ordering ensures a stray frontdoor URL cannot suppress the discovery reload.
+        SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer?.url
+            ?.toUri()?.let { selectedLoginServerUri ->
+                if (isSalesforceWelcomeDiscoveryUrlPath(selectedLoginServerUri)) {
+                    // Reset the top app bar background to White synchronously so the bar flips
+                    // immediately when the user reloads/re-selects Welcome Discovery from Phase 2.
+                    // dynamicBackgroundColor is otherwise only updated by AuthWebViewClient.
+                    // onPageFinished, which runs after the new page loads — the gap leaves the
+                    // Phase-2 color visible on the bar even though the WebView URL has changed.
+                    dynamicBackgroundColor.value = White
+                    // Must precede selectedServer reset — LoginUrlSource same-host short-circuit.
+                    loginUrl.value =
+                        generateSalesforceWelcomeDiscoveryMobileUrl(selectedLoginServerUri).toString()
+                    // Must follow loginUrl — depends on same-host short-circuit seeing new loginUrl.
+                    val welcomeUrl = selectedLoginServerUri.toString()
+                    if (selectedServer.value != welcomeUrl) {
+                        selectedServer.value = welcomeUrl
+                    }
+                    return
+                }
+            }
+
         if (!isUsingFrontDoorBridge) {
             selectedServer.value?.let { server ->
                 // The Web Server Flow code challenge makes the authorization url unique each time,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -466,6 +466,7 @@ open class LoginViewModel(
         onAuthFlowSuccess: (userAccount: UserAccount) -> Unit,
         tokenMigration: Boolean = false,
         loginServer: String? = null,
+        credentialsIdentifier: String? = null,
     ) {
         // Clear cookies after successful authentication to prevent automatic re-login if the user tries to add another user right away.
         if (SalesforceSDKManager.getInstance().clearCookiesAfterLogin) {
@@ -480,6 +481,7 @@ open class LoginViewModel(
             onAuthFlowSuccess = onAuthFlowSuccess,
             buildAccountName = ::buildAccountName,
             tokenMigration = tokenMigration,
+            credentialsIdentifier = credentialsIdentifier,
         )
     }
 
@@ -667,6 +669,8 @@ open class LoginViewModel(
             }
             val verifier = if (isUsingFrontDoorBridge) frontdoorBridgeCodeVerifier else codeVerifier
 
+            val credentialsIdentifier = java.util.UUID.randomUUID().toString()
+
             val tokenResponse = exchangeCode(
                 HttpAccess.DEFAULT,
                 URI.create(server),
@@ -674,9 +678,11 @@ open class LoginViewModel(
                 code,
                 verifier,
                 oAuthConfig.redirectUri,
+                SalesforceSDKManager.getInstance(),
+                credentialsIdentifier,
             )
 
-            onAuthFlowComplete(tokenResponse, onAuthFlowError, onAuthFlowSuccess, tokenMigration, server)
+            onAuthFlowComplete(tokenResponse, onAuthFlowError, onAuthFlowSuccess, tokenMigration, server, credentialsIdentifier)
         }.onFailure { throwable ->
             e(TAG, "Exception occurred while making token request", throwable)
             onAuthFlowError("Token Request Error", throwable.message, throwable)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginServerListItem.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginServerListItem.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -195,7 +196,8 @@ fun LoginServerListItem(
                             modifier = Modifier
                                 .padding(end = PADDING_SIZE.dp)
                                 .size(ICON_SIZE.dp)
-                                .offset { offset },
+                                .offset { offset }
+                                .testTag(LoginViewTestTags.SERVER_DELETE_BUTTON),
                         ) {
                             Icon(
                                 Icons.TwoTone.Delete,
@@ -225,6 +227,7 @@ fun LoginServerListItem(
                         .background(colorScheme.error)
                         .width(DELETE_BUTTON_SIZE.dp)
                         .height(rowHeightDp.value)
+                        .testTag(LoginViewTestTags.SERVER_CONFIRM_DELETE_BUTTON)
                         .clickable { removeServer(server) },
                 ) {
                     val deleteContentDescription = stringResource(sf__server_delete_content_description)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -90,6 +90,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.core.net.toUri
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -98,9 +99,11 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -234,6 +237,7 @@ fun LoginView() {
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun LoginView(
     dynamicBackgroundColor: MutableState<Color>,
@@ -254,6 +258,9 @@ internal fun LoginView(
     )
 
     Scaffold(
+        // Expose Compose testTags as Android resource-ids so UI automation (UIAutomator2/UTAM)
+        // can anchor on the stable, locale-invariant tags rather than localized contentDescriptions.
+        modifier = Modifier.semantics { testTagsAsResourceId = true },
         bottomBar = bottomAppBar,
         contentWindowInsets = WindowInsets.safeDrawing,
         topBar = topAppBar,
@@ -285,7 +292,7 @@ internal fun LoginView(
 }
 
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 internal fun DefaultTopAppBar(
     backgroundColor: Color,
@@ -324,6 +331,7 @@ internal fun DefaultTopAppBar(
                         disabledContainerColor = Color.Transparent,
                         disabledContentColor = Color.Transparent,
                     ),
+                    modifier = Modifier.testTag(LoginViewTestTags.MORE_OPTIONS_BUTTON),
                 ) {
                     Icon(Icons.Default.MoreVert, contentDescription = moreOptionsDescription)
                 }
@@ -335,33 +343,36 @@ internal fun DefaultTopAppBar(
                 DropdownMenu(
                     expanded = showMenu,
                     onDismissRequest = { showMenu = false },
+                    // The menu renders in its own popup window, so opt in here as well to expose
+                    // the menu items' testTags as Android resource-ids for UI automation.
+                    modifier = Modifier.semantics { testTagsAsResourceId = true },
                 ) {
-                    MenuItem(stringResource(sf__pick_server)) {
+                    MenuItem(stringResource(sf__pick_server), testTag = LoginViewTestTags.MENU_ITEM_PICK_SERVER) {
                         showServerPicker.value = true
                         showMenu = false
                     }
-                    MenuItem(stringResource(sf__clear_cookies)) {
+                    MenuItem(stringResource(sf__clear_cookies), testTag = LoginViewTestTags.MENU_ITEM_CLEAR_COOKIES) {
                         clearCookies()
                         reloadWebView()
                         showMenu = false
                     }
-                    MenuItem(stringResource(sf__clear_cache)) {
+                    MenuItem(stringResource(sf__clear_cache), testTag = LoginViewTestTags.MENU_ITEM_CLEAR_CACHE) {
                         clearWebViewCache()
                         reloadWebView()
                         showMenu = false
                     }
-                    MenuItem(stringResource(sf__reload)) {
+                    MenuItem(stringResource(sf__reload), testTag = LoginViewTestTags.MENU_ITEM_RELOAD) {
                         reloadWebView()
                         showMenu = false
                     }
                     onLoginForAdmins?.let {
-                        MenuItem(stringResource(sf__login_for_admins)) {
+                        MenuItem(stringResource(sf__login_for_admins), testTag = LoginViewTestTags.MENU_ITEM_LOGIN_FOR_ADMINS) {
                             it.invoke()
                             showMenu = false
                         }
                     }
                     showDevSupport?.let {
-                        MenuItem(stringResource(sf__dev_support_title_menu_item)) {
+                        MenuItem(stringResource(sf__dev_support_title_menu_item), testTag = LoginViewTestTags.MENU_ITEM_DEV_SUPPORT) {
                             it.invoke()
                             showMenu = false
                         }
@@ -380,6 +391,7 @@ internal fun DefaultTopAppBar(
                             disabledContainerColor = Color.Transparent,
                             disabledContentColor = Color.Transparent,
                         ),
+                        modifier = Modifier.testTag(LoginViewTestTags.BACK_BUTTON),
                     ) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
@@ -403,6 +415,7 @@ internal fun DefaultLoadingIndicator() {
             modifier = Modifier
                 .size(LOADING_INDICATOR_SIZE.dp)
                 .fillMaxSize()
+                .testTag(LoginViewTestTags.LOADING_INDICATOR)
                 .semantics { contentDescription = description },
         )
     }
@@ -411,6 +424,7 @@ internal fun DefaultLoadingIndicator() {
 @Composable
 internal fun MenuItem(
     text: String,
+    testTag: String? = null,
     onClick: () -> Unit,
 ) {
     DropdownMenuItem(
@@ -422,7 +436,9 @@ internal fun MenuItem(
             )
         },
         onClick = onClick,
-        modifier = Modifier.semantics { contentDescription = text }
+        modifier = Modifier
+            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
+            .semantics { contentDescription = text }
     )
 }
 
@@ -469,6 +485,7 @@ internal fun DefaultBottomAppBar(
                                 .padding(PADDING_SIZE.dp)
                                 .height(BUTTON_HEIGHT.dp)
                                 .fillMaxWidth()
+                                .testTag(LoginViewTestTags.LOGIN_BUTTON)
                                 .shadow(LEVEL_3_ELEVATION.dp, buttonShape),
                             shape = buttonShape,
                             contentPadding = PaddingValues(PADDING_SIZE.dp),

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -90,6 +90,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.core.net.toUri
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
@@ -147,10 +148,16 @@ fun LoginView() {
     val viewModel: LoginViewModel =
         viewModel(factory = SalesforceSDKManager.getInstance().loginViewModelFactory)
     val frontDoorBridgeUrl = viewModel.frontDoorBridgeUrl.observeAsState()
+    // Observe selectedServer and loginUrl AS COMPOSE STATE so that recomposition triggers when
+    // either changes — and so titleText is read inside Compose's snapshot system, not via the
+    // non-reactive `defaultTitleText` getter chain (which reads LiveData.getValue() directly and
+    // is invisible to Compose).
+    val selectedServer = viewModel.selectedServer.observeAsState()
+    val loginUrl = viewModel.loginUrl.observeAsState()
     val titleText = if (frontDoorBridgeUrl.value != null) {
         viewModel.frontdoorBridgeServer ?: ""
     } else {
-        viewModel.titleText ?: viewModel.defaultTitleText
+        viewModel.titleText ?: if (loginUrl.value == LoginActivity.ABOUT_BLANK) "" else selectedServer.value ?: ""
     }
     val showDevSupport = with(SalesforceSDKManager.getInstance()) {
         return@with if (isDebugBuild && isDevSupportEnabled()) {
@@ -160,6 +167,10 @@ fun LoginView() {
         }
     }
 
+    // During WD phase 2, selectedServer is the My Domain, so this is false and LFA is shown.
+    // See LoginActivity guard for the programmatic defense-in-depth check.
+    val isWelcomeDiscoveryServer = selectedServer.value
+        ?.let { LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(it.toUri()) } == true
     val topAppBar = viewModel.topAppBar ?: {
         DefaultTopAppBar(
             backgroundColor = viewModel.topBarColor ?: viewModel.dynamicBackgroundColor.value,
@@ -172,7 +183,9 @@ fun LoginView() {
             shouldShowBackButton = viewModel.shouldShowBackButton,
             showDevSupport = showDevSupport,
             finish = { activity.handleBackBehavior() },
-            onLoginForAdmins = { activity.launchLoginForAdminsAction() },
+            onLoginForAdmins = if (isWelcomeDiscoveryServer) null else {
+                { activity.launchLoginForAdminsAction() }
+            },
         )
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginViewTestTags.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginViewTestTags.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.ui.components
+
+/**
+ * Stable, locale-invariant test tags for the Mobile SDK login screen and the
+ * server / account picker bottom sheet.
+ *
+ * Each value is applied to its Compose node via [androidx.compose.ui.platform.testTag]. Because
+ * the composition roots that host these nodes opt in with
+ * `Modifier.semantics { testTagsAsResourceId = true }`, the tags are surfaced to UI automation
+ * (UIAutomator2 / UTAM) as Android `resource-id`s. Unlike the localized `contentDescription`
+ * strings the UI also exposes, these values never change across device languages, so test and
+ * page-object code can anchor on them in any locale — including right-to-left layouts.
+ *
+ * This object is the single source of truth for those values. It is intentionally public so that
+ * SDK instrumented tests, sample-app page objects (e.g. AuthFlowTester), and external UTAM page
+ * objects can all reference the same constants instead of duplicating the literal strings.
+ *
+ * IMPORTANT: These are test anchors only. Do NOT localize them and do NOT reuse them as
+ * user-facing strings.
+ */
+object LoginViewTestTags {
+
+    // region Login screen top bar
+    /** Three-dot "More Options" overflow button in the login top app bar. */
+    const val MORE_OPTIONS_BUTTON = "sf__more_options_button"
+
+    /** Navigation "back" button in the login top app bar (shown conditionally). */
+    const val BACK_BUTTON = "sf__back_button"
+    // endregion
+
+    // region Login screen overflow menu items
+    /** "Change Server" overflow menu item. */
+    const val MENU_ITEM_PICK_SERVER = "sf__menu_item_pick_server"
+
+    /** "Clear Cookies" overflow menu item. */
+    const val MENU_ITEM_CLEAR_COOKIES = "sf__menu_item_clear_cookies"
+
+    /** "Clear Cache" overflow menu item. */
+    const val MENU_ITEM_CLEAR_CACHE = "sf__menu_item_clear_cache"
+
+    /** "Reload" overflow menu item. */
+    const val MENU_ITEM_RELOAD = "sf__menu_item_reload"
+
+    /** "Login for Admins" overflow menu item (shown conditionally). */
+    const val MENU_ITEM_LOGIN_FOR_ADMINS = "sf__menu_item_login_for_admins"
+
+    /** "Developer Support" overflow menu item (debug builds only). */
+    const val MENU_ITEM_DEV_SUPPORT = "sf__menu_item_dev_support"
+    // endregion
+
+    // region Login screen body
+    /** Bottom-bar login action button (biometric / IDP / custom). */
+    const val LOGIN_BUTTON = "sf__login_button"
+
+    /** Indeterminate loading spinner shown over the login WebView. */
+    const val LOADING_INDICATOR = "sf__loading_indicator"
+    // endregion
+
+    // region Picker bottom sheet
+    /** Root container of the login-server picker bottom sheet. */
+    const val SERVER_PICKER = "sf__server_picker"
+
+    /** Root container of the user-account picker bottom sheet. */
+    const val ACCOUNT_PICKER = "sf__account_picker"
+
+    /** Back arrow shown in the picker header while adding a new connection. */
+    const val PICKER_BACK_BUTTON = "sf__picker_back_button"
+
+    /** Close (X) button in the picker header. */
+    const val PICKER_CLOSE_BUTTON = "sf__picker_close_button"
+
+    /** "Add New Connection" button in the login-server picker. */
+    const val CUSTOM_URL_BUTTON = "sf__custom_url_button"
+
+    /** "Add New Account" button in the user-account picker. */
+    const val ADD_NEW_ACCOUNT_BUTTON = "sf__add_new_account_button"
+
+    /** Name field in the picker's "Add Connection" form. */
+    const val PICKER_CUSTOM_LABEL = "sf__picker_custom_label"
+
+    /** URL field in the picker's "Add Connection" form. */
+    const val PICKER_CUSTOM_URL = "sf__picker_custom_url"
+
+    /** Save / apply button in the picker's "Add Connection" form. */
+    const val APPLY_BUTTON = "sf__apply_button"
+    // endregion
+
+    // region Server list item
+    /**
+     * Trash icon on a custom server row that arms the slide-to-delete affordance.
+     *
+     * Every custom server row carries this same tag by design, so a bare match resolves to
+     * multiple nodes. To target a specific row, combine it with a content matcher that
+     * identifies the row:
+     * ```
+     * onNode(hasTestTag(SERVER_DELETE_BUTTON) and hasAncestor(hasText("MyOrg")))
+     * ```
+     */
+    const val SERVER_DELETE_BUTTON = "sf__server_delete_button"
+
+    /**
+     * Revealed confirm-delete target on a custom server row.
+     *
+     * Shared across all custom rows just like [SERVER_DELETE_BUTTON]; combine it with a content
+     * matcher (e.g. `and hasAncestor(hasText("MyOrg"))`) to target a specific row.
+     */
+    const val SERVER_CONFIRM_DELETE_BUTTON = "sf__server_confirm_delete_button"
+    // endregion
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -90,6 +90,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -101,6 +102,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -250,7 +252,7 @@ internal fun TestablePickerBottomSheet(
 
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 @VisibleForTesting
 internal fun PickerBottomSheet(
@@ -269,6 +271,15 @@ internal fun PickerBottomSheet(
     val containerContentDescription = when (pickerStyle) {
         PickerStyle.LoginServerPicker -> stringResource(sf__server_picker_content_description)
         PickerStyle.UserAccountPicker -> stringResource(sf__account_picker_content_description)
+    }
+    // Stable, locale-invariant test anchor for the picker container and its add button.
+    val containerTestTag = when (pickerStyle) {
+        PickerStyle.LoginServerPicker -> LoginViewTestTags.SERVER_PICKER
+        PickerStyle.UserAccountPicker -> LoginViewTestTags.ACCOUNT_PICKER
+    }
+    val addButtonTestTag = when (pickerStyle) {
+        PickerStyle.LoginServerPicker -> LoginViewTestTags.CUSTOM_URL_BUTTON
+        PickerStyle.UserAccountPicker -> LoginViewTestTags.ADD_NEW_ACCOUNT_BUTTON
     }
     val addButtonContentDescription = when (pickerStyle) {
         PickerStyle.LoginServerPicker -> stringResource(sf__custom_url_button_content_description)
@@ -300,7 +311,13 @@ internal fun PickerBottomSheet(
             Column(
                 modifier = Modifier
                     .animateContentSize()
-                    .semantics { contentDescription = containerContentDescription }
+                    // The bottom sheet is hosted in its own window/composition, so opt in here too
+                    // to expose Compose testTags as Android resource-ids for UI automation.
+                    .semantics {
+                        testTagsAsResourceId = true
+                        contentDescription = containerContentDescription
+                    }
+                    .testTag(containerTestTag)
                     .focusRequester(pickerFocus)
                     .focusable(),
             ) {
@@ -326,7 +343,9 @@ internal fun PickerBottomSheet(
                                     disabledContainerColor = Color.Transparent,
                                     disabledContentColor = Color.Transparent,
                                 ),
-                                modifier = Modifier.size(ICON_SIZE.dp),
+                                modifier = Modifier
+                                    .size(ICON_SIZE.dp)
+                                    .testTag(LoginViewTestTags.PICKER_BACK_BUTTON),
                             ) {
                                 Icon(
                                     Icons.AutoMirrored.Filled.ArrowBack,
@@ -362,7 +381,9 @@ internal fun PickerBottomSheet(
                                 disabledContainerColor = Color.Transparent,
                                 disabledContentColor = Color.Transparent,
                             ),
-                            modifier = Modifier.size(ICON_SIZE.dp),
+                            modifier = Modifier
+                                .size(ICON_SIZE.dp)
+                                .testTag(LoginViewTestTags.PICKER_CLOSE_BUTTON),
                         ) {
                             Icon(
                                 Icons.Default.Close,
@@ -475,6 +496,7 @@ internal fun PickerBottomSheet(
                                                 modifier = Modifier
                                                     .padding(PADDING_SIZE.dp)
                                                     .fillMaxWidth()
+                                                    .testTag(addButtonTestTag)
                                                     .semantics { contentDescription = addButtonContentDescription },
                                                 shape = RoundedCornerShape(CORNER_RADIUS.dp),
                                                 contentPadding = PaddingValues(PADDING_SIZE.dp),
@@ -538,7 +560,7 @@ internal fun AddConnection(
                     .fillMaxWidth()
                     .padding(PADDING_SIZE.dp)
                     .focusRequester(focusRequester)
-                    .testTag("sf__picker_custom_label")
+                    .testTag(LoginViewTestTags.PICKER_CUSTOM_LABEL)
                     .semantics { contentDescription = nameFieldDesc },
                 colors = TextFieldDefaults.colors(
                     focusedIndicatorColor = colorScheme.tertiary,
@@ -562,7 +584,7 @@ internal fun AddConnection(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = PADDING_SIZE.dp, end = PADDING_SIZE.dp)
-                    .testTag("sf__picker_custom_url")
+                    .testTag(LoginViewTestTags.PICKER_CUSTOM_URL)
                     .semantics { contentDescription = urlFieldDesc },
                 colors = TextFieldDefaults.colors(
                     focusedIndicatorColor = colorScheme.tertiary,
@@ -586,7 +608,7 @@ internal fun AddConnection(
             modifier = Modifier
                 .padding(PADDING_SIZE.dp)
                 .fillMaxWidth()
-                .testTag("sf__apply_button")
+                .testTag(LoginViewTestTags.APPLY_BUTTON)
                 .semantics { contentDescription = applyButtonDesc },
             shape = RoundedCornerShape(CORNER_RADIUS.dp),
             contentPadding = PaddingValues(PADDING_SIZE.dp),

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -131,9 +131,11 @@ import com.salesforce.androidsdk.R.string.sf__server_url_save
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.app.SalesforceSDKManager
+import androidx.core.net.toUri
 import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
 import com.salesforce.androidsdk.ui.CORNER_RADIUS
+import com.salesforce.androidsdk.ui.LoginActivity
 import com.salesforce.androidsdk.ui.LoginViewModel
 import com.salesforce.androidsdk.ui.PADDING_SIZE
 import com.salesforce.androidsdk.ui.theme.hintTextColor
@@ -177,6 +179,12 @@ internal fun TestablePickerBottomSheet(
             if (newSelectedServer != SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer) {
                 viewModel.loading.value = true
                 SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer = newSelectedServer
+            } else if (LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(newSelectedServer.url.toUri())) {
+                // Re-selecting Welcome Discovery while it is already the selected server should
+                // return the WebView to Phase 1 (welcome.salesforce.com/discovery), even though
+                // LoginServerManager's selection didn't change.  This mirrors the reload-button
+                // behavior the user expects when stuck on a discovered My Domain in Phase 2.
+                viewModel.reloadWebView()
             }
         }
     }

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/app/SmartStoreSDKManager.java
@@ -254,7 +254,7 @@ public class SmartStoreSDKManager extends SalesforceSDKManager {
         if (TextUtils.isEmpty(dbNamePrefix)) {
             dbNamePrefix = DBOpenHelper.DEFAULT_DB_NAME;
         }
-        SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_SMART_STORE_USER);
+        SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_SMART_STORE_USER, account);
         final SQLiteOpenHelper dbOpenHelper = DBOpenHelper.getOpenHelper(getEncryptionKey(), context,
                 dbNamePrefix, account, communityId);
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -44,8 +44,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -721,6 +723,70 @@ public class UserAccountTest {
         response.put("language", TEST_LANGUAGE);
         response.put("locale", TEST_LOCALE);
         return new OAuth2.IdServiceResponse(response);
+    }
+
+    /**
+     * Tests that feature flags survive a toJson round-trip.
+     * Verifies that the FEATURE_FLAGS key is present in the serialized JSON and that the
+     * flags can be read back by manually parsing the JSON array (since the JSON constructor
+     * does not populate featureFlags — that path goes through AccountManager).
+     */
+    @Test
+    public void test_givenUserAccountWithFlags_whenToJson_thenFeatureFlagsKeyPresent() throws JSONException {
+        final UserAccount account = createTestAccount();
+        account.setFeatureFlags(new HashSet<>(Arrays.asList("BW", "WD")));
+
+        final JSONObject json = account.toJson(createAdditionalOauthKeys());
+
+        Assert.assertTrue("JSON should contain FEATURE_FLAGS key", json.has(UserAccount.FEATURE_FLAGS));
+
+        // Verify both flags are serialized in the JSON array
+        org.json.JSONArray flagsArray = json.getJSONArray(UserAccount.FEATURE_FLAGS);
+        HashSet<String> serialized = new HashSet<>();
+        for (int i = 0; i < flagsArray.length(); i++) {
+            serialized.add(flagsArray.getString(i));
+        }
+        Assert.assertTrue("Serialized flags should contain BW", serialized.contains("BW"));
+        Assert.assertTrue("Serialized flags should contain WD", serialized.contains("WD"));
+    }
+
+    /**
+     * Tests that a UserAccount built from JSON without a FEATURE_FLAGS key returns an empty set.
+     */
+    @Test
+    public void test_givenUserAccountJsonMissingFeatureFlags_whenFromJson_thenEmptySet() throws JSONException {
+        final JSONObject testJSON = createTestAccountJSON();
+        // Confirm the helper JSON does not include FEATURE_FLAGS
+        Assert.assertFalse("Test JSON should not have FEATURE_FLAGS", testJSON.has(UserAccount.FEATURE_FLAGS));
+
+        final UserAccount account = new UserAccount(testJSON, "SalesforceSDKTest", createAdditionalOauthKeys());
+
+        Assert.assertNotNull("featureFlags should never be null", account.getFeatureFlags());
+        Assert.assertTrue("featureFlags should be empty when key is absent", account.getFeatureFlags().isEmpty());
+    }
+
+    /**
+     * Tests that setFeatureFlags/getFeatureFlags are symmetric.
+     */
+    @Test
+    public void test_givenUserAccount_whenSetFeatureFlags_thenGetFeatureFlagsReturnsSameValues() {
+        final UserAccount account = createTestAccount();
+        final HashSet<String> flags = new HashSet<>(Arrays.asList("AA", "BB", "CC"));
+        account.setFeatureFlags(flags);
+
+        Assert.assertEquals("getFeatureFlags should return the set values", flags, account.getFeatureFlags());
+    }
+
+    /**
+     * Tests that setFeatureFlags(null) results in an empty set, not a NullPointerException.
+     */
+    @Test
+    public void test_givenUserAccount_whenSetFeatureFlagsNull_thenEmptySet() {
+        final UserAccount account = createTestAccount();
+        account.setFeatureFlags(null);
+
+        Assert.assertNotNull("featureFlags should never be null after setFeatureFlags(null)", account.getFeatureFlags());
+        Assert.assertTrue("featureFlags should be empty after setFeatureFlags(null)", account.getFeatureFlags().isEmpty());
     }
 
     /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
@@ -23,7 +23,10 @@ import com.salesforce.androidsdk.push.PushService.Companion.REGISTRATION_STATUS_
 import com.salesforce.androidsdk.push.PushService.Companion.REGISTRATION_STATUS_SUCCEEDED
 import com.salesforce.androidsdk.push.PushService.Companion.UNREGISTRATION_STATUS_SUCCEEDED
 import com.salesforce.androidsdk.push.PushService.Companion.enqueuePushNotificationsRegistrationWork
+import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.ALL_USERS
+import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationDisabled
+import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationOnAppForeground
 import com.salesforce.androidsdk.rest.ApiVersionStrings.VERSION_NUMBER_TEST
 import com.salesforce.androidsdk.rest.NotificationsActionsResponseBody
 import com.salesforce.androidsdk.rest.NotificationsApiErrorResponseBody
@@ -33,8 +36,13 @@ import com.salesforce.androidsdk.rest.NotificationsTypesResponseBody.Companion.f
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo
 import com.salesforce.androidsdk.rest.RestResponse
+import androidx.lifecycle.LifecycleOwner
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.serialization.json.Json.Default.encodeToJsonElement
 import kotlinx.serialization.json.Json.Default.encodeToString
@@ -89,6 +97,8 @@ class PushServiceTest {
     fun tearDown() {
 
         VERSION_NUMBER_TEST = null
+        PushService.foregroundRegistrationMode = ALL_USERS
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
         cleanupAccounts(accountManager)
 
         userAccountManager = null
@@ -945,6 +955,93 @@ class PushServiceTest {
     fun testRemoveNotificationsCategories() {
         PushService().removeNotificationsCategories()
     }
+
+    // region Foreground Registration Mode Tests
+
+    @Test
+    fun test_givenDefault_thenForegroundRegistrationModeIsAllUsers() {
+        assertEquals(ALL_USERS, PushService.foregroundRegistrationMode)
+    }
+
+    @Test
+    fun test_givenModeCurrentUser_whenSet_thenForegroundRegistrationModeIsCurrentUser() {
+        PushService.foregroundRegistrationMode = CURRENT_USER
+        assertEquals(CURRENT_USER, PushService.foregroundRegistrationMode)
+    }
+
+    @Test
+    fun test_givenModeAllUsers_whenAppEntersForeground_thenRegisterCalledWithNullAccount() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = ALL_USERS
+        createTestAccountInAccountManager(userAccountManager)
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            // account = null causes the worker to iterate all authenticated users
+            verify { PushMessaging.register(any(), null, false) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    @Test
+    fun test_givenModeCurrentUser_whenAppEntersForeground_thenRegisterCalledWithCurrentUser() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = CURRENT_USER
+        createTestAccountInAccountManager(userAccountManager)
+        val currentUser = userAccountManager?.currentUser
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            verify { PushMessaging.register(any(), currentUser, false) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    @Test
+    fun test_givenModeAllUsers_whenNoAuthenticatedUsers_whenAppEntersForeground_thenNoRegistrationOccurs() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = ALL_USERS
+        // No accounts created
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            // With ALL_USERS, register is called with null regardless of how many accounts exist.
+            // The worker then iterates the (empty) authenticated user list and does nothing.
+            verify { PushMessaging.register(any(), null, false) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    @Test
+    fun test_givenModeCurrentUser_whenNoCurrentUser_whenAppEntersForeground_thenNoRegistrationOccurs() {
+        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+        PushService.foregroundRegistrationMode = CURRENT_USER
+        // No accounts — currentUser will be null
+
+        mockkObject(PushMessaging)
+        every { PushMessaging.register(any(), any(), any()) } just Runs
+
+        try {
+            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
+            verify(exactly = 0) { PushMessaging.register(any(), any(), any()) }
+        } finally {
+            unmockkObject(PushMessaging)
+        }
+    }
+
+    // endregion
 
     companion object {
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/PushServiceTest.kt
@@ -26,7 +26,6 @@ import com.salesforce.androidsdk.push.PushService.Companion.enqueuePushNotificat
 import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.ALL_USERS
 import com.salesforce.androidsdk.push.PushService.PushNotificationForegroundRegistrationMode.CURRENT_USER
 import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationDisabled
-import com.salesforce.androidsdk.push.PushService.PushNotificationReRegistrationType.ReRegistrationOnAppForeground
 import com.salesforce.androidsdk.rest.ApiVersionStrings.VERSION_NUMBER_TEST
 import com.salesforce.androidsdk.rest.NotificationsActionsResponseBody
 import com.salesforce.androidsdk.rest.NotificationsApiErrorResponseBody
@@ -36,13 +35,8 @@ import com.salesforce.androidsdk.rest.NotificationsTypesResponseBody.Companion.f
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.ClientInfo
 import com.salesforce.androidsdk.rest.RestResponse
-import androidx.lifecycle.LifecycleOwner
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.serialization.json.Json.Default.encodeToJsonElement
 import kotlinx.serialization.json.Json.Default.encodeToString
@@ -98,7 +92,6 @@ class PushServiceTest {
 
         VERSION_NUMBER_TEST = null
         PushService.foregroundRegistrationMode = ALL_USERS
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
         cleanupAccounts(accountManager)
 
         userAccountManager = null
@@ -970,75 +963,48 @@ class PushServiceTest {
     }
 
     @Test
-    fun test_givenModeAllUsers_whenAppEntersForeground_thenRegisterCalledWithNullAccount() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeAllUsers_whenAppEntersForeground_thenTargetAccountIsNull() {
         PushService.foregroundRegistrationMode = ALL_USERS
         createTestAccountInAccountManager(userAccountManager)
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            // account = null causes the worker to iterate all authenticated users
-            verify { PushMessaging.register(any(), null, false) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        // null account means the worker iterates all authenticated users
+        assertNotNull(target)
+        assertNull(target?.account)
     }
 
     @Test
-    fun test_givenModeCurrentUser_whenAppEntersForeground_thenRegisterCalledWithCurrentUser() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeCurrentUser_whenAppEntersForeground_thenTargetAccountIsCurrentUser() {
         PushService.foregroundRegistrationMode = CURRENT_USER
         createTestAccountInAccountManager(userAccountManager)
         val currentUser = userAccountManager?.currentUser
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            verify { PushMessaging.register(any(), currentUser, false) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        assertNotNull(target)
+        assertEquals(currentUser, target?.account)
     }
 
     @Test
-    fun test_givenModeAllUsers_whenNoAuthenticatedUsers_whenAppEntersForeground_thenNoRegistrationOccurs() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeAllUsers_whenNoAuthenticatedUsers_thenTargetAccountIsNull() {
         PushService.foregroundRegistrationMode = ALL_USERS
-        // No accounts created
+        // No accounts — worker will iterate an empty list and do nothing
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            // With ALL_USERS, register is called with null regardless of how many accounts exist.
-            // The worker then iterates the (empty) authenticated user list and does nothing.
-            verify { PushMessaging.register(any(), null, false) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        assertNotNull(target)
+        assertNull(target?.account)
     }
 
     @Test
-    fun test_givenModeCurrentUser_whenNoCurrentUser_whenAppEntersForeground_thenNoRegistrationOccurs() {
-        PushService.pushNotificationsRegistrationType = ReRegistrationOnAppForeground
+    fun test_givenModeCurrentUser_whenNoCurrentUser_thenTargetIsNull() {
         PushService.foregroundRegistrationMode = CURRENT_USER
-        // No accounts — currentUser will be null
+        // No accounts — currentUser is null, registration must be skipped
 
-        mockkObject(PushMessaging)
-        every { PushMessaging.register(any(), any(), any()) } just Runs
+        val target = SalesforceSDKManager.getInstance().foregroundPushRegistrationTarget()
 
-        try {
-            SalesforceSDKManager.getInstance().onResume(mockk<LifecycleOwner>())
-            verify(exactly = 0) { PushMessaging.register(any(), any(), any()) }
-        } finally {
-            unmockkObject(PushMessaging)
-        }
+        assertNull(target)
     }
 
     // endregion

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.accounts.UserAccountBuilder
+import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
@@ -519,6 +522,106 @@ class SalesforceSDKManagerTests {
         assertNull(sdkManager.appAttestationClient)
     }
 
+    // -------------------------------------------------------------------------
+    // Per-user feature flag tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun test_givenTwoUsers_whenRegisterFeatureForUserA_thenOnlyUserAUAContainsFlag() {
+        val sdkManager = createSdkManagerWithMockedAccountManager()
+
+        val userA = buildMinimalUserAccount(orgId = "org1", userId = "user1")
+        val userB = buildMinimalUserAccount(orgId = "org2", userId = "user2")
+
+        sdkManager.registerUsedAppFeature("XY", userA)
+
+        try {
+            assertTrue(
+                "getUserAgent for userA should contain XY",
+                sdkManager.getUserAgent("", userA).contains("XY")
+            )
+            assertFalse(
+                "getUserAgent for userB should NOT contain XY",
+                sdkManager.getUserAgent("", userB).contains("XY")
+            )
+        } finally {
+            sdkManager.unregisterUsedAppFeature("XY", userA)
+        }
+    }
+
+    @Test
+    fun test_givenGlobalAndPerUserFlags_whenGetUserAgentForUser_thenUnionPresent() {
+        val sdkManager = createSdkManagerWithMockedAccountManager()
+
+        val userA = buildMinimalUserAccount(orgId = "org1", userId = "user1")
+        val userB = buildMinimalUserAccount(orgId = "org2", userId = "user2")
+
+        sdkManager.registerUsedAppFeature("GL")
+        sdkManager.registerUsedAppFeature("PU", userA)
+
+        try {
+            val agentA = sdkManager.getUserAgent("", userA)
+            assertTrue("getUserAgent for userA should contain global flag GL", agentA.contains("GL"))
+            assertTrue("getUserAgent for userA should contain per-user flag PU", agentA.contains("PU"))
+
+            val agentB = sdkManager.getUserAgent("", userB)
+            assertTrue("getUserAgent for userB should contain global flag GL", agentB.contains("GL"))
+            assertFalse("getUserAgent for userB should NOT contain per-user flag PU", agentB.contains("PU"))
+        } finally {
+            sdkManager.unregisterUsedAppFeature("GL")
+            sdkManager.unregisterUsedAppFeature("PU", userA)
+        }
+    }
+
+    @Test
+    fun test_givenNullUser_whenRegisterUsedAppFeature_thenGlobalFlagRegistered() {
+        val sdkManager = SalesforceSDKManager.getInstance()
+
+        sdkManager.registerUsedAppFeature("GF", null)
+
+        try {
+            assertTrue(
+                "isGlobalFeatureRegistered should return true for GF",
+                sdkManager.isGlobalFeatureRegistered("GF")
+            )
+        } finally {
+            sdkManager.unregisterUsedAppFeature("GF")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers for per-user feature flag tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a minimal [UserAccount] for testing using known test constants.
+     * orgId and userId are parameterized so tests can create distinct users.
+     */
+    private fun buildMinimalUserAccount(orgId: String, userId: String): UserAccount =
+        UserAccountBuilder.getInstance()
+            .authToken("test_auth_token")
+            .refreshToken("test_refresh_token")
+            .loginServer("https://test.salesforce.com")
+            .idUrl("https://test.salesforce.com/$orgId/$userId")
+            .instanceServer("https://cs1.salesforce.com")
+            .orgId(orgId)
+            .userId(userId)
+            .username("user_${userId}@example.com")
+            .accountName("user_$userId (https://cs1.salesforce.com) (SalesforceSDKTest)")
+            .build()
+
+    /**
+     * Creates a [SalesforceSDKManager] subclass whose [UserAccountManager] is fully
+     * mocked so that [persistUserFeatureFlags] cannot reach [AccountManager].
+     * This keeps per-user feature flag tests in-memory only.
+     */
+    private fun createSdkManagerWithMockedAccountManager(): SalesforceSDKManager =
+        TestSalesforceSDKManagerWithMockedAccounts(
+            context = getInstrumentation().targetContext,
+            mainActivity = LoginActivity::class.java,
+            loginActivity = LoginActivity::class.java,
+        )
+
     /**
      * Helper to create a test [SalesforceSDKManager] instance with optional
      * [googleCloudProjectId] for app attestation tests.
@@ -570,6 +673,29 @@ class SalesforceSDKManagerTests {
                 ))
                 // No-op for reset() to avoid SharedPreferences access
                 every { reset() } just runs
+            }
+        }
+    }
+
+    /**
+     * A [SalesforceSDKManager] subclass that replaces [userAccountManager] with a
+     * relaxed mock so that [persistUserFeatureFlags] cannot reach [AccountManager].
+     * Per-user feature flag tests use this to stay fully in-memory.
+     */
+    private class TestSalesforceSDKManagerWithMockedAccounts(
+        context: android.content.Context,
+        mainActivity: Class<out Activity>,
+        loginActivity: Class<out Activity>? = null,
+    ) : SalesforceSDKManager(context, mainActivity, loginActivity) {
+
+        override val userAccountManager: UserAccountManager by lazy {
+            mockk<UserAccountManager>(relaxed = true).apply {
+                // buildAccount returns null → persistUserFeatureFlags exits early
+                every { buildAccount(any()) } returns null
+                // currentUser returns null → getUserAgent falls back to no per-user key
+                every { currentUser } returns null
+                // authenticatedUsers returns null → hydratePerUserFeatures is a no-op
+                every { authenticatedUsers } returns null
             }
         }
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/AuthenticationUtilitiesTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/AuthenticationUtilitiesTest.kt
@@ -451,7 +451,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleScreenLockPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.registerUsedAppFeature(FEATURE_SCREEN_LOCK) }
+        verify { mockSdkManager.registerUsedAppFeature(FEATURE_SCREEN_LOCK, account) }
         verify { mockScreenLockManager.storeMobilePolicy(account, enabled = true, 600000) }
     }
 
@@ -472,7 +472,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleScreenLockPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK, account) }
         verify { mockScreenLockManager.cleanUp(account) }
     }
 
@@ -511,7 +511,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleScreenLockPolicy(null, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_SCREEN_LOCK, account) }
         verify { mockScreenLockManager.cleanUp(account) }
     }
 
@@ -555,7 +555,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleBiometricAuthPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH) }
+        verify { mockSdkManager.registerUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account) }
         verify { mockBioAuthManager.storeMobilePolicy(account, enabled = true, 900000) }
     }
 
@@ -576,7 +576,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleBiometricAuthPolicy(userIdentity, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account) }
         verify { mockBioAuthManager.cleanUp(account) }
     }
 
@@ -617,7 +617,7 @@ class AuthenticationUtilitiesTest {
         com.salesforce.androidsdk.auth.handleBiometricAuthPolicy(null, account)
 
         // Then
-        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH) }
+        verify { mockSdkManager.unregisterUsedAppFeature(FEATURE_BIOMETRIC_AUTH, account) }
         verify { mockBioAuthManager.cleanUp(account) }
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -39,6 +39,7 @@ import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
 import com.salesforce.androidsdk.config.LoginServerManager.WELCOME_LOGIN_URL
 import com.salesforce.androidsdk.config.OAuthConfig
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getSHA256Hash
+import com.salesforce.androidsdk.ui.LoginActivity
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.ABOUT_BLANK
 import com.salesforce.androidsdk.ui.LoginViewModel
 import io.mockk.coEvery
@@ -69,6 +70,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.net.URI
+import java.net.URLEncoder
 
 private const val FAKE_SERVER_URL = "shouldMatchNothing.salesforce.com"
 private const val FAKE_JWT = "1234"
@@ -778,12 +780,119 @@ class LoginViewModelTest {
         assertTrue("isUsingFrontDoorBridge should be true", viewModel.isUsingFrontDoorBridge)
         assertEquals("frontDoorBridgeUrl should be front door URL", frontDoorUrl, viewModel.frontDoorBridgeUrl.value)
 
+        // Precondition: invariant ("frontdoor wins over reload") only holds when the
+        // LoginServerManager-selected server is NOT a Welcome Discovery URL.  The Welcome Discovery
+        // branch in reloadWebView intentionally runs before the frontdoor short-circuit.
+        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(
+            (SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer?.url ?: "").toUri()))
+
         // Call reloadWebView
         viewModel.reloadWebView()
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Verify URL did not change
         assertEquals("frontDoorBridgeUrl should still be front door URL", frontDoorUrl, viewModel.frontDoorBridgeUrl.value)
+    }
+
+    @Test
+    fun test_givenLoginServerManagerSelectedServerIsWelcomeDiscovery_whenReloadWebView_thenLoginUrlIsDiscoveryMobileUrl() {
+        val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        loginServerManager.addCustomLoginServer("Welcome", WELCOME_LOGIN_URL)
+        // Simulate Phase 2: VM's selectedServer is the discovered My Domain even though
+        // LoginServerManager still has Welcome Discovery selected.
+        viewModel.selectedServer.value = "https://acme.my.salesforce.com"
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val resultUri = viewModel.loginUrl.value?.toUri()
+        assertNotNull(resultUri)
+        assertTrue(LoginActivity.isSalesforceWelcomeDiscoveryMobileUrl(resultUri!!))
+        assertEquals(viewModel.oAuthConfig.consumerKey,
+            resultUri.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID))
+        assertFalse(viewModel.loginUrl.value!!.contains("/services/oauth2/authorize"))
+    }
+
+    @Test
+    fun test_givenLoginServerManagerSelectedServerIsNotWelcomeDiscovery_whenReloadWebView_thenLoginUrlIsAuthUrl() {
+        // LoginServerManager defaults to Production (login.salesforce.com).
+        viewModel.selectedServer.value = "https://login.salesforce.com"
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val url = viewModel.loginUrl.value
+        assertNotNull(url)
+        assertTrue(url!!.contains("/services/oauth2/authorize"))
+        assertFalse(LoginActivity.isSalesforceWelcomeDiscoveryUrlPath(url.toUri()))
+    }
+
+    @Test
+    fun test_givenLoginServerManagerSelectedServerIsWelcomeDiscovery_whenIsUsingFrontDoorBridge_andReloadWebView_thenLoginUrlIsDiscoveryMobileUrl() {
+        val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        loginServerManager.addCustomLoginServer("Welcome", WELCOME_LOGIN_URL)
+        val frontdoorUrl = "https://example.my.salesforce.com/secur/frontdoor.jsp?sid=fake"
+        viewModel.loginWithFrontDoorBridgeUrl(frontdoorUrl, pkceCodeVerifier = null)
+        assertTrue(viewModel.isUsingFrontDoorBridge)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val resultUri = viewModel.loginUrl.value?.toUri()
+        assertNotNull(resultUri)
+        assertTrue(LoginActivity.isSalesforceWelcomeDiscoveryMobileUrl(resultUri!!))
+        assertNotEquals(frontdoorUrl, viewModel.loginUrl.value)
+    }
+
+    /**
+     * Regression guard for the Phase-2 reload bug: when the user is in Phase 2 of the Welcome
+     * Discovery flow, viewModel.selectedServer is the discovered My Domain (NOT the Welcome URL),
+     * but LoginServerManager retains Welcome as the user's actual server selection.  Reload must
+     * return the WebView to Phase 1.
+     */
+    @Test
+    fun test_givenInPhase2OfWelcomeDiscovery_whenReloadWebView_thenLoginUrlReturnsToPhase1() {
+        val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        loginServerManager.addCustomLoginServer("Welcome", WELCOME_LOGIN_URL)
+        // Phase 2 state: VM mirrors the My Domain from applySalesforceWelcomeLoginHintAndHost.
+        val myDomainUrl = "https://acme.my.salesforce.com"
+        viewModel.selectedServer.value = myDomainUrl
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.reloadWebView()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val resultUri = viewModel.loginUrl.value?.toUri()
+        assertNotNull(resultUri)
+        assertEquals("welcome.salesforce.com", resultUri!!.host)
+        assertEquals(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_URL_PATH, resultUri.path)
+        assertFalse(viewModel.loginUrl.value!!.contains(myDomainUrl))
+        assertFalse(viewModel.loginUrl.value!!.contains("/services/oauth2/authorize"))
+
+        // Reload must also realign VM-level selectedServer back to the Welcome URL so the top
+        // app bar title (defaultTitleText reads selectedServer.value) and the Compose menu
+        // gating ("Login for Admin" hidden when selectedServer is the discovery URL) follow.
+        assertEquals(WELCOME_LOGIN_URL, viewModel.selectedServer.value)
+    }
+
+    @Test
+    fun test_givenConsumerKeyAndAppVersion_whenGenerateSalesforceWelcomeDiscoveryMobileUrl_thenReturnsExpectedUrl() {
+        val input = "https://welcome.salesforce.com/discovery".toUri()
+        val result = viewModel.generateSalesforceWelcomeDiscoveryMobileUrl(input)
+
+        assertEquals("welcome.salesforce.com", result.host)
+        assertEquals("/discovery", result.path)
+        assertEquals(viewModel.oAuthConfig.consumerKey,
+            result.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_ID))
+        assertEquals(URLEncoder.encode(SalesforceSDKManager.getInstance().appVersion, "utf8"),
+            result.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CLIENT_VERSION))
+        assertEquals("sfdc://discocallback",
+            result.getQueryParameter(LoginActivity.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CALLBACK_URL))
+        // Companion validator round-trip:
+        assertTrue(LoginActivity.isSalesforceWelcomeDiscoveryMobileUrl(result))
     }
 
     @Test

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2MockTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2MockTests.kt
@@ -16,7 +16,10 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Buffer
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -215,4 +218,232 @@ class OAuth2MockTests {
             formBody.contains("assertion=__JWT_ASSERTION__"),
         )
     }
+
+    // region DPoP tests
+
+    @Test
+    fun test_givenUseDPoPTrueAndCredentialsIdentifier_whenMakeTokenEndpointRequest_thenDPoPHeaderPresent() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id",
+        )
+
+        val dpopHeader = requestSlot.captured.header("DPoP")
+        assertNotNull("Expected DPoP header to be present", dpopHeader)
+        assertTrue("Expected DPoP header to be non-blank", !dpopHeader.isNullOrBlank())
+    }
+
+    @Test
+    fun test_givenUseDPoPFalse_whenMakeTokenEndpointRequest_thenNoDPoPHeader() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns false
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id",
+        )
+
+        assertNull(
+            "Did not expect DPoP header when isUseDPoP() is false",
+            requestSlot.captured.header("DPoP"),
+        )
+    }
+
+    @Test
+    fun test_givenUseDPoPTrueButNullCredentialsIdentifier_whenMakeTokenEndpointRequest_thenNoDPoPHeader() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            null,
+        )
+
+        assertNull(
+            "Did not expect DPoP header when credentialsIdentifier is null",
+            requestSlot.captured.header("DPoP"),
+        )
+    }
+
+    @Test
+    fun test_givenUseDPoPTrue_whenMakeTokenEndpointRequest_thenTokenTypePersistedOnResponse() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u","token_type":"DPoP"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        val tokenResponse = makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id",
+        )
+
+        assertEquals("DPoP", tokenResponse.tokenType)
+    }
+
+    @Test
+    fun test_givenDPoPTokenType_whenAddAuthorizationHeader_thenDPoPSchemeUsed() {
+        val builder = Request.Builder().url("https://example.com")
+
+        OAuth2.addAuthorizationHeader(builder, "my-access-token", "DPoP")
+
+        val authHeader = builder.build().header("Authorization")
+        assertNotNull(authHeader)
+        assertTrue(
+            "Expected Authorization header to start with 'DPoP ' but got: $authHeader",
+            authHeader!!.startsWith("DPoP "),
+        )
+    }
+
+    @Test
+    fun test_givenBearerTokenType_whenAddAuthorizationHeader_thenBearerSchemeUsed() {
+        val builder = Request.Builder().url("https://example.com")
+
+        OAuth2.addAuthorizationHeader(builder, "my-access-token", "Bearer")
+
+        val authHeader = builder.build().header("Authorization")
+        assertNotNull(authHeader)
+        assertTrue(
+            "Expected Authorization header to start with 'Bearer ' but got: $authHeader",
+            authHeader!!.startsWith("Bearer "),
+        )
+    }
+
+    @Test
+    fun test_givenNullTokenType_whenAddAuthorizationHeader_thenBearerSchemeUsed() {
+        val builder = Request.Builder().url("https://example.com")
+
+        OAuth2.addAuthorizationHeader(builder, "my-access-token", null)
+
+        val authHeader = builder.build().header("Authorization")
+        assertNotNull(authHeader)
+        assertTrue(
+            "Expected Authorization header to start with 'Bearer ' but got: $authHeader",
+            authHeader!!.startsWith("Bearer "),
+        )
+    }
+
+    @Test
+    fun test_givenKeyStoreException_whenMakeTokenEndpointRequest_thenRequestProceedsWithoutDPoPHeader() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        val tokenResponse = makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id-keystore-error",
+        )
+
+        assertNotNull(
+            "Expected token endpoint request to complete even if DPoP key generation fails",
+            tokenResponse,
+        )
+        assertTrue("Expected the request to have been captured", requestSlot.isCaptured)
+    }
+
+    // endregion DPoP tests
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.interfaces.ECPublicKey
+
+@RunWith(AndroidJUnit4::class)
+class DPoPKeyManagerTest {
+
+    private val aliasesToCleanUp = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        aliasesToCleanUp.forEach { DPoPKeyManager.deleteKeyPair(it) }
+        aliasesToCleanUp.clear()
+    }
+
+    private fun trackedAlias(name: String): String {
+        val alias = "dpop_test_$name"
+        aliasesToCleanUp.add(alias)
+        return alias
+    }
+
+    @Test
+    fun test_givenAlias_whenGenerateOrLoad_thenKeyPairIsECSecp256r1() {
+        val alias = trackedAlias("ec_secp256r1")
+        val keyPair = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertTrue(keyPair.public is ECPublicKey)
+        assertEquals("EC", keyPair.public.algorithm)
+    }
+
+    @Test
+    fun test_givenAlias_whenGenerateOrLoadTwice_thenSamePublicKeyReturned() {
+        val alias = trackedAlias("same_pubkey")
+        val first = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        val second = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertEquals(
+            first.public.encoded.toList(),
+            second.public.encoded.toList()
+        )
+    }
+
+    @Test
+    fun test_givenKeyPair_whenDeleted_thenNextCallGeneratesNewKeyPair() {
+        val alias = trackedAlias("delete_regen")
+        val first = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        DPoPKeyManager.deleteKeyPair(alias)
+        val second = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertNotEquals(
+            first.public.encoded.toList(),
+            second.public.encoded.toList()
+        )
+    }
+
+    @Test
+    fun test_givenDifferentAliases_thenDifferentKeyPairs() {
+        val aliasA = trackedAlias("alias_a")
+        val aliasB = trackedAlias("alias_b")
+        val kpA = DPoPKeyManager.generateOrLoadKeyPair(aliasA)
+        val kpB = DPoPKeyManager.generateOrLoadKeyPair(aliasB)
+        assertNotEquals(
+            kpA.public.encoded.toList(),
+            kpB.public.encoded.toList()
+        )
+    }
+
+    @Test
+    fun test_givenCredentialsIdentifier_whenComputingAlias_thenPrefixedWithDpop() {
+        assertEquals("dpop_user-123", DPoPKeyManager.aliasForCredentialsIdentifier("user-123"))
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilderTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilderTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyPair
+import java.security.Signature
+
+@RunWith(AndroidJUnit4::class)
+class DPoPProofBuilderTest {
+
+    private lateinit var keyPair: KeyPair
+    private val alias = "dpop_test_proof_builder"
+
+    @Before
+    fun setUp() {
+        keyPair = DPoPKeyManager.generateOrLoadKeyPair(alias)
+    }
+
+    @After
+    fun tearDown() {
+        DPoPKeyManager.deleteKeyPair(alias)
+    }
+
+    private fun base64UrlDecode(s: String): ByteArray =
+        Base64.decode(s, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+
+    private fun decodeJson(segment: String): JSONObject =
+        JSONObject(String(base64UrlDecode(segment), Charsets.UTF_8))
+
+    private fun rawRsToDer(raw: ByteArray): ByteArray {
+        val r = raw.copyOfRange(0, 32)
+        val s = raw.copyOfRange(32, 64)
+        fun encodeInt(b: ByteArray): ByteArray {
+            val stripped = b.dropWhile { it == 0.toByte() }.toByteArray()
+            val padded =
+                if (stripped.isNotEmpty() && (stripped[0].toInt() and 0x80) != 0)
+                    byteArrayOf(0) + stripped
+                else stripped
+            return byteArrayOf(0x02.toByte(), padded.size.toByte()) + padded
+        }
+        val rEnc = encodeInt(r)
+        val sEnc = encodeInt(s)
+        val body = rEnc + sEnc
+        return byteArrayOf(0x30.toByte(), body.size.toByte()) + body
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenJwsHasThreeSegments() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val parts = proof.split(".")
+        assertEquals(3, parts.size)
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenHeaderHasCorrectFields() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val header = decodeJson(proof.split(".")[0])
+        assertEquals("dpop+jwt", header.getString("typ"))
+        assertEquals("ES256", header.getString("alg"))
+        val jwk = header.getJSONObject("jwk")
+        assertTrue(jwk.has("kty"))
+        assertTrue(jwk.has("crv"))
+        assertTrue(jwk.has("x"))
+        assertTrue(jwk.has("y"))
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenPayloadHasCorrectClaimsAndNoAthOrNonce() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val payload = decodeJson(proof.split(".")[1])
+        assertEquals("POST", payload.getString("htm"))
+        assertTrue(payload.getString("htu").isNotEmpty())
+        assertTrue(payload.getLong("iat") > 0)
+        assertTrue(payload.getString("jti").isNotEmpty())
+        assertFalse(payload.has("ath"))
+        assertFalse(payload.has("nonce"))
+    }
+
+    @Test
+    fun test_givenURLWithQueryAndFragment_whenBuildProof_thenHtuIsCanonical() {
+        val htu = "https://host/token?q=1#frag"
+        val proof = DPoPProofBuilder.buildProof("POST", htu, keyPair)
+        val payload = decodeJson(proof.split(".")[1])
+        assertEquals(htu, payload.getString("htu"))
+    }
+
+    @Test
+    fun test_givenSameKeyPair_whenBuildProofTwice_thenJtisDiffer() {
+        val proof1 = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val proof2 = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val jti1 = decodeJson(proof1.split(".")[1]).getString("jti")
+        val jti2 = decodeJson(proof2.split(".")[1]).getString("jti")
+        assertNotEquals(jti1, jti2)
+    }
+
+    @Test
+    fun test_givenProof_whenSignatureVerifiedWithPublicKey_thenValid() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val parts = proof.split(".")
+        val signingInput = "${parts[0]}.${parts[1]}".toByteArray(Charsets.UTF_8)
+        val rawSig = base64UrlDecode(parts[2])
+        assertEquals(64, rawSig.size)
+        val derSig = rawRsToDer(rawSig)
+        val verifier = Signature.getInstance("SHA256withECDSA")
+        verifier.initVerify(keyPair.public)
+        verifier.update(signingInput)
+        assertTrue(verifier.verify(derSig))
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenJwkCoordinatesAre32BytesEach() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val header = decodeJson(proof.split(".")[0])
+        val jwk = header.getJSONObject("jwk")
+        val xBytes = base64UrlDecode(jwk.getString("x"))
+        val yBytes = base64UrlDecode(jwk.getString("y"))
+        assertEquals(32, xBytes.size)
+        assertEquals(32, yBytes.size)
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelperTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelperTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DPoPURLHelperTest {
+
+    @Test
+    fun test_givenUrlWithQuery_whenCanonicalize_thenQueryStripped() {
+        assertEquals(
+            "https://example.com/token",
+            DPoPURLHelper.canonicalize("https://example.com/token?foo=bar")
+        )
+    }
+
+    @Test
+    fun test_givenUrlWithFragment_whenCanonicalize_thenFragmentStripped() {
+        assertEquals(
+            "https://example.com/token",
+            DPoPURLHelper.canonicalize("https://example.com/token#frag")
+        )
+    }
+
+    @Test
+    fun test_givenUrlWithQueryAndFragment_whenCanonicalize_thenBothStripped() {
+        assertEquals(
+            "https://example.com/token",
+            DPoPURLHelper.canonicalize("https://example.com/token?q=1#frag")
+        )
+    }
+
+    @Test
+    fun test_givenCleanUrl_whenCanonicalize_thenUnchanged() {
+        assertEquals(
+            "https://example.com/services/oauth2/token",
+            DPoPURLHelper.canonicalize("https://example.com/services/oauth2/token")
+        )
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
@@ -143,8 +143,11 @@ class LoginActivityTest {
     fun onLoginForAdminsClick_withNullBrowserCustomTabUrl_doesNotLaunchCustomTab() {
         val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
         every { browserCustomTabUrl.value } returns null
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        every { selectedServer.value } returns "https://example.com"
         val viewModel = mockk<LoginViewModel>(relaxed = true)
         every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
 
         val activity = mockk<LoginActivity>(relaxed = true)
         every { activity.viewModel } returns viewModel
@@ -160,8 +163,11 @@ class LoginActivityTest {
         val testUrl = "https://example.com/services/oauth2/authorize"
         val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
         every { browserCustomTabUrl.value } returns testUrl
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        every { selectedServer.value } returns "https://example.com"
         val viewModel = mockk<LoginViewModel>(relaxed = true)
         every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
 
         val activity = mockk<LoginActivity>(relaxed = true)
         every { activity.viewModel } returns viewModel
@@ -175,6 +181,56 @@ class LoginActivityTest {
         // getter for `adminLoginCustomTabLauncher`. The admin-vs-regular launcher routing is
         // enforced structurally by the 2-line body of `onLoginForAdminsClick`.
         verify(exactly = 1) { activity.loadLoginPageInCustomTab(eq(testUrl), any()) }
+    }
+
+    /**
+     * Phase 2 of Welcome Discovery: viewModel.selectedServer is the discovered My Domain (even
+     * though LoginServerManager still has the Welcome URL selected).  Login for Admin is valid
+     * here and MUST launch the Custom Tab.  Regression guard: keying the no-op off
+     * LoginServerManager.selectedLoginServer instead of viewModel.selectedServer broke this.
+     */
+    @Test
+    fun onLoginForAdminsClick_inWelcomeDiscoveryPhase2_launchesCustomTabAgainstMyDomain() {
+        val testUrl = "https://acme.my.salesforce.com/services/oauth2/authorize"
+        val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
+        every { browserCustomTabUrl.value } returns testUrl
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        // Phase 2: selectedServer is the discovered My Domain, NOT the Welcome URL.
+        every { selectedServer.value } returns "https://acme.my.salesforce.com"
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
+
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.viewModel } returns viewModel
+        every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
+
+        activity.launchLoginForAdminsAction()
+
+        verify(exactly = 1) { activity.loadLoginPageInCustomTab(eq(testUrl), any()) }
+    }
+
+    /**
+     * Phase 1 of Welcome Discovery: viewModel.selectedServer is the Welcome Discovery URL, whose
+     * callback (sfdc://discocallback) is not app-unique.  Login for Admin MUST be a no-op here.
+     */
+    @Test
+    fun onLoginForAdminsClick_inWelcomeDiscoveryPhase1_doesNotLaunchCustomTab() {
+        val browserCustomTabUrl = mockk<MediatorLiveData<String>>()
+        every { browserCustomTabUrl.value } returns "https://welcome.salesforce.com/discovery"
+        val selectedServer = mockk<MediatorLiveData<String>>()
+        every { selectedServer.value } returns "https://welcome.salesforce.com/discovery"
+        val viewModel = mockk<LoginViewModel>(relaxed = true)
+        every { viewModel.browserCustomTabUrl } returns browserCustomTabUrl
+        every { viewModel.selectedServer } returns selectedServer
+
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.viewModel } returns viewModel
+        every { activity.launchLoginForAdminsAction() } answers { callOriginal() }
+
+        activity.launchLoginForAdminsAction()
+
+        verify(exactly = 0) { activity.loadLoginPageInCustomTab(any(), any()) }
     }
 
     // endregion

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginViewActivityTest.kt
@@ -353,6 +353,26 @@ class LoginViewActivityTest {
     }
 
     @Test
+    fun test_givenOnLoginForAdminsIsNull_whenDropdownMenuOpened_thenLoginForAdminsItemIsAbsent() {
+        androidComposeTestRule.setContent {
+            DefaultTopAppBarTestWrapper(
+                onLoginForAdmins = null,
+            )
+        }
+
+        val menu = androidComposeTestRule.onNodeWithContentDescription(
+            androidComposeTestRule.activity.getString(R.string.sf__more_options)
+        )
+        val loginForAdminsButton = androidComposeTestRule.onNodeWithText(
+            androidComposeTestRule.activity.getString(R.string.sf__login_for_admins)
+        )
+
+        menu.assertIsDisplayed()
+        menu.performClick()
+        loginForAdminsButton.assertDoesNotExist()
+    }
+
+    @Test
     fun bottomAppBar_WithNoButton_DisplaysCorrectly() {
         androidComposeTestRule.setContent {
             DefaultBottomAppBarTestWrapper()
@@ -540,7 +560,7 @@ class LoginViewActivityTest {
         shouldShowBackButton: Boolean = false,
         showDevSupport: (() -> Unit)? = { },
         finish: () -> Unit = { },
-        onLoginForAdmins: (() -> Unit) = { },
+        onLoginForAdmins: (() -> Unit)? = { },
     ) {
         DefaultTopAppBar(
             backgroundColor, titleText, titleTextColor, showServerPicker, clearCookies,

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/PickerBottomSheetTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/PickerBottomSheetTest.kt
@@ -45,18 +45,15 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChild
 import androidx.compose.ui.test.onChildAt
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
-import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.rule.GrantPermissionRule
-import com.salesforce.androidsdk.R.string.sf__account_selector_text
-import com.salesforce.androidsdk.R.string.sf__custom_url_button
-import com.salesforce.androidsdk.R.string.sf__pick_server
 import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
 import com.salesforce.androidsdk.ui.components.AddConnection
+import com.salesforce.androidsdk.ui.components.LoginViewTestTags
 import com.salesforce.androidsdk.ui.components.PickerBottomSheet
 import com.salesforce.androidsdk.ui.components.PickerStyle
 import com.salesforce.androidsdk.ui.components.TestablePickerBottomSheet
@@ -66,9 +63,6 @@ import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 
-private const val NAME_FIELD_IDENTIFIER = "Name"
-private const val URL_FIELD_IDENTIFIER = "URL"
-private const val SAVE_BUTTON_IDENTIFIER = "Save"
 private const val TEST_NAME = "Production"
 private const val VALID_URL = "https://login.salesforce.com"
 private const val INVALID_URL = "invalid"
@@ -128,10 +122,8 @@ class PickerBottomSheetTest {
             )
         }
 
-        val context = getInstrumentation().targetContext
-        val button = composeTestRule.onNode(hasText(context.getString(sf__account_selector_text)))
-
-        button.assertIsDisplayed()
+        // Anchor on the locale-invariant container tag rather than the localized title text.
+        composeTestRule.onNodeWithTag(LoginViewTestTags.ACCOUNT_PICKER).assertIsDisplayed()
     }
 
     @OptIn(ExperimentalMaterial3Api::class)
@@ -145,10 +137,8 @@ class PickerBottomSheetTest {
             )
         }
 
-        val context = getInstrumentation().targetContext
-        val button = composeTestRule.onNode(hasText(context.getString(sf__pick_server)))
-
-        button.assertIsDisplayed()
+        // Anchor on the locale-invariant container tag rather than the localized title text.
+        composeTestRule.onNodeWithTag(LoginViewTestTags.SERVER_PICKER).assertIsDisplayed()
     }
 
     // endregion
@@ -168,9 +158,9 @@ class PickerBottomSheetTest {
             AddConnection(getValidServer = serverValidator)
         }
 
-        val nameField = composeTestRule.onNodeWithText(NAME_FIELD_IDENTIFIER)
-        val urlField = composeTestRule.onNodeWithText(URL_FIELD_IDENTIFIER)
-        val saveButton = composeTestRule.onNodeWithText(SAVE_BUTTON_IDENTIFIER)
+        val nameField = composeTestRule.onNodeWithTag(LoginViewTestTags.PICKER_CUSTOM_LABEL)
+        val urlField = composeTestRule.onNodeWithTag(LoginViewTestTags.PICKER_CUSTOM_URL)
+        val saveButton = composeTestRule.onNodeWithTag(LoginViewTestTags.APPLY_BUTTON)
         saveButton.assertIsDisplayed()
         saveButton.assertIsNotEnabled()
 
@@ -201,9 +191,9 @@ class PickerBottomSheetTest {
             )
         }
 
-        val nameField = composeTestRule.onNodeWithText(NAME_FIELD_IDENTIFIER)
-        val urlField = composeTestRule.onNodeWithText(URL_FIELD_IDENTIFIER)
-        val saveButton = composeTestRule.onNodeWithText(SAVE_BUTTON_IDENTIFIER)
+        val nameField = composeTestRule.onNodeWithTag(LoginViewTestTags.PICKER_CUSTOM_LABEL)
+        val urlField = composeTestRule.onNodeWithTag(LoginViewTestTags.PICKER_CUSTOM_URL)
+        val saveButton = composeTestRule.onNodeWithTag(LoginViewTestTags.APPLY_BUTTON)
 
         nameField.performTextInput(TEST_NAME)
         urlField.performTextInput(VALID_URL)
@@ -304,10 +294,7 @@ class PickerBottomSheetTest {
             )
         }
 
-        val context = getInstrumentation().targetContext
-        val button = composeTestRule.onNode(hasText(context.getString(sf__custom_url_button)))
-
-        button.assertIsDisplayed()
+        composeTestRule.onNodeWithTag(LoginViewTestTags.CUSTOM_URL_BUTTON).assertIsDisplayed()
     }
 
     @OptIn(ExperimentalMaterial3Api::class)
@@ -320,10 +307,7 @@ class PickerBottomSheetTest {
             )
         }
 
-        val context = getInstrumentation().targetContext
-        val button = composeTestRule.onNode(hasText(context.getString(sf__custom_url_button)))
-
-        button.assertDoesNotExist()
+        composeTestRule.onNodeWithTag(LoginViewTestTags.CUSTOM_URL_BUTTON).assertDoesNotExist()
     }
 
     @OptIn(ExperimentalMaterial3Api::class)

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -134,6 +134,22 @@ Tests for the Welcome Discovery login flow. Uses the SDK's Login Options "Discov
 | `testWelcomeDiscovery_RegularAuthLoginHost` | Regular Auth | ECA Opaque |
 | `testWelcomeDiscovery_AdvancedAuthLoginHost` | Advanced Auth | Beacon Opaque |
 
+#### LoginWithRestartTests
+Tests that user sessions and per-user feature flags persist across a cold app restart. Each test logs in, kills the app process (leaving the instrumentation runner alive), relaunches the app, and verifies that both session credentials and user-agent feature flags are reloaded correctly from disk. Feature flags tested: BW (browser-based / advanced auth) and WD (welcome discovery).
+
+| Test | App Config | Scopes | Config Type | Feature Flag |
+|------|-----------|--------|-------------|--------------|
+| `testCAOpaque_DefaultScopes_WithRestart` | CA Opaque | Default | Static | — |
+| `testECAOpaque_DefaultScopes_WithRestart` | ECA Opaque | Default | Static | — |
+| `testBeaconOpaque_DefaultScopes_WithRestart` | Beacon Opaque | Default | Static | — |
+| `testECAJwt_DefaultScopes_DynamicConfiguration_WithRestart` | ECA JWT | Default | Dynamic | — |
+| `testECAJwt_SubsetScopes_DynamicConfiguration_WithRestart` | ECA JWT | Subset | Dynamic | — |
+| `testBeaconJwt_DefaultScopes_DynamicConfiguration_WithRestart` | Beacon JWT | Default | Dynamic | — |
+| `testBeaconJwt_SubsetScopes_DynamicConfiguration_WithRestart` | Beacon JWT | Subset | Dynamic | — |
+| `testAdvancedAuth_WithRestart` | Beacon Opaque | Default | Static | BW |
+| `testWelcomeDiscovery_WithRestart` | ECA Opaque | Default | Static | WD |
+| `testMultiUserRestart` | ECA Opaque + ECA JWT | Default | Mixed | — |
+
 ### Validation Per Test
 
 Each `loginAndValidate` call performs the following checks:
@@ -151,13 +167,17 @@ Multi-user tests additionally verify:
 - **User switching** preserves each user's tokens and OAuth configuration
 - **Token refresh** targets the correct user's app after switching
 
+Restart tests additionally verify:
+- Session credentials are **reloaded from disk** after a cold process restart
+- Per-user feature flags (BW, WD) encoded in the user agent string **persist** across restarts via `hydratePerUserFeatures()`
+
 ## Architecture
 
 ### Test Infrastructure
 
 | Component | Description |
 |-----------|-------------|
-| `AuthFlowTest` | Abstract base class providing `loginAndValidate` and `migrateAndValidate` orchestration. Uses `ActivityScenarioRule` + `ComposeTestRule`. Assigns users based on API level to spread credential usage across Firebase Test Lab devices. |
+| `AuthFlowTest` | Abstract base class providing `loginAndValidate`, `migrateAndValidate`, and `restartAndValidateUser` orchestration. Also exposes `restartApp()` (kills only the app process via `pidof` filtered by `myPid`, then relaunches), `addOtherUserAndValidate()`, and `switchToUserAndValidateUser()` helpers for restart and multi-user flows. Uses `ActivityScenarioRule` + `ComposeTestRule`. Assigns users based on API level to spread credential usage across Firebase Test Lab devices. |
 | `UITestConfig` | Deserializes `ui_test_config.json` (from `shared/test/`) into typed enums: `KnownAppConfig`, `KnownLoginHostConfig`, `KnownUserConfig`, `ScopeSelection`. |
 
 ### Page Objects

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.samples.authflowtester
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.BEACON_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for verifying that user sessions and per-user feature flags persist across app restarts.
+ *
+ * Mirrors iOS `LoginWithRestartTests.swift`. Each test logs in, force-stops the process,
+ * relaunches, and asserts that both the session credentials and the feature flags encoded
+ * in the user agent string are reloaded correctly from disk.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class LoginWithRestartTests : AuthFlowTest() {
+
+    // MARK: - Session Persistence
+
+    /** Login with CA Opaque, restart app, verify session persists. */
+    @Test
+    fun testCAOpaque_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = CA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    /** Login with ECA Opaque, restart app, verify session persists. */
+    @Test
+    fun testECAOpaque_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - Feature Flag Persistence After Restart
+
+    /** Login via advanced auth (BW flag set), restart app, verify BW flag persists in user agent. */
+    @Test
+    fun testAdvancedAuth_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = ADVANCED_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = ADVANCED_AUTH,
+            expectAdvancedAuth = true,
+        )
+    }
+
+    /** Login via welcome discovery (WD flag set), restart app, verify WD flag persists in user agent. */
+    @Test
+    fun testWelcomeDiscovery_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+            useWelcomeDiscovery = true,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+            usesWelcomeDiscovery = true,
+        )
+    }
+}

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LoginWithRestartTests.kt
@@ -29,30 +29,35 @@ package com.salesforce.samples.authflowtester
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.BEACON_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.BEACON_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
+import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.SUBSET
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Tests for verifying that user sessions and per-user feature flags persist across app restarts.
  *
- * Mirrors iOS `LoginWithRestartTests.swift`. Each test logs in, force-stops the process,
- * relaunches, and asserts that both the session credentials and the feature flags encoded
- * in the user agent string are reloaded correctly from disk.
+ * Mirrors iOS `LoginWithRestartTests.swift`. Each test logs in, force-stops the process via
+ * `am force-stop`, relaunches, and asserts that both the session credentials and the feature
+ * flags encoded in the user agent string are reloaded correctly from disk.
+ *
+ * NB: Tests use the `user` and `otherUser` derived from the device SDK level (see AuthFlowTest).
  */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class LoginWithRestartTests : AuthFlowTest() {
 
-    // MARK: - Session Persistence
+    // MARK: - Legacy Login Persistence
 
     /** Login with CA Opaque, restart app, verify session persists. */
     @Test
-    fun testCAOpaque_WithRestart() {
+    fun testCAOpaque_DefaultScopes_WithRestart() {
         loginAndValidate(
             knownAppConfig = CA_OPAQUE,
             knownLoginHostConfig = REGULAR_AUTH,
@@ -63,15 +68,90 @@ class LoginWithRestartTests : AuthFlowTest() {
         )
     }
 
+    // MARK: - ECA Login Persistence
+
     /** Login with ECA Opaque, restart app, verify session persists. */
     @Test
-    fun testECAOpaque_WithRestart() {
+    fun testECAOpaque_DefaultScopes_WithRestart() {
         loginAndValidate(
             knownAppConfig = ECA_OPAQUE,
             knownLoginHostConfig = REGULAR_AUTH,
         )
         restartAndValidateUser(
             knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - Beacon Login Persistence
+
+    /** Login with Beacon Opaque, restart app, verify session and child key persist. */
+    @Test
+    fun testBeaconOpaque_DefaultScopes_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - ECA Dynamic Configuration
+
+    /** Login with ECA JWT via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testECAJwt_DefaultScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    /** Login with ECA JWT using subset scopes via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testECAJwt_SubsetScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = ECA_JWT,
+            scopeSelection = SUBSET,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    // MARK: - Beacon Dynamic Configuration
+
+    /** Login with Beacon JWT via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testBeaconJwt_DefaultScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+    }
+
+    /** Login with Beacon JWT using subset scopes via dynamic config, restart app, verify session persists. */
+    @Test
+    fun testBeaconJwt_SubsetScopes_DynamicConfiguration_WithRestart() {
+        loginAndValidate(
+            knownAppConfig = BEACON_JWT,
+            scopeSelection = SUBSET,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+        restartAndValidateUser(
+            knownAppConfig = BEACON_JWT,
             knownLoginHostConfig = REGULAR_AUTH,
         )
     }
@@ -105,5 +185,34 @@ class LoginWithRestartTests : AuthFlowTest() {
             knownLoginHostConfig = REGULAR_AUTH,
             usesWelcomeDiscovery = true,
         )
+    }
+
+    // MARK: - Multi-User Restart
+
+    /** Login two users, restart app, verify both sessions and user agent flags persist. */
+    @Test
+    fun testMultiUserRestart() {
+        // Login user A
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+
+        // Login user B
+        addOtherUserAndValidate(
+            knownAppConfig = ECA_JWT,
+            knownLoginHostConfig = REGULAR_AUTH,
+        )
+
+        // Force-stop and relaunch — credentials must reload from disk
+        restartApp()
+
+        // Verify and switch to user A
+        switchToUserAndValidateUser(user)
+        app.validateApiRequest()
+
+        // Verify and switch to user B
+        switchToUserAndValidateUser(otherUser)
+        app.validateApiRequest()
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -371,8 +371,7 @@ class MultiUserLoginTests: AuthFlowTest() {
     ) {
         app.switchToUser(knownUserConfig)
         composeTestRule.waitForIdle()
-        app.validateUser(knownLoginHostConfig, knownUserConfig)
-        app.validateUserAgent(knownLoginHostConfig, isMultiUser = true)
+        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true)
     }
 
     /**
@@ -416,11 +415,9 @@ class MultiUserLoginTests: AuthFlowTest() {
 
         // Switch to User A — no BW, MU still present
         switchToUserAndValidate(user)
-        app.validateUserAgent(REGULAR_AUTH, isMultiUser = true)
 
         // Switch back to User B — BW back, MU still present
         switchToUserAndValidate(otherUser, ADVANCED_AUTH)
-        app.validateUserAgent(ADVANCED_AUTH, isMultiUser = true)
 
         // Log out User B via SDK — auto-switches to User A; MU must be gone
         val sdkManager = SalesforceSDKManager.getInstance()

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -421,6 +421,21 @@ class MultiUserLoginTests: AuthFlowTest() {
         // Switch back to User B — BW back, MU still present
         switchToUserAndValidate(otherUser, ADVANCED_AUTH)
         app.validateUserAgent(ADVANCED_AUTH, isMultiUser = true)
+
+        // Log out User B via SDK — auto-switches to User A; MU must be gone
+        val sdkManager = SalesforceSDKManager.getInstance()
+        val otherUserAccount = sdkManager.userAccountManager.authenticatedUsers
+            ?.find { it.username == testConfig.getUser(ADVANCED_AUTH, otherUser).username }
+            ?: throw AssertionError("Other user account not found")
+        sdkManager.logout(
+            account = sdkManager.userAccountManager.buildAccount(otherUserAccount),
+            frontActivity = null,
+            showLoginPage = false,
+        )
+        waitForUserCount(sdkManager.userAccountManager, expectedCount = 1)
+
+        // Back on User A — MU gone, no BW
+        app.validateUserAgent(REGULAR_AUTH, isMultiUser = false)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -39,6 +39,7 @@ import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQU
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection
@@ -360,6 +361,7 @@ class MultiUserLoginTests: AuthFlowTest() {
             useHybridAuthToken,
             knownLoginHostConfig,
             knownUserConfig = otherUser,
+            isMultiUser = true,
         )
     }
 
@@ -370,6 +372,7 @@ class MultiUserLoginTests: AuthFlowTest() {
         app.switchToUser(knownUserConfig)
         composeTestRule.waitForIdle()
         app.validateUser(knownLoginHostConfig, knownUserConfig)
+        app.validateUserAgent(knownLoginHostConfig, isMultiUser = true)
     }
 
     /**
@@ -393,6 +396,31 @@ class MultiUserLoginTests: AuthFlowTest() {
             "Timed out after ${timeoutMs}ms waiting for user count to reach " +
                 "$expectedCount (was $finalCount)"
         )
+    }
+
+    @Test
+    fun testAdvancedAuthUser_HasBWFlag_RegularAuthUser_DoesNot() {
+        // User A: regular auth — no BW
+        loginAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = REGULAR_AUTH,
+            knownUserConfig = user,
+            isMultiUser = false,
+        )
+
+        // User B: advanced auth — has BW; now 2 users → MU
+        loginOtherUserAndValidate(
+            knownAppConfig = ECA_OPAQUE,
+            knownLoginHostConfig = ADVANCED_AUTH,
+        )
+
+        // Switch to User A — no BW, MU still present
+        switchToUserAndValidate(user)
+        app.validateUserAgent(REGULAR_AUTH, isMultiUser = true)
+
+        // Switch back to User B — BW back, MU still present
+        switchToUserAndValidate(otherUser, ADVANCED_AUTH)
+        app.validateUserAgent(ADVANCED_AUTH, isMultiUser = true)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
@@ -46,10 +46,9 @@ class RTRLoginTests : AuthFlowTest() {
 
     // region ECA JWT RTR Tests
 
-    // Login with ECA JWT RTR using hybrid auth token flow.
-    // Expected to fail until W-22512846 (Enable Named JWTs for Hybrid Flows) is resolved.
-    // The server currently returns invalid_grant when RTR is used with JWT tokens in hybrid flow.
-    @Ignore("Won't pass until server completes W-22512846")
+    // TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows.
+    // Server currently returns invalid_grant for RTR + JWT tokens in hybrid flow.
+    @Ignore("TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows")
     @Test
     fun testECAJwtRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RefreshTokenMigrationTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RefreshTokenMigrationTests.kt
@@ -205,6 +205,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         knownLoginHostConfig: KnownLoginHostConfig,
         knownUserConfig: KnownUserConfig,
         useWelcomeDiscovery: Boolean,
+        isMultiUser: Boolean,
     ) {
         super.loginAndValidate(
             knownAppConfig = knownAppConfig,
@@ -214,6 +215,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
             knownLoginHostConfig = knownLoginHostConfig,
             knownUserConfig = user,
             useWelcomeDiscovery = useWelcomeDiscovery,
+            isMultiUser = isMultiUser,
         )
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -54,6 +54,7 @@ import com.salesforce.samples.authflowtester.R
 import com.salesforce.samples.authflowtester.REQUEST_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.REVOKE_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.SCROLL_CONTAINER_CONTENT_DESC
+import com.salesforce.samples.authflowtester.USER_AGENT_CONTENT_DESC
 import com.salesforce.samples.authflowtester.components.ACCESS_TOKEN
 import com.salesforce.samples.authflowtester.components.CLIENT_ID
 import com.salesforce.samples.authflowtester.components.REFRESH_TOKEN
@@ -478,5 +479,46 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         return node.fetchSemanticsNode()
             .config[SemanticsProperties.Text]
             .last().text // Value is last; first is the label
+    }
+
+    fun validateUserAgent(
+        knownLoginHostConfig: KnownLoginHostConfig,
+        usesWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
+    ) {
+        expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
+        val ua = getText(USER_AGENT_CONTENT_DESC)
+
+        assert(ua.contains("SalesforceMobileSDK/")) {
+            "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
+        }
+        assert(ua.contains("ftr_")) {
+            "User agent missing 'ftr_' segment: $ua"
+        }
+
+        // Parse flag codes from the ftr_XXXX segment
+        val ftrSegment = ua.substringAfter("ftr_").substringBefore(" ")
+        val flags = ftrSegment.split(".").toSet()
+
+        when (knownLoginHostConfig) {
+            KnownLoginHostConfig.ADVANCED_AUTH -> assert("BW" in flags) {
+                "Expected 'BW' flag for ADVANCED_AUTH in: $ua"
+            }
+            KnownLoginHostConfig.REGULAR_AUTH -> assert("BW" !in flags) {
+                "Expected no 'BW' flag for REGULAR_AUTH in: $ua"
+            }
+        }
+
+        if (usesWelcomeDiscovery) {
+            assert("WD" in flags) {
+                "Expected 'WD' flag for Welcome Discovery in: $ua"
+            }
+        }
+
+        if (isMultiUser) {
+            assert("MU" in flags) {
+                "Expected 'MU' flag for multi-user in: $ua"
+            }
+        }
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -270,6 +270,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         knownUserConfig: KnownUserConfig,
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
     ) {
         val expected = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
 
@@ -306,7 +307,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
 
         // Validate feature flags — UI is already settled, reuse the existing layout traversal
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth)
     }
 
     fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection) {
@@ -494,9 +495,10 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         knownLoginHostConfig: KnownLoginHostConfig,
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
     ) {
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth)
     }
 
     private fun validateUserAgent(
@@ -504,6 +506,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         knownLoginHostConfig: KnownLoginHostConfig,
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
     ) {
         assert(ua.contains("SalesforceMobileSDK/")) {
             "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
@@ -516,12 +519,14 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         val ftrSegment = ua.substringAfter("ftr_").substringBefore(" ")
         val flags = ftrSegment.split(".").toSet()
 
-        when (knownLoginHostConfig) {
-            KnownLoginHostConfig.ADVANCED_AUTH -> assert("BW" in flags) {
-                "Expected 'BW' flag for ADVANCED_AUTH in: $ua"
+        val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == KnownLoginHostConfig.ADVANCED_AUTH
+        if (shouldHaveBW) {
+            assert("BW" in flags) {
+                "Expected 'BW' flag for browser-based auth in: $ua"
             }
-            KnownLoginHostConfig.REGULAR_AUTH -> assert("BW" !in flags) {
-                "Expected no 'BW' flag for REGULAR_AUTH in: $ua"
+        } else {
+            assert("BW" !in flags) {
+                "Expected no 'BW' flag for in-app WebView auth in: $ua"
             }
         }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -265,11 +265,16 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         )
     }
 
-    fun validateUser(knownLoginHostConfig: KnownLoginHostConfig, knownUserConfig: KnownUserConfig) {
+    fun validateUser(
+        knownLoginHostConfig: KnownLoginHostConfig,
+        knownUserConfig: KnownUserConfig,
+        usesWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
+    ) {
         val expected = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
 
         waitForNode(CREDS_SECTION_CONTENT_DESC)
-        
+
         // Wait for the UI to update asynchronously after login or user switch.
         // The view may be recreated and collapsed when the current user state updates.
         try {
@@ -298,6 +303,10 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
             throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for username to show \"${expected.username}\"", e)
         }
         assertEquals(expected.username, getText(USERNAME))
+
+        // Validate feature flags — UI is already settled, reuse the existing layout traversal
+        expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
     }
 
     fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection) {
@@ -487,8 +496,15 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         isMultiUser: Boolean = false,
     ) {
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        val ua = getText(USER_AGENT_CONTENT_DESC)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser)
+    }
 
+    private fun validateUserAgent(
+        ua: String,
+        knownLoginHostConfig: KnownLoginHostConfig,
+        usesWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
+    ) {
         assert(ua.contains("SalesforceMobileSDK/")) {
             "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
         }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
@@ -31,9 +31,9 @@ import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -48,6 +48,7 @@ import androidx.test.espresso.web.webdriver.Locator
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.salesforce.androidsdk.R
+import com.salesforce.androidsdk.ui.components.LoginViewTestTags
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 import com.salesforce.samples.authflowtester.testUtility.testConfig
@@ -76,13 +77,13 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
 
     /**
      * Returns true when the LoginActivity top bar is currently in front
-     * (detected via the SDK's "More Options" content description). Used by
+     * (detected via the SDK's locale-invariant "More Options" test tag). Used by
      * negative tests to assert the user did not advance past login.
      */
     fun isLoginScreenVisible(): Boolean =
         try {
             composeTestRule
-                .onAllNodesWithContentDescription(getString(R.string.sf__more_options))
+                .onAllNodesWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         } catch (_: Throwable) {
@@ -104,12 +105,12 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
 
     fun openLoginOptions() {
         // Tap "More Options" three-dot menu (Compose IconButton)
-        composeTestRule.onNodeWithContentDescription(getString(R.string.sf__more_options))
+        composeTestRule.onNodeWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
             .performClick()
         composeTestRule.waitForIdle()
 
         // Tap "Developer Support" dropdown menu item
-        composeTestRule.onNodeWithText(getString(R.string.sf__dev_support_title_menu_item))
+        composeTestRule.onNodeWithTag(LoginViewTestTags.MENU_ITEM_DEV_SUPPORT)
             .performClick()
         composeTestRule.waitForIdle()
 
@@ -150,12 +151,12 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
      */
     fun tapLoginForAdminsMenuItem() {
         // Tap "More Options" three-dot menu (Compose IconButton)
-        composeTestRule.onNodeWithContentDescription(getString(R.string.sf__more_options))
+        composeTestRule.onNodeWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
             .performClick()
         composeTestRule.waitForIdle()
 
         // Tap "Login for Admins" dropdown menu item
-        composeTestRule.onNodeWithText(getString(R.string.sf__login_for_admins))
+        composeTestRule.onNodeWithTag(LoginViewTestTags.MENU_ITEM_LOGIN_FOR_ADMINS)
             .performClick()
         composeTestRule.waitForIdle()
     }
@@ -171,20 +172,19 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
      */
     fun changeServerByUrl(url: String) {
         // Tap "More Options" three-dot menu (Compose IconButton)
-        composeTestRule.onNodeWithContentDescription(getString(R.string.sf__more_options))
+        composeTestRule.onNodeWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
             .performClick()
         composeTestRule.waitForIdle()
 
         // Tap "Change Server" dropdown menu item
-        composeTestRule.onNodeWithText(getString(R.string.sf__pick_server))
+        composeTestRule.onNodeWithTag(LoginViewTestTags.MENU_ITEM_PICK_SERVER)
             .performClick()
 
         // Wait for server picker bottom sheet to appear
         try {
             composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-                composeTestRule.onAllNodesWithContentDescription(
-                    getString(R.string.sf__server_picker_content_description)
-                ).fetchSemanticsNodes().isNotEmpty()
+                composeTestRule.onAllNodesWithTag(LoginViewTestTags.SERVER_PICKER)
+                    .fetchSemanticsNodes().isNotEmpty()
             }
         } catch (e: ComposeTimeoutException) {
             throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for server picker bottom sheet to appear", e)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -222,18 +222,31 @@ abstract class AuthFlowTest {
     }
 
     /**
-     * Force-stops and relaunches the app process.
+     * Kills the app process and relaunches it, so the SDK reloads all state from disk.
      *
-     * Uses `am force-stop` via UiAutomator shell so the SDK must reload all state from disk,
-     * exercising the same persistence code path as a real device restart. The instrumentation
-     * process stays alive; the Compose/UiAutomator bridge reattaches by package name.
+     * `am force-stop <package>` kills the instrumentation process too because the test
+     * runner shares the app's process. Instead, we get all PIDs for the package via
+     * `pidof`, exclude our own instrumentation PID, and kill only the app PID(s).
+     * This leaves the instrumentation alive while forcing the app to restart cold.
+     *
+     * After the kill, we relaunch via an explicit intent so the SDK re-runs
+     * `hydratePerUserFeatures()` from disk, exercising the same code path as a real restart.
      */
     fun restartApp() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val packageName = context.packageName
+        val device = UiDevice.getInstance(instrumentation)
+        val myPid = android.os.Process.myPid()
 
-        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
+        // Kill all processes in the package except the instrumentation runner's own PID.
+        val pidOutput = device.executeShellCommand("pidof $packageName").trim()
+        if (pidOutput.isNotEmpty()) {
+            pidOutput.split("\\s+".toRegex())
+                .mapNotNull { it.trim().toIntOrNull() }
+                .filter { it != myPid }
+                .forEach { pid -> device.executeShellCommand("kill -9 $pid") }
+        }
         Thread.sleep(1_000)
 
         val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -138,6 +138,7 @@ abstract class AuthFlowTest {
         knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
         knownUserConfig: KnownUserConfig = user,
         useWelcomeDiscovery: Boolean = false,
+        isMultiUser: Boolean = false,
     ) {
         val loginPage = when(knownLoginHostConfig) {
             REGULAR_AUTH -> LoginPageObject(composeTestRule)
@@ -217,6 +218,7 @@ abstract class AuthFlowTest {
         app.validateUser(knownLoginHostConfig, knownUserConfig)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
+        app.validateUserAgent(knownLoginHostConfig, useWelcomeDiscovery, isMultiUser)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -259,7 +259,7 @@ abstract class AuthFlowTest {
         AuthorizationPageObject(composeTestRule).tapAllowAfterLogin(ADVANCED_AUTH)
 
         app.waitForAppLoad()
-        app.validateUser(REGULAR_AUTH, user)
+        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true)
         app.validateOAuthValues(KnownAppConfig.BEACON_OPAQUE, scopeSelection = EMPTY)
         app.validateApiRequest()
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -35,6 +35,7 @@ import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
+import androidx.test.uiautomator.UiDevice
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.samples.authflowtester.AuthFlowTesterActivity
 import com.salesforce.samples.authflowtester.pageObjects.AuthFlowTesterPageObject
@@ -218,6 +219,40 @@ abstract class AuthFlowTest {
         app.validateUser(knownLoginHostConfig, knownUserConfig, useWelcomeDiscovery, isMultiUser)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
+    }
+
+    /**
+     * Force-stops and relaunches the app, then validates the persisted user session.
+     *
+     * Mirrors iOS `restartAndValidateUser`. Uses `am force-stop` via UiAutomator to fully
+     * kill the process (not just recreate the activity), then relaunches via an explicit
+     * intent so the SDK reads all state from disk, exercising the same persistence code
+     * path as a real device restart.
+     */
+    fun restartAndValidateUser(
+        knownAppConfig: KnownAppConfig,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+        knownUserConfig: KnownUserConfig = user,
+        usesWelcomeDiscovery: Boolean = false,
+        expectAdvancedAuth: Boolean = false,
+    ) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val packageName = context.packageName
+
+        // Kill the app process entirely so the SDK must reload state from disk.
+        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
+        Thread.sleep(1_000)
+
+        // Relaunch via explicit intent (mirrors how the ActivityScenarioRule would launch it).
+        val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra(AuthFlowTesterActivity.EXTRA_IS_UI_TESTING, true)
+        }
+        context.startActivity(launchIntent)
+
+        app.waitForAppLoad()
+        app.validateUser(knownLoginHostConfig, knownUserConfig, usesWelcomeDiscovery, expectAdvancedAuth = expectAdvancedAuth)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -215,10 +215,9 @@ abstract class AuthFlowTest {
         }
         app.waitForAppLoad()
 
-        app.validateUser(knownLoginHostConfig, knownUserConfig)
+        app.validateUser(knownLoginHostConfig, knownUserConfig, useWelcomeDiscovery, isMultiUser)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
-        app.validateUserAgent(knownLoginHostConfig, useWelcomeDiscovery, isMultiUser)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -222,12 +222,32 @@ abstract class AuthFlowTest {
     }
 
     /**
+     * Force-stops and relaunches the app process.
+     *
+     * Uses `am force-stop` via UiAutomator shell so the SDK must reload all state from disk,
+     * exercising the same persistence code path as a real device restart. The instrumentation
+     * process stays alive; the Compose/UiAutomator bridge reattaches by package name.
+     */
+    fun restartApp() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val packageName = context.packageName
+
+        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
+        Thread.sleep(1_000)
+
+        val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra(AuthFlowTesterActivity.EXTRA_IS_UI_TESTING, true)
+        }
+        context.startActivity(launchIntent)
+        app.waitForAppLoad()
+    }
+
+    /**
      * Force-stops and relaunches the app, then validates the persisted user session.
      *
-     * Mirrors iOS `restartAndValidateUser`. Uses `am force-stop` via UiAutomator to fully
-     * kill the process (not just recreate the activity), then relaunches via an explicit
-     * intent so the SDK reads all state from disk, exercising the same persistence code
-     * path as a real device restart.
+     * Mirrors iOS `restartAndValidateUser`.
      */
     fun restartAndValidateUser(
         knownAppConfig: KnownAppConfig,
@@ -236,23 +256,43 @@ abstract class AuthFlowTest {
         usesWelcomeDiscovery: Boolean = false,
         expectAdvancedAuth: Boolean = false,
     ) {
-        val instrumentation = InstrumentationRegistry.getInstrumentation()
-        val context = instrumentation.targetContext
-        val packageName = context.packageName
-
-        // Kill the app process entirely so the SDK must reload state from disk.
-        UiDevice.getInstance(instrumentation).executeShellCommand("am force-stop $packageName")
-        Thread.sleep(1_000)
-
-        // Relaunch via explicit intent (mirrors how the ActivityScenarioRule would launch it).
-        val launchIntent = Intent(context, AuthFlowTesterActivity::class.java).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            putExtra(AuthFlowTesterActivity.EXTRA_IS_UI_TESTING, true)
-        }
-        context.startActivity(launchIntent)
-
-        app.waitForAppLoad()
+        restartApp()
         app.validateUser(knownLoginHostConfig, knownUserConfig, usesWelcomeDiscovery, expectAdvancedAuth = expectAdvancedAuth)
+    }
+
+    /**
+     * Adds a second account by tapping "Add New Account", logs in, and validates.
+     * Mirrors iOS `loginOtherUserAndValidate`.
+     */
+    fun addOtherUserAndValidate(
+        knownAppConfig: KnownAppConfig,
+        scopeSelection: ScopeSelection = EMPTY,
+        useWebServerFlow: Boolean = true,
+        useHybridAuthToken: Boolean = true,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+    ) {
+        app.addNewAccount()
+        loginAndValidate(
+            knownAppConfig = knownAppConfig,
+            scopeSelection = scopeSelection,
+            useWebServerFlow = useWebServerFlow,
+            useHybridAuthToken = useHybridAuthToken,
+            knownLoginHostConfig = knownLoginHostConfig,
+            knownUserConfig = otherUser,
+            isMultiUser = true,
+        )
+    }
+
+    /**
+     * Switches to a user already logged in and validates. Mirrors iOS `switchToUserAndValidateUser`.
+     */
+    fun switchToUserAndValidateUser(
+        knownUserConfig: KnownUserConfig,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+    ) {
+        app.switchToUser(knownUserConfig)
+        composeTestRule.waitForIdle()
+        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
@@ -162,6 +162,7 @@ const val MIGRATE_USER_RADIO_CONTENT_DESC = "migrate_user_radio"
 const val ALERT_TITLE_CONTENT_DESC = "alert_title"
 const val ALERT_POSITIVE_BUTTON_CONTENT_DESC = "alert_positive"
 const val SCROLL_CONTAINER_CONTENT_DESC = "scroll_container"
+const val USER_AGENT_CONTENT_DESC = "user_agent"
 
 class AuthFlowTesterActivity : SalesforceActivity() {
     private var client: RestClient? = null

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/BaseComponents.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/BaseComponents.kt
@@ -271,6 +271,7 @@ fun InfoRowView(
     label: String,
     value: String?,
     isSensitive: Boolean = false,
+    contentDescription: String = label,
 ) {
     var isValueVisible by remember { mutableStateOf(!isSensitive) }
     val emptyText = stringResource(R.string.empty_placeholder)
@@ -321,7 +322,7 @@ fun InfoRowView(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(VALUE_WEIGHT)
                 .padding(end = (INNER_CARD_PADDING /2).dp)
-                .semantics { contentDescription = label },
+                .semantics { this.contentDescription = contentDescription },
         )
 
         if (isSensitive && !value.isNullOrEmpty()) {

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/UserCredentialsView.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/components/UserCredentialsView.kt
@@ -36,11 +36,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.ScopeParser.Companion.toScopeParser
 import com.salesforce.androidsdk.ui.theme.sfDarkColors
 import com.salesforce.androidsdk.ui.theme.sfLightColors
 import com.salesforce.androidsdk.util.test.ExcludeFromJacocoGeneratedReport
 import com.salesforce.samples.authflowtester.CREDS_SECTION_CONTENT_DESC
+import com.salesforce.samples.authflowtester.USER_AGENT_CONTENT_DESC
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
@@ -105,6 +107,7 @@ private const val BEACON_CHILD_CONSUMER_SECRET = "Beacon Child Consumer Secret"
 
 // Other fields
 private const val ADDITIONAL_OAUTH_FIELDS = "Additional OAuth Fields"
+private const val USER_AGENT_LABEL = "User Agent"
 
 @Composable
 fun UserCredentialsView(currentUser: UserAccount?) {
@@ -166,8 +169,17 @@ fun UserCredentialsView(currentUser: UserAccount?) {
 
         InfoSection(title = OTHER) {
             InfoRowView(label = ADDITIONAL_OAUTH_FIELDS, value = formatAdditionalOAuthFields(currentUser))
+            InfoRowView(
+                label = USER_AGENT_LABEL,
+                value = getUserAgentString(currentUser),
+                contentDescription = USER_AGENT_CONTENT_DESC,
+            )
         }
     }
+}
+
+private fun getUserAgentString(user: UserAccount?): String {
+    return if (user != null) SalesforceSDKManager.getInstance().getUserAgent("", user) else ""
 }
 
 private fun formatScopes(user: UserAccount?): String? {
@@ -246,6 +258,7 @@ private fun generateCredentialsJSON(user: UserAccount?): String {
 
             putJsonObject(OTHER) {
                 put(ADDITIONAL_OAUTH_FIELDS, formatAdditionalOAuthFields(user))
+                put(USER_AGENT_LABEL, getUserAgentString(user))
             }
         }
 


### PR DESCRIPTION
## Summary

- **New package `com.salesforce.androidsdk.auth.dpop`** with three classes:
  - `DPoPURLHelper` — RFC 9449 §4.2 URL canonicalization (strips query + fragment)
  - `DPoPKeyManager` — Android Keystore EC P-256 keypair lifecycle, scoped per `credentialsIdentifier`
  - `DPoPProofBuilder` — compact JWS construction (JWK export of affineX/Y, jti via SecureRandom, DER→raw R||S signature)
- **`OAuth2.java`** — new `makeTokenEndpointRequest` / `exchangeCode` / `refreshAuthToken` overloads that accept a `credentialsIdentifier`; attaches `DPoP` header when `SalesforceSDKManager.isUseDPoP() == true`; parses `token_type` from token response; `addAuthorizationHeader` now selects `DPoP` or `Bearer` scheme based on token type
- **`SalesforceSDKManager.kt`** — new `isUseDPoP()` / `setUseDPoP(Boolean)` opt-in flag
- **`UserAccount.java` + `UserAccountBuilder.kt`** — new `dpopScope` (keypair alias UUID) and `tokenType` fields, persisted through JSON/Bundle serialization
- **`LoginViewModel.kt` + `AuthenticationUtilities.kt`** — UUID generated at login start, threaded through `exchangeCode`, stored on `UserAccount` via `UserAccountBuilder`
- **`AuthenticatorService.java`** — passes `dpopScope` to `refreshAuthToken` so the same keypair is reused on refresh
- **`RestClient.java` / `ClientManager.java`** — `OAuthRefreshInterceptor` now holds and applies `tokenType`; `AuthTokenProvider.getTokenType()` default method propagates it through refresh

## Test plan

- [ ] `DPoPURLHelperTest` — 4 canonicalization cases
- [ ] `DPoPKeyManagerTest` — generate/reload idempotency, deletion, per-alias isolation
- [ ] `DPoPProofBuilderTest` — JWS structure, claims, signature verification, JWK coordinate size, jti uniqueness
- [ ] `OAuth2MockTests` — 8 new DPoP tests: header present/absent, null credentialsIdentifier, token type persisted, `DPoP`/`Bearer`/null auth scheme selection, request completes gracefully on keystore error

## Out of scope for this story (W-22695293 Phase 2)

- Nonce challenge/retry — Phase 4 (W-22697878)
- API call proofs with `ath` claim — Phase 3
- Automated UI tests — Phase 5

## iOS equivalent

W-22695307 (closed) on `upstream/dpop` branch — this PR brings Android to parity.