### PR TITLE
@W-23431930: [Android] Update sf__app_blocked_error string to reference Salesforce admin

### DIFF
--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -11,7 +11,7 @@
     <string name="sf__managed_app_error">Authentication only allowed from managed device.</string>
     <string name="sf__jwt_authentication_error">JWT authentication error. Please try again.</string>
     <string name="sf__lightning_url_code_exchange_error">Lightning URLs are not supported for OAuth code exchange. Use your My Domain URL instead.</string>
-    <string name="sf__app_blocked_error">This app could not be verified. Contact support.</string>
+    <string name="sf__app_blocked_error">The app couldn\'t be verified. Contact your Salesforce admin.</string>
 
     <!-- SSL errors -->
     <string name="sf__ssl_error">SSL error: %s.</string>


### PR DESCRIPTION
## Summary
Updates the user-facing localized string `sf__app_blocked_error` to direct users to their Salesforce admin instead of generic support.

**Before:** `This app could not be verified. Contact support.`
**After:** `The app couldn't be verified. Contact your Salesforce admin.`

This string is displayed as a toast in `LoginActivity.onAuthFlowError()` when OAuth code exchange fails with a client-blocked error (APP_ATTESTATION_FAILED / APP_ATTESTATION_FAILED_RETRY).

## ⚠️ Localization callout (human review required)
- This changes an `sf__` string in `libs/SalesforceSDK/res/values/sf__strings.xml`. Per repo CLAUDE.md, `sf__` string changes require human review.
- The string exists **only** in the base `values/` locale — there are no translated copies to update.
- The apostrophe is backslash-escaped (`couldn\'t`) as required by the Android resource compiler; it renders as a straight ASCII apostrophe at runtime.

## Platform consistency
The app-attestation / client-blocked flow is **Android-only**; the iOS SDK has no equivalent string, so no iOS counterpart PR is needed.

## Test plan
- [x] `:libs:SalesforceSDK:assembleDebug` builds successfully with the escaped apostrophe.
- No test asserts the literal toast text (the flow has no such coverage today), so none required updating.

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*
