### PR TITLE
Add dpop to pull_request_target branches allowlist (temporary)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,7 +5,9 @@ on:
   # Mitigated by per-job Member Check (see "Check Write Permission" + "Validate Write Permission" steps).
   # Reference: team Github Actions Tribal Knowledge doc.
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master]
+    # dpop is a temporary entry: PRs in the multi-PR DPoP rollout target this
+    # branch. Remove once DPoP is merged back to dev.
+    branches: [dev, master, dpop]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'


### PR DESCRIPTION
## Summary

- Adds `dpop` to the `branches` list under the `pull_request_target` trigger in `.github/workflows/pr.yaml`
- GitHub evaluates `pull_request_target` against the **default branch** (`dev`) copy of the workflow, so the `dpop` branch's copy alone is not sufficient to trigger CI for PRs targeting `dpop`
- This is a **temporary entry** — remove once DPoP merges back to `dev`

## Why now

Three more Android PRs in the DPoP rollout are queued to target `dpop` after #2949:
- W-22697878 (nonce support)
- W-22698013 (automated UI tests)
- W-23192897 (dev-info-screen DPoP state)

Without this, none of them get Firebase Test Lab, codecov, or Danger. The Phase 3 PR (#2949) already shipped two red serialization tests that per-PR CI would have caught.

## Test plan

- [ ] Verify that the next PR targeting `dpop` shows the Pull Request workflow in its checks list
- [ ] Remove the `dpop` entry from this list when DPoP merges back to `dev`