### PR TITLE
feat(W-22695293): DPoP proof JWT at token exchange (Phase 2, Android)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -105,7 +105,7 @@ public class UserAccount {
 	public static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
 	public static final String SCOPE = "scope";
 	public static final String FEATURE_FLAGS = "feature_flags";
-	public static final String DPOP_SCOPE = "dpopScope";
+	public static final String CREDENTIALS_IDENTIFIER = "credentialsIdentifier";
 	public static final String TOKEN_TYPE = "tokenType";
 
 	private static final String TAG = "UserAccount";
@@ -154,7 +154,7 @@ public class UserAccount {
 	private String beaconChildConsumerKey;
 	private String beaconChildConsumerSecret;
 	private String scope;
-	private String dpopScope;
+	private String credentialsIdentifier;
 	private String tokenType;
 	private Set<String> featureFlags = new java.util.HashSet<>();
 
@@ -299,7 +299,7 @@ public class UserAccount {
 			beaconChildConsumerKey = object.optString(BEACON_CHILD_CONSUMER_KEY, null);
 			beaconChildConsumerSecret = object.optString(BEACON_CHILD_CONSUMER_SECRET, null);
 			scope = object.optString(SCOPE, null);
-			dpopScope = object.optString(DPOP_SCOPE, null);
+			credentialsIdentifier = object.optString(CREDENTIALS_IDENTIFIER, null);
 			tokenType = object.optString(TOKEN_TYPE, null);
 			additionalOauthValues = MapUtil.addJSONObjectToMap(object, additionalOauthKeys, additionalOauthValues);
 		}
@@ -358,7 +358,7 @@ public class UserAccount {
 			beaconChildConsumerKey = bundle.getString(BEACON_CHILD_CONSUMER_KEY);
 			beaconChildConsumerSecret = bundle.getString(BEACON_CHILD_CONSUMER_SECRET);
 			scope = bundle.getString(SCOPE);
-			dpopScope = bundle.getString(DPOP_SCOPE);
+			credentialsIdentifier = bundle.getString(CREDENTIALS_IDENTIFIER);
 			tokenType = bundle.getString(TOKEN_TYPE);
 			additionalOauthValues = MapUtil.addBundleToMap(bundle, additionalOauthKeys, additionalOauthValues);
 		}
@@ -749,22 +749,22 @@ public class UserAccount {
 	}
 
 	/**
-	 * Returns the DPoP credentials identifier used as the keystore alias for
+	 * Returns the credentials identifier used as the keystore alias for
 	 * this user's DPoP keypair.
 	 *
-	 * @return DPoP credentials identifier, or null if DPoP is not in use.
+	 * @return Credentials identifier, or null if DPoP is not in use.
 	 */
-	public String getDpopScope() {
-		return dpopScope;
+	public String getCredentialsIdentifier() {
+		return credentialsIdentifier;
 	}
 
 	/**
-	 * Sets the DPoP credentials identifier.
+	 * Sets the credentials identifier.
 	 *
-	 * @param dpopScope DPoP credentials identifier.
+	 * @param credentialsIdentifier Credentials identifier.
 	 */
-	public void setDpopScope(String dpopScope) {
-		this.dpopScope = dpopScope;
+	public void setCredentialsIdentifier(String credentialsIdentifier) {
+		this.credentialsIdentifier = credentialsIdentifier;
 	}
 
 	/**
@@ -1094,7 +1094,7 @@ public class UserAccount {
 			object.put(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 			object.put(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 			object.put(SCOPE, scope);
-			if (dpopScope != null) object.put(DPOP_SCOPE, dpopScope);
+			if (credentialsIdentifier != null) object.put(CREDENTIALS_IDENTIFIER, credentialsIdentifier);
 			if (tokenType != null) object.put(TOKEN_TYPE, tokenType);
 			if (!featureFlags.isEmpty()) {
 				org.json.JSONArray flagsArray = new org.json.JSONArray();
@@ -1162,7 +1162,7 @@ public class UserAccount {
 		object.putString(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 		object.putString(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 		object.putString(SCOPE, scope);
-		if (dpopScope != null) object.putString(DPOP_SCOPE, dpopScope);
+		if (credentialsIdentifier != null) object.putString(CREDENTIALS_IDENTIFIER, credentialsIdentifier);
 		if (tokenType != null) object.putString(TOKEN_TYPE, tokenType);
 		object = MapUtil.addMapToBundle(additionalOauthValues, additionalOauthKeys, object);
 		return object;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -105,6 +105,8 @@ public class UserAccount {
 	public static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
 	public static final String SCOPE = "scope";
 	public static final String FEATURE_FLAGS = "feature_flags";
+	public static final String DPOP_SCOPE = "dpopScope";
+	public static final String TOKEN_TYPE = "tokenType";
 
 	private static final String TAG = "UserAccount";
 	private static final String FORWARD_SLASH = "/";
@@ -152,6 +154,8 @@ public class UserAccount {
 	private String beaconChildConsumerKey;
 	private String beaconChildConsumerSecret;
 	private String scope;
+	private String dpopScope;
+	private String tokenType;
 	private Set<String> featureFlags = new java.util.HashSet<>();
 
 	/**
@@ -295,6 +299,8 @@ public class UserAccount {
 			beaconChildConsumerKey = object.optString(BEACON_CHILD_CONSUMER_KEY, null);
 			beaconChildConsumerSecret = object.optString(BEACON_CHILD_CONSUMER_SECRET, null);
 			scope = object.optString(SCOPE, null);
+			dpopScope = object.optString(DPOP_SCOPE, null);
+			tokenType = object.optString(TOKEN_TYPE, null);
 			additionalOauthValues = MapUtil.addJSONObjectToMap(object, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -352,6 +358,8 @@ public class UserAccount {
 			beaconChildConsumerKey = bundle.getString(BEACON_CHILD_CONSUMER_KEY);
 			beaconChildConsumerSecret = bundle.getString(BEACON_CHILD_CONSUMER_SECRET);
 			scope = bundle.getString(SCOPE);
+			dpopScope = bundle.getString(DPOP_SCOPE);
+			tokenType = bundle.getString(TOKEN_TYPE);
 			additionalOauthValues = MapUtil.addBundleToMap(bundle, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -739,6 +747,44 @@ public class UserAccount {
 	public boolean hasScope(String scopeToCheck) {
 		return new ScopeParser(scope).hasScope(scopeToCheck);
 	}
+
+	/**
+	 * Returns the DPoP credentials identifier used as the keystore alias for
+	 * this user's DPoP keypair.
+	 *
+	 * @return DPoP credentials identifier, or null if DPoP is not in use.
+	 */
+	public String getDpopScope() {
+		return dpopScope;
+	}
+
+	/**
+	 * Sets the DPoP credentials identifier.
+	 *
+	 * @param dpopScope DPoP credentials identifier.
+	 */
+	public void setDpopScope(String dpopScope) {
+		this.dpopScope = dpopScope;
+	}
+
+	/**
+	 * Returns the token type returned by the token endpoint
+	 * (e.g. "Bearer" or "DPoP").
+	 *
+	 * @return Token type, or null if not set.
+	 */
+	public String getTokenType() {
+		return tokenType;
+	}
+
+	/**
+	 * Sets the token type.
+	 *
+	 * @param tokenType Token type.
+	 */
+	public void setTokenType(String tokenType) {
+		this.tokenType = tokenType;
+	}
 	/**
 	 * Returns the beacon child consumer key.
 	 *
@@ -1048,6 +1094,8 @@ public class UserAccount {
 			object.put(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 			object.put(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 			object.put(SCOPE, scope);
+			if (dpopScope != null) object.put(DPOP_SCOPE, dpopScope);
+			if (tokenType != null) object.put(TOKEN_TYPE, tokenType);
 			if (!featureFlags.isEmpty()) {
 				org.json.JSONArray flagsArray = new org.json.JSONArray();
 				for (String f : featureFlags) flagsArray.put(f);
@@ -1114,6 +1162,8 @@ public class UserAccount {
 		object.putString(BEACON_CHILD_CONSUMER_KEY, beaconChildConsumerKey);
 		object.putString(BEACON_CHILD_CONSUMER_SECRET, beaconChildConsumerSecret);
 		object.putString(SCOPE, scope);
+		if (dpopScope != null) object.putString(DPOP_SCOPE, dpopScope);
+		if (tokenType != null) object.putString(TOKEN_TYPE, tokenType);
 		object = MapUtil.addMapToBundle(additionalOauthValues, additionalOauthKeys, object);
 		return object;
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
@@ -72,6 +72,8 @@ class UserAccountBuilder private constructor() {
     private var beaconChildConsumerKey: String? = null
     private var beaconChildConsumerSecret: String? = null
     private var scope: String? = null
+    private var dpopScope: String? = null
+    private var tokenType: String? = null
 
     /**
      * Set fields from token end point response
@@ -108,6 +110,7 @@ class UserAccountBuilder private constructor() {
             .beaconChildConsumerKey(tr.beaconChildConsumerKey)
             .beaconChildConsumerSecret(tr.beaconChildConsumerSecret)
             .scope(tr.scope)
+            .tokenType(tr.tokenType)
     }
 
     /**
@@ -176,6 +179,8 @@ class UserAccountBuilder private constructor() {
             .beaconChildConsumerKey(userAccount.beaconChildConsumerKey)
             .beaconChildConsumerSecret(userAccount.beaconChildConsumerSecret)
             .scope(userAccount.scope)
+            .dpopScope(userAccount.dpopScope)
+            .tokenType(userAccount.tokenType)
     }
 
     /**
@@ -586,12 +591,32 @@ class UserAccountBuilder private constructor() {
     }
 
     /**
+     * Sets DPoP credentials identifier (keystore alias for the DPoP keypair).
+     *
+     * @param dpopScope DPoP credentials identifier.
+     * @return Instance of this class.
+     */
+    fun dpopScope(dpopScope: String?): UserAccountBuilder {
+        return if (!allowUnset && dpopScope == null) this else apply { this.dpopScope = dpopScope }
+    }
+
+    /**
+     * Sets token type (e.g. "Bearer" or "DPoP").
+     *
+     * @param tokenType Token type.
+     * @return Instance of this class.
+     */
+    fun tokenType(tokenType: String?): UserAccountBuilder {
+        return if (!allowUnset && tokenType == null) this else apply { this.tokenType = tokenType }
+    }
+
+    /**
      * Builds and returns a UserAccount object.
      *
      * @return UserAccount object.
      */
     fun build(): UserAccount {
-        return UserAccount(
+        val account = UserAccount(
             authToken,
             refreshToken,
             loginServer,
@@ -631,6 +656,9 @@ class UserAccountBuilder private constructor() {
             apiInstanceServer,
             scope,
         )
+        account.dpopScope = dpopScope
+        account.tokenType = tokenType
+        return account
     }
 
     companion object {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
@@ -72,7 +72,7 @@ class UserAccountBuilder private constructor() {
     private var beaconChildConsumerKey: String? = null
     private var beaconChildConsumerSecret: String? = null
     private var scope: String? = null
-    private var dpopScope: String? = null
+    private var credentialsIdentifier: String? = null
     private var tokenType: String? = null
 
     /**
@@ -179,7 +179,7 @@ class UserAccountBuilder private constructor() {
             .beaconChildConsumerKey(userAccount.beaconChildConsumerKey)
             .beaconChildConsumerSecret(userAccount.beaconChildConsumerSecret)
             .scope(userAccount.scope)
-            .dpopScope(userAccount.dpopScope)
+            .credentialsIdentifier(userAccount.credentialsIdentifier)
             .tokenType(userAccount.tokenType)
     }
 
@@ -591,13 +591,13 @@ class UserAccountBuilder private constructor() {
     }
 
     /**
-     * Sets DPoP credentials identifier (keystore alias for the DPoP keypair).
+     * Sets credentials identifier (keystore alias for the DPoP keypair).
      *
-     * @param dpopScope DPoP credentials identifier.
+     * @param credentialsIdentifier Credentials identifier.
      * @return Instance of this class.
      */
-    fun dpopScope(dpopScope: String?): UserAccountBuilder {
-        return if (!allowUnset && dpopScope == null) this else apply { this.dpopScope = dpopScope }
+    fun credentialsIdentifier(credentialsIdentifier: String?): UserAccountBuilder {
+        return if (!allowUnset && credentialsIdentifier == null) this else apply { this.credentialsIdentifier = credentialsIdentifier }
     }
 
     /**
@@ -656,7 +656,7 @@ class UserAccountBuilder private constructor() {
             apiInstanceServer,
             scope,
         )
-        account.dpopScope = dpopScope
+        account.credentialsIdentifier = credentialsIdentifier
         account.tokenType = tokenType
         return account
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -95,6 +95,7 @@ import com.salesforce.androidsdk.auth.OAuth2.LogoutReason
 import com.salesforce.androidsdk.auth.OAuth2.LogoutReason.UNKNOWN
 import com.salesforce.androidsdk.auth.OAuth2.revokeRefreshToken
 import com.salesforce.androidsdk.auth.RemoteAccessConsumerKeyProvider
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager
 import com.salesforce.androidsdk.auth.idp.SPConfig
 import com.salesforce.androidsdk.auth.idp.interfaces.IDPManager
 import com.salesforce.androidsdk.auth.idp.interfaces.SPManager
@@ -1235,6 +1236,13 @@ open class SalesforceSDKManager protected constructor(
             userAccount,
             showLoginPage
         )
+        userAccount?.dpopScope?.takeIf { it.isNotEmpty() }?.let { scope ->
+            runCatching {
+                DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(scope))
+            }.onFailure { e ->
+                w(TAG, "Failed to delete DPoP key pair on logout", e)
+            }
+        }
         clientMgr.removeAccount(account)
         isLoggingOut = false
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -428,6 +428,20 @@ open class SalesforceSDKManager protected constructor(
     var clearCookiesAfterLogin = true
 
     /**
+     * Opt-in flag for DPoP (Demonstration of Proof-of-Possession, RFC 9449).
+     * When true, the SDK will attach a DPoP proof JWT to token endpoint
+     * requests and use the `DPoP` Authorization scheme for resource requests
+     * when the token endpoint advertises `token_type: DPoP`.
+     */
+    private var useDPoP = false
+
+    fun isUseDPoP(): Boolean = useDPoP
+
+    fun setUseDPoP(useDPoP: Boolean) {
+        this.useDPoP = useDPoP
+    }
+
+    /**
      * The login brand. In the following example, "<brand>" should be set here.
      * https://community.force.com/services/oauth2/authorize/<brand>?response_type=code&...
      *

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1236,9 +1236,9 @@ open class SalesforceSDKManager protected constructor(
             userAccount,
             showLoginPage
         )
-        userAccount?.dpopScope?.takeIf { it.isNotEmpty() }?.let { scope ->
+        userAccount?.credentialsIdentifier?.takeIf { it.isNotEmpty() }?.let { id ->
             runCatching {
-                DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(scope))
+                DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(id))
             }.onFailure { e ->
                 w(TAG, "Failed to delete DPoP key pair on logout", e)
             }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -102,6 +102,7 @@ internal suspend fun onAuthFlowComplete(
     buildAccountName: (username: String?, instanceServer: String?) -> String = ::defaultBuildAccountName,
     nativeLogin: Boolean = false,
     tokenMigration: Boolean = false,
+    credentialsIdentifier: String? = null,
     context: Context = SalesforceSDKManager.getInstance().appContext,
     userAccountManager: UserAccountManager = SalesforceSDKManager.getInstance().userAccountManager,
     blockIntegrationUser: Boolean = (SalesforceSDKManager.getInstance().shouldBlockSalesforceIntegrationUser &&
@@ -164,6 +165,7 @@ internal suspend fun onAuthFlowComplete(
         .loginServer(loginServer)
         .clientId(consumerKey)
         .nativeLogin(nativeLogin)
+        .dpopScope(credentialsIdentifier)
         .build()
 
     // Set additional administrator prefs if they exist

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -165,7 +165,7 @@ internal suspend fun onAuthFlowComplete(
         .loginServer(loginServer)
         .clientId(consumerKey)
         .nativeLogin(nativeLogin)
-        .dpopScope(credentialsIdentifier)
+        .credentialsIdentifier(credentialsIdentifier)
         .build()
 
     // Set additional administrator prefs if they exist

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -139,7 +139,7 @@ public class AuthenticatorService extends Service {
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final OAuth2.TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT,
                         tokenServer, originalUserAccount.getClientIdForRefresh(), originalUserAccount.getRefreshToken(), addlParamsMap,
-                        originalUserAccount.getDpopScope());
+                        originalUserAccount.getCredentialsIdentifier());
 
                 UserAccount updatedUserAccount = UserAccountBuilder.getInstance()
                         .populateFromUserAccount(originalUserAccount)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -138,7 +138,8 @@ public class AuthenticatorService extends Service {
                 final URI tokenServer = OAuth2.overrideLoginServerIfNeeded(originalUserAccount);
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final OAuth2.TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT,
-                        tokenServer, originalUserAccount.getClientIdForRefresh(), originalUserAccount.getRefreshToken(), addlParamsMap);
+                        tokenServer, originalUserAccount.getClientIdForRefresh(), originalUserAccount.getRefreshToken(), addlParamsMap,
+                        originalUserAccount.getDpopScope());
 
                 UserAccount updatedUserAccount = UserAccountBuilder.getInstance()
                         .populateFromUserAccount(originalUserAccount)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -36,6 +36,9 @@ import androidx.annotation.WorkerThread;
 
 import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager;
+import com.salesforce.androidsdk.auth.dpop.DPoPProofBuilder;
+import com.salesforce.androidsdk.auth.dpop.DPoPURLHelper;
 import com.salesforce.androidsdk.rest.RestResponse;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
@@ -45,6 +48,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyPair;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -157,6 +161,8 @@ public class OAuth2 {
     private static final String RETURL = "retURL";
     protected static final String AUTHORIZATION = "Authorization";
     private static final String BEARER = "Bearer ";
+    private static final String TOKEN_TYPE = "token_type";
+    private static final String DPOP = "DPoP";
     private static final String ASSERTION = "assertion";
     private static final String JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     protected static final String OAUTH_AUTH_PATH = "/services/oauth2/authorize";
@@ -448,6 +454,19 @@ public class OAuth2 {
                                                      String clientId, String code, String codeVerifier,
                                                      String callbackUrl, SalesforceSDKManager salesforceSdkManager)
             throws OAuthFailedException, IOException {
+        return exchangeCode(httpAccessor, loginServer, clientId, code, codeVerifier, callbackUrl, salesforceSdkManager, null);
+    }
+
+    /**
+     * An internal, testable Salesforce Mobile SDK overload of
+     * {@link #exchangeCode(HttpAccess, URI, String, String, String, String)} that
+     * accepts a credentials identifier so DPoP proof can be attached when enabled.
+     */
+    public static TokenEndpointResponse exchangeCode(HttpAccess httpAccessor, URI loginServer,
+                                                     String clientId, String code, String codeVerifier,
+                                                     String callbackUrl, SalesforceSDKManager salesforceSdkManager,
+                                                     @Nullable String credentialsIdentifier)
+            throws OAuthFailedException, IOException {
         final FormBody.Builder builder = new FormBody.Builder();
         final boolean useHybridAuthentication = SalesforceSDKManager.getInstance().shouldUseHybridAuthentication();
         final String grantType = useHybridAuthentication ? HYBRID_AUTH_CODE : AUTHORIZATION_CODE;
@@ -457,7 +476,7 @@ public class OAuth2 {
         builder.add(CODE, code);
         builder.add(CODE_VERIFIER, codeVerifier);
         builder.add(REDIRECT_URI, callbackUrl);
-        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, salesforceSdkManager);
+        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, salesforceSdkManager, credentialsIdentifier);
     }
 
     /**
@@ -477,6 +496,29 @@ public class OAuth2 {
                                                          String clientId, String refreshToken,
                                                          Map<String,String> addlParams)
             throws OAuthFailedException, IOException {
+        return refreshAuthToken(httpAccessor, loginServer, clientId, refreshToken, addlParams, null);
+    }
+
+    /**
+     * Gets a new auth token using the refresh token. Overload that accepts a
+     * credentials identifier so DPoP proof can be attached when enabled.
+     *
+     * @param httpAccessor HttpAccess instance.
+     * @param loginServer Login server.
+     * @param clientId Client ID.
+     * @param refreshToken Refresh token.
+     * @param addlParams Additional parameters.
+     * @param credentialsIdentifier Identifier used to look up the DPoP keypair, or null.
+     * @return Token response.
+     *
+     * @throws OAuthFailedException See {@link OAuthFailedException}.
+     * @throws IOException See {@link IOException}.
+     */
+    public static TokenEndpointResponse refreshAuthToken(HttpAccess httpAccessor, URI loginServer,
+                                                         String clientId, String refreshToken,
+                                                         Map<String,String> addlParams,
+                                                         @Nullable String credentialsIdentifier)
+            throws OAuthFailedException, IOException {
         final FormBody.Builder builder = new FormBody.Builder();
         final boolean useHybridAuthentication = SalesforceSDKManager.getInstance().shouldUseHybridAuthentication();
         final String grantType = useHybridAuthentication ? HYBRID_REFRESH : REFRESH_TOKEN;
@@ -492,7 +534,7 @@ public class OAuth2 {
                 }
             }
         }
-        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, SalesforceSDKManager.getInstance());
+        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, SalesforceSDKManager.getInstance(), credentialsIdentifier);
     }
 
     /**
@@ -570,7 +612,21 @@ public class OAuth2 {
      * @param authToken Access token.
      */
     public static Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken) {
-        return builder.header(AUTHORIZATION, BEARER + authToken);
+        return addAuthorizationHeader(builder, authToken, null);
+    }
+
+    /**
+     * Adds the authorization header to the request builder, choosing the
+     * scheme based on the token type. When {@code tokenType} equals
+     * {@code "DPoP"}, the DPoP scheme is used; otherwise Bearer is used.
+     *
+     * @param builder Builder instance.
+     * @param authToken Access token.
+     * @param tokenType Token type (e.g. "Bearer" or "DPoP"), or null for default Bearer.
+     */
+    public static Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken, @Nullable String tokenType) {
+        final String scheme = DPOP.equals(tokenType) ? DPOP + " " : BEARER;
+        return builder.header(AUTHORIZATION, scheme + authToken);
     }
 
     @VisibleForTesting
@@ -579,6 +635,17 @@ public class OAuth2 {
                                                                  URI loginServer,
                                                                  FormBody.Builder formBodyBuilder,
                                                                  SalesforceSDKManager salesforceSdkManager)
+            throws OAuthFailedException, IOException {
+        return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder, salesforceSdkManager, null);
+    }
+
+    @VisibleForTesting
+    @WorkerThread
+    public static TokenEndpointResponse makeTokenEndpointRequest(HttpAccess httpAccessor,
+                                                                 URI loginServer,
+                                                                 FormBody.Builder formBodyBuilder,
+                                                                 SalesforceSDKManager salesforceSdkManager,
+                                                                 @Nullable String credentialsIdentifier)
             throws OAuthFailedException, IOException {
 
         final StringBuilder sb = new StringBuilder(loginServer.toString());
@@ -599,7 +666,21 @@ public class OAuth2 {
 
         final String refreshPath = sb.toString();
         final RequestBody body = formBodyBuilder.build();
-        final Request request = new Request.Builder().url(refreshPath).post(body).build();
+        final Request.Builder requestBuilder = new Request.Builder().url(refreshPath).post(body);
+
+        if (credentialsIdentifier != null && salesforceSdkManager.isUseDPoP()) {
+            try {
+                final String htu = DPoPURLHelper.INSTANCE.canonicalize(refreshPath);
+                final String alias = DPoPKeyManager.INSTANCE.aliasForCredentialsIdentifier(credentialsIdentifier);
+                final KeyPair keyPair = DPoPKeyManager.INSTANCE.generateOrLoadKeyPair(alias);
+                final String proof = DPoPProofBuilder.INSTANCE.buildProof("POST", htu, keyPair, null, null);
+                requestBuilder.header(DPOP, proof);
+            } catch (Exception e) {
+                SalesforceSDKLogger.e(TAG, "Failed to attach DPoP header, proceeding without it", e);
+            }
+        }
+
+        final Request request = requestBuilder.build();
         final Response response = httpAccessor.getOkHttpClient().newCall(request).execute();
         if (response.isSuccessful()) {
             return new TokenEndpointResponse(response);
@@ -949,6 +1030,7 @@ public class OAuth2 {
         public String beaconChildConsumerKey;
         public String beaconChildConsumerSecret;
         public String scope;
+        public String tokenType;
 
         /**
          * Parameterized constructor built from params during user agent login flow.
@@ -990,6 +1072,7 @@ public class OAuth2 {
                 parentSid = callbackUrlParams.get(PARENT_SID);
                 tokenFormat = callbackUrlParams.getOrDefault(TOKEN_FORMAT, "");
                 scope = callbackUrlParams.get(SCOPE);
+                tokenType = callbackUrlParams.get(TOKEN_TYPE);
 
                 // NB: beacon apps not supported with user agent flow so no beacon child fields expected
 
@@ -1073,6 +1156,7 @@ public class OAuth2 {
                     beaconChildConsumerSecret = parsedResponse.getString(LEGACY_BEACON_CHILD_CONSUMER_SECRET);
                 }
                 scope = parsedResponse.optString(SCOPE);
+                tokenType = parsedResponse.optString(TOKEN_TYPE, null);
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.interfaces.ECPublicKey
+import java.security.spec.ECGenParameterSpec
+
+object DPoPKeyManager {
+
+    private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+
+    fun generateOrLoadKeyPair(alias: String): KeyPair {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        val existingKey = keyStore.getKey(alias, null)
+        if (existingKey != null) {
+            val privateKey = existingKey as PrivateKey
+            val publicKey = keyStore.getCertificate(alias).publicKey as ECPublicKey
+            return KeyPair(publicKey, privateKey)
+        }
+        val keyPairGenerator =
+            KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+            alias,
+            KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY
+        )
+            .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+            .setDigests(KeyProperties.DIGEST_SHA256)
+            .setUserAuthenticationRequired(false)
+            .build()
+        keyPairGenerator.initialize(spec)
+        return keyPairGenerator.generateKeyPair()
+    }
+
+    fun deleteKeyPair(alias: String) {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        if (keyStore.containsAlias(alias)) {
+            keyStore.deleteEntry(alias)
+        }
+    }
+
+    fun aliasForCredentialsIdentifier(id: String): String = "dpop_$id"
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilder.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.util.Base64
+import org.json.JSONObject
+import java.security.KeyPair
+import java.security.SecureRandom
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+
+object DPoPProofBuilder {
+
+    fun buildProof(
+        httpMethod: String,
+        htu: String,
+        keyPair: KeyPair,
+        nonce: String? = null,
+        accessToken: String? = null
+    ): String {
+        val publicKey = keyPair.public as ECPublicKey
+        val jwk = buildJwk(publicKey)
+        val header = buildHeader(jwk)
+        val payload = buildPayload(httpMethod, htu)
+        val headerEncoded = base64url(header.toString().toByteArray(Charsets.UTF_8))
+        val payloadEncoded = base64url(payload.toString().toByteArray(Charsets.UTF_8))
+        val signingInput = "$headerEncoded.$payloadEncoded"
+        val signature = sign(signingInput.toByteArray(Charsets.UTF_8), keyPair)
+        val signatureEncoded = base64url(derToRawRS(signature))
+        return "$headerEncoded.$payloadEncoded.$signatureEncoded"
+    }
+
+    private fun buildJwk(publicKey: ECPublicKey): JSONObject {
+        val point = publicKey.w
+        val xBytes = toUnsigned32(point.affineX.toByteArray())
+        val yBytes = toUnsigned32(point.affineY.toByteArray())
+        return JSONObject().apply {
+            put("kty", "EC")
+            put("crv", "P-256")
+            put("x", base64url(xBytes))
+            put("y", base64url(yBytes))
+        }
+    }
+
+    private fun buildHeader(jwk: JSONObject): JSONObject =
+        JSONObject().apply {
+            put("typ", "dpop+jwt")
+            put("alg", "ES256")
+            put("jwk", jwk)
+        }
+
+    private fun buildPayload(httpMethod: String, htu: String): JSONObject {
+        val jti = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        return JSONObject().apply {
+            put("htm", httpMethod.uppercase())
+            put("htu", htu)
+            put("iat", System.currentTimeMillis() / 1000L)
+            put("jti", base64url(jti))
+        }
+    }
+
+    private fun sign(data: ByteArray, keyPair: KeyPair): ByteArray {
+        val sig = Signature.getInstance("SHA256withECDSA")
+        sig.initSign(keyPair.private)
+        sig.update(data)
+        return sig.sign()
+    }
+
+    internal fun derToRawRS(der: ByteArray): ByteArray {
+        var offset = 2
+        offset++
+        val rLen = der[offset++].toInt() and 0xFF
+        val rBytes = der.copyOfRange(offset, offset + rLen)
+        offset += rLen
+        offset++
+        val sLen = der[offset++].toInt() and 0xFF
+        val sBytes = der.copyOfRange(offset, offset + sLen)
+        return toUnsigned32(rBytes) + toUnsigned32(sBytes)
+    }
+
+    internal fun toUnsigned32(bytes: ByteArray): ByteArray {
+        val trimmed = bytes.dropWhile { it == 0.toByte() }.toByteArray()
+        return ByteArray(32 - trimmed.size) + trimmed
+    }
+
+    private fun base64url(bytes: ByteArray): String =
+        Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelper.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelper.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.net.Uri
+
+object DPoPURLHelper {
+    fun canonicalize(url: String): String =
+        Uri.parse(url).buildUpon().clearQuery().fragment(null).build().toString()
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -778,7 +778,7 @@ public class ClientManager {
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final TokenEndpointResponse tr = refreshAuthToken(HttpAccess.DEFAULT,
                         tokenServer, originalUserAccount.getClientIdForRefresh(), currentRefreshToken, addlParamsMap,
-                        originalUserAccount.getDpopScope());
+                        originalUserAccount.getCredentialsIdentifier());
 
                 if (tr.authToken == null) {
                     throw new MalformedTokenException("Token endpoint returned null access token");

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -394,6 +394,7 @@ public class ClientManager {
             String newAuthToken;        // last winner's fresh access token (null on failure)
             String newInstanceUrl;      // last winner's instance URL (losers need it; see RestClient.refreshAccessToken)
             String rotatedRefreshToken; // refresh token after rotation, for losers to adopt
+            String newTokenType;        // last winner's token type (e.g. "Bearer" or "DPoP")
             long lastRefreshTime = -1;
         }
 
@@ -430,6 +431,7 @@ public class ClientManager {
         private String refreshToken;
         private String lastNewInstanceUrl;
         private long lastRefreshTime = -1 /* never refreshed */;
+        private String lastTokenType;
 
         /**
          * Constructor
@@ -570,6 +572,7 @@ public class ClientManager {
             // can leave state.refreshing stuck true.
             String newAuthToken = null;
             String newInstanceUrl = null;
+            String newTokenType = null;
 
             try {
                 /*
@@ -601,6 +604,7 @@ public class ClientManager {
                                     "Access/refresh token already advanced in storage; adopting without refresh");
                             newAuthToken = storedAuthToken;
                             newInstanceUrl = currentAccount.getInstanceServer();
+                            newTokenType = currentAccount.getTokenType();
                             this.refreshToken = storedRefreshToken;
                             return newAuthToken;
                         }
@@ -617,6 +621,7 @@ public class ClientManager {
 
                 newAuthToken = userAccount.getAuthToken();
                 newInstanceUrl = userAccount.getInstanceServer();
+                newTokenType = userAccount.getTokenType();
 
                 Intent broadcastIntent;
                 if (newInstanceUrl != null && !newInstanceUrl.equalsIgnoreCase(lastNewInstanceUrl)) {
@@ -688,6 +693,7 @@ public class ClientManager {
                 // Update this instance's own cache so its getters stay correct.
                 lastNewAuthToken = newAuthToken;
                 lastNewInstanceUrl = newInstanceUrl;
+                lastTokenType = newTokenType;
                 lastRefreshTime = System.currentTimeMillis();
                 // Publish the result to the per-account state and wake any waiting losers.
                 // This is the SINGLE publish path and ALWAYS runs on every winner exit path so
@@ -698,6 +704,7 @@ public class ClientManager {
                         state.newAuthToken = newAuthToken;
                         state.newInstanceUrl = newInstanceUrl;
                         state.rotatedRefreshToken = this.refreshToken;
+                        state.newTokenType = newTokenType;
                         state.lastRefreshTime = System.currentTimeMillis();
                         // Mark a fresh result as available. Bumped ONLY on success so a loser woken
                         // by a failed cycle sees an unchanged generation and correctly returns null
@@ -732,6 +739,7 @@ public class ClientManager {
         private void adoptWinnerResult(RefreshState state) {
             this.lastNewAuthToken = state.newAuthToken;
             this.lastRefreshTime = state.lastRefreshTime;
+            this.lastTokenType = state.newTokenType;
             if (state.newInstanceUrl != null) {
                 this.lastNewInstanceUrl = state.newInstanceUrl;
             }
@@ -753,6 +761,9 @@ public class ClientManager {
         @Override
         public String getInstanceUrl() { return lastNewInstanceUrl; }
 
+        @Override
+        public String getTokenType() { return lastTokenType; }
+
         @NonNull
         private UserAccount refreshStaleToken(Account account) throws NetworkErrorException, OAuthFailedException, MalformedTokenException {
             UserAccount originalUserAccount = UserAccountManager.getInstance().buildUserAccount(account);
@@ -766,7 +777,8 @@ public class ClientManager {
                 final URI tokenServer = OAuth2.overrideLoginServerIfNeeded(originalUserAccount);
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final TokenEndpointResponse tr = refreshAuthToken(HttpAccess.DEFAULT,
-                        tokenServer, originalUserAccount.getClientIdForRefresh(), currentRefreshToken, addlParamsMap);
+                        tokenServer, originalUserAccount.getClientIdForRefresh(), currentRefreshToken, addlParamsMap,
+                        originalUserAccount.getDpopScope());
 
                 if (tr.authToken == null) {
                     throw new MalformedTokenException("Token endpoint returned null access token");

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -90,6 +90,12 @@ public class RestClient {
         String getNewAuthToken();
         String getRefreshToken();
         long getLastRefreshTime();
+
+        /**
+         * @return The token type from the most recent refresh (e.g. "Bearer"
+         * or "DPoP"), or null if not yet known or the server did not specify.
+         */
+        default String getTokenType() { return null; }
     }
 
     /**
@@ -140,10 +146,24 @@ public class RestClient {
      * @param authTokenProvider
      */
     public RestClient(ClientInfo clientInfo, String authToken, HttpAccess httpAccessor, AuthTokenProvider authTokenProvider) {
+        this(clientInfo, authToken, null, httpAccessor, authTokenProvider);
+    }
+
+    /**
+     * Constructs a RestClient with the given clientInfo, authToken, tokenType, httpAccessor and authTokenProvider.
+     * The tokenType determines the Authorization header scheme (e.g. "Bearer" or "DPoP").
+     *
+     * @param clientInfo
+     * @param authToken
+     * @param tokenType
+     * @param httpAccessor
+     * @param authTokenProvider
+     */
+    public RestClient(ClientInfo clientInfo, String authToken, String tokenType, HttpAccess httpAccessor, AuthTokenProvider authTokenProvider) {
         this.clientInfo = clientInfo;
         this.httpAccessor = httpAccessor;
         this.authTokenProvider = authTokenProvider;
-        setOAuthRefreshInterceptor(authToken);
+        setOAuthRefreshInterceptor(authToken, tokenType);
         setOkHttpClientBuilder();
         setOkHttpClient(null);
     }
@@ -183,13 +203,13 @@ public class RestClient {
     /**
      * Sets the OAuthRefreshInterceptor associated with this user account.
      */
-    private synchronized void setOAuthRefreshInterceptor(String authToken) {
+    private synchronized void setOAuthRefreshInterceptor(String authToken, String tokenType) {
         final String cacheKey = getCacheKey();
         OAuthRefreshInterceptor oAuthRefreshInterceptor = OAUTH_REFRESH_INTERCEPTORS.get(cacheKey);
 
         // If none cached, create new one
         if (oAuthRefreshInterceptor == null) {
-            oAuthRefreshInterceptor = new OAuthRefreshInterceptor(clientInfo, authToken, authTokenProvider);
+            oAuthRefreshInterceptor = new OAuthRefreshInterceptor(clientInfo, authToken, tokenType, authTokenProvider);
             OAUTH_REFRESH_INTERCEPTORS.put(cacheKey, oAuthRefreshInterceptor);
         }
         this.oAuthRefreshInterceptor = oAuthRefreshInterceptor;
@@ -704,6 +724,7 @@ public class RestClient {
 
         private final AuthTokenProvider authTokenProvider;
         private String authToken;
+        private String tokenType;
         private ClientInfo clientInfo;
 
         /**
@@ -719,8 +740,22 @@ public class RestClient {
          * @param authTokenProvider
          */
         public OAuthRefreshInterceptor(ClientInfo clientInfo, String authToken, AuthTokenProvider authTokenProvider) {
+            this(clientInfo, authToken, null, authTokenProvider);
+        }
+
+        /**
+         * Overload that accepts a token type, used to select between the Bearer
+         * and DPoP Authorization header schemes.
+         *
+         * @param clientInfo
+         * @param authToken
+         * @param tokenType
+         * @param authTokenProvider
+         */
+        public OAuthRefreshInterceptor(ClientInfo clientInfo, String authToken, String tokenType, AuthTokenProvider authTokenProvider) {
             this.clientInfo = clientInfo;
             this.authToken = authToken;
+            this.tokenType = tokenType;
             this.authTokenProvider = authTokenProvider;
         }
 
@@ -842,7 +877,7 @@ public class RestClient {
          */
         private void setAuthHeader(Request.Builder builder) {
             if (authToken != null) { //Add Auth token to each request if authorized
-                OAuth2.addAuthorizationHeader(builder, authToken);
+                OAuth2.addAuthorizationHeader(builder, authToken, tokenType);
             }
         }
 
@@ -853,6 +888,17 @@ public class RestClient {
          */
         private synchronized void setAuthToken(String newAuthToken) {
             authToken = newAuthToken;
+        }
+
+        /**
+         * Change authToken and tokenType for this RestClient
+         *
+         * @param newAuthToken
+         * @param newTokenType
+         */
+        private synchronized void setAuthToken(String newAuthToken, String newTokenType) {
+            authToken = newAuthToken;
+            tokenType = newTokenType;
         }
 
         /**
@@ -888,8 +934,8 @@ public class RestClient {
                     throw new RefreshTokenRevokedException("Could not refresh token");
                 }
 
-                // Use new token
-                setAuthToken(newAuthToken);
+                // Use new token (and token type, if available)
+                setAuthToken(newAuthToken, authTokenProvider.getTokenType());
 
                 // Check if the instanceUrl changed
                 String instanceUrl = authTokenProvider.getInstanceUrl();

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -466,6 +466,7 @@ open class LoginViewModel(
         onAuthFlowSuccess: (userAccount: UserAccount) -> Unit,
         tokenMigration: Boolean = false,
         loginServer: String? = null,
+        credentialsIdentifier: String? = null,
     ) {
         // Clear cookies after successful authentication to prevent automatic re-login if the user tries to add another user right away.
         if (SalesforceSDKManager.getInstance().clearCookiesAfterLogin) {
@@ -480,6 +481,7 @@ open class LoginViewModel(
             onAuthFlowSuccess = onAuthFlowSuccess,
             buildAccountName = ::buildAccountName,
             tokenMigration = tokenMigration,
+            credentialsIdentifier = credentialsIdentifier,
         )
     }
 
@@ -667,6 +669,8 @@ open class LoginViewModel(
             }
             val verifier = if (isUsingFrontDoorBridge) frontdoorBridgeCodeVerifier else codeVerifier
 
+            val credentialsIdentifier = java.util.UUID.randomUUID().toString()
+
             val tokenResponse = exchangeCode(
                 HttpAccess.DEFAULT,
                 URI.create(server),
@@ -674,9 +678,11 @@ open class LoginViewModel(
                 code,
                 verifier,
                 oAuthConfig.redirectUri,
+                SalesforceSDKManager.getInstance(),
+                credentialsIdentifier,
             )
 
-            onAuthFlowComplete(tokenResponse, onAuthFlowError, onAuthFlowSuccess, tokenMigration, server)
+            onAuthFlowComplete(tokenResponse, onAuthFlowError, onAuthFlowSuccess, tokenMigration, server, credentialsIdentifier)
         }.onFailure { throwable ->
             e(TAG, "Exception occurred while making token request", throwable)
             onAuthFlowError("Token Request Error", throwable.message, throwable)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2MockTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2MockTests.kt
@@ -16,7 +16,10 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.Buffer
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -215,4 +218,232 @@ class OAuth2MockTests {
             formBody.contains("assertion=__JWT_ASSERTION__"),
         )
     }
+
+    // region DPoP tests
+
+    @Test
+    fun test_givenUseDPoPTrueAndCredentialsIdentifier_whenMakeTokenEndpointRequest_thenDPoPHeaderPresent() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id",
+        )
+
+        val dpopHeader = requestSlot.captured.header("DPoP")
+        assertNotNull("Expected DPoP header to be present", dpopHeader)
+        assertTrue("Expected DPoP header to be non-blank", !dpopHeader.isNullOrBlank())
+    }
+
+    @Test
+    fun test_givenUseDPoPFalse_whenMakeTokenEndpointRequest_thenNoDPoPHeader() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns false
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id",
+        )
+
+        assertNull(
+            "Did not expect DPoP header when isUseDPoP() is false",
+            requestSlot.captured.header("DPoP"),
+        )
+    }
+
+    @Test
+    fun test_givenUseDPoPTrueButNullCredentialsIdentifier_whenMakeTokenEndpointRequest_thenNoDPoPHeader() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            null,
+        )
+
+        assertNull(
+            "Did not expect DPoP header when credentialsIdentifier is null",
+            requestSlot.captured.header("DPoP"),
+        )
+    }
+
+    @Test
+    fun test_givenUseDPoPTrue_whenMakeTokenEndpointRequest_thenTokenTypePersistedOnResponse() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u","token_type":"DPoP"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        val tokenResponse = makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id",
+        )
+
+        assertEquals("DPoP", tokenResponse.tokenType)
+    }
+
+    @Test
+    fun test_givenDPoPTokenType_whenAddAuthorizationHeader_thenDPoPSchemeUsed() {
+        val builder = Request.Builder().url("https://example.com")
+
+        OAuth2.addAuthorizationHeader(builder, "my-access-token", "DPoP")
+
+        val authHeader = builder.build().header("Authorization")
+        assertNotNull(authHeader)
+        assertTrue(
+            "Expected Authorization header to start with 'DPoP ' but got: $authHeader",
+            authHeader!!.startsWith("DPoP "),
+        )
+    }
+
+    @Test
+    fun test_givenBearerTokenType_whenAddAuthorizationHeader_thenBearerSchemeUsed() {
+        val builder = Request.Builder().url("https://example.com")
+
+        OAuth2.addAuthorizationHeader(builder, "my-access-token", "Bearer")
+
+        val authHeader = builder.build().header("Authorization")
+        assertNotNull(authHeader)
+        assertTrue(
+            "Expected Authorization header to start with 'Bearer ' but got: $authHeader",
+            authHeader!!.startsWith("Bearer "),
+        )
+    }
+
+    @Test
+    fun test_givenNullTokenType_whenAddAuthorizationHeader_thenBearerSchemeUsed() {
+        val builder = Request.Builder().url("https://example.com")
+
+        OAuth2.addAuthorizationHeader(builder, "my-access-token", null)
+
+        val authHeader = builder.build().header("Authorization")
+        assertNotNull(authHeader)
+        assertTrue(
+            "Expected Authorization header to start with 'Bearer ' but got: $authHeader",
+            authHeader!!.startsWith("Bearer "),
+        )
+    }
+
+    @Test
+    fun test_givenKeyStoreException_whenMakeTokenEndpointRequest_thenRequestProceedsWithoutDPoPHeader() {
+        val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
+            every { appAttestationClient } returns null
+            every { deviceId } returns "__DEVICE_ID__"
+            every { isUseDPoP() } returns true
+        }
+
+        val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
+            .toResponseBody("application/json; charset=utf-8".toMediaType())
+        val okHttpResponse = mockk<Response>(relaxed = true) {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+        }
+        val requestSlot = slot<Request>()
+        val httpAccessor = mockk<HttpAccess>(relaxed = true) {
+            every { okHttpClient } returns mockk {
+                every { newCall(capture(requestSlot)) } returns mockk {
+                    every { execute() } returns okHttpResponse
+                }
+            }
+        }
+
+        val tokenResponse = makeTokenEndpointRequest(
+            httpAccessor,
+            URI("https://login.salesforce.com"),
+            FormBody.Builder(),
+            salesforceSdkManager,
+            "test-scope-id-keystore-error",
+        )
+
+        assertNotNull(
+            "Expected token endpoint request to complete even if DPoP key generation fails",
+            tokenResponse,
+        )
+        assertTrue("Expected the request to have been captured", requestSlot.isCaptured)
+    }
+
+    // endregion DPoP tests
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.interfaces.ECPublicKey
+
+@RunWith(AndroidJUnit4::class)
+class DPoPKeyManagerTest {
+
+    private val aliasesToCleanUp = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        aliasesToCleanUp.forEach { DPoPKeyManager.deleteKeyPair(it) }
+        aliasesToCleanUp.clear()
+    }
+
+    private fun trackedAlias(name: String): String {
+        val alias = "dpop_test_$name"
+        aliasesToCleanUp.add(alias)
+        return alias
+    }
+
+    @Test
+    fun test_givenAlias_whenGenerateOrLoad_thenKeyPairIsECSecp256r1() {
+        val alias = trackedAlias("ec_secp256r1")
+        val keyPair = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertTrue(keyPair.public is ECPublicKey)
+        assertEquals("EC", keyPair.public.algorithm)
+    }
+
+    @Test
+    fun test_givenAlias_whenGenerateOrLoadTwice_thenSamePublicKeyReturned() {
+        val alias = trackedAlias("same_pubkey")
+        val first = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        val second = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertEquals(
+            first.public.encoded.toList(),
+            second.public.encoded.toList()
+        )
+    }
+
+    @Test
+    fun test_givenKeyPair_whenDeleted_thenNextCallGeneratesNewKeyPair() {
+        val alias = trackedAlias("delete_regen")
+        val first = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        DPoPKeyManager.deleteKeyPair(alias)
+        val second = DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertNotEquals(
+            first.public.encoded.toList(),
+            second.public.encoded.toList()
+        )
+    }
+
+    @Test
+    fun test_givenDifferentAliases_thenDifferentKeyPairs() {
+        val aliasA = trackedAlias("alias_a")
+        val aliasB = trackedAlias("alias_b")
+        val kpA = DPoPKeyManager.generateOrLoadKeyPair(aliasA)
+        val kpB = DPoPKeyManager.generateOrLoadKeyPair(aliasB)
+        assertNotEquals(
+            kpA.public.encoded.toList(),
+            kpB.public.encoded.toList()
+        )
+    }
+
+    @Test
+    fun test_givenCredentialsIdentifier_whenComputingAlias_thenPrefixedWithDpop() {
+        assertEquals("dpop_user-123", DPoPKeyManager.aliasForCredentialsIdentifier("user-123"))
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilderTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPProofBuilderTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyPair
+import java.security.Signature
+
+@RunWith(AndroidJUnit4::class)
+class DPoPProofBuilderTest {
+
+    private lateinit var keyPair: KeyPair
+    private val alias = "dpop_test_proof_builder"
+
+    @Before
+    fun setUp() {
+        keyPair = DPoPKeyManager.generateOrLoadKeyPair(alias)
+    }
+
+    @After
+    fun tearDown() {
+        DPoPKeyManager.deleteKeyPair(alias)
+    }
+
+    private fun base64UrlDecode(s: String): ByteArray =
+        Base64.decode(s, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+
+    private fun decodeJson(segment: String): JSONObject =
+        JSONObject(String(base64UrlDecode(segment), Charsets.UTF_8))
+
+    private fun rawRsToDer(raw: ByteArray): ByteArray {
+        val r = raw.copyOfRange(0, 32)
+        val s = raw.copyOfRange(32, 64)
+        fun encodeInt(b: ByteArray): ByteArray {
+            val stripped = b.dropWhile { it == 0.toByte() }.toByteArray()
+            val padded =
+                if (stripped.isNotEmpty() && (stripped[0].toInt() and 0x80) != 0)
+                    byteArrayOf(0) + stripped
+                else stripped
+            return byteArrayOf(0x02.toByte(), padded.size.toByte()) + padded
+        }
+        val rEnc = encodeInt(r)
+        val sEnc = encodeInt(s)
+        val body = rEnc + sEnc
+        return byteArrayOf(0x30.toByte(), body.size.toByte()) + body
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenJwsHasThreeSegments() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val parts = proof.split(".")
+        assertEquals(3, parts.size)
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenHeaderHasCorrectFields() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val header = decodeJson(proof.split(".")[0])
+        assertEquals("dpop+jwt", header.getString("typ"))
+        assertEquals("ES256", header.getString("alg"))
+        val jwk = header.getJSONObject("jwk")
+        assertTrue(jwk.has("kty"))
+        assertTrue(jwk.has("crv"))
+        assertTrue(jwk.has("x"))
+        assertTrue(jwk.has("y"))
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenPayloadHasCorrectClaimsAndNoAthOrNonce() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val payload = decodeJson(proof.split(".")[1])
+        assertEquals("POST", payload.getString("htm"))
+        assertTrue(payload.getString("htu").isNotEmpty())
+        assertTrue(payload.getLong("iat") > 0)
+        assertTrue(payload.getString("jti").isNotEmpty())
+        assertFalse(payload.has("ath"))
+        assertFalse(payload.has("nonce"))
+    }
+
+    @Test
+    fun test_givenURLWithQueryAndFragment_whenBuildProof_thenHtuIsCanonical() {
+        val htu = "https://host/token?q=1#frag"
+        val proof = DPoPProofBuilder.buildProof("POST", htu, keyPair)
+        val payload = decodeJson(proof.split(".")[1])
+        assertEquals(htu, payload.getString("htu"))
+    }
+
+    @Test
+    fun test_givenSameKeyPair_whenBuildProofTwice_thenJtisDiffer() {
+        val proof1 = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val proof2 = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val jti1 = decodeJson(proof1.split(".")[1]).getString("jti")
+        val jti2 = decodeJson(proof2.split(".")[1]).getString("jti")
+        assertNotEquals(jti1, jti2)
+    }
+
+    @Test
+    fun test_givenProof_whenSignatureVerifiedWithPublicKey_thenValid() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val parts = proof.split(".")
+        val signingInput = "${parts[0]}.${parts[1]}".toByteArray(Charsets.UTF_8)
+        val rawSig = base64UrlDecode(parts[2])
+        assertEquals(64, rawSig.size)
+        val derSig = rawRsToDer(rawSig)
+        val verifier = Signature.getInstance("SHA256withECDSA")
+        verifier.initVerify(keyPair.public)
+        verifier.update(signingInput)
+        assertTrue(verifier.verify(derSig))
+    }
+
+    @Test
+    fun test_givenKeyPair_whenBuildProof_thenJwkCoordinatesAre32BytesEach() {
+        val proof = DPoPProofBuilder.buildProof("POST", "https://example.com/token", keyPair)
+        val header = decodeJson(proof.split(".")[0])
+        val jwk = header.getJSONObject("jwk")
+        val xBytes = base64UrlDecode(jwk.getString("x"))
+        val yBytes = base64UrlDecode(jwk.getString("y"))
+        assertEquals(32, xBytes.size)
+        assertEquals(32, yBytes.size)
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelperTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPURLHelperTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DPoPURLHelperTest {
+
+    @Test
+    fun test_givenUrlWithQuery_whenCanonicalize_thenQueryStripped() {
+        assertEquals(
+            "https://example.com/token",
+            DPoPURLHelper.canonicalize("https://example.com/token?foo=bar")
+        )
+    }
+
+    @Test
+    fun test_givenUrlWithFragment_whenCanonicalize_thenFragmentStripped() {
+        assertEquals(
+            "https://example.com/token",
+            DPoPURLHelper.canonicalize("https://example.com/token#frag")
+        )
+    }
+
+    @Test
+    fun test_givenUrlWithQueryAndFragment_whenCanonicalize_thenBothStripped() {
+        assertEquals(
+            "https://example.com/token",
+            DPoPURLHelper.canonicalize("https://example.com/token?q=1#frag")
+        )
+    }
+
+    @Test
+    fun test_givenCleanUrl_whenCanonicalize_thenUnchanged() {
+        assertEquals(
+            "https://example.com/services/oauth2/token",
+            DPoPURLHelper.canonicalize("https://example.com/services/oauth2/token")
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **New package `com.salesforce.androidsdk.auth.dpop`** with three classes:
  - `DPoPURLHelper` — RFC 9449 §4.2 URL canonicalization (strips query + fragment)
  - `DPoPKeyManager` — Android Keystore EC P-256 keypair lifecycle, scoped per `credentialsIdentifier`
  - `DPoPProofBuilder` — compact JWS construction (JWK export of affineX/Y, jti via SecureRandom, DER→raw R||S signature)
- **`OAuth2.java`** — new `makeTokenEndpointRequest` / `exchangeCode` / `refreshAuthToken` overloads that accept a `credentialsIdentifier`; attaches `DPoP` header when `SalesforceSDKManager.isUseDPoP() == true`; parses `token_type` from token response; `addAuthorizationHeader` now selects `DPoP` or `Bearer` scheme based on token type
- **`SalesforceSDKManager.kt`** — new `isUseDPoP()` / `setUseDPoP(Boolean)` opt-in flag
- **`UserAccount.java` + `UserAccountBuilder.kt`** — new `dpopScope` (keypair alias UUID) and `tokenType` fields, persisted through JSON/Bundle serialization
- **`LoginViewModel.kt` + `AuthenticationUtilities.kt`** — UUID generated at login start, threaded through `exchangeCode`, stored on `UserAccount` via `UserAccountBuilder`
- **`AuthenticatorService.java`** — passes `dpopScope` to `refreshAuthToken` so the same keypair is reused on refresh
- **`RestClient.java` / `ClientManager.java`** — `OAuthRefreshInterceptor` now holds and applies `tokenType`; `AuthTokenProvider.getTokenType()` default method propagates it through refresh

## Test plan

- [ ] `DPoPURLHelperTest` — 4 canonicalization cases
- [ ] `DPoPKeyManagerTest` — 5 tests: generate/reload idempotency, deletion, per-alias isolation, alias prefix
- [ ] `DPoPProofBuilderTest` — 7 tests: JWS structure, claims, signature verification, JWK coordinate size, jti uniqueness
- [ ] `OAuth2MockTests` — 8 new DPoP tests: header present/absent, null credentialsIdentifier, token type persisted, `DPoP`/`Bearer`/null auth scheme selection, request completes gracefully on keystore error

## Out of scope for this story (W-22695293 Phase 2)

- Nonce challenge/retry — Phase 4 (W-22697878)
- API call proofs with `ath` claim — Phase 3
- Automated UI tests — Phase 5

## iOS equivalent

W-22695307 (closed) on `upstream/dpop` branch — this PR brings Android to parity.