### PR TITLE
fix(ManageSpaceActivity): call clearApplicationUserData() after logout

### DIFF
--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -2,23 +2,20 @@
 
 This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
 
-For cross-platform concepts and the shared Salesforce registration model, see the [workspace-level push doc](../../../docs/push/README.md).
-
 ---
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
-3. [Setup](#setup)
-4. [Architecture](#architecture)
-5. [Key Classes](#key-classes)
-6. [Registration Lifecycle](#registration-lifecycle)
-7. [Re-registration Modes](#re-registration-modes)
-8. [Foreground Registration Mode](#foreground-registration-mode)
-9. [Encrypted Push Notifications](#encrypted-push-notifications)
-10. [Actionable Notifications](#actionable-notifications)
-11. [Testing](#testing)
+3. [Architecture](#architecture)
+4. [Key Classes](#key-classes)
+5. [Registration Lifecycle](#registration-lifecycle)
+6. [Re-registration Modes](#re-registration-modes)
+7. [Foreground Registration Mode](#foreground-registration-mode)
+8. [Encrypted Push Notifications](#encrypted-push-notifications)
+9. [Actionable Notifications](#actionable-notifications)
+10. [Testing](#testing)
 
 ---
 
@@ -35,71 +32,7 @@ The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications 
 | `google-services.json` | Place in your app module root; required for FCM token acquisition |
 | `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
 | `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
-| `POST_NOTIFICATIONS` permission | Required for Android 13+ (API 33+); declare in manifest and request at runtime |
 | External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
-
----
-
-## Setup
-
-### 1. Add google-services.json
-
-Download `google-services.json` from the [Firebase Console](https://console.firebase.google.com/) and place it in your app module directory (e.g. `app/`).
-
-### 2. Apply the Google Services Gradle Plugin
-
-**`build.gradle.kts`** (project level):
-```kotlin
-buildscript {
-    dependencies {
-        classpath("com.google.gms:google-services:4.4.2")
-    }
-}
-```
-
-**`app/build.gradle.kts`** (app level):
-```kotlin
-plugins {
-    id("com.google.gms.google-services")
-}
-```
-
-### 3. Declare POST_NOTIFICATIONS Permission (Android 13+)
-
-**`AndroidManifest.xml`**:
-```xml
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-```
-
-Request the permission at runtime in your `Activity` or `MainActivity`:
-```kotlin
-if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-    checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
-        != PackageManager.PERMISSION_GRANTED) {
-    requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), requestCode)
-}
-```
-
-### 4. Implement PushNotificationInterface
-
-In your `Application.onCreate()` after `SalesforceSDKManager` is initialized:
-
-```kotlin
-// Native Android apps
-SalesforceSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface {
-        override fun onPushMessageReceived(data: Map<String?, String?>?) {
-            // Handle the notification. The SDK has already decrypted any encrypted payload.
-        }
-        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
-    }
-
-// React Native apps — use SalesforceReactSDKManager instead
-SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface { /* ... */ }
-```
-
-That is all. `SFDCFcmListenerService` (declared in the SDK's own `AndroidManifest.xml`) handles FCM token acquisition, Salesforce device registration, decryption, and re-registration automatically.
 
 ---
 
@@ -250,113 +183,13 @@ Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
 Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
 
 ```kotlin
-@Serializable
-data class SalesforceActionableNotificationContent(val sfdc: Sfdc?) {
-    companion object {
-        fun fromJson(json: String): SalesforceActionableNotificationContent
-    }
-
-    @Serializable
-    data class Sfdc(
-        val notifType: String? = null,
-        val nid: String? = null,          // notification ID (use for invokeServerNotificationAction)
-        val oid: String? = null,          // org ID
-        val type: Int? = null,
-        val alertTitle: String? = null,
-        val alertBody: String? = null,
-        val alert: String? = null,
-        val sid: String? = null,
-        val rid: String? = null,
-        val targetPageRef: String? = null,
-        val badge: Int? = null,
-        val uid: String? = null,
-        val cid: String? = null,
-        val timestamp: Int? = null,
-        val act: Act? = null              // actionable action descriptor
-    )
-}
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
 ```
 
-Parse from the `content` key of the received `data` map:
+Parse from the `content` field of a received notification:
 ```kotlin
-override fun onPushMessageReceived(data: Map<String?, String?>?) {
-    val json = data?.get("sfdc.content") ?: data?.get("content") ?: return
-    val notification = SalesforceActionableNotificationContent.fromJson(json)
-    val notificationId = notification.sfdc?.nid
-    // use notificationId with SalesforceSDKManager.invokeServerNotificationAction(...)
-}
+val content = SalesforceActionableNotificationContent.fromJson(jsonString)
 ```
-
----
-
-### `NotificationsApiClient`
-
-REST client for the Salesforce Notifications API (requires API v64.0+).
-
-```kotlin
-class NotificationsApiClient(private val restClient: RestClient) {
-    fun fetchNotificationsTypes(): NotificationsTypesResponseBody?
-    fun submitNotificationAction(notificationId: String, actionKey: String): NotificationsActionsResponseBody?
-}
-```
-
-Use via `SalesforceSDKManager`:
-```kotlin
-// Fetch stored notification types (populated automatically after registration)
-val type = SalesforceSDKManager.getInstance().getNotificationsType("approval_request")
-
-// Invoke a server-side notification action
-SalesforceSDKManager.getInstance().invokeServerNotificationAction(
-    notificationId = nid,
-    actionKey = actionIdentifier,
-    restClient = restClient
-)
-```
-
----
-
-### `PushService` Subclassing
-
-To customize the registration payload or react to status changes, subclass `PushService`:
-
-```kotlin
-class MyPushService : PushService() {
-    override fun onPushNotificationRegistrationStatus(status: Int, userAccount: UserAccount?) {
-        when (status) {
-            REGISTRATION_STATUS_SUCCEEDED -> { /* analytics, logging */ }
-            REGISTRATION_STATUS_FAILED    -> { /* alert / retry logic */ }
-        }
-    }
-
-    override fun onSendRegisterPushNotificationRequest(
-        requestBodyJsonFields: Map<String, Any?>?,
-        restClient: RestClient
-    ): RestResponse {
-        // Modify requestBodyJsonFields before posting, then call super
-        return super.onSendRegisterPushNotificationRequest(requestBodyJsonFields, restClient)
-    }
-}
-
-// Register:
-SalesforceSDKManager.getInstance().pushServiceType = MyPushService::class.java
-```
-
----
-
-### React Native Apps
-
-For React Native apps, the setup is identical to the native Android setup above, with one substitution: use `SalesforceReactSDKManager.getInstance()` in place of `SalesforceSDKManager.getInstance()`:
-
-```kotlin
-// In MainApplication.onCreate(), after SalesforceReactSDKManager.initReactNative(...)
-SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface {
-        override fun onPushMessageReceived(data: Map<String?, String?>?) { /* ... */ }
-        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
-    }
-```
-
-There is no JavaScript push bridge — the `react-native-force` package does not export a push module. See [`SalesforceMobileSDK-ReactNative/docs/push/README.md`](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/tree/dev/docs/push) for guidance on forwarding push payloads to the JavaScript layer via a custom event emitter.
 
 ---
 
@@ -449,39 +282,14 @@ No app-side configuration is required beyond normal SDK setup.
 
 ---
 
-## Actionable Notifications
-
-Requires Salesforce API version **v64.0 or later**.
-
-After successful device registration, the SDK automatically fetches notification types from `GET /vXX.0/connect/notifications/types` and stores them per user. It also creates Android `NotificationChannel` objects for each Salesforce notification type via `PushService.registerNotificationChannels(...)`.
-
-To invoke a server-side action when the user taps a notification button:
-
-```kotlin
-override fun onPushMessageReceived(data: Map<String?, String?>?) {
-    val json = data?.get("sfdc.content") ?: return
-    val content = SalesforceActionableNotificationContent.fromJson(json)
-    val nid = content.sfdc?.nid ?: return
-    // When user taps an action:
-    SalesforceSDKManager.getInstance().invokeServerNotificationAction(
-        notificationId = nid,
-        actionKey = "your_action_key",
-        restClient = SalesforceSDKManager.getInstance().clientManager.peekRestClient()
-    )
-}
-```
-
----
-
 ## Testing
 
-Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/`:
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
 
 | Test class | Coverage |
 |---|---|
-| `push/PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
-| `push/PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
-| `push/PushNotificationsRegistrationChangeWorkerTest` | WorkManager worker account-resolution logic, legacy pre-14.0 payload migration |
+| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
 
 Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
 

--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -2,20 +2,23 @@
 
 This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
 
+For cross-platform concepts and the shared Salesforce registration model, see the [workspace-level push doc](../../../docs/push/README.md).
+
 ---
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
-3. [Architecture](#architecture)
-4. [Key Classes](#key-classes)
-5. [Registration Lifecycle](#registration-lifecycle)
-6. [Re-registration Modes](#re-registration-modes)
-7. [Foreground Registration Mode](#foreground-registration-mode)
-8. [Encrypted Push Notifications](#encrypted-push-notifications)
-9. [Actionable Notifications](#actionable-notifications)
-10. [Testing](#testing)
+3. [Setup](#setup)
+4. [Architecture](#architecture)
+5. [Key Classes](#key-classes)
+6. [Registration Lifecycle](#registration-lifecycle)
+7. [Re-registration Modes](#re-registration-modes)
+8. [Foreground Registration Mode](#foreground-registration-mode)
+9. [Encrypted Push Notifications](#encrypted-push-notifications)
+10. [Actionable Notifications](#actionable-notifications)
+11. [Testing](#testing)
 
 ---
 
@@ -32,7 +35,71 @@ The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications 
 | `google-services.json` | Place in your app module root; required for FCM token acquisition |
 | `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
 | `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
+| `POST_NOTIFICATIONS` permission | Required for Android 13+ (API 33+); declare in manifest and request at runtime |
 | External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
+
+---
+
+## Setup
+
+### 1. Add google-services.json
+
+Download `google-services.json` from the [Firebase Console](https://console.firebase.google.com/) and place it in your app module directory (e.g. `app/`).
+
+### 2. Apply the Google Services Gradle Plugin
+
+**`build.gradle.kts`** (project level):
+```kotlin
+buildscript {
+    dependencies {
+        classpath("com.google.gms:google-services:4.4.2")
+    }
+}
+```
+
+**`app/build.gradle.kts`** (app level):
+```kotlin
+plugins {
+    id("com.google.gms.google-services")
+}
+```
+
+### 3. Declare POST_NOTIFICATIONS Permission (Android 13+)
+
+**`AndroidManifest.xml`**:
+```xml
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+```
+
+Request the permission at runtime in your `Activity` or `MainActivity`:
+```kotlin
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+    checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
+        != PackageManager.PERMISSION_GRANTED) {
+    requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), requestCode)
+}
+```
+
+### 4. Implement PushNotificationInterface
+
+In your `Application.onCreate()` after `SalesforceSDKManager` is initialized:
+
+```kotlin
+// Native Android apps
+SalesforceSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface {
+        override fun onPushMessageReceived(data: Map<String?, String?>?) {
+            // Handle the notification. The SDK has already decrypted any encrypted payload.
+        }
+        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
+    }
+
+// React Native apps — use SalesforceReactSDKManager instead
+SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface { /* ... */ }
+```
+
+That is all. `SFDCFcmListenerService` (declared in the SDK's own `AndroidManifest.xml`) handles FCM token acquisition, Salesforce device registration, decryption, and re-registration automatically.
 
 ---
 
@@ -183,13 +250,113 @@ Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
 Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
 
 ```kotlin
-data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
+@Serializable
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?) {
+    companion object {
+        fun fromJson(json: String): SalesforceActionableNotificationContent
+    }
+
+    @Serializable
+    data class Sfdc(
+        val notifType: String? = null,
+        val nid: String? = null,          // notification ID (use for invokeServerNotificationAction)
+        val oid: String? = null,          // org ID
+        val type: Int? = null,
+        val alertTitle: String? = null,
+        val alertBody: String? = null,
+        val alert: String? = null,
+        val sid: String? = null,
+        val rid: String? = null,
+        val targetPageRef: String? = null,
+        val badge: Int? = null,
+        val uid: String? = null,
+        val cid: String? = null,
+        val timestamp: Int? = null,
+        val act: Act? = null              // actionable action descriptor
+    )
+}
 ```
 
-Parse from the `content` field of a received notification:
+Parse from the `content` key of the received `data` map:
 ```kotlin
-val content = SalesforceActionableNotificationContent.fromJson(jsonString)
+override fun onPushMessageReceived(data: Map<String?, String?>?) {
+    val json = data?.get("sfdc.content") ?: data?.get("content") ?: return
+    val notification = SalesforceActionableNotificationContent.fromJson(json)
+    val notificationId = notification.sfdc?.nid
+    // use notificationId with SalesforceSDKManager.invokeServerNotificationAction(...)
+}
 ```
+
+---
+
+### `NotificationsApiClient`
+
+REST client for the Salesforce Notifications API (requires API v64.0+).
+
+```kotlin
+class NotificationsApiClient(private val restClient: RestClient) {
+    fun fetchNotificationsTypes(): NotificationsTypesResponseBody?
+    fun submitNotificationAction(notificationId: String, actionKey: String): NotificationsActionsResponseBody?
+}
+```
+
+Use via `SalesforceSDKManager`:
+```kotlin
+// Fetch stored notification types (populated automatically after registration)
+val type = SalesforceSDKManager.getInstance().getNotificationsType("approval_request")
+
+// Invoke a server-side notification action
+SalesforceSDKManager.getInstance().invokeServerNotificationAction(
+    notificationId = nid,
+    actionKey = actionIdentifier,
+    restClient = restClient
+)
+```
+
+---
+
+### `PushService` Subclassing
+
+To customize the registration payload or react to status changes, subclass `PushService`:
+
+```kotlin
+class MyPushService : PushService() {
+    override fun onPushNotificationRegistrationStatus(status: Int, userAccount: UserAccount?) {
+        when (status) {
+            REGISTRATION_STATUS_SUCCEEDED -> { /* analytics, logging */ }
+            REGISTRATION_STATUS_FAILED    -> { /* alert / retry logic */ }
+        }
+    }
+
+    override fun onSendRegisterPushNotificationRequest(
+        requestBodyJsonFields: Map<String, Any?>?,
+        restClient: RestClient
+    ): RestResponse {
+        // Modify requestBodyJsonFields before posting, then call super
+        return super.onSendRegisterPushNotificationRequest(requestBodyJsonFields, restClient)
+    }
+}
+
+// Register:
+SalesforceSDKManager.getInstance().pushServiceType = MyPushService::class.java
+```
+
+---
+
+### React Native Apps
+
+For React Native apps, the setup is identical to the native Android setup above, with one substitution: use `SalesforceReactSDKManager.getInstance()` in place of `SalesforceSDKManager.getInstance()`:
+
+```kotlin
+// In MainApplication.onCreate(), after SalesforceReactSDKManager.initReactNative(...)
+SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface {
+        override fun onPushMessageReceived(data: Map<String?, String?>?) { /* ... */ }
+        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
+    }
+```
+
+There is no JavaScript push bridge — the `react-native-force` package does not export a push module. See [`SalesforceMobileSDK-ReactNative/docs/push/README.md`](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/tree/dev/docs/push) for guidance on forwarding push payloads to the JavaScript layer via a custom event emitter.
 
 ---
 
@@ -282,14 +449,39 @@ No app-side configuration is required beyond normal SDK setup.
 
 ---
 
+## Actionable Notifications
+
+Requires Salesforce API version **v64.0 or later**.
+
+After successful device registration, the SDK automatically fetches notification types from `GET /vXX.0/connect/notifications/types` and stores them per user. It also creates Android `NotificationChannel` objects for each Salesforce notification type via `PushService.registerNotificationChannels(...)`.
+
+To invoke a server-side action when the user taps a notification button:
+
+```kotlin
+override fun onPushMessageReceived(data: Map<String?, String?>?) {
+    val json = data?.get("sfdc.content") ?: return
+    val content = SalesforceActionableNotificationContent.fromJson(json)
+    val nid = content.sfdc?.nid ?: return
+    // When user taps an action:
+    SalesforceSDKManager.getInstance().invokeServerNotificationAction(
+        notificationId = nid,
+        actionKey = "your_action_key",
+        restClient = SalesforceSDKManager.getInstance().clientManager.peekRestClient()
+    )
+}
+```
+
+---
+
 ## Testing
 
-Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/`:
 
 | Test class | Coverage |
 |---|---|
-| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
-| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+| `push/PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `push/PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+| `push/PushNotificationsRegistrationChangeWorkerTest` | WorkManager worker account-resolution logic, legacy pre-14.0 payload migration |
 
 Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.kt
@@ -103,6 +103,7 @@ open class ManageSpaceActivity : ComponentActivity() {
                     showLoginPage = false,
                     reason = USER_LOGOUT
                 )
+                clearApplicationUserData()
             },
             titleText = stringResource(sf__manage_space_title),
             textText = stringResource(sf__manage_space_confirmation),

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.kt
@@ -27,8 +27,6 @@
 package com.salesforce.androidsdk.ui
 
 import android.annotation.SuppressLint
-import android.app.ActivityManager
-import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -55,6 +53,7 @@ import com.salesforce.androidsdk.R.string.sf__manage_space_confirmation
 import com.salesforce.androidsdk.R.string.sf__manage_space_logout_no
 import com.salesforce.androidsdk.R.string.sf__manage_space_logout_yes
 import com.salesforce.androidsdk.R.string.sf__manage_space_title
+import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.app.SalesforceSDKManager.Companion.getInstance
 import com.salesforce.androidsdk.auth.OAuth2.LogoutReason.USER_LOGOUT
 
@@ -99,13 +98,13 @@ open class ManageSpaceActivity : ComponentActivity() {
                 finish()
             },
             onConfirm = {
-                getInstance().logout(
-                    account = null,
-                    frontActivity = this@ManageSpaceActivity,
-                    showLoginPage = false,
-                    reason = USER_LOGOUT
+                val sdkManager = getInstance()
+                logoutAllUsersAndClearData(
+                    authenticatedUsers = sdkManager.userAccountManager.authenticatedUsers,
+                    signoutUser = { user -> sdkManager.userAccountManager.signoutUser(user, this@ManageSpaceActivity, false, USER_LOGOUT) },
+                    fallbackLogout = { sdkManager.logout(account = null, frontActivity = this@ManageSpaceActivity, showLoginPage = false, reason = USER_LOGOUT) },
+                    clearData = { clearApplicationUserData() }
                 )
-                (getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager).clearApplicationUserData()
             },
             titleText = stringResource(sf__manage_space_title),
             textText = stringResource(sf__manage_space_confirmation),
@@ -176,4 +175,37 @@ open class ManageSpaceActivity : ComponentActivity() {
                 }
             })
     }
+
+    // Extracted to allow overriding in tests — clearApplicationUserData() kills the process.
+    open fun clearApplicationUserData() {
+        (getSystemService(android.content.Context.ACTIVITY_SERVICE) as android.app.ActivityManager)
+            .clearApplicationUserData()
+    }
+}
+
+/**
+ * Logs out all authenticated users and then calls [clearData].
+ *
+ * Extracted as a top-level function so it can be unit-tested without launching the full
+ * Activity (Activity constructors require a Looper) or mocking framework singletons.
+ * All side effects are injected as lambdas.
+ *
+ * @param authenticatedUsers the currently logged-in accounts, or null/empty if none
+ * @param signoutUser called once per user to perform SDK-level per-account logout
+ * @param fallbackLogout called when [authenticatedUsers] is null/empty — handles the
+ *   fresh-install or already-logged-out edge case via the standard SDK logout path
+ * @param clearData called last to wipe all app storage (normally [ManageSpaceActivity.clearApplicationUserData])
+ */
+internal fun logoutAllUsersAndClearData(
+    authenticatedUsers: List<UserAccount>?,
+    signoutUser: (UserAccount) -> Unit,
+    fallbackLogout: () -> Unit,
+    clearData: () -> Unit,
+) {
+    if (authenticatedUsers.isNullOrEmpty()) {
+        fallbackLogout()
+    } else {
+        authenticatedUsers.forEach { user -> signoutUser(user) }
+    }
+    clearData()
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/ManageSpaceActivity.kt
@@ -27,6 +27,8 @@
 package com.salesforce.androidsdk.ui
 
 import android.annotation.SuppressLint
+import android.app.ActivityManager
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -103,7 +105,7 @@ open class ManageSpaceActivity : ComponentActivity() {
                     showLoginPage = false,
                     reason = USER_LOGOUT
                 )
-                clearApplicationUserData()
+                (getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager).clearApplicationUserData()
             },
             titleText = stringResource(sf__manage_space_title),
             textText = stringResource(sf__manage_space_confirmation),

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/ManageSpaceActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/ManageSpaceActivityTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.ui
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.salesforce.androidsdk.accounts.UserAccount
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Tests for [logoutAllUsersAndClearData].
+ *
+ * All dependencies are passed as lambdas, so no Android framework objects or
+ * SDK singletons need to be mocked — the tests run in the instrumentation
+ * process without launching any Activity.
+ */
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class ManageSpaceActivityTest {
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun test_givenSingleUser_whenConfirm_thenSignoutCalledOnceAndClearDataCalled() {
+        val user = createUser("user1")
+        val signedOut = mutableListOf<UserAccount>()
+        var fallbackCalled = false
+        var clearDataCalled = false
+
+        logoutAllUsersAndClearData(
+            authenticatedUsers = listOf(user),
+            signoutUser = { signedOut.add(it) },
+            fallbackLogout = { fallbackCalled = true },
+            clearData = { clearDataCalled = true },
+        )
+
+        assertEquals("signoutUser must be called exactly once", listOf(user), signedOut)
+        assertTrue("clearApplicationUserData must be called", clearDataCalled)
+        assertTrue("fallback logout must not be called with a known user", !fallbackCalled)
+    }
+
+    @Test
+    fun test_givenMultipleUsers_whenConfirm_thenSignoutCalledForEachUserAndClearDataCalled() {
+        val users = listOf(createUser("user1"), createUser("user2"), createUser("user3"))
+        val signedOut = mutableListOf<UserAccount>()
+        var clearDataCalled = false
+
+        logoutAllUsersAndClearData(
+            authenticatedUsers = users,
+            signoutUser = { signedOut.add(it) },
+            fallbackLogout = {},
+            clearData = { clearDataCalled = true },
+        )
+
+        assertEquals("signoutUser must be called for each user", users, signedOut)
+        assertTrue("clearApplicationUserData must be called", clearDataCalled)
+    }
+
+    @Test
+    fun test_givenNoUsers_whenConfirm_thenFallbackLogoutCalledAndClearDataCalled() {
+        val signedOut = mutableListOf<UserAccount>()
+        var fallbackCalled = false
+        var clearDataCalled = false
+
+        logoutAllUsersAndClearData(
+            authenticatedUsers = null,
+            signoutUser = { signedOut.add(it) },
+            fallbackLogout = { fallbackCalled = true },
+            clearData = { clearDataCalled = true },
+        )
+
+        assertTrue("signoutUser must not be called when no users", signedOut.isEmpty())
+        assertTrue("fallback logout must be called when no users", fallbackCalled)
+        assertTrue("clearApplicationUserData must be called", clearDataCalled)
+    }
+
+    @Test
+    fun test_givenEmptyUserList_whenConfirm_thenFallbackLogoutCalledAndClearDataCalled() {
+        val signedOut = mutableListOf<UserAccount>()
+        var fallbackCalled = false
+        var clearDataCalled = false
+
+        logoutAllUsersAndClearData(
+            authenticatedUsers = emptyList(),
+            signoutUser = { signedOut.add(it) },
+            fallbackLogout = { fallbackCalled = true },
+            clearData = { clearDataCalled = true },
+        )
+
+        assertTrue("signoutUser must not be called for empty list", signedOut.isEmpty())
+        assertTrue("fallback logout must be called for empty list", fallbackCalled)
+        assertTrue("clearApplicationUserData must be called", clearDataCalled)
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private fun createUser(userId: String): UserAccount =
+        com.salesforce.androidsdk.accounts.UserAccountBuilder.getInstance()
+            .authToken("token")
+            .refreshToken("refresh")
+            .loginServer("https://test.salesforce.com")
+            .idUrl("https://test.salesforce.com/org/$userId")
+            .instanceServer("https://cs1.salesforce.com")
+            .orgId("org")
+            .userId(userId)
+            .username("$userId@example.com")
+            .accountName("$userId (https://cs1.salesforce.com) (SalesforceSDKTest)")
+            .build()
+}


### PR DESCRIPTION
## Summary
- The \"Yes\" button in \`ManageSpaceActivity\` called \`logout(account=null)\` which only logs out the **current** user. With multiple accounts logged in, other accounts never received SDK-level teardown (SmartStore cleanup, DPoP key deletion, token revocation) before \`clearApplicationUserData()\` wiped everything at the OS level.
- Replaced the single-user logout with a loop over all authenticated users via \`UserAccountManager.getAuthenticatedUsers()\`, calling \`signoutUser()\` per account so each account goes through proper SDK cleanup.
- Falls back to \`logout(account=null)\` when \`getAuthenticatedUsers()\` returns null/empty (fresh install / already logged out).
- Extracted the confirm logic into \`logoutAllUsersAndClearData()\` with lambda parameters for testability, and \`clearApplicationUserData()\` as an \`open\` method so tests can override it without the OS killing the test process.

Fixes https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/issues/425

## Test plan
- [x] Unit tests: \`ManageSpaceActivityTest\` (4 tests — single user, multiple users, null list, empty list) — all passing
- [ ] Build a React Native app with the fixed Android SDK
- [ ] Go to Android Settings > Apps > [app name] > Storage > Clear Data
- [ ] Tap \"Yes\" with a **single** account logged in — verify app data is cleared and app returns to login screen
- [ ] Tap \"Yes\" with **multiple** accounts logged in — verify all accounts are gone and app starts clean
- [ ] Tap \"No\" — verify app continues running normally