### PR TITLE
Allow dpop as valid base branch in TestOrchestrator Danger check

### DIFF
--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -4,7 +4,8 @@
 warn("Big PR, try to keep changes smaller if you can.", sticky: true) if git.lines_of_code > 1000
 
 # Redirect contributors to PR to dev.
-fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if github.branch_for_base != "dev"
+# dpop is a temporary exception for the multi-PR DPoP rollout. Remove once DPoP merges back to dev.
+fail("Please re-submit this PR to the dev branch, we may have already fixed your issue.", sticky: true) if !["dev", "dpop"].include?(github.branch_for_base)
 
 # List of Android libraries for testing
 LIBS = ['SalesforceAnalytics', 'SalesforceSDK', 'SmartStore', 'MobileSync', 'SalesforceHybrid']


### PR DESCRIPTION
## Summary

- `TestOrchestrator.rb` has `fail(...) if github.branch_for_base != "dev"` which blocks all PRs targeting `dpop`
- Adds `dpop` as a temporary exception alongside `dev`, matching the same pattern as #2950 for `pr.yaml`
- **Temporary entry** — remove once DPoP merges back to `dev`

## Why

PR #2949 is now triggering the `Pull Request` workflow (thanks to #2950), but Danger immediately fails it with *"Please re-submit this PR to the dev branch"* because the base is `dpop`, not `dev`.

## Test plan

- [ ] Verify PR #2949 (or the next dpop-targeting PR) passes the Danger `test-orchestrator` step after this merges
- [ ] Remove the `dpop` exception from this file when DPoP merges back to `dev`