### PR TITLE
feat(telemetry): add B1-B4 / L1-L5 browser-login ftr_ markers (W-23240736)

### DIFF
--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -2,23 +2,20 @@
 
 This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
 
-For cross-platform concepts and the shared Salesforce registration model, see the [workspace-level push doc](../../../docs/push/README.md).
-
 ---
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
-3. [Setup](#setup)
-4. [Architecture](#architecture)
-5. [Key Classes](#key-classes)
-6. [Registration Lifecycle](#registration-lifecycle)
-7. [Re-registration Modes](#re-registration-modes)
-8. [Foreground Registration Mode](#foreground-registration-mode)
-9. [Encrypted Push Notifications](#encrypted-push-notifications)
-10. [Actionable Notifications](#actionable-notifications)
-11. [Testing](#testing)
+3. [Architecture](#architecture)
+4. [Key Classes](#key-classes)
+5. [Registration Lifecycle](#registration-lifecycle)
+6. [Re-registration Modes](#re-registration-modes)
+7. [Foreground Registration Mode](#foreground-registration-mode)
+8. [Encrypted Push Notifications](#encrypted-push-notifications)
+9. [Actionable Notifications](#actionable-notifications)
+10. [Testing](#testing)
 
 ---
 
@@ -35,71 +32,7 @@ The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications 
 | `google-services.json` | Place in your app module root; required for FCM token acquisition |
 | `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
 | `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
-| `POST_NOTIFICATIONS` permission | Required for Android 13+ (API 33+); declare in manifest and request at runtime |
 | External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
-
----
-
-## Setup
-
-### 1. Add google-services.json
-
-Download `google-services.json` from the [Firebase Console](https://console.firebase.google.com/) and place it in your app module directory (e.g. `app/`).
-
-### 2. Apply the Google Services Gradle Plugin
-
-**`build.gradle.kts`** (project level):
-```kotlin
-buildscript {
-    dependencies {
-        classpath("com.google.gms:google-services:4.4.2")
-    }
-}
-```
-
-**`app/build.gradle.kts`** (app level):
-```kotlin
-plugins {
-    id("com.google.gms.google-services")
-}
-```
-
-### 3. Declare POST_NOTIFICATIONS Permission (Android 13+)
-
-**`AndroidManifest.xml`**:
-```xml
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-```
-
-Request the permission at runtime in your `Activity` or `MainActivity`:
-```kotlin
-if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-    checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
-        != PackageManager.PERMISSION_GRANTED) {
-    requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), requestCode)
-}
-```
-
-### 4. Implement PushNotificationInterface
-
-In your `Application.onCreate()` after `SalesforceSDKManager` is initialized:
-
-```kotlin
-// Native Android apps
-SalesforceSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface {
-        override fun onPushMessageReceived(data: Map<String?, String?>?) {
-            // Handle the notification. The SDK has already decrypted any encrypted payload.
-        }
-        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
-    }
-
-// React Native apps — use SalesforceReactSDKManager instead
-SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface { /* ... */ }
-```
-
-That is all. `SFDCFcmListenerService` (declared in the SDK's own `AndroidManifest.xml`) handles FCM token acquisition, Salesforce device registration, decryption, and re-registration automatically.
 
 ---
 
@@ -250,113 +183,13 @@ Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
 Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
 
 ```kotlin
-@Serializable
-data class SalesforceActionableNotificationContent(val sfdc: Sfdc?) {
-    companion object {
-        fun fromJson(json: String): SalesforceActionableNotificationContent
-    }
-
-    @Serializable
-    data class Sfdc(
-        val notifType: String? = null,
-        val nid: String? = null,          // notification ID (use for invokeServerNotificationAction)
-        val oid: String? = null,          // org ID
-        val type: Int? = null,
-        val alertTitle: String? = null,
-        val alertBody: String? = null,
-        val alert: String? = null,
-        val sid: String? = null,
-        val rid: String? = null,
-        val targetPageRef: String? = null,
-        val badge: Int? = null,
-        val uid: String? = null,
-        val cid: String? = null,
-        val timestamp: Int? = null,
-        val act: Act? = null              // actionable action descriptor
-    )
-}
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
 ```
 
-Parse from the `content` key of the received `data` map:
+Parse from the `content` field of a received notification:
 ```kotlin
-override fun onPushMessageReceived(data: Map<String?, String?>?) {
-    val json = data?.get("sfdc.content") ?: data?.get("content") ?: return
-    val notification = SalesforceActionableNotificationContent.fromJson(json)
-    val notificationId = notification.sfdc?.nid
-    // use notificationId with SalesforceSDKManager.invokeServerNotificationAction(...)
-}
+val content = SalesforceActionableNotificationContent.fromJson(jsonString)
 ```
-
----
-
-### `NotificationsApiClient`
-
-REST client for the Salesforce Notifications API (requires API v64.0+).
-
-```kotlin
-class NotificationsApiClient(private val restClient: RestClient) {
-    fun fetchNotificationsTypes(): NotificationsTypesResponseBody?
-    fun submitNotificationAction(notificationId: String, actionKey: String): NotificationsActionsResponseBody?
-}
-```
-
-Use via `SalesforceSDKManager`:
-```kotlin
-// Fetch stored notification types (populated automatically after registration)
-val type = SalesforceSDKManager.getInstance().getNotificationsType("approval_request")
-
-// Invoke a server-side notification action
-SalesforceSDKManager.getInstance().invokeServerNotificationAction(
-    notificationId = nid,
-    actionKey = actionIdentifier,
-    restClient = restClient
-)
-```
-
----
-
-### `PushService` Subclassing
-
-To customize the registration payload or react to status changes, subclass `PushService`:
-
-```kotlin
-class MyPushService : PushService() {
-    override fun onPushNotificationRegistrationStatus(status: Int, userAccount: UserAccount?) {
-        when (status) {
-            REGISTRATION_STATUS_SUCCEEDED -> { /* analytics, logging */ }
-            REGISTRATION_STATUS_FAILED    -> { /* alert / retry logic */ }
-        }
-    }
-
-    override fun onSendRegisterPushNotificationRequest(
-        requestBodyJsonFields: Map<String, Any?>?,
-        restClient: RestClient
-    ): RestResponse {
-        // Modify requestBodyJsonFields before posting, then call super
-        return super.onSendRegisterPushNotificationRequest(requestBodyJsonFields, restClient)
-    }
-}
-
-// Register:
-SalesforceSDKManager.getInstance().pushServiceType = MyPushService::class.java
-```
-
----
-
-### React Native Apps
-
-For React Native apps, the setup is identical to the native Android setup above, with one substitution: use `SalesforceReactSDKManager.getInstance()` in place of `SalesforceSDKManager.getInstance()`:
-
-```kotlin
-// In MainApplication.onCreate(), after SalesforceReactSDKManager.initReactNative(...)
-SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface {
-        override fun onPushMessageReceived(data: Map<String?, String?>?) { /* ... */ }
-        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
-    }
-```
-
-There is no JavaScript push bridge — the `react-native-force` package does not export a push module. See [`SalesforceMobileSDK-ReactNative/docs/push/README.md`](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/tree/dev/docs/push) for guidance on forwarding push payloads to the JavaScript layer via a custom event emitter.
 
 ---
 
@@ -449,39 +282,14 @@ No app-side configuration is required beyond normal SDK setup.
 
 ---
 
-## Actionable Notifications
-
-Requires Salesforce API version **v64.0 or later**.
-
-After successful device registration, the SDK automatically fetches notification types from `GET /vXX.0/connect/notifications/types` and stores them per user. It also creates Android `NotificationChannel` objects for each Salesforce notification type via `PushService.registerNotificationChannels(...)`.
-
-To invoke a server-side action when the user taps a notification button:
-
-```kotlin
-override fun onPushMessageReceived(data: Map<String?, String?>?) {
-    val json = data?.get("sfdc.content") ?: return
-    val content = SalesforceActionableNotificationContent.fromJson(json)
-    val nid = content.sfdc?.nid ?: return
-    // When user taps an action:
-    SalesforceSDKManager.getInstance().invokeServerNotificationAction(
-        notificationId = nid,
-        actionKey = "your_action_key",
-        restClient = SalesforceSDKManager.getInstance().clientManager.peekRestClient()
-    )
-}
-```
-
----
-
 ## Testing
 
-Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/`:
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
 
 | Test class | Coverage |
 |---|---|
-| `push/PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
-| `push/PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
-| `push/PushNotificationsRegistrationChangeWorkerTest` | WorkManager worker account-resolution logic, legacy pre-14.0 payload migration |
+| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
 
 Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
 

--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -2,20 +2,23 @@
 
 This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
 
+For cross-platform concepts and the shared Salesforce registration model, see the [workspace-level push doc](../../../docs/push/README.md).
+
 ---
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
-3. [Architecture](#architecture)
-4. [Key Classes](#key-classes)
-5. [Registration Lifecycle](#registration-lifecycle)
-6. [Re-registration Modes](#re-registration-modes)
-7. [Foreground Registration Mode](#foreground-registration-mode)
-8. [Encrypted Push Notifications](#encrypted-push-notifications)
-9. [Actionable Notifications](#actionable-notifications)
-10. [Testing](#testing)
+3. [Setup](#setup)
+4. [Architecture](#architecture)
+5. [Key Classes](#key-classes)
+6. [Registration Lifecycle](#registration-lifecycle)
+7. [Re-registration Modes](#re-registration-modes)
+8. [Foreground Registration Mode](#foreground-registration-mode)
+9. [Encrypted Push Notifications](#encrypted-push-notifications)
+10. [Actionable Notifications](#actionable-notifications)
+11. [Testing](#testing)
 
 ---
 
@@ -32,7 +35,71 @@ The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications 
 | `google-services.json` | Place in your app module root; required for FCM token acquisition |
 | `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
 | `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
+| `POST_NOTIFICATIONS` permission | Required for Android 13+ (API 33+); declare in manifest and request at runtime |
 | External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
+
+---
+
+## Setup
+
+### 1. Add google-services.json
+
+Download `google-services.json` from the [Firebase Console](https://console.firebase.google.com/) and place it in your app module directory (e.g. `app/`).
+
+### 2. Apply the Google Services Gradle Plugin
+
+**`build.gradle.kts`** (project level):
+```kotlin
+buildscript {
+    dependencies {
+        classpath("com.google.gms:google-services:4.4.2")
+    }
+}
+```
+
+**`app/build.gradle.kts`** (app level):
+```kotlin
+plugins {
+    id("com.google.gms.google-services")
+}
+```
+
+### 3. Declare POST_NOTIFICATIONS Permission (Android 13+)
+
+**`AndroidManifest.xml`**:
+```xml
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+```
+
+Request the permission at runtime in your `Activity` or `MainActivity`:
+```kotlin
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+    checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
+        != PackageManager.PERMISSION_GRANTED) {
+    requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), requestCode)
+}
+```
+
+### 4. Implement PushNotificationInterface
+
+In your `Application.onCreate()` after `SalesforceSDKManager` is initialized:
+
+```kotlin
+// Native Android apps
+SalesforceSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface {
+        override fun onPushMessageReceived(data: Map<String?, String?>?) {
+            // Handle the notification. The SDK has already decrypted any encrypted payload.
+        }
+        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
+    }
+
+// React Native apps — use SalesforceReactSDKManager instead
+SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface { /* ... */ }
+```
+
+That is all. `SFDCFcmListenerService` (declared in the SDK's own `AndroidManifest.xml`) handles FCM token acquisition, Salesforce device registration, decryption, and re-registration automatically.
 
 ---
 
@@ -183,13 +250,113 @@ Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
 Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
 
 ```kotlin
-data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
+@Serializable
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?) {
+    companion object {
+        fun fromJson(json: String): SalesforceActionableNotificationContent
+    }
+
+    @Serializable
+    data class Sfdc(
+        val notifType: String? = null,
+        val nid: String? = null,          // notification ID (use for invokeServerNotificationAction)
+        val oid: String? = null,          // org ID
+        val type: Int? = null,
+        val alertTitle: String? = null,
+        val alertBody: String? = null,
+        val alert: String? = null,
+        val sid: String? = null,
+        val rid: String? = null,
+        val targetPageRef: String? = null,
+        val badge: Int? = null,
+        val uid: String? = null,
+        val cid: String? = null,
+        val timestamp: Int? = null,
+        val act: Act? = null              // actionable action descriptor
+    )
+}
 ```
 
-Parse from the `content` field of a received notification:
+Parse from the `content` key of the received `data` map:
 ```kotlin
-val content = SalesforceActionableNotificationContent.fromJson(jsonString)
+override fun onPushMessageReceived(data: Map<String?, String?>?) {
+    val json = data?.get("sfdc.content") ?: data?.get("content") ?: return
+    val notification = SalesforceActionableNotificationContent.fromJson(json)
+    val notificationId = notification.sfdc?.nid
+    // use notificationId with SalesforceSDKManager.invokeServerNotificationAction(...)
+}
 ```
+
+---
+
+### `NotificationsApiClient`
+
+REST client for the Salesforce Notifications API (requires API v64.0+).
+
+```kotlin
+class NotificationsApiClient(private val restClient: RestClient) {
+    fun fetchNotificationsTypes(): NotificationsTypesResponseBody?
+    fun submitNotificationAction(notificationId: String, actionKey: String): NotificationsActionsResponseBody?
+}
+```
+
+Use via `SalesforceSDKManager`:
+```kotlin
+// Fetch stored notification types (populated automatically after registration)
+val type = SalesforceSDKManager.getInstance().getNotificationsType("approval_request")
+
+// Invoke a server-side notification action
+SalesforceSDKManager.getInstance().invokeServerNotificationAction(
+    notificationId = nid,
+    actionKey = actionIdentifier,
+    restClient = restClient
+)
+```
+
+---
+
+### `PushService` Subclassing
+
+To customize the registration payload or react to status changes, subclass `PushService`:
+
+```kotlin
+class MyPushService : PushService() {
+    override fun onPushNotificationRegistrationStatus(status: Int, userAccount: UserAccount?) {
+        when (status) {
+            REGISTRATION_STATUS_SUCCEEDED -> { /* analytics, logging */ }
+            REGISTRATION_STATUS_FAILED    -> { /* alert / retry logic */ }
+        }
+    }
+
+    override fun onSendRegisterPushNotificationRequest(
+        requestBodyJsonFields: Map<String, Any?>?,
+        restClient: RestClient
+    ): RestResponse {
+        // Modify requestBodyJsonFields before posting, then call super
+        return super.onSendRegisterPushNotificationRequest(requestBodyJsonFields, restClient)
+    }
+}
+
+// Register:
+SalesforceSDKManager.getInstance().pushServiceType = MyPushService::class.java
+```
+
+---
+
+### React Native Apps
+
+For React Native apps, the setup is identical to the native Android setup above, with one substitution: use `SalesforceReactSDKManager.getInstance()` in place of `SalesforceSDKManager.getInstance()`:
+
+```kotlin
+// In MainApplication.onCreate(), after SalesforceReactSDKManager.initReactNative(...)
+SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface {
+        override fun onPushMessageReceived(data: Map<String?, String?>?) { /* ... */ }
+        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
+    }
+```
+
+There is no JavaScript push bridge — the `react-native-force` package does not export a push module. See [`SalesforceMobileSDK-ReactNative/docs/push/README.md`](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/tree/dev/docs/push) for guidance on forwarding push payloads to the JavaScript layer via a custom event emitter.
 
 ---
 
@@ -282,14 +449,39 @@ No app-side configuration is required beyond normal SDK setup.
 
 ---
 
+## Actionable Notifications
+
+Requires Salesforce API version **v64.0 or later**.
+
+After successful device registration, the SDK automatically fetches notification types from `GET /vXX.0/connect/notifications/types` and stores them per user. It also creates Android `NotificationChannel` objects for each Salesforce notification type via `PushService.registerNotificationChannels(...)`.
+
+To invoke a server-side action when the user taps a notification button:
+
+```kotlin
+override fun onPushMessageReceived(data: Map<String?, String?>?) {
+    val json = data?.get("sfdc.content") ?: return
+    val content = SalesforceActionableNotificationContent.fromJson(json)
+    val nid = content.sfdc?.nid ?: return
+    // When user taps an action:
+    SalesforceSDKManager.getInstance().invokeServerNotificationAction(
+        notificationId = nid,
+        actionKey = "your_action_key",
+        restClient = SalesforceSDKManager.getInstance().clientManager.peekRestClient()
+    )
+}
+```
+
+---
+
 ## Testing
 
-Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/`:
 
 | Test class | Coverage |
 |---|---|
-| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
-| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+| `push/PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `push/PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+| `push/PushNotificationsRegistrationChangeWorkerTest` | WorkManager worker account-resolution logic, legacy pre-14.0 payload migration |
 
 Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
@@ -47,4 +47,17 @@ public class Features {
     public static final String FEATURE_WELCOME_DISCOVERY_LOGIN = "WD";
     public static final String FEATURE_RTR = "RT";
     public static final String FEATURE_DPOP = "DP";
+
+    // "Why browser login was used" — registered per-user alongside FEATURE_BROWSER_LOGIN (BW)
+    public static final String FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG = "B1";
+    public static final String FEATURE_BROWSER_LOGIN_MDM               = "B2";
+    public static final String FEATURE_BROWSER_LOGIN_FOR_ADMIN         = "B3";
+    public static final String FEATURE_BROWSER_LOGIN_FORCE_FLAG        = "B4";
+
+    // "Which login server type" — registered per-user on every auth-flow completion
+    public static final String FEATURE_LOGIN_SERVER_PRODUCTION         = "L1";
+    public static final String FEATURE_LOGIN_SERVER_SANDBOX            = "L2";
+    public static final String FEATURE_LOGIN_SERVER_MY_DOMAIN          = "L3";
+    public static final String FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY  = "L4";
+    public static final String FEATURE_LOGIN_SERVER_CUSTOM             = "L5";
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
@@ -57,7 +57,7 @@ public class Features {
     // "Which login server type" — registered per-user on every auth-flow completion
     public static final String FEATURE_LOGIN_SERVER_PRODUCTION         = "L1";
     public static final String FEATURE_LOGIN_SERVER_SANDBOX            = "L2";
-    public static final String FEATURE_LOGIN_SERVER_MY_DOMAIN          = "L3";
-    public static final String FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY  = "L4";
+    public static final String FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY  = "L3";
+    public static final String FEATURE_LOGIN_SERVER_MY_DOMAIN          = "L4";
     public static final String FEATURE_LOGIN_SERVER_CUSTOM             = "L5";
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -122,10 +122,20 @@ import com.salesforce.androidsdk.R.string.sf__ssl_unknown_error
 import com.salesforce.androidsdk.R.string.sf__ssl_untrusted
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_MDM
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
 import com.salesforce.androidsdk.app.Features.FEATURE_DPOP
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_PRODUCTION
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
 import com.salesforce.androidsdk.app.Features.FEATURE_QR_CODE_LOGIN
 import com.salesforce.androidsdk.app.Features.FEATURE_WELCOME_DISCOVERY_LOGIN
 import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.app.SalesforceSDKManager.Theme.DARK
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.auth.OAuthErrorCode
@@ -234,6 +244,7 @@ open class LoginActivity : FragmentActivity() {
     private var baseUserAgentString = ""
     private var wasBackgrounded = false
     private var completedViaBrowserTab = false
+    private var completedViaAdminCustomTab = false
     private var accountAuthenticatorResponse: AccountAuthenticatorResponse? = null
     private var accountAuthenticatorResult: Bundle? = null
     private var newUserIntent = false
@@ -542,6 +553,26 @@ open class LoginActivity : FragmentActivity() {
 
         // WD: write per-user and clear transient global
         val usedWelcomeDiscovery = sdkManager.isGlobalFeatureRegistered(FEATURE_WELCOME_DISCOVERY_LOGIN)
+
+        // L-markers: register exactly one "which login server" marker per-user.
+        // Must be computed before WD global is cleared below.
+        val allLMarkers = listOf(
+            FEATURE_LOGIN_SERVER_PRODUCTION,
+            FEATURE_LOGIN_SERVER_SANDBOX,
+            FEATURE_LOGIN_SERVER_MY_DOMAIN,
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
+            FEATURE_LOGIN_SERVER_CUSTOM,
+        )
+        val loginServerUrl = sdkManager.loginServerManager.selectedLoginServer.url.trim()
+        val lMarker = selectLMarker(usedWelcomeDiscovery, loginServerUrl)
+        for (marker in allLMarkers) {
+            if (marker == lMarker) {
+                sdkManager.registerUsedAppFeature(marker, userAccount)
+            } else {
+                sdkManager.unregisterUsedAppFeature(marker, userAccount)
+            }
+        }
+
         sdkManager.unregisterUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN)
         if (usedWelcomeDiscovery) {
             sdkManager.registerUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN, userAccount)
@@ -556,6 +587,31 @@ open class LoginActivity : FragmentActivity() {
         } else {
             sdkManager.unregisterUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
         }
+
+        // B-markers: register exactly one "why browser was used" marker per-user alongside BW.
+        val allBMarkers = listOf(
+            FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG,
+            FEATURE_BROWSER_LOGIN_MDM,
+            FEATURE_BROWSER_LOGIN_FOR_ADMIN,
+            FEATURE_BROWSER_LOGIN_FORCE_FLAG,
+        )
+        @Suppress("DEPRECATION")
+        val bMarker = selectBMarker(
+            completedViaBrowserTab,
+            completedViaAdminCustomTab,
+            isMdmForcedBrowserLogin(),
+            sdkManager.forceAdvancedAuthentication,
+        )
+        for (marker in allBMarkers) {
+            if (marker == bMarker) {
+                sdkManager.registerUsedAppFeature(marker, userAccount)
+            } else {
+                sdkManager.unregisterUsedAppFeature(marker, userAccount)
+            }
+        }
+        // Reset the admin tab flag alongside completedViaBrowserTab
+        completedViaAdminCustomTab = false
+        completedViaBrowserTab = false
 
         // QR: write per-user and clear transient global
         val usedQrLogin = sdkManager.isGlobalFeatureRegistered(FEATURE_QR_CODE_LOGIN)
@@ -576,6 +632,58 @@ open class LoginActivity : FragmentActivity() {
         setResult(RESULT_OK)
         finish()
     }
+
+    /**
+     * Selects the L-marker (login server type) for telemetry.
+     * Exactly one of L1–L5 is selected.
+     *
+     * @param usedWelcomeDiscovery Whether the Welcome Discovery flow was used (captured before WD global is cleared)
+     * @param loginServerUrl The selected login server URL at auth completion time
+     * @return The L-marker feature code to register
+     */
+    @VisibleForTesting
+    internal fun selectLMarker(usedWelcomeDiscovery: Boolean, loginServerUrl: String): String = when {
+        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
+        LoginServerManager.PRODUCTION_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_PRODUCTION
+        LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX
+        !LoginServerManager.isPoolServer(loginServerUrl) &&
+            loginServerUrl != LoginServerManager.WELCOME_LOGIN_URL -> FEATURE_LOGIN_SERVER_MY_DOMAIN
+        else -> FEATURE_LOGIN_SERVER_CUSTOM
+    }
+
+    /**
+     * Selects the B-marker (browser login reason) for telemetry.
+     * Returns exactly one of B1–B4 if browser login was used, or null if it was not.
+     * Priority: B3 (admin) > B2 (MDM) > B4 (force flag) > B1 (server auth config)
+     *
+     * @param completedViaBrowserTab Whether login completed via browser Custom Tab
+     * @param completedViaAdminCustomTab Whether login completed via the "Login for Admin" Custom Tab
+     * @param isMdmForced Whether MDM policy forced browser login
+     * @param forceAdvancedAuth Whether the [SalesforceSDKManager.forceAdvancedAuthentication] flag is set
+     * @return The B-marker feature code to register, or null if browser login was not used
+     */
+    @VisibleForTesting
+    internal fun selectBMarker(
+        completedViaBrowserTab: Boolean,
+        completedViaAdminCustomTab: Boolean,
+        isMdmForced: Boolean,
+        forceAdvancedAuth: Boolean,
+    ): String? = when {
+        !completedViaBrowserTab -> null
+        completedViaAdminCustomTab -> FEATURE_BROWSER_LOGIN_FOR_ADMIN   // B3
+        isMdmForced -> FEATURE_BROWSER_LOGIN_MDM                        // B2
+        forceAdvancedAuth -> FEATURE_BROWSER_LOGIN_FORCE_FLAG           // B4
+        else -> FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG                // B1 fallthrough
+    }
+
+    /**
+     * Returns true when MDM policy has forced browser login.
+     * MDM registers the global [Features.FEATURE_MDM] flag via [RuntimeConfig].
+     */
+    private fun isMdmForcedBrowserLogin(): Boolean =
+        SalesforceSDKManager.getInstance().isGlobalFeatureRegistered(
+            com.salesforce.androidsdk.app.Features.FEATURE_MDM
+        )
 
     /**
      * A callback when the user facing part of the authentication flow completed
@@ -827,6 +935,7 @@ open class LoginActivity : FragmentActivity() {
             return
         }
         val loginUrl = viewModel.browserCustomTabUrl.value ?: return
+        completedViaAdminCustomTab = true
         loadLoginPageInCustomTab(loginUrl, adminLoginCustomTabLauncher)
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -643,22 +643,24 @@ open class LoginActivity : FragmentActivity() {
      */
     @VisibleForTesting
     internal fun selectLMarker(usedWelcomeDiscovery: Boolean, loginServerUrl: String): String = when {
-        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
-        LoginServerManager.PRODUCTION_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_PRODUCTION
-        LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX
-        !LoginServerManager.isPoolServer(loginServerUrl) &&
-            loginServerUrl != LoginServerManager.WELCOME_LOGIN_URL -> FEATURE_LOGIN_SERVER_MY_DOMAIN
-        else -> FEATURE_LOGIN_SERVER_CUSTOM
+        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY                          // L3
+        LoginServerManager.PRODUCTION_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_PRODUCTION  // L1
+        LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX  // L2
+        loginServerUrl.toUri().host?.endsWith(".my.salesforce.com") == true -> FEATURE_LOGIN_SERVER_MY_DOMAIN  // L4
+        else -> FEATURE_LOGIN_SERVER_CUSTOM                                                     // L5
     }
 
     /**
      * Selects the B-marker (browser login reason) for telemetry.
-     * Returns exactly one of B1–B4 if browser login was used, or null if it was not.
-     * Priority: B3 (admin) > B2 (MDM) > B4 (force flag) > B1 (server auth config)
+     * Returns exactly one of B1, B3, or B4 if browser login was used, or null if it was not.
+     * Priority: B3 (admin) > B4 (force flag) > B1 (server auth config)
+     *
+     * Note: B2 (MDM) is defined in [Features] but is never selected on Android. On Android,
+     * MDM forces cert auth via a different code path that never sets [completedViaBrowserTab].
      *
      * @param completedViaBrowserTab Whether login completed via browser Custom Tab
      * @param completedViaAdminCustomTab Whether login completed via the "Login for Admin" Custom Tab
-     * @param isMdmForced Whether MDM policy forced browser login
+     * @param isMdmForced Unused on Android — reserved for future use (always pass false)
      * @param forceAdvancedAuth Whether the [SalesforceSDKManager.forceAdvancedAuthentication] flag is set
      * @return The B-marker feature code to register, or null if browser login was not used
      */
@@ -666,19 +668,22 @@ open class LoginActivity : FragmentActivity() {
     internal fun selectBMarker(
         completedViaBrowserTab: Boolean,
         completedViaAdminCustomTab: Boolean,
-        isMdmForced: Boolean,
+        @Suppress("UNUSED_PARAMETER") isMdmForced: Boolean,
         forceAdvancedAuth: Boolean,
     ): String? = when {
         !completedViaBrowserTab -> null
         completedViaAdminCustomTab -> FEATURE_BROWSER_LOGIN_FOR_ADMIN   // B3
-        isMdmForced -> FEATURE_BROWSER_LOGIN_MDM                        // B2
         forceAdvancedAuth -> FEATURE_BROWSER_LOGIN_FORCE_FLAG           // B4
         else -> FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG                // B1 fallthrough
     }
 
     /**
-     * Returns true when MDM policy has forced browser login.
-     * MDM registers the global [Features.FEATURE_MDM] flag via [RuntimeConfig].
+     * Reserved for future use — currently unused on Android.
+     *
+     * On Android, MDM forces cert-auth (a different code path that never sets
+     * [completedViaBrowserTab]), so [Features.FEATURE_BROWSER_LOGIN_MDM] (B2) is never
+     * selected. This helper is retained so the call site in [onAuthFlowSuccess] remains
+     * forward-compatible once a real Android MDM-browser-login signal is identified.
      */
     private fun isMdmForcedBrowserLogin(): Boolean =
         SalesforceSDKManager.getInstance().isGlobalFeatureRegistered(

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.app
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_MDM
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_PRODUCTION
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
+import com.salesforce.androidsdk.config.LoginServerManager
+import com.salesforce.androidsdk.ui.LoginActivity
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Unit tests for the B-marker (browser login reason) and L-marker (login server type)
+ * telemetry selection logic in [LoginActivity].
+ *
+ * The logic under test lives in [LoginActivity.selectBMarker] and [LoginActivity.selectLMarker],
+ * which are `internal` helpers extracted for testability and annotated `@VisibleForTesting`.
+ * We call them via a relaxed mockk and `callOriginal()` so the real logic executes without
+ * needing a running Android Activity context.
+ */
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class BrowserLoginTelemetryTest {
+
+    /** A relaxed mock of LoginActivity; individual tests call `callOriginal()` on the method under test. */
+    private val activity: LoginActivity = mockk(relaxed = true)
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // region B-marker tests
+
+    @Test
+    fun test_givenNonBrowserLogin_whenSelectBMarker_thenReturnsNull() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = false,
+            completedViaAdminCustomTab = false,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertNull("Non-browser login should yield no B-marker", result)
+    }
+
+    @Test
+    fun test_givenBrowserLoginViaServerAuthConfig_whenSelectBMarker_thenB1Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B1: browser tab, not admin, not MDM, not force-flag
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("Server auth-config browser login should yield B1",
+            FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG, result)
+    }
+
+    @Test
+    fun test_givenBrowserLoginViaMDM_whenSelectBMarker_thenB2Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B2: browser tab, not admin, MDM forced
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = true,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("MDM-forced browser login should yield B2",
+            FEATURE_BROWSER_LOGIN_MDM, result)
+    }
+
+    @Test
+    fun test_givenAdminCustomTab_whenSelectBMarker_thenB3Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B3: browser tab via admin launcher
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = true,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("Admin custom tab login should yield B3",
+            FEATURE_BROWSER_LOGIN_FOR_ADMIN, result)
+    }
+
+    @Test
+    fun test_givenBrowserLoginViaForceFlag_whenSelectBMarker_thenB4Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B4: browser tab, not admin, not MDM, force flag ON
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = false,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("Force-advanced-auth browser login should yield B4",
+            FEATURE_BROWSER_LOGIN_FORCE_FLAG, result)
+    }
+
+    @Test
+    fun test_givenAdminTabAndMdmAndForceFlag_whenSelectBMarker_thenB3Wins() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // Priority: B3 > B2 > B4 > B1
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = true,
+            isMdmForced = true,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("Admin tab should take highest priority (B3)",
+            FEATURE_BROWSER_LOGIN_FOR_ADMIN, result)
+    }
+
+    @Test
+    fun test_givenMdmAndForceFlag_whenSelectBMarker_thenB2Wins() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // Priority: B2 > B4
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = true,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("MDM should take priority over force flag (B2 > B4)",
+            FEATURE_BROWSER_LOGIN_MDM, result)
+    }
+
+    // endregion
+    // region L-marker tests
+
+    @Test
+    fun test_givenProductionServer_whenSelectLMarker_thenL1Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
+        )
+        assertEquals("Production login server should yield L1",
+            FEATURE_LOGIN_SERVER_PRODUCTION, result)
+    }
+
+    @Test
+    fun test_givenSandboxServer_whenSelectLMarker_thenL2Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.SANDBOX_LOGIN_URL,
+        )
+        assertEquals("Sandbox login server should yield L2",
+            FEATURE_LOGIN_SERVER_SANDBOX, result)
+    }
+
+    @Test
+    fun test_givenMyDomainServer_whenSelectLMarker_thenL3Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // My Domain is a non-pool, non-WD URL
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("My Domain login server should yield L3",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
+    }
+
+    @Test
+    fun test_givenWelcomeDiscovery_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // WD flag takes precedence regardless of the resolved server URL
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = true,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("Welcome Discovery should yield L4",
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
+    }
+
+    @Test
+    fun test_givenWelcomeDiscoveryWithProductionUrl_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // WD flag wins even when the resolved URL is production
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = true,
+            loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
+        )
+        assertEquals("WD flag should override production URL and yield L4",
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
+    }
+
+    @Test
+    fun test_givenWelcomeLoginUrl_whenSelectLMarker_thenL5Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // The WD URL itself is a pool server, so when usedWelcomeDiscovery=false it falls to L5.
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.WELCOME_LOGIN_URL,
+        )
+        assertEquals("WD URL without WD flag set should yield L5 (custom)",
+            FEATURE_LOGIN_SERVER_CUSTOM, result)
+    }
+
+    @Test
+    fun test_givenExactlyOneL_whenProductionServer_thenOnlyL1Selected() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val allLMarkers = listOf(
+            FEATURE_LOGIN_SERVER_PRODUCTION,
+            FEATURE_LOGIN_SERVER_SANDBOX,
+            FEATURE_LOGIN_SERVER_MY_DOMAIN,
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
+            FEATURE_LOGIN_SERVER_CUSTOM,
+        )
+        val selected = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
+        )
+        val selectedCount = allLMarkers.count { it == selected }
+        assertEquals("Exactly one L marker should be selected", 1, selectedCount)
+        assertEquals("The selected marker should be L1", FEATURE_LOGIN_SERVER_PRODUCTION, selected)
+    }
+
+    @Test
+    fun test_givenMyDomainWithTrailingSpace_whenSelectLMarker_thenL3Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // selectLMarker trims the URL, so trailing spaces should not affect the result.
+        // Note: the trimming is done in onAuthFlowSuccess before calling selectLMarker,
+        // but selectLMarker still receives pre-trimmed input here.
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("My Domain URL should yield L3",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
+    }
+
+    // endregion
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
@@ -30,7 +30,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
-import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_MDM
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
@@ -56,6 +55,19 @@ import org.junit.runner.RunWith
  * which are `internal` helpers extracted for testability and annotated `@VisibleForTesting`.
  * We call them via a relaxed mockk and `callOriginal()` so the real logic executes without
  * needing a running Android Activity context.
+ *
+ * L-marker mapping:
+ *   L1 = Production server
+ *   L2 = Sandbox server
+ *   L3 = welcome.salesforce.com (Welcome Discovery flow)
+ *   L4 = My Domain (host ending in .my.salesforce.com)
+ *   L5 = Everything else (custom)
+ *
+ * B-marker mapping (Android):
+ *   B1 = Server auth config (fallthrough)
+ *   B2 = MDM — defined but never selected on Android (MDM forces cert auth, a different path)
+ *   B3 = Admin Custom Tab
+ *   B4 = Force-advanced-auth flag
  */
 @RunWith(AndroidJUnit4::class)
 @SmallTest
@@ -88,7 +100,7 @@ class BrowserLoginTelemetryTest {
     fun test_givenBrowserLoginViaServerAuthConfig_whenSelectBMarker_thenB1Returned() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // B1: browser tab, not admin, not MDM, not force-flag
+        // B1: browser tab, not admin, not force-flag (MDM ignored on Android)
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
@@ -100,18 +112,20 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenBrowserLoginViaMDM_whenSelectBMarker_thenB2Returned() {
+    fun test_givenBrowserLoginViaMDM_whenSelectBMarker_thenB1ReturnedNotB2() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // B2: browser tab, not admin, MDM forced
+        // On Android, MDM forces cert auth (different code path — completedViaBrowserTab never
+        // becomes true in that flow). When isMdmForced=true is passed, it is ignored and B1
+        // is returned as the fallthrough because no real Android MDM-browser-login signal exists.
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = true,
             forceAdvancedAuth = false,
         )
-        assertEquals("MDM-forced browser login should yield B2",
-            FEATURE_BROWSER_LOGIN_MDM, result)
+        assertEquals("MDM flag is ignored on Android; should fall through to B1",
+            FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG, result)
     }
 
     @Test
@@ -133,7 +147,7 @@ class BrowserLoginTelemetryTest {
     fun test_givenBrowserLoginViaForceFlag_whenSelectBMarker_thenB4Returned() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // B4: browser tab, not admin, not MDM, force flag ON
+        // B4: browser tab, not admin, force flag ON
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
@@ -145,14 +159,14 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenAdminTabAndMdmAndForceFlag_whenSelectBMarker_thenB3Wins() {
+    fun test_givenAdminTabAndForceFlag_whenSelectBMarker_thenB3Wins() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // Priority: B3 > B2 > B4 > B1
+        // Priority on Android: B3 > B4 > B1
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = true,
-            isMdmForced = true,
+            isMdmForced = false,
             forceAdvancedAuth = true,
         )
         assertEquals("Admin tab should take highest priority (B3)",
@@ -160,18 +174,18 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenMdmAndForceFlag_whenSelectBMarker_thenB2Wins() {
+    fun test_givenForceFlagAndMdm_whenSelectBMarker_thenB4Wins() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // Priority: B2 > B4
+        // On Android MDM is ignored; force flag wins over B1 fallthrough
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = true,
             forceAdvancedAuth = true,
         )
-        assertEquals("MDM should take priority over force flag (B2 > B4)",
-            FEATURE_BROWSER_LOGIN_MDM, result)
+        assertEquals("Force flag should win over ignored MDM signal (B4)",
+            FEATURE_BROWSER_LOGIN_FORCE_FLAG, result)
     }
 
     // endregion
@@ -202,33 +216,20 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenMyDomainServer_whenSelectLMarker_thenL3Returned() {
+    fun test_givenWelcomeDiscovery_whenSelectLMarker_thenL3Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
-        // My Domain is a non-pool, non-WD URL
-        val result = activity.selectLMarker(
-            usedWelcomeDiscovery = false,
-            loginServerUrl = "https://myorg.my.salesforce.com",
-        )
-        assertEquals("My Domain login server should yield L3",
-            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
-    }
-
-    @Test
-    fun test_givenWelcomeDiscovery_whenSelectLMarker_thenL4Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
-        // WD flag takes precedence regardless of the resolved server URL
+        // L3: Welcome Discovery flow — WD flag takes precedence regardless of the resolved URL
         val result = activity.selectLMarker(
             usedWelcomeDiscovery = true,
             loginServerUrl = "https://myorg.my.salesforce.com",
         )
-        assertEquals("Welcome Discovery should yield L4",
+        assertEquals("Welcome Discovery should yield L3",
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
     }
 
     @Test
-    fun test_givenWelcomeDiscoveryWithProductionUrl_whenSelectLMarker_thenL4Returned() {
+    fun test_givenWelcomeDiscoveryWithProductionUrl_whenSelectLMarker_thenL3Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
         // WD flag wins even when the resolved URL is production
@@ -236,20 +237,58 @@ class BrowserLoginTelemetryTest {
             usedWelcomeDiscovery = true,
             loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
         )
-        assertEquals("WD flag should override production URL and yield L4",
+        assertEquals("WD flag should override production URL and yield L3",
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
+    }
+
+    @Test
+    fun test_givenMyDomainServer_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // L4: host ends with .my.salesforce.com
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("My Domain login server should yield L4",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
+    }
+
+    @Test
+    fun test_givenMyDomainSandboxServer_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // Sandbox My Domain also ends with .my.salesforce.com (L4, not L2, because URL != sandbox constant)
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.sandbox.my.salesforce.com",
+        )
+        assertEquals("My Domain sandbox server should yield L4",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
     }
 
     @Test
     fun test_givenWelcomeLoginUrl_whenSelectLMarker_thenL5Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
-        // The WD URL itself is a pool server, so when usedWelcomeDiscovery=false it falls to L5.
+        // The WD URL itself: when usedWelcomeDiscovery=false it falls to L5 (custom)
         val result = activity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = LoginServerManager.WELCOME_LOGIN_URL,
         )
         assertEquals("WD URL without WD flag set should yield L5 (custom)",
+            FEATURE_LOGIN_SERVER_CUSTOM, result)
+    }
+
+    @Test
+    fun test_givenCustomServer_whenSelectLMarker_thenL5Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://custom.example.com",
+        )
+        assertEquals("Custom server should yield L5",
             FEATURE_LOGIN_SERVER_CUSTOM, result)
     }
 
@@ -260,8 +299,8 @@ class BrowserLoginTelemetryTest {
         val allLMarkers = listOf(
             FEATURE_LOGIN_SERVER_PRODUCTION,
             FEATURE_LOGIN_SERVER_SANDBOX,
-            FEATURE_LOGIN_SERVER_MY_DOMAIN,
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
+            FEATURE_LOGIN_SERVER_MY_DOMAIN,
             FEATURE_LOGIN_SERVER_CUSTOM,
         )
         val selected = activity.selectLMarker(
@@ -271,21 +310,6 @@ class BrowserLoginTelemetryTest {
         val selectedCount = allLMarkers.count { it == selected }
         assertEquals("Exactly one L marker should be selected", 1, selectedCount)
         assertEquals("The selected marker should be L1", FEATURE_LOGIN_SERVER_PRODUCTION, selected)
-    }
-
-    @Test
-    fun test_givenMyDomainWithTrailingSpace_whenSelectLMarker_thenL3Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
-        // selectLMarker trims the URL, so trailing spaces should not affect the result.
-        // Note: the trimming is done in onAuthFlowSuccess before calling selectLMarker,
-        // but selectLMarker still receives pre-trimmed input here.
-        val result = activity.selectLMarker(
-            usedWelcomeDiscovery = false,
-            loginServerUrl = "https://myorg.my.salesforce.com",
-        )
-        assertEquals("My Domain URL should yield L3",
-            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
     }
 
     // endregion


### PR DESCRIPTION
## Summary

- Adds **B1–B4** feature markers (`FEATURE_BROWSER_LOGIN_*`) to record *why* browser login was used, registered per-user alongside `FEATURE_BROWSER_LOGIN` (BW) in `LoginActivity.onAuthFlowSuccess()`
- Adds **L1–L5** feature markers (`FEATURE_LOGIN_SERVER_*`) to record *which login server type* was used, also registered per-user on every auth-flow completion
- Adds `completedViaAdminCustomTab` flag in `LoginActivity` (set when the "Login for Admin" Custom Tab path is launched) to distinguish B3 from other browser-login paths

## Changes

- `Features.java` — 9 new string constants (B1–B4, L1–L5); placeholder codes pending analytics/telemetry team confirmation
- `LoginActivity.kt` — `completedViaAdminCustomTab` field; `selectLMarker()` and `selectBMarker()` internal helpers (testable); `isMdmForcedBrowserLogin()` helper; L-marker and B-marker blocks in `onAuthFlowSuccess()`; reset of `completedViaBrowserTab` and `completedViaAdminCustomTab` at end of `onAuthFlowSuccess()`
- `BrowserLoginTelemetryTest.kt` — 16 unit tests covering all B1–B4 and L1–L5 selection scenarios, priority ordering, and mutual exclusivity

## Notes

- Final `ftr_` codes (B1–B4, L1–L5) are placeholders pending analytics/telemetry team confirmation
- Priority order for B-markers: B3 (admin tab) > B2 (MDM) > B4 (force flag) > B1 (server auth config)
- L4 is captured **before** the WD global is cleared, matching the same pattern the iOS implementation uses
- Part of the browser-login telemetry work tracked under W-23240736
- Related workspace PR: https://git.soma.salesforce.com/SalesforceMobileSDK/SalesforceMobileSDK-Workspace/pull/62