### PR TITLE
Enforce app-specific account types

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -1424,13 +1424,11 @@ open class SalesforceSDKManager protected constructor(
     /** The authentication account type, which should match authenticator.xml */
     val accountType: String by lazy {
         val type = appContext.getString(account_type)
-        if (type == "com.salesforce.androidsdk") {
-            // TODO: Turn this logline into an assert in 14.0
-            e(TAG, "No app specific account type found.  To ensure users " +
-                    "can login override the \"account_type\" value in your strings.xml.")
+        check(type != "com.salesforce.androidsdk") {
+            "No app specific account type found. To ensure users can log in, " +
+                    "override the \"account_type\" value in your strings.xml."
         }
-
-        return@lazy type
+        type
     }
 
     override fun toString() =

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerAccountTypeTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/SalesforceSDKManagerAccountTypeTest.kt
@@ -1,0 +1,48 @@
+package com.salesforce.androidsdk.app
+
+import android.app.Activity
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.salesforce.androidsdk.R
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class SalesforceSDKManagerAccountTypeTest {
+
+    @Test
+    fun accountTypeThrowsWhenAppUsesLegacyValue() {
+        val manager = createManager(LEGACY_ACCOUNT_TYPE)
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            manager.accountType
+        }
+
+        assertEquals(
+            "No app specific account type found. To ensure users can log in, " +
+                    "override the \"account_type\" value in your strings.xml.",
+            exception.message,
+        )
+    }
+
+    @Test
+    fun accountTypeReturnsAppSpecificValue() {
+        val accountType = "com.example.app.login"
+        val manager = createManager(accountType)
+
+        assertEquals(accountType, manager.accountType)
+    }
+
+    private fun createManager(accountType: String): SalesforceSDKManager {
+        val context = mockk<Context>(relaxed = true) {
+            every { getString(R.string.account_type) } returns accountType
+        }
+        return SalesforceSDKManager(context, Activity::class.java)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the legacy account type error log with an enforced state check
- fail with actionable guidance when an app does not override account_type
- add instrumentation coverage for legacy and app-specific values

## Testing
- ./gradlew :libs:SalesforceSDK:compileDebugAndroidTestKotlin
- focused SalesforceSDKManagerAccountTypeTest on Pixel 8 Pro API 35 emulator

## Work Item
- W-19388464