### PR TITLE
Fix KeyValueStoreInspectorActivityTest and SmartStoreInspectorActivityTest

### DIFF
--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/KeyValueStoreInspectorActivityTest.java
@@ -37,6 +37,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.hamcrest.CoreMatchers.allOf;
 
+import android.Manifest;
+import android.os.Build;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 
@@ -44,6 +46,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.matcher.RootMatchers;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
+import androidx.test.rule.GrantPermissionRule;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -57,6 +60,7 @@ import com.salesforce.androidsdk.smartstore.ui.KeyValueStoreInspectorActivity;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -77,6 +81,12 @@ public class KeyValueStoreInspectorActivityTest {
     private final String VALUE_2 = "this is a different value in ";
     private final String VALUE_3 = "this is a third value in ";
     private final String GLOBAL_STORE_TEXT = KeyValueStoreInspectorActivity.GLOBAL_STORE;
+
+    // Pre-grant POST_NOTIFICATIONS so the permission dialog doesn't steal focus from the activity
+    @Rule
+    public GrantPermissionRule permissionRule = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+            ? GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
+            : GrantPermissionRule.grant();
 
     public ActivityScenario<KeyValueStoreInspectorActivity> activityScenario;
     public KeyValueStoreInspectorActivity keyValueStoreInspectorActivity;

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreInspectorActivityTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartStoreInspectorActivityTest.java
@@ -33,7 +33,9 @@ import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 
+import android.Manifest;
 import android.content.Context;
+import android.os.Build;
 import android.widget.ListAdapter;
 import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
@@ -42,6 +44,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.MediumTest;
 import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.GrantPermissionRule;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiObjectNotFoundException;
@@ -59,6 +62,7 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -80,6 +84,12 @@ public class SmartStoreInspectorActivityTest {
 
 	private Context targetContext;
 	private SmartStore store;
+
+	// Pre-grant POST_NOTIFICATIONS so the permission dialog doesn't steal focus from the activity
+	@Rule
+	public GrantPermissionRule permissionRule = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+			? GrantPermissionRule.grant(Manifest.permission.POST_NOTIFICATIONS)
+			: GrantPermissionRule.grant();
 
 	public ActivityScenario<SmartStoreInspectorActivity> activityScenario;
 	public SmartStoreInspectorActivity smartStoreInspectorActivity;


### PR DESCRIPTION
## Problem

`KeyValueStoreInspectorActivityTest` and `SmartStoreInspectorActivityTest` were failing with:

```
androidx.test.espresso.NoActivityResumedException: No activities in stage RESUMED
```

`ShowDeveloperSupportNotifier` requests `POST_NOTIFICATIONS` at runtime when the inspector activities launch. On Android 13+ (API 33) this causes `GrantPermissionsActivity` to push on top of the stack and steal window focus before Espresso can interact with any views.

## Fix

Add a `GrantPermissionRule` to pre-grant `POST_NOTIFICATIONS` before the activity launches — the same pattern already used by `DevInfoActivityTest`, `LoginViewActivityTest`, `PickerBottomSheetActivityTest`, etc. in `SalesforceSDKTest`.

## Test results

- `KeyValueStoreInspectorActivityTest`: 11/11 passed ✅
- `SmartStoreInspectorActivityTest`: 10/10 passed ✅