### PR TITLE
feat(W-23195021): register RT per-user flag on Refresh Token Rotation detection

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
@@ -45,4 +45,5 @@ public class Features {
     public static final String FEATURE_NATIVE_LOGIN = "NL";
     public static final String FEATURE_QR_CODE_LOGIN = "QR";
     public static final String FEATURE_WELCOME_DISCOVERY_LOGIN = "WD";
+    public static final String FEATURE_RTR = "RT";
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -47,6 +47,7 @@ import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.accounts.UserAccountBuilder;
 import com.salesforce.androidsdk.accounts.UserAccountManager;
 import com.salesforce.androidsdk.analytics.EventBuilderHelper;
+import com.salesforce.androidsdk.app.Features;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.AuthenticatorService;
 import com.salesforce.androidsdk.auth.HttpAccess;
@@ -786,6 +787,8 @@ public class ClientManager {
                 // update this provider's cached copy.
                 if (tr.refreshToken != null && !tr.refreshToken.equals(refreshToken)) {
                     refreshToken = tr.refreshToken;
+                    // Surface RTR as a per-user feature flag
+                    SalesforceSDKManager.getInstance().registerUsedAppFeature(Features.FEATURE_RTR, updatedUserAccount);
                 }
 
                 return updatedUserAccount;

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
@@ -574,6 +574,33 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    fun test_givenRTRDetected_whenRegisterRTFeature_thenRTFlagAppearsInUserAgentForUser() {
+        val sdkManager = createSdkManagerWithMockedAccountManager()
+
+        val userA = buildMinimalUserAccount(orgId = "org1", userId = "user1")
+        val userB = buildMinimalUserAccount(orgId = "org2", userId = "user2")
+
+        // Act: simulate what ClientManager does on RTR detection
+        sdkManager.registerUsedAppFeature(Features.FEATURE_RTR, userA)
+
+        try {
+            // Assert: RT appears in per-user user agent for userA
+            val agentA = sdkManager.getUserAgent("", userA)
+            assertTrue("User agent for userA should contain ftr_ segment", agentA.contains("ftr_"))
+            assertTrue("User agent for userA should contain RT flag", agentA.contains(Features.FEATURE_RTR))
+
+            // Assert: RT does NOT appear in user agent for a different user
+            val agentB = sdkManager.getUserAgent("", userB)
+            assertFalse(
+                "User agent for userB should NOT contain RT flag (per-user isolation)",
+                agentB.contains(Features.FEATURE_RTR)
+            )
+        } finally {
+            sdkManager.unregisterUsedAppFeature(Features.FEATURE_RTR, userA)
+        }
+    }
+
+    @Test
     fun test_givenNullUser_whenRegisterUsedAppFeature_thenGlobalFlagRegistered() {
         val sdkManager = SalesforceSDKManager.getInstance()
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerMockTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/ClientManagerMockTest.kt
@@ -81,6 +81,7 @@ class ClientManagerMockTest {
                 logout(any(), any(), any(), any())
             } returns Unit
             every { registerUsedAppFeature(any()) } returns true
+            every { registerUsedAppFeature(any(), any()) } returns true
             every { unregisterUsedAppFeature(any()) } returns true
             every { userAccountManager } returns mockUserAccountManager
             every { deviceId } returns "test-device-id-123"

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -496,9 +496,10 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
         expectAdvancedAuth: Boolean = false,
+        isRtr: Boolean = false,
     ) {
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, isRtr)
     }
 
     private fun validateUserAgent(
@@ -507,6 +508,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
         expectAdvancedAuth: Boolean = false,
+        isRtr: Boolean = false,
     ) {
         assert(ua.contains("SalesforceMobileSDK/")) {
             "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
@@ -539,6 +541,12 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         if (isMultiUser) {
             assert("MU" in flags) {
                 "Expected 'MU' flag for multi-user in: $ua"
+            }
+        }
+
+        if (isRtr) {
+            assert("RT" in flags) {
+                "Expected 'RT' flag after Refresh Token Rotation in: $ua"
             }
         }
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -536,17 +536,29 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
             assert("WD" in flags) {
                 "Expected 'WD' flag for Welcome Discovery in: $ua"
             }
+        } else {
+            assert("WD" !in flags) {
+                "Expected no 'WD' flag when Welcome Discovery was not used in: $ua"
+            }
         }
 
         if (isMultiUser) {
             assert("MU" in flags) {
                 "Expected 'MU' flag for multi-user in: $ua"
             }
+        } else {
+            assert("MU" !in flags) {
+                "Expected no 'MU' flag when only one user is logged in, in: $ua"
+            }
         }
 
         if (isRtr) {
             assert("RT" in flags) {
                 "Expected 'RT' flag after Refresh Token Rotation in: $ua"
+            }
+        } else {
+            assert("RT" !in flags) {
+                "Expected no 'RT' flag when Refresh Token Rotation has not occurred in: $ua"
             }
         }
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -441,7 +441,10 @@ abstract class AuthFlowTest {
         app.validateApiRequest()
     }
 
-    fun assertRevokeAndRefreshWorks(isRtr: Boolean) {
+    fun assertRevokeAndRefreshWorks(
+        isRtr: Boolean,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+    ) {
         val (preAccessToken, preRefreshToken) = app.getTokens()
         app.revokeAccessToken()
         app.validateApiRequest()
@@ -451,6 +454,7 @@ abstract class AuthFlowTest {
 
         if (isRtr) {
             assert(preRefreshToken != postRefreshToken) { "Refresh token should have rotated (RTR app)" }
+            app.validateUserAgent(knownLoginHostConfig = knownLoginHostConfig, isRtr = true)
         } else {
             assert(preRefreshToken == postRefreshToken) { "Refresh token should not have changed (non-RTR app)" }
         }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -454,9 +454,10 @@ abstract class AuthFlowTest {
 
         if (isRtr) {
             assert(preRefreshToken != postRefreshToken) { "Refresh token should have rotated (RTR app)" }
-            app.validateUserAgent(knownLoginHostConfig = knownLoginHostConfig, isRtr = true)
         } else {
             assert(preRefreshToken == postRefreshToken) { "Refresh token should not have changed (non-RTR app)" }
         }
+
+        app.validateUserAgent(knownLoginHostConfig = knownLoginHostConfig, isRtr = isRtr)
     }
 }


### PR DESCRIPTION
## Summary

- Adds `FEATURE_RTR = "RT"` constant to `Features.java`
- In `ClientManager.java`, registers the `RT` feature flag as a per-user flag on the `updatedUserAccount` whenever the token endpoint returns a new refresh token (Refresh Token Rotation detected)
- Adds `test_givenRTRDetected_whenRegisterRTFeature_thenRTFlagAppearsInUserAgentForUser` to `SalesforceSDKManagerTests.kt`, verifying that the RT flag appears in the user agent for the affected user and is isolated from other users

## Test plan

- [ ] Build passes: `./gradlew :libs:SalesforceSDK:assembleDebug :libs:SalesforceSDK:assembleAndroidTest`
- [ ] Run `SalesforceSDKManagerTests#test_givenRTRDetected_whenRegisterRTFeature_thenRTFlagAppearsInUserAgentForUser` on a connected device/emulator to verify RTR flag isolation
- [ ] Run full `SalesforceSDKManagerTests` suite to verify no regressions in per-user feature flag tests
- [ ] Manual: trigger a token refresh that returns a new refresh token and confirm the `ftr_` segment in the user agent contains `RT`

## GUS

W-23195021