### PR TITLE
Add flag to force advanced authentication

### DIFF
--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -124,6 +124,7 @@
     <string name="sf__dev_support_login_options_title">Login Options</string>
     <string name="sf__login_options_webserver_toggle_content_description">Toggle Web Server</string>
     <string name="sf__login_options_hybrid_toggle_content_description">Toggle Hybrid Token</string>
+    <string name="sf__login_options_force_advanced_auth_toggle_content_description">Toggle Force Advanced Authentication</string>
     <string name="sf__login_options_dynamic_config_toggle_content_description">Toggle Dynamic Config</string>
     <string name="sf__login_options_consumer_key_field_content_description">Consumer Key Field</string>
     <string name="sf__login_options_redirect_uri_field_content_description">Redirect URI Field</string>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1596,7 +1596,7 @@ open class SalesforceSDKManager protected constructor(
 //                "Use Web Server Authentication" to "$useWebServerAuthentication",
 //                "Use Hybrid Authentication Token" to "$useHybridAuthentication",
 //                "Support Welcome Discovery" to "$supportsWelcomeDiscovery",
-//                "Force Advanced Authentication", "$forceAdvancedAuthentication",
+//                "Force Advanced Authentication" to "$forceAdvancedAuthentication",
 //                "Browser Login Enabled" to "$isBrowserLoginEnabled",
 //                "IDP Enabled" to "$isIDPLoginFlowEnabled",
 //                "Identity Provider" to "$isIdentityProvider",

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -481,6 +481,11 @@ open class SalesforceSDKManager protected constructor(
     @set:Synchronized
     var useHybridAuthentication = true
 
+    // Backing field for [forceAdvancedAuthentication].  The SDK reads this directly so its own
+    // internal use of the flag doesn't trigger the deprecation warning on the public property.
+    @Volatile
+    private var _forceAdvancedAuthentication = true
+
     /**
      * Forces advanced (browser based) authentication to always be used for login, regardless of
      * the target server's auth configuration, including standard login servers with no My Domain.
@@ -489,7 +494,11 @@ open class SalesforceSDKManager protected constructor(
     @Deprecated("Will be removed in 15.0 when WebView login is removed entirely.")
     @get:JvmName("shouldForceAdvancedAuthentication")
     @set:Synchronized
-    var forceAdvancedAuthentication = true
+    var forceAdvancedAuthentication: Boolean
+        get() = _forceAdvancedAuthentication
+        set(value) {
+            _forceAdvancedAuthentication = value
+        }
 
     // Used to ensure the webview is reloaded when Dev Menu Login Options are changed.
     internal var loginDevMenuReload = false
@@ -1561,7 +1570,7 @@ open class SalesforceSDKManager protected constructor(
             "User Agent", userAgent,
             "Use Web Server Authentication", "$useWebServerAuthentication",
             "Use Hybrid Authentication Token", "$useHybridAuthentication",
-            "Force Advanced Authentication", "$forceAdvancedAuthentication",
+            "Force Advanced Authentication", "$_forceAdvancedAuthentication",
             "Browser Login Enabled", "$isBrowserLoginEnabled",
             "IDP Enabled", "$isIDPLoginFlowEnabled",
             "Identity Provider", "$isIdentityProvider",
@@ -1596,7 +1605,7 @@ open class SalesforceSDKManager protected constructor(
 //                "Use Web Server Authentication" to "$useWebServerAuthentication",
 //                "Use Hybrid Authentication Token" to "$useHybridAuthentication",
 //                "Support Welcome Discovery" to "$supportsWelcomeDiscovery",
-//                "Force Advanced Authentication" to "$forceAdvancedAuthentication",
+//                "Force Advanced Authentication" to "$_forceAdvancedAuthentication",
 //                "Browser Login Enabled" to "$isBrowserLoginEnabled",
 //                "IDP Enabled" to "$isIDPLoginFlowEnabled",
 //                "Identity Provider" to "$isIdentityProvider",
@@ -2167,7 +2176,7 @@ open class SalesforceSDKManager protected constructor(
                     // Standard login servers have no auth-config to source a shared-session value from, so
                     // browser login is gated solely on the force flag and shared session stays false.
                     setBrowserLoginEnabled(
-                        browserLoginEnabled = forceAdvancedAuthentication,
+                        browserLoginEnabled = _forceAdvancedAuthentication,
                         shareBrowserSessionEnabled = false
                     )
 
@@ -2176,7 +2185,7 @@ open class SalesforceSDKManager protected constructor(
                 }
                 else -> getMyDomainAuthConfig(httpAccess, loginServer).let { authConfig ->
                     setBrowserLoginEnabled(
-                        browserLoginEnabled = forceAdvancedAuthentication || (authConfig?.isBrowserLoginEnabled ?: false),
+                        browserLoginEnabled = _forceAdvancedAuthentication || (authConfig?.isBrowserLoginEnabled ?: false),
                         shareBrowserSessionEnabled = authConfig?.isShareBrowserSessionEnabled ?: false
                     )
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -156,6 +156,7 @@ import java.util.SortedSet
 import java.util.UUID.randomUUID
 import java.util.concurrent.ConcurrentSkipListSet
 import java.util.regex.Pattern
+import kotlin.time.Duration.Companion.milliseconds
 import com.salesforce.androidsdk.auth.idp.IDPManager as DefaultIDPManager
 import com.salesforce.androidsdk.auth.idp.SPManager as DefaultSPManager
 import com.salesforce.androidsdk.auth.interfaces.NativeLoginManager as NativeLoginManagerInterface
@@ -475,6 +476,16 @@ open class SalesforceSDKManager protected constructor(
     @get:JvmName("shouldUseHybridAuthentication")
     @set:Synchronized
     var useHybridAuthentication = true
+
+    /**
+     * Forces advanced (browser based) authentication to always be used for login, regardless of
+     * the target server's auth configuration, including standard login servers with no My Domain.
+     * Defaults to true.
+     */
+    @Deprecated("Will be removed in 15.0 when WebView login is removed entirely.")
+    @get:JvmName("shouldForceAdvancedAuthentication")
+    @set:Synchronized
+    var forceAdvancedAuthentication = true
 
     // Used to ensure the webview is reloaded when Dev Menu Login Options are changed.
     internal var loginDevMenuReload = false
@@ -1476,6 +1487,7 @@ open class SalesforceSDKManager protected constructor(
             "User Agent", userAgent,
             "Use Web Server Authentication", "$useWebServerAuthentication",
             "Use Hybrid Authentication Token", "$useHybridAuthentication",
+            "Force Advanced Authentication", "$forceAdvancedAuthentication",
             "Browser Login Enabled", "$isBrowserLoginEnabled",
             "IDP Enabled", "$isIDPLoginFlowEnabled",
             "Identity Provider", "$isIdentityProvider",
@@ -1510,6 +1522,7 @@ open class SalesforceSDKManager protected constructor(
 //                "Use Web Server Authentication" to "$useWebServerAuthentication",
 //                "Use Hybrid Authentication Token" to "$useHybridAuthentication",
 //                "Support Welcome Discovery" to "$supportsWelcomeDiscovery",
+//                "Force Advanced Authentication", "$forceAdvancedAuthentication",
 //                "Browser Login Enabled" to "$isBrowserLoginEnabled",
 //                "IDP Enabled" to "$isIDPLoginFlowEnabled",
 //                "Identity Provider" to "$isIdentityProvider",
@@ -2057,28 +2070,42 @@ open class SalesforceSDKManager protected constructor(
         completion: (() -> Unit),
     ) = CoroutineScope(Default).launch {
         // If this takes more than five seconds it can cause Android's application not responding report.
-        withTimeoutOrNull(5000L) {
+        withTimeoutOrNull(5000L.milliseconds) {
             val loginServer = (loginServerUrl ?: loginServerManager.selectedLoginServer.url).trim()
-            if (loginServer == PRODUCTION_LOGIN_URL || loginServer == WELCOME_LOGIN_URL || loginServer == SANDBOX_LOGIN_URL || !isHttpsUrl(loginServer) || loginServer.toHttpUrlOrNull() == null) {
-                setBrowserLoginEnabled(
-                    browserLoginEnabled = false,
-                    shareBrowserSessionEnabled = false
-                )
+            val isStandardLoginServer = loginServer == PRODUCTION_LOGIN_URL || loginServer == SANDBOX_LOGIN_URL
+            val isInvalidServer = !isHttpsUrl(loginServer) || loginServer.toHttpUrlOrNull() == null
 
-                // Disable Salesforce App Attestation for login servers that are not My Domain servers.
-                appAttestationClient?.apiHostName = null
+            when {
+                loginServer == WELCOME_LOGIN_URL || isInvalidServer -> {
+                    // The Welcome Discovery host and malformed servers are never forced into advanced authentication
+                    setBrowserLoginEnabled(
+                        browserLoginEnabled = false,
+                        shareBrowserSessionEnabled = false
+                    )
 
-                return@withTimeoutOrNull
-            }
+                    // Disable Salesforce App Attestation for login servers that are not My Domain servers.
+                    appAttestationClient?.apiHostName = null
+                }
+                isStandardLoginServer -> {
+                    // Standard login servers have no auth-config to source a shared-session value from, so
+                    // browser login is gated solely on the force flag and shared session stays false.
+                    setBrowserLoginEnabled(
+                        browserLoginEnabled = forceAdvancedAuthentication,
+                        shareBrowserSessionEnabled = false
+                    )
 
-            getMyDomainAuthConfig(httpAccess, loginServer).let { authConfig ->
-                setBrowserLoginEnabled(
-                    browserLoginEnabled = authConfig?.isBrowserLoginEnabled ?: false,
-                    shareBrowserSessionEnabled = authConfig?.isShareBrowserSessionEnabled ?: false
-                )
+                    // Disable Salesforce App Attestation for login servers that are not My Domain servers.
+                    appAttestationClient?.apiHostName = null
+                }
+                else -> getMyDomainAuthConfig(httpAccess, loginServer).let { authConfig ->
+                    setBrowserLoginEnabled(
+                        browserLoginEnabled = forceAdvancedAuthentication || (authConfig?.isBrowserLoginEnabled ?: false),
+                        shareBrowserSessionEnabled = authConfig?.isShareBrowserSessionEnabled ?: false
+                    )
 
-                // Consider enabling Salesforce App Attestation for login servers that are My Domain servers.
-                appAttestationClient?.apiHostName = loginServer.toUri().host
+                    // Consider enabling Salesforce App Attestation for login servers that are My Domain servers.
+                    appAttestationClient?.apiHostName = loginServer.toUri().host
+                }
             }
         }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginOptionsActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginOptionsActivity.kt
@@ -95,6 +95,7 @@ import com.salesforce.androidsdk.util.test.ExcludeFromJacocoGeneratedReport
 class LoginOptionsActivity: ComponentActivity() {
     val useWebServer = MutableLiveData(SalesforceSDKManager.getInstance().useWebServerAuthentication)
     val useHybridToken = MutableLiveData(SalesforceSDKManager.getInstance().useHybridAuthentication)
+    val forceAdvancedAuth = MutableLiveData(SalesforceSDKManager.getInstance().forceAdvancedAuthentication)
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Override
@@ -116,6 +117,13 @@ class LoginOptionsActivity: ComponentActivity() {
                 value -> SalesforceSDKManager.getInstance().useHybridAuthentication = value
             },
         )
+        forceAdvancedAuth.observe(
+            /* owner = */ this,
+            Observer<Boolean> {
+                // onChanged lambda
+                value -> SalesforceSDKManager.getInstance().forceAdvancedAuthentication = value
+            },
+        )
 
         setContent {
             MaterialTheme(colorScheme = SalesforceSDKManager.getInstance().colorScheme()) {
@@ -133,6 +141,7 @@ class LoginOptionsActivity: ComponentActivity() {
                         innerPadding,
                         useWebServer,
                         useHybridToken,
+                        forceAdvancedAuth,
                         SalesforceSDKManager.getInstance().debugOverrideAppConfig,
                     )
                 }
@@ -310,8 +319,10 @@ fun LoginOptionsScreen(
     innerPadding: PaddingValues,
     useWebServer: MutableLiveData<Boolean>,
     useHybridToken: MutableLiveData<Boolean>,
+    forceAdvancedAuth: MutableLiveData<Boolean>,
     overrideConfig: OAuthConfig?,
     bootConfig: BootConfig = BootConfig.getBootConfig(LocalContext.current),
+    sdkManager: SalesforceSDKManager? = SalesforceSDKManager.getInstance(),
 ) {
     var useDynamicConfig by remember { mutableStateOf(overrideConfig != null) }
 
@@ -330,6 +341,11 @@ fun LoginOptionsScreen(
             "Use Hybrid Auth Token",
             stringResource(R.string.sf__login_options_hybrid_toggle_content_description),
             useHybridToken,
+        )
+        OptionToggle(
+            "Force Advanced Authentication",
+            stringResource(R.string.sf__login_options_force_advanced_auth_toggle_content_description),
+            forceAdvancedAuth,
         )
 
         HorizontalDivider()
@@ -385,8 +401,7 @@ fun LoginOptionsScreen(
         // Welcome Discovery simulation editor: visible only when the launcher Activity flagged
         // the process as UI-testing (and only in debug builds, enforced by the setter).
         // Mirrors iOS' IS_UI_TESTING gate in LoginOptionsViewController.swift.
-        val sdkManager = SalesforceSDKManager.getInstance()
-        if (sdkManager.isDebugBuild && sdkManager.isUiTesting) {
+        if (sdkManager?.isDebugBuild == true && sdkManager.isUiTesting) {
             HorizontalDivider()
 
             var simulateDiscovery by remember {
@@ -548,10 +563,12 @@ fun LoginOptionsScreenPreview() {
         innerPadding = PaddingValues(0.dp),
         useWebServer = MutableLiveData(true),
         useHybridToken = MutableLiveData(false),
+        forceAdvancedAuth = MutableLiveData(true),
         overrideConfig = null,
         bootConfig = object : BootConfig() {
             override fun getRemoteAccessConsumerKey() = consumerKey
             override fun getOauthRedirectURI() = redirect
         },
+        sdkManager = null,
     )
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginOptionsActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginOptionsActivity.kt
@@ -95,9 +95,14 @@ import com.salesforce.androidsdk.util.test.ExcludeFromJacocoGeneratedReport
 class LoginOptionsActivity: ComponentActivity() {
     val useWebServer = MutableLiveData(SalesforceSDKManager.getInstance().useWebServerAuthentication)
     val useHybridToken = MutableLiveData(SalesforceSDKManager.getInstance().useHybridAuthentication)
+
+    // This dev-menu toggle is the intended consumer of the deprecated force-advanced-auth flag, so
+    // suppress the deprecation nudge here (it fires on the public property from outside the SDK).
+    @Suppress("DEPRECATION")
     val forceAdvancedAuth = MutableLiveData(SalesforceSDKManager.getInstance().forceAdvancedAuthentication)
 
     @OptIn(ExperimentalMaterial3Api::class)
+    @Suppress("DEPRECATION")
     @Override
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
@@ -100,6 +102,7 @@ class SalesforceSDKManagerTests {
             loginServerManager.reset()
             isBrowserLoginEnabled = false
             isShareBrowserSessionEnabled = false
+            forceAdvancedAuthentication = true
         }
         unmockkAll()
     }
@@ -107,20 +110,17 @@ class SalesforceSDKManagerTests {
     @Test
     fun salesforceSdkManager_Updates_onFetchAuthenticationConfigurationForMyDomainLoginServer() {
 
+        // Legacy behavior: with the force flag off, browser login follows the server's
+        // auth-config (which opts out in responseBodyString).
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
+
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
-
-        SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
-            LoginServer(
-                "Example",
-                "https://www.example.com",
-                true
-            )
-        )
 
         runBlocking {
             SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
                 httpAccess = httpAccess,
+                loginServerUrl = "https://www.example.com", // IETF-Reserved Test Domain
             ) {
                 /* Completion Does Not Require Verification */
             }.join()
@@ -136,17 +136,10 @@ class SalesforceSDKManagerTests {
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
 
-        SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
-            LoginServer(
-                "Welcome",
-                WELCOME_LOGIN_URL,
-                true
-            )
-        )
-
         runBlocking {
             SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
                 httpAccess = httpAccess,
+                loginServerUrl = WELCOME_LOGIN_URL,
             ) {
                 /* Completion Does Not Require Verification */
             }.join()
@@ -158,6 +151,10 @@ class SalesforceSDKManagerTests {
 
     @Test
     fun salesforceSdkManager_Updates_onFetchAuthenticationConfigurationForSandboxLoginServer() {
+
+        // Legacy behavior: with the force flag off, a standard sandbox login server
+        // disables browser login.
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
 
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
@@ -182,17 +179,10 @@ class SalesforceSDKManagerTests {
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
 
-        SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
-            LoginServer(
-                "Non-HTTPS",
-                "http://www.example.com", // IETF-Reserved Test Domain
-                true
-            )
-        )
-
         runBlocking {
             SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
                 httpAccess = httpAccess,
+                loginServerUrl = "http://www.example.com", // IETF-Reserved Test Domain
             ) {
                 /* Completion Does Not Require Verification */
             }.join()
@@ -208,17 +198,10 @@ class SalesforceSDKManagerTests {
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
 
-        SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
-            LoginServer(
-                "Invalid",
-                "invalid_url",
-                true
-            )
-        )
-
         runBlocking {
             SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
                 httpAccess = httpAccess,
+                loginServerUrl = "invalid_url",
             ) {
                 /* Completion Does Not Require Verification */
             }.join()
@@ -233,17 +216,13 @@ class SalesforceSDKManagerTests {
     @Test
     fun salesforceSdkManager_DoesNotUpdate_onFetchAuthenticationConfigurationWithError() {
 
+        // Legacy behavior: with the force flag off, a failed auth-config fetch leaves the
+        // (false) browser-login values unchanged.
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
+
         // Login Server: "My Domain"/Other URL, OkHttpClient Throws And Catch By AuthConfigUtil
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = false
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = false
-
-        SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
-            LoginServer(
-                "Example",
-                "https://www.example.com",
-                true
-            )
-        )
 
         // Mocks
         val httpAccessThrows = mockk<HttpAccess>()
@@ -252,6 +231,7 @@ class SalesforceSDKManagerTests {
         runBlocking {
             SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
                 httpAccess = httpAccessThrows,
+                loginServerUrl = "https://www.example.com",
             ) {
                 /* Completion Does Not Require Verification */
             }.join()
@@ -264,6 +244,10 @@ class SalesforceSDKManagerTests {
 
     @Test
     fun salesforceSdkManager_Updates_onFetchAuthenticationConfigurationForProductionLoginServer() {
+
+        // Legacy behavior: with the force flag off, a standard production login server
+        // disables browser login.
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
 
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
@@ -291,6 +275,10 @@ class SalesforceSDKManagerTests {
     @Test
     fun fetchAuthenticationConfiguration_withLoginServerUrlOverride_usesOverrideOverPersistedSelectedServer() {
 
+        // Legacy behavior: with the force flag off, the overridden My Domain server follows
+        // its auth-config (which opts out in responseBodyString).
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
+
         SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
             LoginServer("Production", PRODUCTION_LOGIN_URL, false)
         )
@@ -313,6 +301,203 @@ class SalesforceSDKManagerTests {
             PRODUCTION_LOGIN_URL,
             SalesforceSDKManager.getInstance().loginServerManager.selectedLoginServer.url,
         )
+    }
+
+    @Test
+    fun fetchAuthenticationConfiguration_ForceFlagOnAndMyDomainOptsOut_EnablesBrowserLogin() {
+
+        // The force flag is on by default, but set it explicitly for clarity.
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
+
+        SalesforceSDKManager.getInstance().isBrowserLoginEnabled = false
+        SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = false
+
+        // My Domain auth-config that opts out of browser login; the force flag must still
+        // enable it.
+        val httpAccessOptOut = buildHttpAccessReturning(
+            useNativeBrowser = false,
+            shareBrowserSession = false,
+        )
+
+        runBlocking {
+            SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
+                httpAccess = httpAccessOptOut,
+                loginServerUrl = "https://www.example.com",
+            ) {
+                /* Completion Does Not Require Verification */
+            }.join()
+        }
+
+        assertTrue(SalesforceSDKManager.getInstance().isBrowserLoginEnabled)
+        assertFalse(SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled)
+    }
+
+    @Test
+    fun fetchAuthenticationConfiguration_ForceFlagOnAndMyDomainSharesSession_KeepsShareBrowserSessionEnabled() {
+
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
+
+        SalesforceSDKManager.getInstance().isBrowserLoginEnabled = false
+        SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = false
+
+        // My Domain auth-config that opts in to a shared browser session.  The force flag must
+        // not clobber the server's shared-session value.
+        val httpAccessShareSession = buildHttpAccessReturning(
+            useNativeBrowser = true,
+            shareBrowserSession = true,
+        )
+
+        runBlocking {
+            SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
+                httpAccess = httpAccessShareSession,
+                loginServerUrl = "https://www.example.com",
+            ) {
+                /* Completion Does Not Require Verification */
+            }.join()
+        }
+
+        assertTrue(SalesforceSDKManager.getInstance().isBrowserLoginEnabled)
+        assertTrue(SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled)
+    }
+
+    @Test
+    fun fetchAuthenticationConfiguration_ForceFlagOnAndStandardLoginServer_EnablesBrowserLoginWithoutSharedSession() {
+
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
+
+        SalesforceSDKManager.getInstance().isBrowserLoginEnabled = false
+        SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = false
+
+        SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
+            LoginServer(
+                "Production",
+                PRODUCTION_LOGIN_URL,
+                false
+            )
+        )
+
+        runBlocking {
+            SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
+                httpAccess = httpAccess,
+            ) {
+                /* Completion Does Not Require Verification */
+            }.join()
+        }
+
+        // Standard login servers have no auth-config, so browser login is gated solely on the
+        // force flag and shared session stays false.
+        assertTrue(SalesforceSDKManager.getInstance().isBrowserLoginEnabled)
+        assertFalse(SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled)
+    }
+
+    @Test
+    fun fetchAuthenticationConfiguration_ForceFlagOffAndServerOptsOut_DisablesBrowserLogin() {
+
+        // With the force flag off, browser login follows the server's auth-config.
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
+
+        SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
+        SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
+
+        val httpAccessOptOut = buildHttpAccessReturning(
+            useNativeBrowser = false,
+            shareBrowserSession = false,
+        )
+
+        runBlocking {
+            SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
+                httpAccess = httpAccessOptOut,
+                loginServerUrl = "https://www.example.com",
+            ) {
+                /* Completion Does Not Require Verification */
+            }.join()
+        }
+
+        assertFalse(SalesforceSDKManager.getInstance().isBrowserLoginEnabled)
+        assertFalse(SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled)
+    }
+
+    @Test
+    fun fetchAuthenticationConfiguration_ForceFlagOffAndServerOptsIn_EnablesBrowserLogin() {
+
+        // With the force flag off, browser login follows the server's auth-config - the legacy
+        // opt-in path must continue to work.
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
+
+        SalesforceSDKManager.getInstance().isBrowserLoginEnabled = false
+        SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = false
+
+        val httpAccessOptIn = buildHttpAccessReturning(
+            useNativeBrowser = true,
+            shareBrowserSession = false,
+        )
+
+        runBlocking {
+            SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
+                httpAccess = httpAccessOptIn,
+                loginServerUrl = "https://www.example.com",
+            ) {
+                /* Completion Does Not Require Verification */
+            }.join()
+        }
+
+        assertTrue(SalesforceSDKManager.getInstance().isBrowserLoginEnabled)
+        assertFalse(SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled)
+    }
+
+    @Test
+    fun forceAdvancedAuthentication_FreshManager_DefaultsToTrue() {
+
+        // A freshly initialized manager defaults the force-advanced-authentication flag to true.
+        val salesforceSdkManager = createTestSalesforceSDKManager()
+
+        assertTrue(salesforceSdkManager.forceAdvancedAuthentication)
+    }
+
+    @Test
+    fun fetchAuthenticationConfiguration_ForceFlagOnAndWelcomeDiscoveryHost_DisablesBrowserLogin() {
+
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
+
+        SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
+        SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
+
+        // The Welcome Discovery host is excluded from forced advanced authentication (phase-1
+        // exclusion) and keeps the legacy disabled behavior even with the force flag on.
+        runBlocking {
+            SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
+                httpAccess = httpAccess,
+                loginServerUrl = WELCOME_LOGIN_URL,
+            ) {
+                /* Completion Does Not Require Verification */
+            }.join()
+        }
+
+        assertFalse(SalesforceSDKManager.getInstance().isBrowserLoginEnabled)
+        assertFalse(SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled)
+    }
+
+    @Test
+    fun fetchAuthenticationConfiguration_ForceFlagOnAndNonHttpsServer_DisablesBrowserLogin() {
+
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
+
+        SalesforceSDKManager.getInstance().isBrowserLoginEnabled = true
+        SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = true
+
+        // Non-HTTPS servers are excluded from forced advanced authentication and keep the legacy
+        // disabled behavior even with the force flag on.
+        runBlocking {
+            SalesforceSDKManager.getInstance().fetchAuthenticationConfiguration(
+                httpAccess = httpAccess,
+                loginServerUrl = "http://www.example.com", // IETF-Reserved Test Domain
+            ) {
+                /* Completion Does Not Require Verification */
+            }.join()
+        }
+
+        assertFalse(SalesforceSDKManager.getInstance().isBrowserLoginEnabled)
+        assertFalse(SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled)
     }
 
     @Test
@@ -391,11 +576,16 @@ class SalesforceSDKManagerTests {
 
     @Test
     fun getDevActions_ReturnsAllActions_ForNonLoginActivity() {
-        // Arrange
+        // Arrange: a manager with a signed-in user, so Logout/Switch User are eligible.
+        // Stubbing the current user keeps this deterministic instead of depending on
+        // whatever Salesforce account happens to be present on the test device.
+        val salesforceSdkManager = createTestSalesforceSDKManagerWithCurrentUser(
+            mockk<UserAccount>(relaxed = true)
+        )
         val mockActivity = mockk<Activity>(relaxed = true)
 
         // Act
-        val devActions = SalesforceSDKManager.getInstance().getDevActions(mockActivity)
+        val devActions = salesforceSdkManager.getDevActions(mockActivity)
 
         // Assert
         assertEquals(4, devActions.size)
@@ -411,11 +601,16 @@ class SalesforceSDKManagerTests {
 
     @Test
     fun getDevActions_ExcludesLogoutAndSwitchUser_ForLoginActivity() {
-        // Arrange
+        // Arrange: even with a signed-in user, the Login screen must never expose
+        // Logout/Switch User.  Stubbing the current user proves the LoginActivity check
+        // is what excludes them (not merely the absence of a user).
+        val salesforceSdkManager = createTestSalesforceSDKManagerWithCurrentUser(
+            mockk<UserAccount>(relaxed = true)
+        )
         val mockLoginActivity = mockk<LoginActivity>(relaxed = true)
 
         // Act
-        val devActions = SalesforceSDKManager.getInstance().getDevActions(mockLoginActivity)
+        val devActions = salesforceSdkManager.getDevActions(mockLoginActivity)
 
         // Assert
         assertEquals(2, devActions.size)
@@ -425,6 +620,24 @@ class SalesforceSDKManagerTests {
         assertFalse(devActions.containsKey("Switch User"))
         assertNotNull(devActions["Show dev info"])
         assertNotNull(devActions["Login Options"])
+    }
+
+    @Test
+    fun getDevActions_ExcludesLogoutAndSwitchUser_WhenNoCurrentUser() {
+        // Arrange: no signed-in user (cachedCurrentUser == null), so Logout/Switch User
+        // are excluded even on a non-Login activity.
+        val salesforceSdkManager = createTestSalesforceSDKManagerWithCurrentUser(null)
+        val mockActivity = mockk<Activity>(relaxed = true)
+
+        // Act
+        val devActions = salesforceSdkManager.getDevActions(mockActivity)
+
+        // Assert
+        assertEquals(2, devActions.size)
+        assertTrue(devActions.containsKey("Show dev info"))
+        assertTrue(devActions.containsKey("Login Options"))
+        assertFalse(devActions.containsKey("Logout"))
+        assertFalse(devActions.containsKey("Switch User"))
     }
 
     @Test
@@ -520,6 +733,43 @@ class SalesforceSDKManagerTests {
     }
 
     /**
+     * Builds an [HttpAccess] mock whose My Domain auth-config response advertises the provided
+     * `UseAndroidNativeBrowserForAuthentication` and `shareBrowserSessionAndroid` values.  This
+     * mirrors the default mock wiring in [setup] but lets a test vary the auth-config body so the
+     * force-advanced-authentication decision can be exercised against opt-in / opt-out servers.
+     */
+    private fun buildHttpAccessReturning(
+        useNativeBrowser: Boolean,
+        shareBrowserSession: Boolean,
+    ): HttpAccess {
+        val bodyJson =
+            "{\"MobileSDK\":{\"UseAndroidNativeBrowserForAuthentication\":$useNativeBrowser,\"shareBrowserSessionAndroid\":$shareBrowserSession}}"
+
+        val responseBody = mockk<ResponseBody>().apply {
+            every { contentType() } returns "application/json;charset=UTF-8".toMediaType()
+            every { bytes() } returns bodyJson.toByteArray()
+        }
+
+        val response = mockk<Response>().apply {
+            every { isSuccessful } returns true
+            every { body } returns responseBody
+            every { close() } just runs
+        }
+
+        val call = mockk<Call>().apply {
+            every { execute() } returns response
+        }
+
+        val okHttpClient = mockk<OkHttpClient>().apply {
+            every { newCall(any()) } returns call
+        }
+
+        return mockk<HttpAccess>().apply {
+            every { getOkHttpClient() } returns okHttpClient
+        }
+    }
+
+    /**
      * Helper to create a test [SalesforceSDKManager] instance with optional
      * [googleCloudProjectId] for app attestation tests.
      */
@@ -541,6 +791,26 @@ class SalesforceSDKManagerTests {
     }
 
     /**
+     * Builds a test [SalesforceSDKManager] whose [UserAccountManager.getCachedCurrentUser]
+     * returns [currentUser] (which may be null).  This lets dev-menu tests control the
+     * signed-in state deterministically instead of depending on the accounts present on
+     * the test device.
+     */
+    private fun createTestSalesforceSDKManagerWithCurrentUser(
+        currentUser: UserAccount?
+    ): SalesforceSDKManager {
+        val userAccountManager = mockk<UserAccountManager>(relaxed = true).apply {
+            every { cachedCurrentUser } returns currentUser
+        }
+        return TestSalesforceSDKManagerWithAttestation(
+            context = getInstrumentation().targetContext,
+            mainActivity = LoginActivity::class.java,
+            loginActivity = LoginActivity::class.java,
+            testUserAccountManager = userAccountManager,
+        )
+    }
+
+    /**
      * A minimal subclass of [SalesforceSDKManager] that exposes the protected
      * primary constructor so that tests can supply a [googleCloudProjectId].
      *
@@ -553,6 +823,7 @@ class SalesforceSDKManagerTests {
         loginActivity: Class<out Activity>? = null,
         googleCloudProjectId: Long? = null,
         private val testLoginServer: LoginServer? = null,
+        private val testUserAccountManager: UserAccountManager? = null,
     ) : SalesforceSDKManager(context, mainActivity, loginActivity, null, googleCloudProjectId) {
 
         /**
@@ -571,6 +842,16 @@ class SalesforceSDKManagerTests {
                 // No-op for reset() to avoid SharedPreferences access
                 every { reset() } just runs
             }
+        }
+
+        /**
+         * Override to provide a test-supplied UserAccountManager so tests can control
+         * the cached current user deterministically, instead of depending on whatever
+         * Salesforce account happens to be present on the device.  Falls back to the
+         * default (device-backed) manager when no test instance is supplied.
+         */
+        override val userAccountManager: UserAccountManager by lazy {
+            testUserAccountManager ?: super.userAccountManager
         }
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
@@ -96,6 +96,7 @@ class SalesforceSDKManagerTests {
     }
 
     @After
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun teardown() {
         // Reset all singleton state to ensure test isolation
         // This prevents state leakage between tests
@@ -109,6 +110,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun salesforceSdkManager_Updates_onFetchAuthenticationConfigurationForMyDomainLoginServer() {
 
         // Legacy behavior: with the force flag off, browser login follows the server's
@@ -151,6 +153,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun salesforceSdkManager_Updates_onFetchAuthenticationConfigurationForSandboxLoginServer() {
 
         // Legacy behavior: with the force flag off, a standard sandbox login server
@@ -215,6 +218,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun salesforceSdkManager_DoesNotUpdate_onFetchAuthenticationConfigurationWithError() {
 
         // Legacy behavior: with the force flag off, a failed auth-config fetch leaves the
@@ -244,6 +248,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun salesforceSdkManager_Updates_onFetchAuthenticationConfigurationForProductionLoginServer() {
 
         // Legacy behavior: with the force flag off, a standard production login server
@@ -274,6 +279,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_withLoginServerUrlOverride_usesOverrideOverPersistedSelectedServer() {
 
         // Legacy behavior: with the force flag off, the overridden My Domain server follows
@@ -305,6 +311,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_ForceFlagOnAndMyDomainOptsOut_EnablesBrowserLogin() {
 
         // The force flag is on by default, but set it explicitly for clarity.
@@ -334,6 +341,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_ForceFlagOnAndMyDomainSharesSession_KeepsShareBrowserSessionEnabled() {
 
         SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
@@ -362,6 +370,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_ForceFlagOnAndStandardLoginServer_EnablesBrowserLoginWithoutSharedSession() {
 
         SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
@@ -392,6 +401,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_ForceFlagOffAndServerOptsOut_DisablesBrowserLogin() {
 
         // With the force flag off, browser login follows the server's auth-config.
@@ -419,6 +429,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_ForceFlagOffAndServerOptsIn_EnablesBrowserLogin() {
 
         // With the force flag off, browser login follows the server's auth-config - the legacy
@@ -447,6 +458,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun forceAdvancedAuthentication_FreshManager_DefaultsToTrue() {
 
         // A freshly initialized manager defaults the force-advanced-authentication flag to true.
@@ -456,6 +468,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_ForceFlagOnAndWelcomeDiscoveryHost_DisablesBrowserLogin() {
 
         SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
@@ -479,6 +492,7 @@ class SalesforceSDKManagerTests {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun fetchAuthenticationConfiguration_ForceFlagOnAndNonHttpsServer_DisablesBrowserLogin() {
 
         SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerTests.kt
@@ -378,6 +378,12 @@ class SalesforceSDKManagerTests {
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = false
         SalesforceSDKManager.getInstance().isShareBrowserSessionEnabled = false
 
+        // Deliberately differs from the My Domain tests above: persist a standard server via
+        // setSelectedLoginServer and omit the loginServerUrl override so the default no-override
+        // branch of fetchAuthenticationConfiguration is exercised (it resolves the target from
+        // loginServerManager.selectedLoginServer).  A standard server (Production) is required to
+        // reach the isStandardLoginServer branch; the transient My Domain override used elsewhere
+        // would fall through to the My Domain auth-config path instead.
         SalesforceSDKManager.getInstance().loginServerManager.setSelectedLoginServer(
             LoginServer(
                 "Production",

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -194,9 +194,20 @@ class LoginViewModelTest {
         viewModel.browserCustomTabUrl.observeForever { }
         viewModel.loginUrl.observeForever { }
 
+        val sdkManager = SalesforceSDKManager.getInstance()
+        val originalForceAdvancedAuth = sdkManager.forceAdvancedAuthentication
+        val originalBrowserLoginEnabled = sdkManager.isBrowserLoginEnabled
         try {
+            // This test validates the User Agent flow WebView modality, which only exists when
+            // advanced authentication is NOT forced.  With the force flag on (the default) browser
+            // login is enabled, so useWebServerFlow() would be true and the WebView itself would use
+            // the Web Server flow — leaving no "User Agent flow active" scenario to validate.  Pin
+            // both the flag and the browser-login gate off so the assertion is deterministic
+            // regardless of state left on the shared singleton by earlier tests.
+            sdkManager.forceAdvancedAuthentication = false
+            sdkManager.isBrowserLoginEnabled = false
             // Force User Agent flow for the WebView.
-            SalesforceSDKManager.getInstance().useWebServerAuthentication = false
+            sdkManager.useWebServerAuthentication = false
 
             viewModel.reloadWebView()
             testDispatcher.scheduler.advanceUntilIdle()
@@ -228,7 +239,9 @@ class LoginViewModelTest {
                 loginUrl!!.contains("response_type=code")
             )
         } finally {
-            SalesforceSDKManager.getInstance().useWebServerAuthentication = true
+            sdkManager.useWebServerAuthentication = true
+            sdkManager.isBrowserLoginEnabled = originalBrowserLoginEnabled
+            sdkManager.forceAdvancedAuthentication = originalForceAdvancedAuth
         }
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -233,6 +233,44 @@ class LoginViewModelTest {
     }
 
     @Test
+    fun browserCustomTabUrl_UsesWebServerFlow_WhenForceFlagOnAndWebServerAuthDisabled() {
+        viewModel.browserCustomTabUrl.observeForever { }
+        viewModel.loginUrl.observeForever { }
+
+        val originalForceAdvancedAuth = SalesforceSDKManager.getInstance().forceAdvancedAuthentication
+        try {
+            // Security invariant: even when the force-advanced-authentication flag is on AND the
+            // app has opted out of the Web Server flow for the WebView, the browser custom tab
+            // (advanced authentication) must always use the Web Server flow (response_type=code +
+            // PKCE) and never the User Agent flow (response_type=token).
+            SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
+            SalesforceSDKManager.getInstance().useWebServerAuthentication = false
+
+            viewModel.reloadWebView()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val browserCustomTabUrl = viewModel.browserCustomTabUrl.value
+            assertNotNull("browserCustomTabUrl should always be generated", browserCustomTabUrl)
+
+            assertTrue(
+                "browserCustomTabUrl should use response_type=code. URL: $browserCustomTabUrl",
+                browserCustomTabUrl!!.contains("response_type=code")
+            )
+            assertTrue(
+                "browserCustomTabUrl should include a PKCE code_challenge. URL: $browserCustomTabUrl",
+                browserCustomTabUrl.contains("code_challenge=")
+            )
+            assertFalse(
+                "browserCustomTabUrl must never use the User Agent flow (response_type=token). URL: $browserCustomTabUrl",
+                browserCustomTabUrl.contains("response_type=token")
+            )
+        } finally {
+            SalesforceSDKManager.getInstance().useWebServerAuthentication = true
+            SalesforceSDKManager.getInstance().forceAdvancedAuthentication = originalForceAdvancedAuth
+        }
+    }
+
+    @Test
     fun browserCustomTabUrl_UpdatesOn_selectedServerChange() {
         viewModel.browserCustomTabUrl.observeForever { }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -190,6 +190,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun browserCustomTabUrl_UsesWebServerFlow_EvenWhenUserAgentFlowIsActive() {
         viewModel.browserCustomTabUrl.observeForever { }
         viewModel.loginUrl.observeForever { }
@@ -246,6 +247,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun browserCustomTabUrl_UsesWebServerFlow_WhenForceFlagOnAndWebServerAuthDisabled() {
         viewModel.browserCustomTabUrl.observeForever { }
         viewModel.loginUrl.observeForever { }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityScenarioTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityScenarioTest.kt
@@ -227,51 +227,65 @@ class LoginActivityScenarioTest {
 
     @Test
     fun loginActivity_ReloadsWebview_OnResumeWithLoginOptionChanges() {
+        // This test drives the in-app WebView reload path, which only exists when advanced
+        // authentication is NOT forced.  With the force flag on (the default) the login server's
+        // auth-config fetch enables browser login, causing LoginActivity to launch a Chrome Custom
+        // Tab over itself; the tab stops the activity so it never returns to RESUMED and the
+        // moveToState() calls below fail.  Pin the flag off before launching so the WebView path is
+        // exercised, and restore it afterward so we don't leak state onto the shared singleton.
+        val sdkManager = SalesforceSDKManager.getInstance()
+        val originalForceAdvancedAuth = sdkManager.forceAdvancedAuthentication
+        sdkManager.forceAdvancedAuthentication = false
+
         // Set loginDevMenuReload to false initially
-        SalesforceSDKManager.getInstance().loginDevMenuReload = false
+        sdkManager.loginDevMenuReload = false
 
-        launch<LoginActivity>(
-            Intent(
-                getApplicationContext(),
-                LoginActivity::class.java
-            )
-        ).use { activityScenario ->
-            // Get the initial login URL
-            var initialUrl: String? = null
-            activityScenario.onActivity { activity ->
-                initialUrl = activity.viewModel.loginUrl.value
-            }
-
-            // Pause the activity (simulating going to dev menu)
-            activityScenario.moveToState(STARTED)
-
-            // Simulate changing login options in dev menu
-            activityScenario.onActivity { _ ->
-                SalesforceSDKManager.getInstance().loginDevMenuReload = true
-            }
-
-            // Resume the activity
-            activityScenario.moveToState(RESUMED)
-
-            // Verify the webview was reloaded (URL should be regenerated)
-            activityScenario.onActivity { activity ->
-                // The reload flag should be reset to false
-                assertFalse(
-                    "loginDevMenuReload should be reset to false after reload",
-                    SalesforceSDKManager.getInstance().loginDevMenuReload
+        try {
+            launch<LoginActivity>(
+                Intent(
+                    getApplicationContext(),
+                    LoginActivity::class.java
                 )
+            ).use { activityScenario ->
+                // Get the initial login URL
+                var initialUrl: String? = null
+                activityScenario.onActivity { activity ->
+                    initialUrl = activity.viewModel.loginUrl.value
+                }
 
-                // For Web Server Flow, the URL changes each time due to code challenge
-                // Verify that reloadWebView was called by checking the URL changed
-                val newUrl = activity.viewModel.loginUrl.value
-                if (SalesforceSDKManager.getInstance().useWebServerAuthentication) {
-                    // Web Server Flow generates a new code challenge each time
-                    assertTrue(
-                        "Login URL should have changed after reload for Web Server Flow",
-                        newUrl != initialUrl
+                // Pause the activity (simulating going to dev menu)
+                activityScenario.moveToState(STARTED)
+
+                // Simulate changing login options in dev menu
+                activityScenario.onActivity { _ ->
+                    SalesforceSDKManager.getInstance().loginDevMenuReload = true
+                }
+
+                // Resume the activity
+                activityScenario.moveToState(RESUMED)
+
+                // Verify the webview was reloaded (URL should be regenerated)
+                activityScenario.onActivity { activity ->
+                    // The reload flag should be reset to false
+                    assertFalse(
+                        "loginDevMenuReload should be reset to false after reload",
+                        SalesforceSDKManager.getInstance().loginDevMenuReload
                     )
+
+                    // For Web Server Flow, the URL changes each time due to code challenge
+                    // Verify that reloadWebView was called by checking the URL changed
+                    val newUrl = activity.viewModel.loginUrl.value
+                    if (SalesforceSDKManager.getInstance().useWebServerAuthentication) {
+                        // Web Server Flow generates a new code challenge each time
+                        assertTrue(
+                            "Login URL should have changed after reload for Web Server Flow",
+                            newUrl != initialUrl
+                        )
+                    }
                 }
             }
+        } finally {
+            sdkManager.forceAdvancedAuthentication = originalForceAdvancedAuth
         }
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityScenarioTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityScenarioTest.kt
@@ -226,6 +226,7 @@ class LoginActivityScenarioTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun loginActivity_ReloadsWebview_OnResumeWithLoginOptionChanges() {
         // This test drives the in-app WebView reload path, which only exists when advanced
         // authentication is NOT forced.  With the force flag on (the default) the login server's

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginOptionsActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginOptionsActivityTest.kt
@@ -88,6 +88,7 @@ class LoginOptionsActivityTest {
     private lateinit var saveButton: SemanticsNodeInteraction
 
     @Before
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun setup() {
         // Save original values
         originalUseWebServer = SalesforceSDKManager.getInstance().useWebServerAuthentication
@@ -122,6 +123,7 @@ class LoginOptionsActivityTest {
     }
 
     @After
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun teardown() {
         // Restore original values
         SalesforceSDKManager.getInstance().useWebServerAuthentication = originalUseWebServer
@@ -243,6 +245,7 @@ class LoginOptionsActivityTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
     fun loginOptionsActivity_ForceAdvancedAuthToggle_ReflectsAndUpdatesSdkManager() {
         // Set initial state via the activity's LiveData: force flag off.
         composeTestRule.activity.runOnUiThread {
@@ -282,6 +285,7 @@ class LoginOptionsActivityTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Deliberately exercises the deprecated forceAdvancedAuthentication flag and devSupportInfos.
     fun devSupportInfos_IncludesForceAdvancedAuthentication_WithCurrentValue() {
         // The dev-support info surfaces the force-advanced-authentication flag and its value.
         SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginOptionsActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginOptionsActivityTest.kt
@@ -77,12 +77,14 @@ class LoginOptionsActivityTest {
 
     private var originalUseWebServer: Boolean = false
     private var originalUseHybridToken: Boolean = false
+    private var originalForceAdvancedAuth: Boolean = true
     private lateinit var dynamicToggle: SemanticsNodeInteraction
     private lateinit var consumerKeyField: SemanticsNodeInteraction
     private lateinit var redirectUriField: SemanticsNodeInteraction
     private lateinit var scopesField: SemanticsNodeInteraction
     private lateinit var webserverToggle: SemanticsNodeInteraction
     private lateinit var hybridToggle: SemanticsNodeInteraction
+    private lateinit var forceAdvancedAuthToggle: SemanticsNodeInteraction
     private lateinit var saveButton: SemanticsNodeInteraction
 
     @Before
@@ -90,6 +92,7 @@ class LoginOptionsActivityTest {
         // Save original values
         originalUseWebServer = SalesforceSDKManager.getInstance().useWebServerAuthentication
         originalUseHybridToken = SalesforceSDKManager.getInstance().useHybridAuthentication
+        originalForceAdvancedAuth = SalesforceSDKManager.getInstance().forceAdvancedAuthentication
         SalesforceSDKManager.getInstance().loginDevMenuReload = false
 
         dynamicToggle = composeTestRule.onNodeWithContentDescription(
@@ -110,6 +113,9 @@ class LoginOptionsActivityTest {
         hybridToggle = composeTestRule.onNodeWithContentDescription(
             composeTestRule.activity.getString(R.string.sf__login_options_hybrid_toggle_content_description),
         )
+        forceAdvancedAuthToggle = composeTestRule.onNodeWithContentDescription(
+            composeTestRule.activity.getString(R.string.sf__login_options_force_advanced_auth_toggle_content_description),
+        )
         saveButton = composeTestRule.onNodeWithText(
             composeTestRule.activity.getString(R.string.sf__login_options_save_and_login),
         )
@@ -120,6 +126,7 @@ class LoginOptionsActivityTest {
         // Restore original values
         SalesforceSDKManager.getInstance().useWebServerAuthentication = originalUseWebServer
         SalesforceSDKManager.getInstance().useHybridAuthentication = originalUseHybridToken
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = originalForceAdvancedAuth
         SalesforceSDKManager.getInstance().debugOverrideAppConfig = null
         SalesforceSDKManager.getInstance().loginDevMenuReload = false
     }
@@ -233,6 +240,63 @@ class LoginOptionsActivityTest {
             false,
             composeTestRule.activity.useHybridToken.value
         )
+    }
+
+    @Test
+    fun loginOptionsActivity_ForceAdvancedAuthToggle_ReflectsAndUpdatesSdkManager() {
+        // Set initial state via the activity's LiveData: force flag off.
+        composeTestRule.activity.runOnUiThread {
+            SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
+            composeTestRule.activity.forceAdvancedAuth.value = false
+        }
+        composeTestRule.waitForIdle()
+
+        // The toggle reflects the SDK manager value.
+        forceAdvancedAuthToggle.performScrollTo()
+        forceAdvancedAuthToggle.assertIsDisplayed()
+        forceAdvancedAuthToggle.assertIsOff()
+        assertFalse(
+            "Force Advanced Authentication should be disabled initially",
+            SalesforceSDKManager.getInstance().forceAdvancedAuthentication
+        )
+
+        // Toggling on writes the value through to the SDK manager.
+        forceAdvancedAuthToggle.performClick()
+        composeTestRule.waitForIdle()
+
+        forceAdvancedAuthToggle.assertIsOn()
+        assertTrue(
+            "Force Advanced Authentication should be enabled after toggling on",
+            SalesforceSDKManager.getInstance().forceAdvancedAuthentication
+        )
+
+        // Toggling off writes the value back through to the SDK manager.
+        forceAdvancedAuthToggle.performClick()
+        composeTestRule.waitForIdle()
+
+        forceAdvancedAuthToggle.assertIsOff()
+        assertFalse(
+            "Force Advanced Authentication should be disabled after toggling off",
+            SalesforceSDKManager.getInstance().forceAdvancedAuthentication
+        )
+    }
+
+    @Test
+    fun devSupportInfos_IncludesForceAdvancedAuthentication_WithCurrentValue() {
+        // The dev-support info surfaces the force-advanced-authentication flag and its value.
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = true
+        val devSupportInfosOn = SalesforceSDKManager.getInstance().devSupportInfos
+        val labelIndexOn = devSupportInfosOn.indexOf("Force Advanced Authentication")
+        assertTrue(
+            "devSupportInfos should include the Force Advanced Authentication label",
+            labelIndexOn >= 0
+        )
+        assertEquals("true", devSupportInfosOn[labelIndexOn + 1])
+
+        SalesforceSDKManager.getInstance().forceAdvancedAuthentication = false
+        val devSupportInfosOff = SalesforceSDKManager.getInstance().devSupportInfos
+        val labelIndexOff = devSupportInfosOff.indexOf("Force Advanced Authentication")
+        assertEquals("false", devSupportInfosOff[labelIndexOff + 1])
     }
 
     @Test

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/NegativeLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/NegativeLoginTests.kt
@@ -31,7 +31,7 @@ import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.salesforce.androidsdk.app.SalesforceSDKManager
-import com.salesforce.samples.authflowtester.pageObjects.LoginPageObject
+import com.salesforce.samples.authflowtester.pageObjects.ChromeCustomTabPageObject
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE
@@ -90,12 +90,20 @@ class NegativeLoginTests : AuthFlowTest() {
         val (userAccessToken, userRefreshToken) = app.getTokens()
 
         // Open the user picker and add a new account, which routes through the
-        // login screen. Set a different dynamic config (ECA Opaque) but do not
-        // submit credentials.
+        // login screen. Under forced advanced authentication the login screen
+        // auto-launches a Chrome Custom Tab, so back out of it to reach the top
+        // bar before opening Login Options. Set a different dynamic config (ECA
+        // Opaque) but do not submit credentials.
         app.addNewAccount()
-        val loginPage = LoginPageObject(composeTestRule)
+        val loginPage = ChromeCustomTabPageObject(composeTestRule)
+        loginPage.backOutToLoginActivity()
         loginPage.openLoginOptions()
         loginOptions.setOverrideBootConfig(ECA_OPAQUE, EMPTY)
+
+        // Saving Login Options re-launches the Custom Tab. Back out of it (and dismiss the
+        // resulting server picker) so navigateBackToApp only has to walk the remaining
+        // LoginActivity -> AccountSwitcher -> AuthFlowTester stack.
+        loginPage.backOutToLoginActivity()
         navigateBackToApp()
 
         // The existing user must remain the only authenticated account.

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
@@ -26,11 +26,17 @@
  */
 package com.salesforce.samples.authflowtester.pageObjects
 
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
+import com.salesforce.androidsdk.R
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 import com.salesforce.samples.authflowtester.testUtility.testConfig
 
@@ -58,7 +64,68 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         tapLogin()
         setPassword(password)
         tapLogin()
-        AuthorizationPageObject(composeTestRule).tapAllowAfterLogin(knownLoginHostConfig)
+        // Under forced advanced authentication every login completes in the Custom Tab, so the
+        // OAuth approval page is always rendered there regardless of the configured host.
+        AuthorizationPageObject(composeTestRule).tapAllowAfterLogin(ADVANCED_AUTH)
+    }
+
+    override fun welcomeLogin(knownLoginHostConfig: KnownLoginHostConfig, knownUserConfig: KnownUserConfig) {
+        skipGoogleSignIn()
+        val (_, password) = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
+        // The OAuth login_hint already pre-filled the username; advance, enter password, submit.
+        tapLogin()
+        setPassword(password)
+        tapLogin()
+        AuthorizationPageObject(composeTestRule).tapAllowAfterLogin(ADVANCED_AUTH)
+    }
+
+    /**
+     * Forced advanced authentication auto-launches a Chrome Custom Tab over the Compose
+     * LoginActivity, so its top bar (and the "More Options" menu the [LoginPageObject] Compose
+     * actions depend on) is not reachable while the tab is in front. This backs out of the tab
+     * to surface the LoginActivity again.
+     *
+     * Backing out returns `RESULT_CANCELED`, which the SDK handles by clearing the WebView and
+     * raising the login-server-picker bottom sheet (`clearWebView(showServerPicker = true)`). The
+     * picker's scrim sits over the top bar, so it is dismissed here as well, leaving the bare
+     * LoginActivity ready for a Compose top-bar action (Login Options, Change Server, Login for
+     * Admins). After that action changes the dynamic config or server, the SDK re-launches the
+     * Custom Tab (debug `loginDevMenuReload` -> `reloadWebView`) and login completes in the tab.
+     *
+     * The Custom Tab launches asynchronously (after the auth-config network fetch resolves and the
+     * OAuth URL is generated), so this waits up to [TIMEOUT_MS] for the tab to appear before
+     * backing out. No-op when no Custom Tab appears within the timeout (we are already on the
+     * LoginActivity).
+     */
+    override fun backOutToLoginActivity() {
+        val closeButton = device.findObject(
+            UiSelector().resourceId("com.android.chrome:id/close_button")
+        )
+        if (!closeButton.waitForExists(TIMEOUT_MS)) {
+            return
+        }
+        closeButton.click()
+        dismissServerPickerIfPresent()
+    }
+
+    /** Dismisses the login-server-picker bottom sheet via its Close button, if it is showing. */
+    private fun dismissServerPickerIfPresent() {
+        val closeDescription = getString(R.string.sf__server_close_button_content_description)
+        val appeared = try {
+            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+                composeTestRule.onAllNodesWithContentDescription(closeDescription)
+                    .fetchSemanticsNodes().isNotEmpty()
+            }
+            true
+        } catch (_: ComposeTimeoutException) {
+            // The picker never appeared (e.g. shared browser session re-auth); nothing to dismiss.
+            false
+        }
+
+        if (appeared) {
+            composeTestRule.onNodeWithContentDescription(closeDescription).performClick()
+            composeTestRule.waitForIdle()
+        }
     }
 
     override fun setUsername(name: String) {
@@ -129,15 +196,32 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         }
     }
 
-    fun tapCloseButton(): Boolean {
+    /**
+     * True when a Chrome Custom Tab is currently in front, detected via its close button.
+     * Used by negative tests to assert the user remained in the auth flow (tab) rather than
+     * advancing into the app.
+     */
+    fun isCustomTabDisplayed(): Boolean {
         val closeButton = device.findObject(
             UiSelector().resourceId("com.android.chrome:id/close_button")
         )
-        return if (closeButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
-            closeButton.click()
-            true
-        } else {
-            false
-        }
+        return closeButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)
+    }
+
+    /**
+     * Waits up to [timeoutMs] for a Chrome Custom Tab to come to the front (detected via its close
+     * button) and returns whether it appeared.
+     *
+     * Unlike [isCustomTabDisplayed] (which uses [QUICK_CHECK_TIMEOUT_MS] for tabs that either show
+     * immediately or not at all), this uses the full [TIMEOUT_MS] window so it can wait out the
+     * asynchronous auth-config fetch that precedes a tab (re)launch under forced advanced
+     * authentication. Best-effort: a `false` return simply means no tab launched within the
+     * window, in which case the caller proceeds as if already on the LoginActivity.
+     */
+    fun waitForCustomTab(timeoutMs: Long = TIMEOUT_MS): Boolean {
+        val closeButton = device.findObject(
+            UiSelector().resourceId("com.android.chrome:id/close_button")
+        )
+        return closeButton.waitForExists(timeoutMs)
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
@@ -40,13 +40,18 @@ import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.AD
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 import com.salesforce.samples.authflowtester.testUtility.testConfig
 
-private const val RETRY_COUNT = 3
 /**
  * Short timeout for checking optional local Chrome UI elements that either appear
  * immediately or not at all (e.g., first-run dialogs, password save prompts).
  * These are not dependent on server-side rendering.
  */
 private const val QUICK_CHECK_TIMEOUT_MS = 500L
+
+/**
+ * Ceiling for clearing Chrome's First Run Experience, which on a cold profile (every FTL device) is
+ * a slow multi-page sequence. Longer than [TIMEOUT_MS]; only fully spent when no tab ever appears.
+ */
+private const val FRE_DISMISS_TIMEOUT_MS = 30_000L
 
 /**
  * Handles Custom Tab interactions.
@@ -80,24 +85,16 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
     }
 
     /**
-     * Forced advanced authentication auto-launches a Chrome Custom Tab over the Compose
-     * LoginActivity, so its top bar (and the "More Options" menu the [LoginPageObject] Compose
-     * actions depend on) is not reachable while the tab is in front. This backs out of the tab
-     * to surface the LoginActivity again.
-     *
-     * Backing out returns `RESULT_CANCELED`, which the SDK handles by clearing the WebView and
-     * raising the login-server-picker bottom sheet (`clearWebView(showServerPicker = true)`). The
-     * picker's scrim sits over the top bar, so it is dismissed here as well, leaving the bare
-     * LoginActivity ready for a Compose top-bar action (Login Options, Change Server, Login for
-     * Admins). After that action changes the dynamic config or server, the SDK re-launches the
-     * Custom Tab (debug `loginDevMenuReload` -> `reloadWebView`) and login completes in the tab.
-     *
-     * The Custom Tab launches asynchronously (after the auth-config network fetch resolves and the
-     * OAuth URL is generated), so this waits up to [TIMEOUT_MS] for the tab to appear before
-     * backing out. No-op when no Custom Tab appears within the timeout (we are already on the
+     * Surfaces the LoginActivity by backing out of the Custom Tab that forced advanced auth
+     * auto-launches over it (the tab hides the Compose top bar the [LoginPageObject] actions need).
+     * Backing out returns `RESULT_CANCELED`, which the SDK handles by raising the server-picker
+     * bottom sheet; that is dismissed here too so a subsequent top-bar action can re-launch the tab.
+     * Waits up to [TIMEOUT_MS] for the async tab launch; no-op if no tab appears (already on the
      * LoginActivity).
      */
     override fun backOutToLoginActivity() {
+        // Clear the FRE first; until it is gone it covers the tab toolbar (the close button).
+        skipGoogleSignIn()
         val closeButton = device.findObject(
             UiSelector().resourceId("com.android.chrome:id/close_button")
         )
@@ -169,31 +166,72 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         loginButton.click()
     }
 
+    /**
+     * Clears Chrome's First Run Experience so the Custom Tab can render. On a cold Chrome (every FTL
+     * device, since `clearPackageData=true` wipes Chrome per test) the tab's first launch is covered
+     * by a multi-page FRE that renders slowly, hiding the tab toolbar every tab-facing helper keys
+     * off. Loops until the tab is in front, dismissing whichever FRE control shows each pass. Called
+     * first by every entry point that touches the tab, and idempotent: a warm Chrome returns at once.
+     */
     fun skipGoogleSignIn() {
-        val continueButton = device.findObject(
-            UiSelector().resourceId("com.android.chrome:id/signin_fre_dismiss_button")
-        )
-        val noButton = device.findObject(
-            UiSelector().resourceId("com.android.chrome:id/negative_button")
-        )
-        val legacyContinueButton = device.findObject(
-            UiSelector().resourceId("com.android.chrome:id/terms_accept")
-        )
+        val deadline = System.currentTimeMillis() + FRE_DISMISS_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
+            if (isCustomTabDisplayed()) {
+                return
+            }
+            if (!dismissOneFreControl()) {
+                // Nothing to dismiss yet; the next FRE page may still be rendering, so re-check.
+                device.waitForIdle(QUICK_CHECK_TIMEOUT_MS)
+            }
+        }
+    }
 
-        repeat(times = RETRY_COUNT) {
-            if (continueButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
-                continueButton.click()
-                return@repeat
-            } else if (legacyContinueButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
-                legacyContinueButton.click()
-                return@repeat
+    /**
+     * Dismisses a single FRE control if one is on screen, returning true if it clicked something.
+     * Decline buttons are tried before accept buttons so the flow advances without a Google sign-in;
+     * each is matched by resource id first, then by its en-locale label (FTL pins `locale=en`).
+     */
+    private fun dismissOneFreControl(): Boolean {
+        val dismissByIdOrText = listOf(
+            "com.android.chrome:id/signin_fre_dismiss_button",
+            "com.android.chrome:id/negative_button",
+        )
+        for (resourceId in dismissByIdOrText) {
+            val button = device.findObject(UiSelector().resourceId(resourceId))
+            if (button.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
+                button.click()
+                return true
+            }
+        }
+        for (label in listOf("Use without an account", "No thanks", "No Thanks")) {
+            val button = device.findObject(UiSelector().textContains(label))
+            if (button.exists()) {
+                button.click()
+                return true
             }
         }
 
-        if (noButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
-            noButton.click()
-            return
+        // The initial UMA/ToS page has no decline option; accepting it is required to advance.
+        val acceptByIdOrText = listOf(
+            "com.android.chrome:id/terms_accept",
+            "com.android.chrome:id/positive_button",
+        )
+        for (resourceId in acceptByIdOrText) {
+            val button = device.findObject(UiSelector().resourceId(resourceId))
+            if (button.waitForExists(QUICK_CHECK_TIMEOUT_MS)) {
+                button.click()
+                return true
+            }
         }
+        for (label in listOf("Accept & continue", "Got it")) {
+            val button = device.findObject(UiSelector().textContains(label))
+            if (button.exists()) {
+                button.click()
+                return true
+            }
+        }
+
+        return false
     }
 
     /**
@@ -209,16 +247,14 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
     }
 
     /**
-     * Waits up to [timeoutMs] for a Chrome Custom Tab to come to the front (detected via its close
-     * button) and returns whether it appeared.
-     *
-     * Unlike [isCustomTabDisplayed] (which uses [QUICK_CHECK_TIMEOUT_MS] for tabs that either show
-     * immediately or not at all), this uses the full [TIMEOUT_MS] window so it can wait out the
-     * asynchronous auth-config fetch that precedes a tab (re)launch under forced advanced
-     * authentication. Best-effort: a `false` return simply means no tab launched within the
-     * window, in which case the caller proceeds as if already on the LoginActivity.
+     * Waits up to [timeoutMs] for the Custom Tab to come to the front, returning whether it did.
+     * Uses the full [TIMEOUT_MS] window (vs [isCustomTabDisplayed]) to wait out the async auth-config
+     * fetch preceding a tab (re)launch. Best-effort: `false` means no tab launched, so the caller
+     * proceeds as if already on the LoginActivity.
      */
     fun waitForCustomTab(timeoutMs: Long = TIMEOUT_MS): Boolean {
+        // Clear the FRE first; until it is gone it covers the tab toolbar (the close button).
+        skipGoogleSignIn()
         val closeButton = device.findObject(
             UiSelector().resourceId("com.android.chrome:id/close_button")
         )

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginOptionsPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginOptionsPageObject.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.espresso.Espresso.closeSoftKeyboard
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.salesforce.androidsdk.R
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection
@@ -45,6 +47,23 @@ import com.salesforce.samples.authflowtester.testUtility.testConfig
  * Page object for the SDK's Login Options screen.
  */
 class LoginOptionsPageObject(composeTestRule: ComposeTestRule): BasePageObject(composeTestRule) {
+
+    private val device by lazy { UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()) }
+
+    /**
+     * Dismisses the Login Options screen with a system back press when there is nothing to Save
+     * (the Save button is what normally calls `activity.finish()`).
+     *
+     * Uses UiAutomator's [UiDevice.pressBack] rather than `Espresso.pressBack()`: dismissing
+     * LoginOptionsActivity re-arms the dev-menu reload, so LoginActivity immediately re-launches the
+     * Chrome Custom Tab (a separate process) and stops itself.  `Espresso.pressBack()` asserts an
+     * app activity is RESUMED afterward and would throw `NoActivityResumedException` ("Pressed back
+     * and killed the app") once the tab is in front; UiAutomator dispatches the key without that
+     * post-condition.
+     */
+    fun dismiss() {
+        device.pressBack()
+    }
 
     fun enableWebServerFlow() = toggleIfOff(
         getString(R.string.sf__login_options_webserver_toggle_content_description)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
@@ -45,8 +45,6 @@ import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.DriverAtoms.webKeys
 import androidx.test.espresso.web.webdriver.Locator
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import com.salesforce.androidsdk.R
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
@@ -57,13 +55,27 @@ internal const val PASSWORD_ID = "password"
 internal const val LOGIN_BUTTON_ID = "Login"
 
 /**
+ * Interval between retries of the dev-support dialog tap in [LoginPageObject.openLoginOptions].
+ * Short enough to re-issue a tap promptly once the dialog's fade-in animation completes.
+ */
+private const val DIALOG_TAP_RETRY_INTERVAL_MS = 250L
+
+/**
  * Page object for the Salesforce login WebView.
  * Uses Espresso WebView APIs since the login form is an in-app WebView
  * embedded via AndroidView in the SDK's LoginActivity Compose layout.
  */
 open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(composeTestRule) {
 
-    private val device by lazy { UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()) }
+    /**
+     * Surfaces the LoginActivity so its Compose top bar can be driven.  For the in-app WebView
+     * login this is a no-op: the WebView is embedded in the LoginActivity, so the top bar is
+     * already in front.  [ChromeCustomTabPageObject] overrides this to back out of the Chrome
+     * Custom Tab that forced advanced authentication launches over the activity.
+     */
+    open fun backOutToLoginActivity() {
+        // No-op: the WebView login is already on the LoginActivity.
+    }
 
     open fun login(knownLoginHostConfig: KnownLoginHostConfig, knownUserConfig: KnownUserConfig) {
         val (username, password) = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
@@ -73,21 +85,6 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
         tapLogin()
         AuthorizationPageObject(composeTestRule).tapAllowAfterLogin(knownLoginHostConfig)
     }
-
-    /**
-     * Returns true when the LoginActivity top bar is currently in front
-     * (detected via the SDK's "More Options" content description). Used by
-     * negative tests to assert the user did not advance past login.
-     */
-    fun isLoginScreenVisible(): Boolean =
-        try {
-            composeTestRule
-                .onAllNodesWithContentDescription(getString(R.string.sf__more_options))
-                .fetchSemanticsNodes()
-                .isNotEmpty()
-        } catch (_: Throwable) {
-            false
-        }
 
     /**
      * Welcome Discovery login: the OAuth `login_hint` already pre-filled the username
@@ -125,20 +122,44 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
             throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for Developer Support dialog to appear", e)
         }
 
-        // Tap "Login Options" in the native AlertDialog (not Compose)
-        onView(withText(getString(R.string.sf__dev_support_login_options_title)))
-            .inRoot(isDialog())
-            .perform(click())
-
-        // Wait for LoginOptionsActivity's Compose content to render.
-        try {
-            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-                composeTestRule.onAllNodesWithContentDescription(
-                    getString(R.string.sf__login_options_dynamic_config_toggle_content_description)
-                ).fetchSemanticsNodes().isNotEmpty()
+        // Tap "Login Options" in the native AlertDialog (not Compose) and wait for
+        // LoginOptionsActivity's Compose content to render.
+        //
+        // The dev-support dialog is shown from a coroutine (SalesforceSDKManager.showDevSupportDialog)
+        // and its window fades in.  On a device with animations enabled (unlike Firebase Test Lab,
+        // which disables them), a single tap issued the instant the dialog view exists can land while
+        // the window opacity is still below Android's anti-tap-jacking threshold, in which case
+        // InputDispatcher silently drops the touch ("Not sending motion ... opacity ... is below the
+        // threshold") and the activity never launches.  Re-issue the tap until the screen renders so a
+        // touch dropped during the fade-in is simply retried once the window is opaque.
+        val deadline = System.currentTimeMillis() + TIMEOUT_MS
+        var rendered = false
+        while (!rendered && System.currentTimeMillis() < deadline) {
+            // Re-issue the tap only while the dialog is still up.  A successful tap dismisses the
+            // dialog, so once it is gone a prior tap landed and we just keep waiting for the render;
+            // tapping a missing dialog would throw NoMatchingRootException.
+            try {
+                onView(withText(getString(R.string.sf__dev_support_login_options_title)))
+                    .inRoot(isDialog())
+                    .perform(click())
+            } catch (_: RuntimeException) {
+                // Dialog no longer present (a prior tap already dismissed it); fall through to wait.
             }
-        } catch (e: ComposeTimeoutException) {
-            throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for Login Options screen to render", e)
+
+            rendered = try {
+                composeTestRule.waitUntil(timeoutMillis = DIALOG_TAP_RETRY_INTERVAL_MS) {
+                    composeTestRule.onAllNodesWithContentDescription(
+                        getString(R.string.sf__login_options_dynamic_config_toggle_content_description)
+                    ).fetchSemanticsNodes().isNotEmpty()
+                }
+                true
+            } catch (_: ComposeTimeoutException) {
+                false
+            }
+        }
+
+        if (!rendered) {
+            throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for Login Options screen to render")
         }
         Thread.sleep(TIMEOUT_MS / 4)
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -31,7 +31,6 @@ import android.content.Intent
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
-import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -40,8 +39,8 @@ import com.salesforce.samples.authflowtester.AuthFlowTesterActivity
 import com.salesforce.samples.authflowtester.pageObjects.AuthFlowTesterPageObject
 import com.salesforce.samples.authflowtester.pageObjects.AuthorizationPageObject
 import com.salesforce.samples.authflowtester.pageObjects.LoginOptionsPageObject
-import com.salesforce.samples.authflowtester.pageObjects.ChromeCustomTabPageObject
 import com.salesforce.samples.authflowtester.pageObjects.LoginPageObject
+import com.salesforce.samples.authflowtester.pageObjects.ChromeCustomTabPageObject
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.EMPTY
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
@@ -86,14 +85,14 @@ abstract class AuthFlowTest {
     val user: KnownUserConfig by lazy {
         val minSdk = InstrumentationRegistry.getInstrumentation().targetContext
             .applicationInfo.minSdkVersion
-        val userNumber = (Build.VERSION.SDK_INT - minSdk) % KnownUserConfig.values().count()
-        KnownUserConfig.values()[userNumber]
+        val userNumber = (Build.VERSION.SDK_INT - minSdk) % KnownUserConfig.entries.toTypedArray().count()
+        KnownUserConfig.entries[userNumber]
     }
 
     // For MultiUser tests
     val otherUser: KnownUserConfig by lazy {
-        val userNumber = (user.ordinal + 1) % KnownUserConfig.values().count()
-        KnownUserConfig.values()[userNumber]
+        val userNumber = (user.ordinal + 1) % KnownUserConfig.entries.toTypedArray().count()
+        KnownUserConfig.entries[userNumber]
     }
 
     @After
@@ -106,27 +105,108 @@ abstract class AuthFlowTest {
                     showLoginPage = false,
                 )
             }
+
+            // Restore the mutable SDK auth options to their defaults.
+            forceAdvancedAuthentication = true
+            useWebServerAuthentication = true
+            useHybridAuthentication = true
+
+            // Reset the selected login server back to REGULAR_AUTH.
+            val regularAuthUrl = testConfig.getLoginHost(REGULAR_AUTH).url
+            loginServerManager.getLoginServerFromURL(regularAuthUrl)?.let { regularAuthServer ->
+                loginServerManager.setSelectedLoginServer(regularAuthServer)
+            }
         }
     }
 
     /**
-     * Ensures we're on REGULAR_AUTH server before opening Login Options.
-     * Server selection is "sticky" so previous test might have left it on ADVANCED_AUTH.
+     * Sets the mutable [SalesforceSDKManager] options that select the login surface.
+     *
+     * Disabling forced advanced authentication is how the User Agent Flow tests reach the in-app
+     * WebView: it is the pre-14.0 behavior the flag now defaults away from.  Both the force flag
+     * and the derived [SalesforceSDKManager.isBrowserLoginEnabled] cache are written because the
+     * latter is only recomputed on a real server change (via `fetchAuthenticationConfiguration`),
+     * not on a same-server WebView reload — see [ensureRegularAuthServer].  [cleanup] restores the
+     * defaults so this never leaks into the forced-advanced-auth majority of tests.
      */
-    private fun ensureRegularAuthServer() {
-        // Close any Chrome Custom Tab that might be open from previous test
-        val chromeTab = ChromeCustomTabPageObject(composeTestRule)
-        if (chromeTab.tapCloseButton()) {
-            Thread.sleep(500)  // Wait for Chrome tab to close
+    private fun setForcedAdvancedAuthEnabled(enabled: Boolean) {
+        with(SalesforceSDKManager.getInstance()) {
+            forceAdvancedAuthentication = enabled
+            isBrowserLoginEnabled = enabled
         }
+    }
 
-        // Switch back to REGULAR_AUTH using LoginServerManager
+    /**
+     * Ensures we're on the REGULAR_AUTH server before driving the login flow.
+     * Server selection is "sticky" so a previous test might have left it on ADVANCED_AUTH.
+     *
+     * The LoginActivity always launches with the default `forceAdvancedAuthentication = true`, so
+     * it auto-launches a Custom Tab over itself.  When we are already on REGULAR_AUTH and
+     * want the Custom Tab, that auto-launched tab is exactly the surface we want and we leave it
+     * untouched.
+     *
+     * We only back out (and dismiss the resulting server picker) when we actually need to change
+     * something: switch off a sticky ADVANCED_AUTH selection, or turn off forced advanced
+     * authentication for the User Agent Flow so the surface reloads as the in-app WebView.  Backing
+     * out also guarantees the launch-time auth-config fetch has completed — the tab only appears
+     * once it resolves — so the browser-login state has settled and can be safely overridden below
+     * without an in-flight fetch clobbering it.
+     *
+     * @param expectCustomTab True for the default forced-advanced-auth (Custom Tab) flows; when a
+     * server switch is needed the REGULAR_AUTH re-selection re-launches the tab and we wait for it.
+     * False for the User Agent Flow cases, which disable forced advanced authentication so the
+     * re-selection loads the in-app WebView instead.
+     */
+    private fun ensureRegularAuthServer(expectCustomTab: Boolean) {
+        val chromePage = ChromeCustomTabPageObject(composeTestRule)
         val regularAuthUrl = testConfig.getLoginHost(REGULAR_AUTH).url
         val loginServerManager = SalesforceSDKManager.getInstance().loginServerManager
+        val alreadyOnRegularAuth =
+            loginServerManager.selectedLoginServer?.url?.trim() == regularAuthUrl.trim()
+
+        if (expectCustomTab && alreadyOnRegularAuth) {
+            // Majority path: forced advanced authentication auto-launched the Custom Tab on the
+            // already-selected REGULAR_AUTH server, so it is exactly the surface we want.  Leave it
+            // in front and let the caller complete login in it; only make sure it has finished
+            // launching (the launch is async, gated on the auth-config fetch) before returning.
+            chromePage.waitForCustomTab()
+            return
+        }
+
+        // We need to change the server and/or the login surface.  Resume the LoginActivity by
+        // backing out of the auto-launched Custom Tab first.
+        chromePage.backOutToLoginActivity()
+
+        if (!expectCustomTab) {
+            // User Agent Flow requires the in-app WebView, which is only used when browser (Custom
+            // Tab) login is disabled.  Turn off forced advanced authentication so the re-selection
+            // below recomputes browser login as disabled, and clear the cached flag directly so a
+            // same-server re-selection (which only reloads the WebView without re-running the
+            // auth-config fetch) also sees it disabled.  Safe here because the back-out above proves
+            // the launch-time fetch has settled.  See LoginViewModel.useWebServerFlow / the
+            // browserCustomTab launch gate.
+            setForcedAdvancedAuthEnabled(false)
+        }
+
+        // Switch to REGULAR_AUTH using LoginServerManager. With the activity resumed this fires the
+        // pending-server observers.  A real server change re-runs the auth-config fetch; a
+        // same-server re-selection (the flag-off case, already on REGULAR_AUTH) just reloads the
+        // login surface — now as the in-app WebView.
         val regularAuthServer = loginServerManager.getLoginServerFromURL(regularAuthUrl)
         if (regularAuthServer != null) {
             loginServerManager.setSelectedLoginServer(regularAuthServer)
-            Thread.sleep(500)  // Wait for server change to take effect
+
+            if (expectCustomTab) {
+                // Reaching here means the server actually changed (a sticky ADVANCED_AUTH
+                // selection).  The re-launch is asynchronous: the SDK first runs an auth-config
+                // network fetch (bounded by a multi-second timeout) and only then generates the
+                // OAuth URL and launches the Custom Tab. Wait for that tab to actually appear rather
+                // than sleeping a fixed interval, so the harness is settled on the REGULAR_AUTH tab
+                // before the caller's next step. (No-op if no tab launches within the window.)
+                chromePage.waitForCustomTab()
+            }
+            // For the WebView path there is nothing to wait for: the WebView page-object actions
+            // retry internally until the reloaded login form is ready.
         }
     }
 
@@ -139,12 +219,21 @@ abstract class AuthFlowTest {
         knownUserConfig: KnownUserConfig = user,
         useWelcomeDiscovery: Boolean = false,
     ) {
-        val loginPage = when(knownLoginHostConfig) {
-            REGULAR_AUTH -> LoginPageObject(composeTestRule)
-            ADVANCED_AUTH -> ChromeCustomTabPageObject(composeTestRule)
-        }
+        // Under the default forced advanced authentication (useWebServerFlow = true) every login
+        // completes in a Custom Tab: a ChromeCustomTabPageObject serves both roles — its
+        // inherited Compose actions (openLoginOptions/changeServer) drive the LoginActivity top bar
+        // after backing out of the tab, and its overridden credential actions drive the tab itself.
+        //
+        // The User Agent Flow (useWebServerFlow = false) cannot run through the Custom Tab — browser
+        // login forces Web Server Flow/PKCE — so those cases disable forced advanced authentication
+        // (see [ensureRegularAuthServer]) and drive the in-app WebView via the base LoginPageObject
+        // instead.  Its backOutToLoginActivity() is a no-op, so the shared flow below is safe either
+        // way.
+        val loginPage: LoginPageObject =
+            if (useWebServerFlow) ChromeCustomTabPageObject(composeTestRule)
+            else LoginPageObject(composeTestRule)
 
-        ensureRegularAuthServer()
+        ensureRegularAuthServer(expectCustomTab = useWebServerFlow)
 
         val needsLoginOptions = !useWebServerFlow || !useHybridAuthToken ||
                 knownAppConfig != CA_OPAQUE || scopeSelection != EMPTY ||
@@ -152,6 +241,10 @@ abstract class AuthFlowTest {
 
         if (needsLoginOptions) {
 
+            // Reach Login Options via the top bar.  For the Custom Tab flow the auto-launched tab
+            // covers the top bar, so back out first; for the WebView flow this is a no-op (the top
+            // bar is already in front).
+            loginPage.backOutToLoginActivity()
             loginPage.openLoginOptions()
 
             if (!useWebServerFlow) {
@@ -175,12 +268,15 @@ abstract class AuthFlowTest {
             }
 
             if (knownAppConfig == CA_OPAQUE && scopeSelection == EMPTY) {
-                // No boot config override needed; nothing to save in that section.
-                Espresso.pressBack()
+                // No boot config override needed; nothing to save in that section, so dismiss with a
+                // system back press (which finishes the activity just like the Save button would).
+                loginOptions.dismiss()
             } else {
                 // setOverrideBootConfig taps Save which calls activity.finish().
                 loginOptions.setOverrideBootConfig(knownAppConfig, scopeSelection)
             }
+            // Dismissing Login Options re-arms the dev-menu reload (loginDevMenuReload), so the
+            // SDK regenerates the OAuth URL and re-launches the Custom Tab on LoginActivity.onResume.
         }
 
         if (useWelcomeDiscovery) {
@@ -190,26 +286,24 @@ abstract class AuthFlowTest {
             // simulated host with the simulated login_hint.  We then complete login with
             // the standard flow (which retypes the username; the pre-fill is exercised
             // server-side via the OAuth login_hint parameter).
-            val webViewLoginPage = LoginPageObject(composeTestRule)
-            webViewLoginPage.changeServerByUrl(WELCOME_DISCOVERY_URL)
-
-            // The simulated host determines the surface: regular_auth -> in-app WebView,
-            // advanced_auth -> Chrome Custom Tab.  In both cases the OAuth login_hint
-            // already pre-filled the username; only the password step remains.
-            val welcomeLoginPage: LoginPageObject = when (knownLoginHostConfig) {
-                REGULAR_AUTH -> webViewLoginPage
-                ADVANCED_AUTH -> {
-                    val chrome = ChromeCustomTabPageObject(composeTestRule)
-                    chrome.skipGoogleSignIn()
-                    chrome
-                }
-            }
-            welcomeLoginPage.welcomeLogin(knownLoginHostConfig, knownUserConfig)
+            //
+            // Changing the server is a top-bar action, so back out of the (re-launched) Custom
+            // Tab first.  Forced advanced authentication then drives the simulated My Domain into
+            // the Custom Tab for both hosts, where only the password step remains.
+            loginPage.backOutToLoginActivity()
+            loginPage.changeServerByUrl(WELCOME_DISCOVERY_URL)
+            loginPage.welcomeLogin(knownLoginHostConfig, knownUserConfig)
         } else {
             if (knownLoginHostConfig != REGULAR_AUTH) {
+                // A non-regular host only occurs on the forced-advanced-auth (Custom Tab) path;
+                // switching servers is a top-bar action, so back out of the tab first.  Selecting
+                // the new server re-launches the Custom Tab on that host.
+                loginPage.backOutToLoginActivity()
                 loginPage.changeServer(knownLoginHostConfig)
             }
 
+            // Credentials are entered on the surface now in front: the Custom Tab for the
+            // forced-advanced-auth flow, or the in-app WebView for the User Agent Flow.
             loginPage.login(knownLoginHostConfig, knownUserConfig)
         }
         app.waitForAppLoad()
@@ -225,24 +319,46 @@ abstract class AuthFlowTest {
     }
 
     /**
-     * Exercises the "Login for Admins" flow: starts on the REGULAR_AUTH server (in-app
-     * WebView), opens the overflow menu, taps "Login for Admins" to launch a Chrome
-     * Custom Tab, completes login in Chrome, and validates the resulting user/tokens.
+     * Exercises the "Login for Admins" flow: starts on the REGULAR_AUTH server, opens the
+     * overflow menu, taps "Login for Admins" to launch a Chrome Custom Tab, completes login in
+     * Chrome, and validates the resulting user/tokens.
+     *
+     * "Login for Admins" always hands off to a Custom Tab built from the cached
+     * [com.salesforce.androidsdk.ui.LoginViewModel.browserCustomTabUrl], which is always the Web
+     * Server Flow/PKCE URL regardless of `useWebServerFlow` — that is the point of the feature: an
+     * org can require a browser-based admin sign-in even when the app itself uses the in-app WebView.
+     *
+     * @param useWebServerFlow True (default) exercises the forced-advanced-auth login surface: the
+     * LoginActivity auto-launches a Custom Tab, so each top-bar action (Login Options, then Login
+     * for Admins) is preceded by a back-out — which `clearWebView` performs while preserving the
+     * cached admin tab URL.  False disables forced advanced authentication so the base login uses
+     * the in-app WebView (with Web Server Flow off); the admin hand-off still launches its Custom
+     * Tab.  The back-outs are no-ops on the WebView path, so both share one code path.
      */
     fun adminLoginAndValidate(useWebServerFlow: Boolean = true) {
-        val loginPage = LoginPageObject(composeTestRule)
+        // The top-bar surface (Login Options / Login for Admins menu) is the Custom Tab for the
+        // default forced-advanced-auth flow, or the in-app WebView when it is disabled.  The admin
+        // hand-off always completes in a Custom Tab.
+        val topBarPage: LoginPageObject =
+            if (useWebServerFlow) ChromeCustomTabPageObject(composeTestRule)
+            else LoginPageObject(composeTestRule)
         val chromePage = ChromeCustomTabPageObject(composeTestRule)
 
-        ensureRegularAuthServer()
+        ensureRegularAuthServer(expectCustomTab = useWebServerFlow)
 
-        loginPage.openLoginOptions()
+        // Reach Login Options via the top bar (back-out is a no-op on the WebView path).
+        topBarPage.backOutToLoginActivity()
+        topBarPage.openLoginOptions()
         if (!useWebServerFlow) {
             loginOptions.disableWebServerFlow()
         }
         loginOptions.setOverrideBootConfig(KnownAppConfig.BEACON_OPAQUE, scopeSelection = EMPTY)
 
-        // Launch the admin custom tab from the WebView login view.
-        loginPage.tapLoginForAdminsMenuItem()
+        // Dismissing Login Options re-launches the Custom Tab on the forced-advanced-auth path;
+        // back out again to reach the overflow menu (no-op on the WebView path), then launch the
+        // dedicated admin custom tab.
+        topBarPage.backOutToLoginActivity()
+        topBarPage.tapLoginForAdminsMenuItem()
 
         // Complete login in Chrome. User credentials are the REGULAR_AUTH server's users
         // since that is the selected login host; the admin flow just swaps the surface
@@ -267,14 +383,18 @@ abstract class AuthFlowTest {
      * Opens Login Options, applies the supplied dynamic boot-config override
      * (arbitrary consumer key, redirect URI, scopes), submits credentials, and
      * expects login to fail. Asserts that no new authenticated user account
-     * was created and the LoginActivity remains in front.
+     * was created and the login flow (Custom Tab) remains in front.
+     *
+     * Under forced advanced authentication credentials are entered in the
+     * Chrome Custom Tab. On failure the OAuth flow never redirects to the
+     * callback URL, so the tab stays in front (showing either the OAuth error
+     * page or the still-unsubmitted login form) and no user is created.
      *
      * Uses bounded polling to confirm the failure: at any point during the
      * wait, if a new user account appears or the AuthFlowTester app loads,
      * the test fails immediately (login should not have succeeded). The
-     * polling window terminates once the LoginActivity remains visible
-     * without a user being created — the steady-state we expect after the
-     * SDK's reloadWebView call.
+     * polling window terminates once the Custom Tab remains in front without a
+     * user being created — the steady-state we expect for a rejected login.
      */
     fun loginAndExpectFailure(
         consumerKey: String,
@@ -282,20 +402,24 @@ abstract class AuthFlowTest {
         scopes: String? = null,
         knownUserConfig: KnownUserConfig = user,
     ) {
-        val loginPage = LoginPageObject(composeTestRule)
-        ensureRegularAuthServer()
+        val loginPage = ChromeCustomTabPageObject(composeTestRule)
+        ensureRegularAuthServer(expectCustomTab = true)
 
         val userAccountManager = SalesforceSDKManager.getInstance().userAccountManager
         val initialUserCount = userAccountManager.authenticatedUsers?.size ?: 0
 
+        // Back out of the auto-launched Custom Tab to reach Login Options, apply the override,
+        // then let the Custom Tab re-launch with the new dynamic config.
+        loginPage.backOutToLoginActivity()
         loginPage.openLoginOptions()
         loginOptions.setOverrideBootConfigRaw(consumerKey, redirectUri, scopes)
 
-        // Submit credentials. Some failure modes (e.g. invalid consumer key)
-        // cause the OAuth /authorize endpoint to render an error page rather
-        // than the username form, in which case the WebView never exposes
-        // the username/password elements and the page-object actions throw.
-        // That is itself a successful failure: the user could not log in.
+        // Submit credentials in the Custom Tab. Some failure modes (e.g. invalid consumer key)
+        // cause the OAuth /authorize endpoint to render an error page rather than the username
+        // form, in which case the tab never exposes the username/password fields and the
+        // page-object actions throw. That is itself a successful failure: the user could not
+        // log in.
+        loginPage.skipGoogleSignIn()
         val (username, password) = testConfig.getUser(REGULAR_AUTH, knownUserConfig)
         try {
             loginPage.setUsername(username)
@@ -303,11 +427,11 @@ abstract class AuthFlowTest {
             loginPage.setPassword(password)
             loginPage.tapLogin()
         } catch (e: AssertionError) {
-            // Verify the failure was due to a missing login form, not a
-            // different test-infrastructure issue. The LoginActivity must
-            // still be in front (otherwise we crashed somewhere unexpected).
-            assert(loginPage.isLoginScreenVisible()) {
-                "WebView page-object action threw outside the LoginActivity: ${e.message}"
+            // Verify the failure was due to a missing login form, not a different
+            // test-infrastructure issue. The Custom Tab must still be in front (otherwise we
+            // crashed somewhere unexpected).
+            assert(loginPage.isCustomTabDisplayed()) {
+                "Custom Tab page-object action threw without the Custom Tab in front: ${e.message}"
             }
         }
 
@@ -324,9 +448,9 @@ abstract class AuthFlowTest {
             Thread.sleep(POLL_INTERVAL_MS)
         }
 
-        // After the polling window, confirm we are still on the login screen.
-        assert(loginPage.isLoginScreenVisible()) {
-            "Expected to remain on the login screen after a failed login"
+        // After the polling window, confirm we are still in the login flow (Custom Tab).
+        assert(loginPage.isCustomTabDisplayed()) {
+            "Expected to remain in the login flow (Custom Tab) after a failed login"
         }
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/main/AndroidManifest.xml
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/AndroidManifest.xml
@@ -52,6 +52,46 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+
+            <!-- Intent filter for advanced authentication with CA Opaque app -->
+            <intent-filter>
+                <data android:scheme="caadvancedopaque"
+                    android:host="success"
+                    android:path="/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <!-- Intent filter for advanced authentication with CA JWT app -->
+            <intent-filter>
+                <data android:scheme="caadvancedjwt"
+                    android:host="success"
+                    android:path="/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <!-- Intent filter for advanced authentication with ECA Opaque app -->
+            <intent-filter>
+                <data android:scheme="ecaadvancedopaque"
+                    android:host="success"
+                    android:path="/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <!-- Intent filter for advanced authentication with ECA JWT app -->
+            <intent-filter>
+                <data android:scheme="ecaadvancedjwt"
+                    android:host="success"
+                    android:path="/done" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
## Summary

Adds a new `forceAdvancedAuthentication` flag on `SalesforceSDKManager` that forces advanced (browser-based / Chrome Custom Tab) authentication for interactive login, regardless of the target server's My Domain auth-configuration — including standard login servers such as `login.salesforce.com`.

- **Flag ON (new default):** Advanced Auth is always used for interactive login. Welcome Discovery (phase 1) and non-My-Domain/standard endpoints behave as described below.
- **Flag OFF:** Legacy behavior — Advanced Auth is used only when the server's My Domain auth-configuration opts into it.

Apps that don't set the flag get the new "force on" default; apps needing the old behavior must explicitly set it OFF. The property is marked `@Deprecated` — it exists to bridge the transition and will be removed in 15.0 when WebView login is removed entirely.

## Changes

- **`SalesforceSDKManager`**: new `@Deprecated` `forceAdvancedAuthentication` property (defaults `true`). Reworked the auth-modality decision in `fetchAuthenticationConfiguration` so the flag overrides the My-Domain *enable* gate while still honoring the server's `shareBrowserSession` value where one exists. Standard login servers skip the auth-config fetch and gate browser login solely on the flag; the Welcome Discovery host and malformed servers are never forced. Added the flag to dev-support info.
- **`LoginOptionsActivity`**: new "Force Advanced Authentication" dev-menu toggle wired to the flag; made the composable's `SalesforceSDKManager` injectable so the Compose preview renders without the singleton.
- **`sf__strings.xml`**: one new string, `sf__login_options_force_advanced_auth_toggle_content_description`.
- **Tests**: new `SalesforceSDKManagerTests` cases covering the flag on/off × My Domain / standard / Welcome Discovery / non-HTTPS matrix; a `LoginViewModelTest` case asserting the custom tab always uses the Web Server flow (PKCE, never `response_type=token`); `LoginOptionsActivityTest` coverage for the new toggle. Also made the dev-menu `getDevActions` tests deterministic (stub the current user instead of depending on device account state).
- **AuthFlowTester**: instrumented-test harness updated so login paths drive the Chrome Custom Tab under the new default, with matching redirect intent filters in the manifest.
