### PR TITLE
Moving to SQLCipher 4.17.0

### DIFF
--- a/.claude/skills/update-sqlcipher/SKILL.md
+++ b/.claude/skills/update-sqlcipher/SKILL.md
@@ -178,6 +178,7 @@ When creating the PR:
 
 Recent SQLCipher updates in the project:
 
+- **4.17.0** - SQLite 3.53.3, LibTomCrypt 1.18.2 (2026-07-08)
 - **4.16.0** - SQLite 3.53.1, LibTomCrypt 1.18.2 (2026-05-12)
 - **4.15.0** - Previous version
 - **4.10.0** - Previous version (PR #2744)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ play-integrity = "1.6.0"
 accompanist = "0.37.3"
 
 # SmartStore
-sqlcipher-android = "4.16.0"
+sqlcipher-android = "4.17.0"
 
 # Hybrid / React Native
 cordova-framework = "15.0.0"

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreTest.java
@@ -116,7 +116,7 @@ public class SmartStoreTest extends SmartStoreTestCase {
 	 */
 	@Test
 	public void testSQLCipherVersion() {
-		Assert.assertEquals("Wrong sqlcipher version", "4.16.0 community", store.getSQLCipherVersion());
+		Assert.assertEquals("Wrong sqlcipher version", "4.17.0 community", store.getSQLCipherVersion());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Bumps `net.zetetic:sqlcipher-android` from 4.16.0 to 4.17.0
- Updates `testSQLCipherVersion` assertion to `"4.17.0 community"`
- LibTomCrypt provider version unchanged at 1.18.2
- SQLite version bumped from 3.53.1 to 3.53.3

## Release notes
https://www.zetetic.net/blog/2026/07/08/sqlcipher-4.17.0-release/

Key changes in 4.17.0:
- SQLite 3.53.3 (fixes two FTS5 memory corruption CVEs: CVE-2026-11822, CVE-2026-11824)
- No breaking API changes
- Improved thread safety and error handling in LibTomCrypt provider

## GUS
W-23369878

## Test plan
- [ ] CI: SmartStore connected tests pass
- [ ] `testSQLCipherVersion` passes with `"4.17.0 community"`
- [ ] `testCipherProviderVersion` passes with `"1.18.2"`
- [ ] `testCipherFIPSStatus` returns false