### PR TITLE
[W-23059472] Introduce OAuthErrorCode enum for token endpoint error responses

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -26,8 +26,6 @@
  */
 package com.salesforce.androidsdk.auth;
 
-import static com.salesforce.androidsdk.auth.OAuth2.CLIENT_BLOCKED_RETRY_ERROR;
-
 import android.accounts.AbstractAccountAuthenticator;
 import android.accounts.Account;
 import android.accounts.AccountAuthenticatorResponse;
@@ -155,7 +153,7 @@ public class AuthenticatorService extends Service {
                 SalesforceSDKLogger.i(TAG, "Token endpoint error: (Error: " + ofe.response.error + ", Status Code: " + ofe.httpStatusCode + ")", ofe);
 
                 // Terminal errors (except retriable attestation) redirect to login.
-                if (!CLIENT_BLOCKED_RETRY_ERROR.equals(ofe.response.error) && ofe.isRefreshTokenInvalid()) {
+                if (ofe.response.errorCode != OAuthErrorCode.CLIENT_BLOCKED_RETRY && ofe.isRefreshTokenInvalid()) {
                     return makeAuthIntentBundle(response, options);
                 }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -153,7 +153,7 @@ public class AuthenticatorService extends Service {
                 SalesforceSDKLogger.i(TAG, "Token endpoint error: (Error: " + ofe.response.error + ", Status Code: " + ofe.httpStatusCode + ")", ofe);
 
                 // Terminal errors (except retriable attestation) redirect to login.
-                if (ofe.response.errorCode != OAuthErrorCode.CLIENT_BLOCKED_RETRY && ofe.isRefreshTokenInvalid()) {
+                if (ofe.response.errorCode != OAuthErrorCode.APP_ATTESTATION_FAILED_RETRY && ofe.isRefreshTokenInvalid()) {
                     return makeAuthIntentBundle(response, options);
                 }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -107,12 +107,6 @@ public class OAuth2 {
     public static final String LOGIN_HINT = "login_hint";
     private static final String REFRESH_TOKEN = "refresh_token";  // Grant Type Values
 
-    /** Token endpoint error: device/app permanently blocked by attestation. Triggers logout. */
-    public static final String CLIENT_BLOCKED_ERROR = "client_blocked";
-
-    /** Token endpoint error: attestation could not be verified but may succeed on retry. Does not trigger logout. */
-    public static final String CLIENT_BLOCKED_RETRY_ERROR = "client_blocked_retry";
-
     /**
      *  OAuth 2.0 authorization endpoint request body parameter names:
      *  Salesforce App Attestation External Client App Attestation
@@ -894,6 +888,7 @@ public class OAuth2 {
 
         public String error;
         public String errorDescription;
+        public OAuthErrorCode errorCode;
 
         /**
          * Parameterized constructor built from an error response.
@@ -905,8 +900,10 @@ public class OAuth2 {
                 final JSONObject parsedResponse = (new RestResponse(response)).asJSONObject();
                 error = parsedResponse.getString(ERROR);
                 errorDescription = parsedResponse.getString(ERROR_DESCRIPTION);
+                errorCode = OAuthErrorCode.from(error);
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token error response", e);
+                errorCode = OAuthErrorCode.UNKNOWN;
             }
         }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuthErrorCode.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuthErrorCode.kt
@@ -38,8 +38,8 @@ enum class OAuthErrorCode(val error: String?) {
     APP_NOT_FOUND("app_not_found"),
     AUTHORIZATION_PENDING("authorization_pending"),
     BAD_JTI_CLAIM("bad_jti_claim"),
-    CLIENT_BLOCKED("client_blocked"),
-    CLIENT_BLOCKED_RETRY("client_blocked_retry"),
+    APP_ATTESTATION_FAILED("client_blocked"),
+    APP_ATTESTATION_FAILED_RETRY("client_blocked_retry"),
     ECAPP_POLICY_NOT_FOUND("ecapp_policy_not_found"),
     EXCEEDED_REGISTRATION_LIMIT("exceeded_registration_limit"),
     FAIL_CLOSE_APP_BLOCKED("fail_close_app_blocked"),
@@ -49,6 +49,7 @@ enum class OAuthErrorCode(val error: String?) {
     INVALID_APP_ACCESS("invalid_app_access"),
     INVALID_ASSERTION_TYPE("invalid_assertion_type"),
     INVALID_BASIC_AUTH_HEADER("invalid_basic_auth_header"),
+    INVALID_DPOP_PROOF("invalid_dpop_proof"),
     INVALID_CLIENT("invalid_client"),
     INVALID_CLIENT_ID("invalid_client_id"),
     INVALID_DISTRIBUTION_STATE("invalid_distribution_state"),
@@ -75,6 +76,7 @@ enum class OAuthErrorCode(val error: String?) {
     UNSUPPORTED_GRANT_TYPE("unsupported_grant_type"),
     UNSUPPORTED_RESPONSE_TYPE("unsupported_response_type"),
     UNSUPPORTED_TOKEN_TYPE("unsupported_token_type"),
+    USE_DPOP_NONCE("use_dpop_nonce"),
     UNKNOWN(null),
     ;
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuthErrorCode.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuthErrorCode.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth
+
+/**
+ * Typed representation of the OAuth token endpoint error values defined by the
+ * Salesforce server in OauthErrorCode.java (core/identity-common-api).
+ *
+ * Use [from] to parse the raw `error` string from a token endpoint response.
+ */
+enum class OAuthErrorCode(val error: String?) {
+    ACCESS_DENIED("access_denied"),
+    APP_BLOCKED("app_blocked"),
+    APP_NOT_FOUND("app_not_found"),
+    AUTHORIZATION_PENDING("authorization_pending"),
+    BAD_JTI_CLAIM("bad_jti_claim"),
+    CLIENT_BLOCKED("client_blocked"),
+    CLIENT_BLOCKED_RETRY("client_blocked_retry"),
+    ECAPP_POLICY_NOT_FOUND("ecapp_policy_not_found"),
+    EXCEEDED_REGISTRATION_LIMIT("exceeded_registration_limit"),
+    FAIL_CLOSE_APP_BLOCKED("fail_close_app_blocked"),
+    FAILED_REGISTRATION("failed_registration"),
+    IMMEDIATE_UNSUCCESSFUL("immediate_unsuccessful"),
+    INSTALLATION_ERROR("installation_error"),
+    INVALID_APP_ACCESS("invalid_app_access"),
+    INVALID_ASSERTION_TYPE("invalid_assertion_type"),
+    INVALID_BASIC_AUTH_HEADER("invalid_basic_auth_header"),
+    INVALID_CLIENT("invalid_client"),
+    INVALID_CLIENT_ID("invalid_client_id"),
+    INVALID_DISTRIBUTION_STATE("invalid_distribution_state"),
+    INVALID_EXPID("invalid_expid"),
+    INVALID_GRANT("invalid_grant"),
+    INVALID_OTP("invalid_otp"),
+    INVALID_REQUEST("invalid_request"),
+    INVALID_SCOPE("invalid_scope"),
+    INVALID_SESSION_LEVEL("invalid_session_level"),
+    INVALID_TOKEN("invalid_token"),
+    LOGIN_ERROR("login_error"),
+    OAUTH_FLOW_DISABLED("oauth_flow_disabled"),
+    OAUTH_POLICY_NOT_FOUND("oauth_policy_not_found"),
+    OTP_ERROR("otp_error"),
+    REDIRECT_URI_MISSING("redirect_uri_missing"),
+    REDIRECT_URI_MISMATCH("redirect_uri_mismatch"),
+    REGISTRATION_ERROR("registration_error"),
+    SERVER_ERROR("server_error"),
+    SERVICE_UNAVAILABLE("service_unavailable"),
+    SLOW_DOWN("slow_down"),
+    SYSTEM_DOWN("system_down"),
+    UNKNOWN_ERROR("unknown_error"),
+    UNSUPPORTED_EXPID("unsupported_expid"),
+    UNSUPPORTED_GRANT_TYPE("unsupported_grant_type"),
+    UNSUPPORTED_RESPONSE_TYPE("unsupported_response_type"),
+    UNSUPPORTED_TOKEN_TYPE("unsupported_token_type"),
+    UNKNOWN(null),
+    ;
+
+    companion object {
+        /**
+         * Returns the [OAuthErrorCode] whose [error] string matches [error], or
+         * [UNKNOWN] if the value is null, empty, or not recognized.
+         */
+        @JvmStatic
+        fun from(error: String?): OAuthErrorCode =
+            if (error.isNullOrEmpty()) UNKNOWN
+            else entries.firstOrNull { it.error == error } ?: UNKNOWN
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -26,8 +26,6 @@
  */
 package com.salesforce.androidsdk.rest;
 
-import static com.salesforce.androidsdk.auth.OAuth2.CLIENT_BLOCKED_ERROR;
-import static com.salesforce.androidsdk.auth.OAuth2.CLIENT_BLOCKED_RETRY_ERROR;
 import static com.salesforce.androidsdk.auth.OAuth2.LogoutReason.CLIENT_BLOCKED;
 import static com.salesforce.androidsdk.auth.OAuth2.LogoutReason.REFRESH_TOKEN_EXPIRED;
 import static com.salesforce.androidsdk.auth.OAuth2.refreshAuthToken;
@@ -51,6 +49,7 @@ import com.salesforce.androidsdk.app.Features;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.AuthenticatorService;
 import com.salesforce.androidsdk.auth.HttpAccess;
+import com.salesforce.androidsdk.auth.OAuthErrorCode;
 import com.salesforce.androidsdk.auth.OAuth2;
 import com.salesforce.androidsdk.auth.OAuth2.LogoutReason;
 import com.salesforce.androidsdk.auth.OAuth2.OAuthFailedException;
@@ -646,23 +645,26 @@ public class ClientManager {
                  */
                 final String errorType;
                 final String errorDesc;
+                final OAuthErrorCode errorCode;
                 if (e instanceof OAuthFailedException) {
                     final TokenErrorResponse tokenError = ((OAuthFailedException) e).getTokenErrorResponse();
                     errorType = tokenError.error;
                     errorDesc = tokenError.errorDescription;
+                    errorCode = tokenError.errorCode;
                 } else {
                     errorType = null;
                     errorDesc = null;
+                    errorCode = OAuthErrorCode.UNKNOWN;
                 }
 
-                if (!CLIENT_BLOCKED_RETRY_ERROR.equals(errorType)) {
+                if (errorCode != OAuthErrorCode.CLIENT_BLOCKED_RETRY) {
                     // Terminal error (client_blocked, invalid_grant, malformed token, etc.) — logout.
                     if (clientManager.revokedTokenShouldLogout) {
                         if (Looper.myLooper() == null) {
                             Looper.prepare();
                         }
                         final boolean showLoginPage = accounts.length == 1;
-                        final LogoutReason reason = CLIENT_BLOCKED_ERROR.equals(errorType)
+                        final LogoutReason reason = errorCode == OAuthErrorCode.CLIENT_BLOCKED
                                 ? CLIENT_BLOCKED
                                 : REFRESH_TOKEN_EXPIRED;
                         // Note: As of writing (2024) this call will never succeed because revoke API is an

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -657,14 +657,14 @@ public class ClientManager {
                     errorCode = OAuthErrorCode.UNKNOWN;
                 }
 
-                if (errorCode != OAuthErrorCode.CLIENT_BLOCKED_RETRY) {
+                if (errorCode != OAuthErrorCode.APP_ATTESTATION_FAILED_RETRY) {
                     // Terminal error (client_blocked, invalid_grant, malformed token, etc.) — logout.
                     if (clientManager.revokedTokenShouldLogout) {
                         if (Looper.myLooper() == null) {
                             Looper.prepare();
                         }
                         final boolean showLoginPage = accounts.length == 1;
-                        final LogoutReason reason = errorCode == OAuthErrorCode.CLIENT_BLOCKED
+                        final LogoutReason reason = errorCode == OAuthErrorCode.APP_ATTESTATION_FAILED
                                 ? CLIENT_BLOCKED
                                 : REFRESH_TOKEN_EXPIRED;
                         // Note: As of writing (2024) this call will never succeed because revoke API is an

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -614,8 +614,8 @@ open class LoginActivity : FragmentActivity() {
 
         viewModel.clearCookies()
         val isClientBlocked = e is OAuthFailedException
-            && (e.tokenErrorResponse.errorCode == OAuthErrorCode.CLIENT_BLOCKED
-                || e.tokenErrorResponse.errorCode == OAuthErrorCode.CLIENT_BLOCKED_RETRY)
+            && (e.tokenErrorResponse.errorCode == OAuthErrorCode.APP_ATTESTATION_FAILED
+                || e.tokenErrorResponse.errorCode == OAuthErrorCode.APP_ATTESTATION_FAILED_RETRY)
         val isLightningTokenEndpointFailure = e is OAuthFailedException
             && e.tokenErrorResponse.errorCode == OAuthErrorCode.UNSUPPORTED_GRANT_TYPE
             && viewModel.selectedServer.value?.contains(".lightning.") == true

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -127,8 +127,7 @@ import com.salesforce.androidsdk.app.Features.FEATURE_WELCOME_DISCOVERY_LOGIN
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.app.SalesforceSDKManager.Theme.DARK
 import com.salesforce.androidsdk.auth.HttpAccess
-import com.salesforce.androidsdk.auth.OAuth2.CLIENT_BLOCKED_ERROR
-import com.salesforce.androidsdk.auth.OAuth2.CLIENT_BLOCKED_RETRY_ERROR
+import com.salesforce.androidsdk.auth.OAuthErrorCode
 import com.salesforce.androidsdk.auth.OAuth2.OAuthFailedException
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse
 import com.salesforce.androidsdk.auth.OAuth2.swapJWTForTokens
@@ -615,10 +614,10 @@ open class LoginActivity : FragmentActivity() {
 
         viewModel.clearCookies()
         val isClientBlocked = e is OAuthFailedException
-            && (e.tokenErrorResponse.error == CLIENT_BLOCKED_ERROR
-                || e.tokenErrorResponse.error == CLIENT_BLOCKED_RETRY_ERROR)
+            && (e.tokenErrorResponse.errorCode == OAuthErrorCode.CLIENT_BLOCKED
+                || e.tokenErrorResponse.errorCode == OAuthErrorCode.CLIENT_BLOCKED_RETRY)
         val isLightningTokenEndpointFailure = e is OAuthFailedException
-            && e.tokenErrorResponse.error == "unsupported_grant_type"
+            && e.tokenErrorResponse.errorCode == OAuthErrorCode.UNSUPPORTED_GRANT_TYPE
             && viewModel.selectedServer.value?.contains(".lightning.") == true
         if (isLightningTokenEndpointFailure) {
             w(TAG, "Code exchange failed with unsupported_grant_type against Lightning URL: ${viewModel.selectedServer.value}. Lightning URLs do not support authorization_code grant type. Use a My Domain login server URL instead.")

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelMockTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelMockTest.kt
@@ -35,8 +35,6 @@ import com.salesforce.androidsdk.accounts.UserAccountBuilder
 import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.accounts.UserAccountTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
-import com.salesforce.androidsdk.auth.OAuth2.CLIENT_BLOCKED_ERROR
-import com.salesforce.androidsdk.auth.OAuth2.CLIENT_BLOCKED_RETRY_ERROR
 import com.salesforce.androidsdk.auth.OAuth2.OAuthFailedException
 import com.salesforce.androidsdk.auth.OAuth2.TIMESTAMP_FORMAT
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse
@@ -811,7 +809,7 @@ class LoginViewModelMockTest {
         val spyViewModel = spyk(viewModel)
 
         val tokenErrorResponse = mockk<TokenErrorResponse>(relaxed = true)
-        tokenErrorResponse.error = CLIENT_BLOCKED_ERROR
+        tokenErrorResponse.error = "client_blocked"
         tokenErrorResponse.errorDescription = "App is blocked"
         val oauthException = OAuthFailedException(tokenErrorResponse, 403)
         setupExchangeCodeMock(oauthException)
@@ -830,7 +828,7 @@ class LoginViewModelMockTest {
         val spyViewModel = spyk(viewModel)
 
         val tokenErrorResponse = mockk<TokenErrorResponse>(relaxed = true)
-        tokenErrorResponse.error = CLIENT_BLOCKED_RETRY_ERROR
+        tokenErrorResponse.error = "client_blocked_retry"
         tokenErrorResponse.errorDescription = "App is blocked (retry)"
         val oauthException = OAuthFailedException(tokenErrorResponse, 403)
         setupExchangeCodeMock(oauthException)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuthErrorCodeTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuthErrorCodeTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [OAuthErrorCode].
+ *
+ * These are pure Kotlin enum tests — no Android instrumentation required.
+ */
+class OAuthErrorCodeTest {
+
+    @Test
+    fun test_givenKnownClientBlockedValue_when_from_then_returnsClientBlocked() {
+        val result = OAuthErrorCode.from("client_blocked")
+        assertEquals(OAuthErrorCode.CLIENT_BLOCKED, result)
+    }
+
+    @Test
+    fun test_givenKnownClientBlockedRetryValue_when_from_then_returnsClientBlockedRetry() {
+        val result = OAuthErrorCode.from("client_blocked_retry")
+        assertEquals(OAuthErrorCode.CLIENT_BLOCKED_RETRY, result)
+    }
+
+    @Test
+    fun test_givenUnknownValue_when_from_then_returnsUnknown() {
+        val result = OAuthErrorCode.from("not_a_real_error_code")
+        assertEquals(OAuthErrorCode.UNKNOWN, result)
+    }
+
+    @Test
+    fun test_givenNull_when_from_then_returnsUnknown() {
+        val result = OAuthErrorCode.from(null)
+        assertEquals(OAuthErrorCode.UNKNOWN, result)
+    }
+
+    @Test
+    fun test_givenEmptyString_when_from_then_returnsUnknown() {
+        val result = OAuthErrorCode.from("")
+        assertEquals(OAuthErrorCode.UNKNOWN, result)
+    }
+
+    @Test
+    fun test_givenAllNonUnknownEntries_when_from_then_roundTrips() {
+        OAuthErrorCode.entries
+            .filter { it != OAuthErrorCode.UNKNOWN }
+            .forEach { entry ->
+                val result = OAuthErrorCode.from(entry.error)
+                assertEquals(
+                    "Expected OAuthErrorCode.from(\"${entry.error}\") to return $entry",
+                    entry,
+                    result,
+                )
+            }
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuthErrorCodeTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuthErrorCodeTest.kt
@@ -37,15 +37,15 @@ import org.junit.Test
 class OAuthErrorCodeTest {
 
     @Test
-    fun test_givenKnownClientBlockedValue_when_from_then_returnsClientBlocked() {
+    fun test_givenKnownClientBlockedValue_when_from_then_returnsAppAttestationFailed() {
         val result = OAuthErrorCode.from("client_blocked")
-        assertEquals(OAuthErrorCode.CLIENT_BLOCKED, result)
+        assertEquals(OAuthErrorCode.APP_ATTESTATION_FAILED, result)
     }
 
     @Test
-    fun test_givenKnownClientBlockedRetryValue_when_from_then_returnsClientBlockedRetry() {
+    fun test_givenKnownClientBlockedRetryValue_when_from_then_returnsAppAttestationFailedRetry() {
         val result = OAuthErrorCode.from("client_blocked_retry")
-        assertEquals(OAuthErrorCode.CLIENT_BLOCKED_RETRY, result)
+        assertEquals(OAuthErrorCode.APP_ATTESTATION_FAILED_RETRY, result)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Introduces `OAuthErrorCode.kt` — a typed Kotlin enum mirroring the ~42 distinct wire values from the server-side `OauthErrorCode.java` (core/identity-common-api), plus an `UNKNOWN` fallback
- Adds `errorCode: OAuthErrorCode` field to `OAuth2.TokenErrorResponse`, populated at parse time
- Removes `OAuth2.CLIENT_BLOCKED_ERROR` and `CLIENT_BLOCKED_RETRY_ERROR` string constants (added in dev, not yet shipped — no deprecation needed)
- Updates `LoginActivity.onAuthFlowError()`, `ClientManager`, and `AuthenticatorService` to switch on `errorCode` enum instead of raw string comparisons
- Groundwork for App Attestation error handling (W-22699714)

## Files Changed
- `OAuthErrorCode.kt` (**new**) — 42 enum entries + `UNKNOWN` fallback + `from(String?)` factory
- `OAuth2.java` — `TokenErrorResponse.errorCode` field; remove `CLIENT_BLOCKED_*` constants
- `LoginActivity.kt` — enum-based `isClientBlocked` and `isLightningTokenEndpointFailure`
- `ClientManager.java` — enum-based logout reason logic
- `AuthenticatorService.java` — enum-based retry bypass logic
- `OAuthErrorCodeTest.kt` (**new**) — 5 unit tests (known values, unknown, null, empty, round-trip)
- `LoginViewModelMockTest.kt` — remove removed constant imports, use string literals

## Test Plan
- [x] `./gradlew :libs:SalesforceSDK:assembleDebug` — passes
- [x] `./gradlew :libs:SalesforceSDK:assembleAndroidTest` — passes
- [x] `./gradlew :libs:SalesforceSDK:lintDebug` — passes