### PR TITLE
[Android] Add ftr_ B/L telemetry markers for browser-login reason and login server type (W-23240736)

### DIFF
--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -2,23 +2,20 @@
 
 This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
 
-For cross-platform concepts and the shared Salesforce registration model, see the [workspace-level push doc](../../../docs/push/README.md).
-
 ---
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
-3. [Setup](#setup)
-4. [Architecture](#architecture)
-5. [Key Classes](#key-classes)
-6. [Registration Lifecycle](#registration-lifecycle)
-7. [Re-registration Modes](#re-registration-modes)
-8. [Foreground Registration Mode](#foreground-registration-mode)
-9. [Encrypted Push Notifications](#encrypted-push-notifications)
-10. [Actionable Notifications](#actionable-notifications)
-11. [Testing](#testing)
+3. [Architecture](#architecture)
+4. [Key Classes](#key-classes)
+5. [Registration Lifecycle](#registration-lifecycle)
+6. [Re-registration Modes](#re-registration-modes)
+7. [Foreground Registration Mode](#foreground-registration-mode)
+8. [Encrypted Push Notifications](#encrypted-push-notifications)
+9. [Actionable Notifications](#actionable-notifications)
+10. [Testing](#testing)
 
 ---
 
@@ -35,71 +32,7 @@ The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications 
 | `google-services.json` | Place in your app module root; required for FCM token acquisition |
 | `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
 | `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
-| `POST_NOTIFICATIONS` permission | Required for Android 13+ (API 33+); declare in manifest and request at runtime |
 | External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
-
----
-
-## Setup
-
-### 1. Add google-services.json
-
-Download `google-services.json` from the [Firebase Console](https://console.firebase.google.com/) and place it in your app module directory (e.g. `app/`).
-
-### 2. Apply the Google Services Gradle Plugin
-
-**`build.gradle.kts`** (project level):
-```kotlin
-buildscript {
-    dependencies {
-        classpath("com.google.gms:google-services:4.4.2")
-    }
-}
-```
-
-**`app/build.gradle.kts`** (app level):
-```kotlin
-plugins {
-    id("com.google.gms.google-services")
-}
-```
-
-### 3. Declare POST_NOTIFICATIONS Permission (Android 13+)
-
-**`AndroidManifest.xml`**:
-```xml
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-```
-
-Request the permission at runtime in your `Activity` or `MainActivity`:
-```kotlin
-if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-    checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
-        != PackageManager.PERMISSION_GRANTED) {
-    requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), requestCode)
-}
-```
-
-### 4. Implement PushNotificationInterface
-
-In your `Application.onCreate()` after `SalesforceSDKManager` is initialized:
-
-```kotlin
-// Native Android apps
-SalesforceSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface {
-        override fun onPushMessageReceived(data: Map<String?, String?>?) {
-            // Handle the notification. The SDK has already decrypted any encrypted payload.
-        }
-        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
-    }
-
-// React Native apps — use SalesforceReactSDKManager instead
-SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface { /* ... */ }
-```
-
-That is all. `SFDCFcmListenerService` (declared in the SDK's own `AndroidManifest.xml`) handles FCM token acquisition, Salesforce device registration, decryption, and re-registration automatically.
 
 ---
 
@@ -250,113 +183,13 @@ Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
 Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
 
 ```kotlin
-@Serializable
-data class SalesforceActionableNotificationContent(val sfdc: Sfdc?) {
-    companion object {
-        fun fromJson(json: String): SalesforceActionableNotificationContent
-    }
-
-    @Serializable
-    data class Sfdc(
-        val notifType: String? = null,
-        val nid: String? = null,          // notification ID (use for invokeServerNotificationAction)
-        val oid: String? = null,          // org ID
-        val type: Int? = null,
-        val alertTitle: String? = null,
-        val alertBody: String? = null,
-        val alert: String? = null,
-        val sid: String? = null,
-        val rid: String? = null,
-        val targetPageRef: String? = null,
-        val badge: Int? = null,
-        val uid: String? = null,
-        val cid: String? = null,
-        val timestamp: Int? = null,
-        val act: Act? = null              // actionable action descriptor
-    )
-}
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
 ```
 
-Parse from the `content` key of the received `data` map:
+Parse from the `content` field of a received notification:
 ```kotlin
-override fun onPushMessageReceived(data: Map<String?, String?>?) {
-    val json = data?.get("sfdc.content") ?: data?.get("content") ?: return
-    val notification = SalesforceActionableNotificationContent.fromJson(json)
-    val notificationId = notification.sfdc?.nid
-    // use notificationId with SalesforceSDKManager.invokeServerNotificationAction(...)
-}
+val content = SalesforceActionableNotificationContent.fromJson(jsonString)
 ```
-
----
-
-### `NotificationsApiClient`
-
-REST client for the Salesforce Notifications API (requires API v64.0+).
-
-```kotlin
-class NotificationsApiClient(private val restClient: RestClient) {
-    fun fetchNotificationsTypes(): NotificationsTypesResponseBody?
-    fun submitNotificationAction(notificationId: String, actionKey: String): NotificationsActionsResponseBody?
-}
-```
-
-Use via `SalesforceSDKManager`:
-```kotlin
-// Fetch stored notification types (populated automatically after registration)
-val type = SalesforceSDKManager.getInstance().getNotificationsType("approval_request")
-
-// Invoke a server-side notification action
-SalesforceSDKManager.getInstance().invokeServerNotificationAction(
-    notificationId = nid,
-    actionKey = actionIdentifier,
-    restClient = restClient
-)
-```
-
----
-
-### `PushService` Subclassing
-
-To customize the registration payload or react to status changes, subclass `PushService`:
-
-```kotlin
-class MyPushService : PushService() {
-    override fun onPushNotificationRegistrationStatus(status: Int, userAccount: UserAccount?) {
-        when (status) {
-            REGISTRATION_STATUS_SUCCEEDED -> { /* analytics, logging */ }
-            REGISTRATION_STATUS_FAILED    -> { /* alert / retry logic */ }
-        }
-    }
-
-    override fun onSendRegisterPushNotificationRequest(
-        requestBodyJsonFields: Map<String, Any?>?,
-        restClient: RestClient
-    ): RestResponse {
-        // Modify requestBodyJsonFields before posting, then call super
-        return super.onSendRegisterPushNotificationRequest(requestBodyJsonFields, restClient)
-    }
-}
-
-// Register:
-SalesforceSDKManager.getInstance().pushServiceType = MyPushService::class.java
-```
-
----
-
-### React Native Apps
-
-For React Native apps, the setup is identical to the native Android setup above, with one substitution: use `SalesforceReactSDKManager.getInstance()` in place of `SalesforceSDKManager.getInstance()`:
-
-```kotlin
-// In MainApplication.onCreate(), after SalesforceReactSDKManager.initReactNative(...)
-SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
-    object : PushNotificationInterface {
-        override fun onPushMessageReceived(data: Map<String?, String?>?) { /* ... */ }
-        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
-    }
-```
-
-There is no JavaScript push bridge — the `react-native-force` package does not export a push module. See [`SalesforceMobileSDK-ReactNative/docs/push/README.md`](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/tree/dev/docs/push) for guidance on forwarding push payloads to the JavaScript layer via a custom event emitter.
 
 ---
 
@@ -449,39 +282,14 @@ No app-side configuration is required beyond normal SDK setup.
 
 ---
 
-## Actionable Notifications
-
-Requires Salesforce API version **v64.0 or later**.
-
-After successful device registration, the SDK automatically fetches notification types from `GET /vXX.0/connect/notifications/types` and stores them per user. It also creates Android `NotificationChannel` objects for each Salesforce notification type via `PushService.registerNotificationChannels(...)`.
-
-To invoke a server-side action when the user taps a notification button:
-
-```kotlin
-override fun onPushMessageReceived(data: Map<String?, String?>?) {
-    val json = data?.get("sfdc.content") ?: return
-    val content = SalesforceActionableNotificationContent.fromJson(json)
-    val nid = content.sfdc?.nid ?: return
-    // When user taps an action:
-    SalesforceSDKManager.getInstance().invokeServerNotificationAction(
-        notificationId = nid,
-        actionKey = "your_action_key",
-        restClient = SalesforceSDKManager.getInstance().clientManager.peekRestClient()
-    )
-}
-```
-
----
-
 ## Testing
 
-Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/`:
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
 
 | Test class | Coverage |
 |---|---|
-| `push/PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
-| `push/PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
-| `push/PushNotificationsRegistrationChangeWorkerTest` | WorkManager worker account-resolution logic, legacy pre-14.0 payload migration |
+| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
 
 Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
 

--- a/docs/push/README.md
+++ b/docs/push/README.md
@@ -2,20 +2,23 @@
 
 This document covers the push notification subsystem in `libs/SalesforceSDK`. All classes live in the package `com.salesforce.androidsdk.push`.
 
+For cross-platform concepts and the shared Salesforce registration model, see the [workspace-level push doc](../../../docs/push/README.md).
+
 ---
 
 ## Table of Contents
 
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
-3. [Architecture](#architecture)
-4. [Key Classes](#key-classes)
-5. [Registration Lifecycle](#registration-lifecycle)
-6. [Re-registration Modes](#re-registration-modes)
-7. [Foreground Registration Mode](#foreground-registration-mode)
-8. [Encrypted Push Notifications](#encrypted-push-notifications)
-9. [Actionable Notifications](#actionable-notifications)
-10. [Testing](#testing)
+3. [Setup](#setup)
+4. [Architecture](#architecture)
+5. [Key Classes](#key-classes)
+6. [Registration Lifecycle](#registration-lifecycle)
+7. [Re-registration Modes](#re-registration-modes)
+8. [Foreground Registration Mode](#foreground-registration-mode)
+9. [Encrypted Push Notifications](#encrypted-push-notifications)
+10. [Actionable Notifications](#actionable-notifications)
+11. [Testing](#testing)
 
 ---
 
@@ -32,7 +35,71 @@ The SDK integrates Firebase Cloud Messaging (FCM) to deliver push notifications 
 | `google-services.json` | Place in your app module root; required for FCM token acquisition |
 | `com.google.gms:google-services` plugin | Apply in your app-level `build.gradle.kts` |
 | `PushNotificationInterface` implementation | Register via `SalesforceSDKManager.getInstance().pushNotificationReceiver` |
+| `POST_NOTIFICATIONS` permission | Required for Android 13+ (API 33+); declare in manifest and request at runtime |
 | External Client App | Connected app with push notification endpoint enabled in your Salesforce org |
+
+---
+
+## Setup
+
+### 1. Add google-services.json
+
+Download `google-services.json` from the [Firebase Console](https://console.firebase.google.com/) and place it in your app module directory (e.g. `app/`).
+
+### 2. Apply the Google Services Gradle Plugin
+
+**`build.gradle.kts`** (project level):
+```kotlin
+buildscript {
+    dependencies {
+        classpath("com.google.gms:google-services:4.4.2")
+    }
+}
+```
+
+**`app/build.gradle.kts`** (app level):
+```kotlin
+plugins {
+    id("com.google.gms.google-services")
+}
+```
+
+### 3. Declare POST_NOTIFICATIONS Permission (Android 13+)
+
+**`AndroidManifest.xml`**:
+```xml
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+```
+
+Request the permission at runtime in your `Activity` or `MainActivity`:
+```kotlin
+if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+    checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS)
+        != PackageManager.PERMISSION_GRANTED) {
+    requestPermissions(arrayOf(android.Manifest.permission.POST_NOTIFICATIONS), requestCode)
+}
+```
+
+### 4. Implement PushNotificationInterface
+
+In your `Application.onCreate()` after `SalesforceSDKManager` is initialized:
+
+```kotlin
+// Native Android apps
+SalesforceSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface {
+        override fun onPushMessageReceived(data: Map<String?, String?>?) {
+            // Handle the notification. The SDK has already decrypted any encrypted payload.
+        }
+        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
+    }
+
+// React Native apps — use SalesforceReactSDKManager instead
+SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface { /* ... */ }
+```
+
+That is all. `SFDCFcmListenerService` (declared in the SDK's own `AndroidManifest.xml`) handles FCM token acquisition, Salesforce device registration, decryption, and re-registration automatically.
 
 ---
 
@@ -183,13 +250,113 @@ Encryption scheme: RSA-OAEP-SHA256 wrapping a 128-bit AES key + 128-bit IV.
 Serializable data class modelling the Salesforce actionable notification payload under the `sfdc` key.
 
 ```kotlin
-data class SalesforceActionableNotificationContent(val sfdc: Sfdc?)
+@Serializable
+data class SalesforceActionableNotificationContent(val sfdc: Sfdc?) {
+    companion object {
+        fun fromJson(json: String): SalesforceActionableNotificationContent
+    }
+
+    @Serializable
+    data class Sfdc(
+        val notifType: String? = null,
+        val nid: String? = null,          // notification ID (use for invokeServerNotificationAction)
+        val oid: String? = null,          // org ID
+        val type: Int? = null,
+        val alertTitle: String? = null,
+        val alertBody: String? = null,
+        val alert: String? = null,
+        val sid: String? = null,
+        val rid: String? = null,
+        val targetPageRef: String? = null,
+        val badge: Int? = null,
+        val uid: String? = null,
+        val cid: String? = null,
+        val timestamp: Int? = null,
+        val act: Act? = null              // actionable action descriptor
+    )
+}
 ```
 
-Parse from the `content` field of a received notification:
+Parse from the `content` key of the received `data` map:
 ```kotlin
-val content = SalesforceActionableNotificationContent.fromJson(jsonString)
+override fun onPushMessageReceived(data: Map<String?, String?>?) {
+    val json = data?.get("sfdc.content") ?: data?.get("content") ?: return
+    val notification = SalesforceActionableNotificationContent.fromJson(json)
+    val notificationId = notification.sfdc?.nid
+    // use notificationId with SalesforceSDKManager.invokeServerNotificationAction(...)
+}
 ```
+
+---
+
+### `NotificationsApiClient`
+
+REST client for the Salesforce Notifications API (requires API v64.0+).
+
+```kotlin
+class NotificationsApiClient(private val restClient: RestClient) {
+    fun fetchNotificationsTypes(): NotificationsTypesResponseBody?
+    fun submitNotificationAction(notificationId: String, actionKey: String): NotificationsActionsResponseBody?
+}
+```
+
+Use via `SalesforceSDKManager`:
+```kotlin
+// Fetch stored notification types (populated automatically after registration)
+val type = SalesforceSDKManager.getInstance().getNotificationsType("approval_request")
+
+// Invoke a server-side notification action
+SalesforceSDKManager.getInstance().invokeServerNotificationAction(
+    notificationId = nid,
+    actionKey = actionIdentifier,
+    restClient = restClient
+)
+```
+
+---
+
+### `PushService` Subclassing
+
+To customize the registration payload or react to status changes, subclass `PushService`:
+
+```kotlin
+class MyPushService : PushService() {
+    override fun onPushNotificationRegistrationStatus(status: Int, userAccount: UserAccount?) {
+        when (status) {
+            REGISTRATION_STATUS_SUCCEEDED -> { /* analytics, logging */ }
+            REGISTRATION_STATUS_FAILED    -> { /* alert / retry logic */ }
+        }
+    }
+
+    override fun onSendRegisterPushNotificationRequest(
+        requestBodyJsonFields: Map<String, Any?>?,
+        restClient: RestClient
+    ): RestResponse {
+        // Modify requestBodyJsonFields before posting, then call super
+        return super.onSendRegisterPushNotificationRequest(requestBodyJsonFields, restClient)
+    }
+}
+
+// Register:
+SalesforceSDKManager.getInstance().pushServiceType = MyPushService::class.java
+```
+
+---
+
+### React Native Apps
+
+For React Native apps, the setup is identical to the native Android setup above, with one substitution: use `SalesforceReactSDKManager.getInstance()` in place of `SalesforceSDKManager.getInstance()`:
+
+```kotlin
+// In MainApplication.onCreate(), after SalesforceReactSDKManager.initReactNative(...)
+SalesforceReactSDKManager.getInstance().pushNotificationReceiver =
+    object : PushNotificationInterface {
+        override fun onPushMessageReceived(data: Map<String?, String?>?) { /* ... */ }
+        override fun supplyFirebaseMessaging(): FirebaseMessaging? = null
+    }
+```
+
+There is no JavaScript push bridge — the `react-native-force` package does not export a push module. See [`SalesforceMobileSDK-ReactNative/docs/push/README.md`](https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/tree/dev/docs/push) for guidance on forwarding push payloads to the JavaScript layer via a custom event emitter.
 
 ---
 
@@ -282,14 +449,39 @@ No app-side configuration is required beyond normal SDK setup.
 
 ---
 
+## Actionable Notifications
+
+Requires Salesforce API version **v64.0 or later**.
+
+After successful device registration, the SDK automatically fetches notification types from `GET /vXX.0/connect/notifications/types` and stores them per user. It also creates Android `NotificationChannel` objects for each Salesforce notification type via `PushService.registerNotificationChannels(...)`.
+
+To invoke a server-side action when the user taps a notification button:
+
+```kotlin
+override fun onPushMessageReceived(data: Map<String?, String?>?) {
+    val json = data?.get("sfdc.content") ?: return
+    val content = SalesforceActionableNotificationContent.fromJson(json)
+    val nid = content.sfdc?.nid ?: return
+    // When user taps an action:
+    SalesforceSDKManager.getInstance().invokeServerNotificationAction(
+        notificationId = nid,
+        actionKey = "your_action_key",
+        restClient = SalesforceSDKManager.getInstance().clientManager.peekRestClient()
+    )
+}
+```
+
+---
+
 ## Testing
 
-Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/`:
+Push notification tests are in `libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/`:
 
 | Test class | Coverage |
 |---|---|
-| `PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
-| `PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+| `push/PushServiceTest` | SFDC registration/unregistration endpoint communication, notification channel creation/deletion, status callbacks, HTTP error handling |
+| `push/PushMessagingTest` | Notification type storage/retrieval, `SalesforceSDKManager` notification API delegation, `NotificationsApiClient` content-type behaviour |
+| `push/PushNotificationsRegistrationChangeWorkerTest` | WorkManager worker account-resolution logic, legacy pre-14.0 payload migration |
 
 Tests use [MockK](https://mockk.io/) to mock `RestClient` and `RestResponse`. They run as instrumented tests on-device or on Firebase Test Lab:
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
@@ -59,5 +59,5 @@ public class Features {
     public static final String FEATURE_LOGIN_SERVER_SANDBOX            = "L2";
     public static final String FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY  = "L3";
     public static final String FEATURE_LOGIN_SERVER_MY_DOMAIN          = "L4";
-    public static final String FEATURE_LOGIN_SERVER_CUSTOM             = "L5";
+    public static final String FEATURE_LOGIN_SERVER_OTHER              = "L5";
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
@@ -47,4 +47,17 @@ public class Features {
     public static final String FEATURE_WELCOME_DISCOVERY_LOGIN = "WD";
     public static final String FEATURE_RTR = "RT";
     public static final String FEATURE_DPOP = "DP";
+
+    // "Why browser login was used" — registered per-user alongside FEATURE_BROWSER_LOGIN (BW)
+    public static final String FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG = "B1";
+    public static final String FEATURE_BROWSER_LOGIN_MDM               = "B2";
+    public static final String FEATURE_BROWSER_LOGIN_FOR_ADMIN         = "B3";
+    public static final String FEATURE_BROWSER_LOGIN_FORCE_FLAG        = "B4";
+
+    // "Which login server type" — registered per-user on every auth-flow completion
+    public static final String FEATURE_LOGIN_SERVER_PRODUCTION         = "L1";
+    public static final String FEATURE_LOGIN_SERVER_SANDBOX            = "L2";
+    public static final String FEATURE_LOGIN_SERVER_MY_DOMAIN          = "L3";
+    public static final String FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY  = "L4";
+    public static final String FEATURE_LOGIN_SERVER_CUSTOM             = "L5";
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/Features.java
@@ -57,7 +57,7 @@ public class Features {
     // "Which login server type" — registered per-user on every auth-flow completion
     public static final String FEATURE_LOGIN_SERVER_PRODUCTION         = "L1";
     public static final String FEATURE_LOGIN_SERVER_SANDBOX            = "L2";
-    public static final String FEATURE_LOGIN_SERVER_MY_DOMAIN          = "L3";
-    public static final String FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY  = "L4";
+    public static final String FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY  = "L3";
+    public static final String FEATURE_LOGIN_SERVER_MY_DOMAIN          = "L4";
     public static final String FEATURE_LOGIN_SERVER_CUSTOM             = "L5";
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/config/LoginServerManager.java
@@ -73,9 +73,39 @@ public class LoginServerManager {
 	public static final String WELCOME_LOGIN_URL = "https://welcome.salesforce.com/discovery";
 	public static final String SANDBOX_LOGIN_URL = "https://test.salesforce.com";
 
+	/**
+	 * Returns true when {@code serverUrl} is the production login pool:
+	 * https://login.salesforce.com or internal variants like https://login.test1.pc-rnd.salesforce.com.
+	 * My-domain URLs (containing ".my.") are never production-pool servers.
+	 */
+	public static boolean isProductionLoginServer(@NonNull String serverUrl) {
+		try {
+			String host = new java.net.URI(serverUrl).getHost();
+			if (host == null) return false;
+			return host.startsWith("login.") && host.endsWith(".salesforce.com") && !host.contains(".my.");
+		} catch (java.net.URISyntaxException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Returns true when {@code serverUrl} is a My Domain server:
+	 * host ends with .my.salesforce.com or contains .my. before .salesforce.com
+	 * (covers internal envs like https://mobilesdksdb32.test1.my.pc-rnd.salesforce.com).
+	 */
+	public static boolean isMyDomainServer(@NonNull String serverUrl) {
+		try {
+			String host = new java.net.URI(serverUrl).getHost();
+			if (host == null) return false;
+			return host.endsWith(".salesforce.com") && host.contains(".my.");
+		} catch (java.net.URISyntaxException e) {
+			return false;
+		}
+	}
+
 	/** Returns true when {@code serverUrl} is one of the three Salesforce pool (non-my-domain) servers. */
 	public static boolean isPoolServer(@NonNull String serverUrl) {
-		return PRODUCTION_LOGIN_URL.equals(serverUrl)
+		return isProductionLoginServer(serverUrl)
 			|| SANDBOX_LOGIN_URL.equals(serverUrl)
 			|| WELCOME_LOGIN_URL.equals(serverUrl);
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -127,7 +127,7 @@ import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_MDM
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
 import com.salesforce.androidsdk.app.Features.FEATURE_DPOP
-import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_OTHER
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_PRODUCTION
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
@@ -561,7 +561,7 @@ open class LoginActivity : FragmentActivity() {
             FEATURE_LOGIN_SERVER_SANDBOX,
             FEATURE_LOGIN_SERVER_MY_DOMAIN,
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
-            FEATURE_LOGIN_SERVER_CUSTOM,
+            FEATURE_LOGIN_SERVER_OTHER,
         )
         val loginServerUrl = sdkManager.loginServerManager.selectedLoginServer.url.trim()
         val lMarker = selectLMarker(usedWelcomeDiscovery, loginServerUrl)
@@ -643,11 +643,11 @@ open class LoginActivity : FragmentActivity() {
      */
     @VisibleForTesting
     internal fun selectLMarker(usedWelcomeDiscovery: Boolean, loginServerUrl: String): String = when {
-        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY                          // L3
-        LoginServerManager.PRODUCTION_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_PRODUCTION  // L1
+        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY                         // L3
+        LoginServerManager.isProductionLoginServer(loginServerUrl) -> FEATURE_LOGIN_SERVER_PRODUCTION  // L1
         LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX  // L2
-        loginServerUrl.toUri().host?.endsWith(".my.salesforce.com") == true -> FEATURE_LOGIN_SERVER_MY_DOMAIN  // L4
-        else -> FEATURE_LOGIN_SERVER_CUSTOM                                                     // L5
+        LoginServerManager.isMyDomainServer(loginServerUrl) -> FEATURE_LOGIN_SERVER_MY_DOMAIN   // L4
+        else -> FEATURE_LOGIN_SERVER_OTHER                                                      // L5
     }
 
     /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -122,10 +122,20 @@ import com.salesforce.androidsdk.R.string.sf__ssl_unknown_error
 import com.salesforce.androidsdk.R.string.sf__ssl_untrusted
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_MDM
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
 import com.salesforce.androidsdk.app.Features.FEATURE_DPOP
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_PRODUCTION
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
 import com.salesforce.androidsdk.app.Features.FEATURE_QR_CODE_LOGIN
 import com.salesforce.androidsdk.app.Features.FEATURE_WELCOME_DISCOVERY_LOGIN
 import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.app.SalesforceSDKManager.Theme.DARK
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.auth.OAuthErrorCode
@@ -234,6 +244,7 @@ open class LoginActivity : FragmentActivity() {
     private var baseUserAgentString = ""
     private var wasBackgrounded = false
     private var completedViaBrowserTab = false
+    private var completedViaAdminCustomTab = false
     private var accountAuthenticatorResponse: AccountAuthenticatorResponse? = null
     private var accountAuthenticatorResult: Bundle? = null
     private var newUserIntent = false
@@ -542,6 +553,26 @@ open class LoginActivity : FragmentActivity() {
 
         // WD: write per-user and clear transient global
         val usedWelcomeDiscovery = sdkManager.isGlobalFeatureRegistered(FEATURE_WELCOME_DISCOVERY_LOGIN)
+
+        // L-markers: register exactly one "which login server" marker per-user.
+        // Must be computed before WD global is cleared below.
+        val allLMarkers = listOf(
+            FEATURE_LOGIN_SERVER_PRODUCTION,
+            FEATURE_LOGIN_SERVER_SANDBOX,
+            FEATURE_LOGIN_SERVER_MY_DOMAIN,
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
+            FEATURE_LOGIN_SERVER_CUSTOM,
+        )
+        val loginServerUrl = sdkManager.loginServerManager.selectedLoginServer.url.trim()
+        val lMarker = selectLMarker(usedWelcomeDiscovery, loginServerUrl)
+        for (marker in allLMarkers) {
+            if (marker == lMarker) {
+                sdkManager.registerUsedAppFeature(marker, userAccount)
+            } else {
+                sdkManager.unregisterUsedAppFeature(marker, userAccount)
+            }
+        }
+
         sdkManager.unregisterUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN)
         if (usedWelcomeDiscovery) {
             sdkManager.registerUsedAppFeature(FEATURE_WELCOME_DISCOVERY_LOGIN, userAccount)
@@ -556,6 +587,31 @@ open class LoginActivity : FragmentActivity() {
         } else {
             sdkManager.unregisterUsedAppFeature(FEATURE_BROWSER_LOGIN, userAccount)
         }
+
+        // B-markers: register exactly one "why browser was used" marker per-user alongside BW.
+        val allBMarkers = listOf(
+            FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG,
+            FEATURE_BROWSER_LOGIN_MDM,
+            FEATURE_BROWSER_LOGIN_FOR_ADMIN,
+            FEATURE_BROWSER_LOGIN_FORCE_FLAG,
+        )
+        @Suppress("DEPRECATION")
+        val bMarker = selectBMarker(
+            completedViaBrowserTab,
+            completedViaAdminCustomTab,
+            isMdmForcedBrowserLogin(),
+            sdkManager.forceAdvancedAuthentication,
+        )
+        for (marker in allBMarkers) {
+            if (marker == bMarker) {
+                sdkManager.registerUsedAppFeature(marker, userAccount)
+            } else {
+                sdkManager.unregisterUsedAppFeature(marker, userAccount)
+            }
+        }
+        // Reset the admin tab flag alongside completedViaBrowserTab
+        completedViaAdminCustomTab = false
+        completedViaBrowserTab = false
 
         // QR: write per-user and clear transient global
         val usedQrLogin = sdkManager.isGlobalFeatureRegistered(FEATURE_QR_CODE_LOGIN)
@@ -576,6 +632,58 @@ open class LoginActivity : FragmentActivity() {
         setResult(RESULT_OK)
         finish()
     }
+
+    /**
+     * Selects the L-marker (login server type) for telemetry.
+     * Exactly one of L1–L5 is selected.
+     *
+     * @param usedWelcomeDiscovery Whether the Welcome Discovery flow was used (captured before WD global is cleared)
+     * @param loginServerUrl The selected login server URL at auth completion time
+     * @return The L-marker feature code to register
+     */
+    @VisibleForTesting
+    internal fun selectLMarker(usedWelcomeDiscovery: Boolean, loginServerUrl: String): String = when {
+        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
+        LoginServerManager.PRODUCTION_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_PRODUCTION
+        LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX
+        !LoginServerManager.isPoolServer(loginServerUrl) &&
+            loginServerUrl != LoginServerManager.WELCOME_LOGIN_URL -> FEATURE_LOGIN_SERVER_MY_DOMAIN
+        else -> FEATURE_LOGIN_SERVER_CUSTOM
+    }
+
+    /**
+     * Selects the B-marker (browser login reason) for telemetry.
+     * Returns exactly one of B1–B4 if browser login was used, or null if it was not.
+     * Priority: B3 (admin) > B2 (MDM) > B4 (force flag) > B1 (server auth config)
+     *
+     * @param completedViaBrowserTab Whether login completed via browser Custom Tab
+     * @param completedViaAdminCustomTab Whether login completed via the "Login for Admin" Custom Tab
+     * @param isMdmForced Whether MDM policy forced browser login
+     * @param forceAdvancedAuth Whether the [SalesforceSDKManager.forceAdvancedAuthentication] flag is set
+     * @return The B-marker feature code to register, or null if browser login was not used
+     */
+    @VisibleForTesting
+    internal fun selectBMarker(
+        completedViaBrowserTab: Boolean,
+        completedViaAdminCustomTab: Boolean,
+        isMdmForced: Boolean,
+        forceAdvancedAuth: Boolean,
+    ): String? = when {
+        !completedViaBrowserTab -> null
+        completedViaAdminCustomTab -> FEATURE_BROWSER_LOGIN_FOR_ADMIN   // B3
+        isMdmForced -> FEATURE_BROWSER_LOGIN_MDM                        // B2
+        forceAdvancedAuth -> FEATURE_BROWSER_LOGIN_FORCE_FLAG           // B4
+        else -> FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG                // B1 fallthrough
+    }
+
+    /**
+     * Returns true when MDM policy has forced browser login.
+     * MDM registers the global [Features.FEATURE_MDM] flag via [RuntimeConfig].
+     */
+    private fun isMdmForcedBrowserLogin(): Boolean =
+        SalesforceSDKManager.getInstance().isGlobalFeatureRegistered(
+            com.salesforce.androidsdk.app.Features.FEATURE_MDM
+        )
 
     /**
      * A callback when the user facing part of the authentication flow completed
@@ -827,6 +935,7 @@ open class LoginActivity : FragmentActivity() {
             return
         }
         val loginUrl = viewModel.browserCustomTabUrl.value ?: return
+        completedViaAdminCustomTab = true
         loadLoginPageInCustomTab(loginUrl, adminLoginCustomTabLauncher)
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -643,22 +643,24 @@ open class LoginActivity : FragmentActivity() {
      */
     @VisibleForTesting
     internal fun selectLMarker(usedWelcomeDiscovery: Boolean, loginServerUrl: String): String = when {
-        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
-        LoginServerManager.PRODUCTION_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_PRODUCTION
-        LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX
-        !LoginServerManager.isPoolServer(loginServerUrl) &&
-            loginServerUrl != LoginServerManager.WELCOME_LOGIN_URL -> FEATURE_LOGIN_SERVER_MY_DOMAIN
-        else -> FEATURE_LOGIN_SERVER_CUSTOM
+        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY                          // L3
+        LoginServerManager.PRODUCTION_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_PRODUCTION  // L1
+        LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX  // L2
+        loginServerUrl.toUri().host?.endsWith(".my.salesforce.com") == true -> FEATURE_LOGIN_SERVER_MY_DOMAIN  // L4
+        else -> FEATURE_LOGIN_SERVER_CUSTOM                                                     // L5
     }
 
     /**
      * Selects the B-marker (browser login reason) for telemetry.
-     * Returns exactly one of B1–B4 if browser login was used, or null if it was not.
-     * Priority: B3 (admin) > B2 (MDM) > B4 (force flag) > B1 (server auth config)
+     * Returns exactly one of B1, B3, or B4 if browser login was used, or null if it was not.
+     * Priority: B3 (admin) > B4 (force flag) > B1 (server auth config)
+     *
+     * Note: B2 (MDM) is defined in [Features] but is never selected on Android. On Android,
+     * MDM forces cert auth via a different code path that never sets [completedViaBrowserTab].
      *
      * @param completedViaBrowserTab Whether login completed via browser Custom Tab
      * @param completedViaAdminCustomTab Whether login completed via the "Login for Admin" Custom Tab
-     * @param isMdmForced Whether MDM policy forced browser login
+     * @param isMdmForced Unused on Android — reserved for future use (always pass false)
      * @param forceAdvancedAuth Whether the [SalesforceSDKManager.forceAdvancedAuthentication] flag is set
      * @return The B-marker feature code to register, or null if browser login was not used
      */
@@ -666,19 +668,22 @@ open class LoginActivity : FragmentActivity() {
     internal fun selectBMarker(
         completedViaBrowserTab: Boolean,
         completedViaAdminCustomTab: Boolean,
-        isMdmForced: Boolean,
+        @Suppress("UNUSED_PARAMETER") isMdmForced: Boolean,
         forceAdvancedAuth: Boolean,
     ): String? = when {
         !completedViaBrowserTab -> null
         completedViaAdminCustomTab -> FEATURE_BROWSER_LOGIN_FOR_ADMIN   // B3
-        isMdmForced -> FEATURE_BROWSER_LOGIN_MDM                        // B2
         forceAdvancedAuth -> FEATURE_BROWSER_LOGIN_FORCE_FLAG           // B4
         else -> FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG                // B1 fallthrough
     }
 
     /**
-     * Returns true when MDM policy has forced browser login.
-     * MDM registers the global [Features.FEATURE_MDM] flag via [RuntimeConfig].
+     * Reserved for future use — currently unused on Android.
+     *
+     * On Android, MDM forces cert-auth (a different code path that never sets
+     * [completedViaBrowserTab]), so [Features.FEATURE_BROWSER_LOGIN_MDM] (B2) is never
+     * selected. This helper is retained so the call site in [onAuthFlowSuccess] remains
+     * forward-compatible once a real Android MDM-browser-login signal is identified.
      */
     private fun isMdmForcedBrowserLogin(): Boolean =
         SalesforceSDKManager.getInstance().isGlobalFeatureRegistered(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -345,6 +345,11 @@ open class LoginActivity : FragmentActivity() {
         // we can safely ignore that scenario.
         with(SalesforceSDKManager.getInstance()) {
             if (isDebugBuild && loginDevMenuReload) {
+                // Login Options may have changed the auth surface (e.g. disabled Web Server Flow).
+                // Reset completedViaBrowserTab so a subsequent in-app WebView login does not
+                // inherit the browser-tab path.  If reloadWebView() re-launches a Custom Tab,
+                // loadLoginPageInCustomTab() will set it back to true before login completes.
+                completedViaBrowserTab = false
                 viewModel.reloadWebView()
                 loginDevMenuReload = false
             }
@@ -1794,9 +1799,6 @@ open class LoginActivity : FragmentActivity() {
         override fun onActivityResult(result: ActivityResult) {
             // Check if the user backed out of the custom tab.
             if (result.resultCode == RESULT_CANCELED) {
-                // The tab was dismissed without completing login — clear the flag so that
-                // a subsequent in-app WebView login does not inherit the browser-tab path.
-                activity.completedViaBrowserTab = false
                 if (activity.viewModel.singleServerCustomTabActivity) {
                     // Show blank page and spinner until PKCE is done.
                     activity.viewModel.loginUrl.value = ABOUT_BLANK

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -634,50 +634,6 @@ open class LoginActivity : FragmentActivity() {
     }
 
     /**
-     * Selects the L-marker (login server type) for telemetry.
-     * Exactly one of L1–L5 is selected.
-     *
-     * @param usedWelcomeDiscovery Whether the Welcome Discovery flow was used (captured before WD global is cleared)
-     * @param loginServerUrl The selected login server URL at auth completion time
-     * @return The L-marker feature code to register
-     */
-    @VisibleForTesting
-    internal fun selectLMarker(usedWelcomeDiscovery: Boolean, loginServerUrl: String): String = when {
-        usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY                         // L3
-        LoginServerManager.isProductionLoginServer(loginServerUrl) -> FEATURE_LOGIN_SERVER_PRODUCTION  // L1
-        LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX  // L2
-        LoginServerManager.isMyDomainServer(loginServerUrl) -> FEATURE_LOGIN_SERVER_MY_DOMAIN   // L4
-        else -> FEATURE_LOGIN_SERVER_OTHER                                                      // L5
-    }
-
-    /**
-     * Selects the B-marker (browser login reason) for telemetry.
-     * Returns exactly one of B1, B3, or B4 if browser login was used, or null if it was not.
-     * Priority: B3 (admin) > B4 (force flag) > B1 (server auth config)
-     *
-     * Note: B2 (MDM) is defined in [Features] but is never selected on Android. On Android,
-     * MDM forces cert auth via a different code path that never sets [completedViaBrowserTab].
-     *
-     * @param completedViaBrowserTab Whether login completed via browser Custom Tab
-     * @param completedViaAdminCustomTab Whether login completed via the "Login for Admin" Custom Tab
-     * @param isMdmForced Unused on Android — reserved for future use (always pass false)
-     * @param forceAdvancedAuth Whether the [SalesforceSDKManager.forceAdvancedAuthentication] flag is set
-     * @return The B-marker feature code to register, or null if browser login was not used
-     */
-    @VisibleForTesting
-    internal fun selectBMarker(
-        completedViaBrowserTab: Boolean,
-        completedViaAdminCustomTab: Boolean,
-        @Suppress("UNUSED_PARAMETER") isMdmForced: Boolean,
-        forceAdvancedAuth: Boolean,
-    ): String? = when {
-        !completedViaBrowserTab -> null
-        completedViaAdminCustomTab -> FEATURE_BROWSER_LOGIN_FOR_ADMIN   // B3
-        forceAdvancedAuth -> FEATURE_BROWSER_LOGIN_FORCE_FLAG           // B4
-        else -> FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG                // B1 fallthrough
-    }
-
-    /**
      * Reserved for future use — currently unused on Android.
      *
      * On Android, MDM forces cert-auth (a different code path that never sets
@@ -1488,6 +1444,53 @@ open class LoginActivity : FragmentActivity() {
             val blue = rgbMatch.groupValues[3].toIntOrNull() ?: return null
 
             return Color(red, green, blue)
+        }
+
+        // endregion
+        // region Telemetry marker selection
+
+        /**
+         * Selects the L-marker (login server type) for telemetry.
+         * Exactly one of L1–L5 is selected.
+         *
+         * @param usedWelcomeDiscovery Whether the Welcome Discovery flow was used (captured before WD global is cleared)
+         * @param loginServerUrl The selected login server URL at auth completion time
+         * @return The L-marker feature code to register
+         */
+        @VisibleForTesting
+        internal fun selectLMarker(usedWelcomeDiscovery: Boolean, loginServerUrl: String): String = when {
+            usedWelcomeDiscovery -> FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY                         // L3
+            LoginServerManager.isProductionLoginServer(loginServerUrl) -> FEATURE_LOGIN_SERVER_PRODUCTION  // L1
+            LoginServerManager.SANDBOX_LOGIN_URL == loginServerUrl -> FEATURE_LOGIN_SERVER_SANDBOX  // L2
+            LoginServerManager.isMyDomainServer(loginServerUrl) -> FEATURE_LOGIN_SERVER_MY_DOMAIN   // L4
+            else -> FEATURE_LOGIN_SERVER_OTHER                                                      // L5
+        }
+
+        /**
+         * Selects the B-marker (browser login reason) for telemetry.
+         * Returns exactly one of B1, B3, or B4 if browser login was used, or null if it was not.
+         * Priority: B3 (admin) > B4 (force flag) > B1 (server auth config)
+         *
+         * Note: B2 (MDM) is defined in [Features] but is never selected on Android. On Android,
+         * MDM forces cert auth via a different code path that never sets [completedViaBrowserTab].
+         *
+         * @param completedViaBrowserTab Whether login completed via browser Custom Tab
+         * @param completedViaAdminCustomTab Whether login completed via the "Login for Admin" Custom Tab
+         * @param isMdmForced Unused on Android — reserved for future use (always pass false)
+         * @param forceAdvancedAuth Whether the [SalesforceSDKManager.forceAdvancedAuthentication] flag is set
+         * @return The B-marker feature code to register, or null if browser login was not used
+         */
+        @VisibleForTesting
+        internal fun selectBMarker(
+            completedViaBrowserTab: Boolean,
+            completedViaAdminCustomTab: Boolean,
+            @Suppress("UNUSED_PARAMETER") isMdmForced: Boolean,
+            forceAdvancedAuth: Boolean,
+        ): String? = when {
+            !completedViaBrowserTab -> null
+            completedViaAdminCustomTab -> FEATURE_BROWSER_LOGIN_FOR_ADMIN   // B3
+            forceAdvancedAuth -> FEATURE_BROWSER_LOGIN_FORCE_FLAG           // B4
+            else -> FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG                // B1 fallthrough
         }
 
         // endregion

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -1794,6 +1794,9 @@ open class LoginActivity : FragmentActivity() {
         override fun onActivityResult(result: ActivityResult) {
             // Check if the user backed out of the custom tab.
             if (result.resultCode == RESULT_CANCELED) {
+                // The tab was dismissed without completing login — clear the flag so that
+                // a subsequent in-app WebView login does not inherit the browser-tab path.
+                activity.completedViaBrowserTab = false
                 if (activity.viewModel.singleServerCustomTabActivity) {
                     // Show blank page and spinner until PKCE is done.
                     activity.viewModel.loginUrl.value = ABOUT_BLANK

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
@@ -38,10 +38,6 @@ import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
 import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.ui.LoginActivity
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.unmockkAll
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -52,9 +48,8 @@ import org.junit.runner.RunWith
  * telemetry selection logic in [LoginActivity].
  *
  * The logic under test lives in [LoginActivity.selectBMarker] and [LoginActivity.selectLMarker],
- * which are `internal` helpers extracted for testability and annotated `@VisibleForTesting`.
- * We call them via a relaxed mockk and `callOriginal()` so the real logic executes without
- * needing a running Android Activity context.
+ * which are companion object helpers annotated `@VisibleForTesting`. They are pure functions
+ * that require no Activity context, so they are called directly without mocking.
  *
  * L-marker mapping:
  *   L1 = Production server
@@ -73,21 +68,11 @@ import org.junit.runner.RunWith
 @SmallTest
 class BrowserLoginTelemetryTest {
 
-    /** A relaxed mock of LoginActivity; individual tests call `callOriginal()` on the method under test. */
-    private val activity: LoginActivity = mockk(relaxed = true)
-
-    @After
-    fun tearDown() {
-        unmockkAll()
-    }
-
     // region B-marker tests
 
     @Test
     fun test_givenNonBrowserLogin_whenSelectBMarker_thenReturnsNull() {
-        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
-
-        val result = activity.selectBMarker(
+        val result = LoginActivity.selectBMarker(
             completedViaBrowserTab = false,
             completedViaAdminCustomTab = false,
             isMdmForced = false,
@@ -98,10 +83,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenBrowserLoginViaServerAuthConfig_whenSelectBMarker_thenB1Returned() {
-        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
-
         // B1: browser tab, not admin, not force-flag (MDM ignored on Android)
-        val result = activity.selectBMarker(
+        val result = LoginActivity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = false,
@@ -113,12 +96,10 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenBrowserLoginViaMDM_whenSelectBMarker_thenB1ReturnedNotB2() {
-        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
-
         // On Android, MDM forces cert auth (different code path — completedViaBrowserTab never
         // becomes true in that flow). When isMdmForced=true is passed, it is ignored and B1
         // is returned as the fallthrough because no real Android MDM-browser-login signal exists.
-        val result = activity.selectBMarker(
+        val result = LoginActivity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = true,
@@ -130,10 +111,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenAdminCustomTab_whenSelectBMarker_thenB3Returned() {
-        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
-
         // B3: browser tab via admin launcher
-        val result = activity.selectBMarker(
+        val result = LoginActivity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = true,
             isMdmForced = false,
@@ -145,10 +124,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenBrowserLoginViaForceFlag_whenSelectBMarker_thenB4Returned() {
-        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
-
         // B4: browser tab, not admin, force flag ON
-        val result = activity.selectBMarker(
+        val result = LoginActivity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = false,
@@ -160,10 +137,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenAdminTabAndForceFlag_whenSelectBMarker_thenB3Wins() {
-        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
-
         // Priority on Android: B3 > B4 > B1
-        val result = activity.selectBMarker(
+        val result = LoginActivity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = true,
             isMdmForced = false,
@@ -175,10 +150,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenForceFlagAndMdm_whenSelectBMarker_thenB4Wins() {
-        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
-
         // On Android MDM is ignored; force flag wins over B1 fallthrough
-        val result = activity.selectBMarker(
+        val result = LoginActivity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = true,
@@ -193,9 +166,7 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenProductionServer_whenSelectLMarker_thenL1Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
         )
@@ -205,9 +176,7 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenSandboxServer_whenSelectLMarker_thenL2Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = LoginServerManager.SANDBOX_LOGIN_URL,
         )
@@ -217,10 +186,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenWelcomeDiscovery_whenSelectLMarker_thenL3Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         // L3: Welcome Discovery flow — WD flag takes precedence regardless of the resolved URL
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = true,
             loginServerUrl = "https://myorg.my.salesforce.com",
         )
@@ -230,10 +197,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenWelcomeDiscoveryWithProductionUrl_whenSelectLMarker_thenL3Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         // WD flag wins even when the resolved URL is production
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = true,
             loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
         )
@@ -243,10 +208,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenMyDomainServer_whenSelectLMarker_thenL4Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         // L4: host ends with .my.salesforce.com
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = "https://myorg.my.salesforce.com",
         )
@@ -256,10 +219,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenMyDomainSandboxServer_whenSelectLMarker_thenL4Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         // Sandbox My Domain also ends with .my.salesforce.com (L4, not L2, because URL != sandbox constant)
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = "https://myorg.sandbox.my.salesforce.com",
         )
@@ -269,10 +230,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenWelcomeLoginUrl_whenSelectLMarker_thenL5Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         // The WD URL itself: when usedWelcomeDiscovery=false it falls to L5 (other)
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = LoginServerManager.WELCOME_LOGIN_URL,
         )
@@ -282,9 +241,7 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenOtherServer_whenSelectLMarker_thenL5Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = "https://custom.example.com",
         )
@@ -294,10 +251,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenInternalProductionPoolServer_whenSelectLMarker_thenL1Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         // Internal env: login.test1.pc-rnd.salesforce.com — should map to L1
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = "https://login.test1.pc-rnd.salesforce.com",
         )
@@ -307,10 +262,8 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenInternalMyDomainServer_whenSelectLMarker_thenL4Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         // Internal env: mobilesdksdb32.test1.my.pc-rnd.salesforce.com — should map to L4
-        val result = activity.selectLMarker(
+        val result = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = "https://mobilesdksdb32.test1.my.pc-rnd.salesforce.com",
         )
@@ -320,8 +273,6 @@ class BrowserLoginTelemetryTest {
 
     @Test
     fun test_givenExactlyOneL_whenProductionServer_thenOnlyL1Selected() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
         val allLMarkers = listOf(
             FEATURE_LOGIN_SERVER_PRODUCTION,
             FEATURE_LOGIN_SERVER_SANDBOX,
@@ -329,7 +280,7 @@ class BrowserLoginTelemetryTest {
             FEATURE_LOGIN_SERVER_MY_DOMAIN,
             FEATURE_LOGIN_SERVER_OTHER,
         )
-        val selected = activity.selectLMarker(
+        val selected = LoginActivity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
         )

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
@@ -31,7 +31,7 @@ import androidx.test.filters.SmallTest
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
-import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_OTHER
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_PRODUCTION
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
@@ -61,7 +61,7 @@ import org.junit.runner.RunWith
  *   L2 = Sandbox server
  *   L3 = welcome.salesforce.com (Welcome Discovery flow)
  *   L4 = My Domain (host ending in .my.salesforce.com)
- *   L5 = Everything else (custom)
+ *   L5 = Everything else (other)
  *
  * B-marker mapping (Android):
  *   B1 = Server auth config (fallthrough)
@@ -271,25 +271,51 @@ class BrowserLoginTelemetryTest {
     fun test_givenWelcomeLoginUrl_whenSelectLMarker_thenL5Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
-        // The WD URL itself: when usedWelcomeDiscovery=false it falls to L5 (custom)
+        // The WD URL itself: when usedWelcomeDiscovery=false it falls to L5 (other)
         val result = activity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = LoginServerManager.WELCOME_LOGIN_URL,
         )
-        assertEquals("WD URL without WD flag set should yield L5 (custom)",
-            FEATURE_LOGIN_SERVER_CUSTOM, result)
+        assertEquals("WD URL without WD flag set should yield L5 (other)",
+            FEATURE_LOGIN_SERVER_OTHER, result)
     }
 
     @Test
-    fun test_givenCustomServer_whenSelectLMarker_thenL5Returned() {
+    fun test_givenOtherServer_whenSelectLMarker_thenL5Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
         val result = activity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = "https://custom.example.com",
         )
-        assertEquals("Custom server should yield L5",
-            FEATURE_LOGIN_SERVER_CUSTOM, result)
+        assertEquals("Other server should yield L5",
+            FEATURE_LOGIN_SERVER_OTHER, result)
+    }
+
+    @Test
+    fun test_givenInternalProductionPoolServer_whenSelectLMarker_thenL1Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // Internal env: login.test1.pc-rnd.salesforce.com — should map to L1
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://login.test1.pc-rnd.salesforce.com",
+        )
+        assertEquals("Internal production pool server should yield L1",
+            FEATURE_LOGIN_SERVER_PRODUCTION, result)
+    }
+
+    @Test
+    fun test_givenInternalMyDomainServer_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // Internal env: mobilesdksdb32.test1.my.pc-rnd.salesforce.com — should map to L4
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://mobilesdksdb32.test1.my.pc-rnd.salesforce.com",
+        )
+        assertEquals("Internal My Domain server should yield L4",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
     }
 
     @Test
@@ -301,7 +327,7 @@ class BrowserLoginTelemetryTest {
             FEATURE_LOGIN_SERVER_SANDBOX,
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
             FEATURE_LOGIN_SERVER_MY_DOMAIN,
-            FEATURE_LOGIN_SERVER_CUSTOM,
+            FEATURE_LOGIN_SERVER_OTHER,
         )
         val selected = activity.selectLMarker(
             usedWelcomeDiscovery = false,

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.app
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_MDM
+import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_PRODUCTION
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
+import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
+import com.salesforce.androidsdk.config.LoginServerManager
+import com.salesforce.androidsdk.ui.LoginActivity
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Unit tests for the B-marker (browser login reason) and L-marker (login server type)
+ * telemetry selection logic in [LoginActivity].
+ *
+ * The logic under test lives in [LoginActivity.selectBMarker] and [LoginActivity.selectLMarker],
+ * which are `internal` helpers extracted for testability and annotated `@VisibleForTesting`.
+ * We call them via a relaxed mockk and `callOriginal()` so the real logic executes without
+ * needing a running Android Activity context.
+ */
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class BrowserLoginTelemetryTest {
+
+    /** A relaxed mock of LoginActivity; individual tests call `callOriginal()` on the method under test. */
+    private val activity: LoginActivity = mockk(relaxed = true)
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // region B-marker tests
+
+    @Test
+    fun test_givenNonBrowserLogin_whenSelectBMarker_thenReturnsNull() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = false,
+            completedViaAdminCustomTab = false,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertNull("Non-browser login should yield no B-marker", result)
+    }
+
+    @Test
+    fun test_givenBrowserLoginViaServerAuthConfig_whenSelectBMarker_thenB1Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B1: browser tab, not admin, not MDM, not force-flag
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("Server auth-config browser login should yield B1",
+            FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG, result)
+    }
+
+    @Test
+    fun test_givenBrowserLoginViaMDM_whenSelectBMarker_thenB2Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B2: browser tab, not admin, MDM forced
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = true,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("MDM-forced browser login should yield B2",
+            FEATURE_BROWSER_LOGIN_MDM, result)
+    }
+
+    @Test
+    fun test_givenAdminCustomTab_whenSelectBMarker_thenB3Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B3: browser tab via admin launcher
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = true,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("Admin custom tab login should yield B3",
+            FEATURE_BROWSER_LOGIN_FOR_ADMIN, result)
+    }
+
+    @Test
+    fun test_givenBrowserLoginViaForceFlag_whenSelectBMarker_thenB4Returned() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // B4: browser tab, not admin, not MDM, force flag ON
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = false,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("Force-advanced-auth browser login should yield B4",
+            FEATURE_BROWSER_LOGIN_FORCE_FLAG, result)
+    }
+
+    @Test
+    fun test_givenAdminTabAndMdmAndForceFlag_whenSelectBMarker_thenB3Wins() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // Priority: B3 > B2 > B4 > B1
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = true,
+            isMdmForced = true,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("Admin tab should take highest priority (B3)",
+            FEATURE_BROWSER_LOGIN_FOR_ADMIN, result)
+    }
+
+    @Test
+    fun test_givenMdmAndForceFlag_whenSelectBMarker_thenB2Wins() {
+        every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
+
+        // Priority: B2 > B4
+        val result = activity.selectBMarker(
+            completedViaBrowserTab = true,
+            completedViaAdminCustomTab = false,
+            isMdmForced = true,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("MDM should take priority over force flag (B2 > B4)",
+            FEATURE_BROWSER_LOGIN_MDM, result)
+    }
+
+    // endregion
+    // region L-marker tests
+
+    @Test
+    fun test_givenProductionServer_whenSelectLMarker_thenL1Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
+        )
+        assertEquals("Production login server should yield L1",
+            FEATURE_LOGIN_SERVER_PRODUCTION, result)
+    }
+
+    @Test
+    fun test_givenSandboxServer_whenSelectLMarker_thenL2Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.SANDBOX_LOGIN_URL,
+        )
+        assertEquals("Sandbox login server should yield L2",
+            FEATURE_LOGIN_SERVER_SANDBOX, result)
+    }
+
+    @Test
+    fun test_givenMyDomainServer_whenSelectLMarker_thenL3Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // My Domain is a non-pool, non-WD URL
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("My Domain login server should yield L3",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
+    }
+
+    @Test
+    fun test_givenWelcomeDiscovery_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // WD flag takes precedence regardless of the resolved server URL
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = true,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("Welcome Discovery should yield L4",
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
+    }
+
+    @Test
+    fun test_givenWelcomeDiscoveryWithProductionUrl_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // WD flag wins even when the resolved URL is production
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = true,
+            loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
+        )
+        assertEquals("WD flag should override production URL and yield L4",
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
+    }
+
+    @Test
+    fun test_givenWelcomeLoginUrl_whenSelectLMarker_thenL5Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // The WD URL itself is a pool server, so when usedWelcomeDiscovery=false it falls to L5.
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.WELCOME_LOGIN_URL,
+        )
+        assertEquals("WD URL without WD flag set should yield L5 (custom)",
+            FEATURE_LOGIN_SERVER_CUSTOM, result)
+    }
+
+    @Test
+    fun test_givenExactlyOneL_whenProductionServer_thenOnlyL1Selected() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val allLMarkers = listOf(
+            FEATURE_LOGIN_SERVER_PRODUCTION,
+            FEATURE_LOGIN_SERVER_SANDBOX,
+            FEATURE_LOGIN_SERVER_MY_DOMAIN,
+            FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
+            FEATURE_LOGIN_SERVER_CUSTOM,
+        )
+        val selected = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
+        )
+        val selectedCount = allLMarkers.count { it == selected }
+        assertEquals("Exactly one L marker should be selected", 1, selectedCount)
+        assertEquals("The selected marker should be L1", FEATURE_LOGIN_SERVER_PRODUCTION, selected)
+    }
+
+    @Test
+    fun test_givenMyDomainWithTrailingSpace_whenSelectLMarker_thenL3Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // selectLMarker trims the URL, so trailing spaces should not affect the result.
+        // Note: the trimming is done in onAuthFlowSuccess before calling selectLMarker,
+        // but selectLMarker still receives pre-trimmed input here.
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("My Domain URL should yield L3",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
+    }
+
+    // endregion
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
@@ -30,7 +30,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG
-import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_MDM
 import com.salesforce.androidsdk.app.Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_CUSTOM
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
@@ -56,6 +55,19 @@ import org.junit.runner.RunWith
  * which are `internal` helpers extracted for testability and annotated `@VisibleForTesting`.
  * We call them via a relaxed mockk and `callOriginal()` so the real logic executes without
  * needing a running Android Activity context.
+ *
+ * L-marker mapping:
+ *   L1 = Production server
+ *   L2 = Sandbox server
+ *   L3 = welcome.salesforce.com (Welcome Discovery flow)
+ *   L4 = My Domain (host ending in .my.salesforce.com)
+ *   L5 = Everything else (custom)
+ *
+ * B-marker mapping (Android):
+ *   B1 = Server auth config (fallthrough)
+ *   B2 = MDM — defined but never selected on Android (MDM forces cert auth, a different path)
+ *   B3 = Admin Custom Tab
+ *   B4 = Force-advanced-auth flag
  */
 @RunWith(AndroidJUnit4::class)
 @SmallTest
@@ -88,7 +100,7 @@ class BrowserLoginTelemetryTest {
     fun test_givenBrowserLoginViaServerAuthConfig_whenSelectBMarker_thenB1Returned() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // B1: browser tab, not admin, not MDM, not force-flag
+        // B1: browser tab, not admin, not force-flag (MDM ignored on Android)
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
@@ -100,18 +112,20 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenBrowserLoginViaMDM_whenSelectBMarker_thenB2Returned() {
+    fun test_givenBrowserLoginViaMDM_whenSelectBMarker_thenB1ReturnedNotB2() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // B2: browser tab, not admin, MDM forced
+        // On Android, MDM forces cert auth (different code path — completedViaBrowserTab never
+        // becomes true in that flow). When isMdmForced=true is passed, it is ignored and B1
+        // is returned as the fallthrough because no real Android MDM-browser-login signal exists.
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = true,
             forceAdvancedAuth = false,
         )
-        assertEquals("MDM-forced browser login should yield B2",
-            FEATURE_BROWSER_LOGIN_MDM, result)
+        assertEquals("MDM flag is ignored on Android; should fall through to B1",
+            FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG, result)
     }
 
     @Test
@@ -133,7 +147,7 @@ class BrowserLoginTelemetryTest {
     fun test_givenBrowserLoginViaForceFlag_whenSelectBMarker_thenB4Returned() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // B4: browser tab, not admin, not MDM, force flag ON
+        // B4: browser tab, not admin, force flag ON
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
@@ -145,14 +159,14 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenAdminTabAndMdmAndForceFlag_whenSelectBMarker_thenB3Wins() {
+    fun test_givenAdminTabAndForceFlag_whenSelectBMarker_thenB3Wins() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // Priority: B3 > B2 > B4 > B1
+        // Priority on Android: B3 > B4 > B1
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = true,
-            isMdmForced = true,
+            isMdmForced = false,
             forceAdvancedAuth = true,
         )
         assertEquals("Admin tab should take highest priority (B3)",
@@ -160,18 +174,18 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenMdmAndForceFlag_whenSelectBMarker_thenB2Wins() {
+    fun test_givenForceFlagAndMdm_whenSelectBMarker_thenB4Wins() {
         every { activity.selectBMarker(any(), any(), any(), any()) } answers { callOriginal() }
 
-        // Priority: B2 > B4
+        // On Android MDM is ignored; force flag wins over B1 fallthrough
         val result = activity.selectBMarker(
             completedViaBrowserTab = true,
             completedViaAdminCustomTab = false,
             isMdmForced = true,
             forceAdvancedAuth = true,
         )
-        assertEquals("MDM should take priority over force flag (B2 > B4)",
-            FEATURE_BROWSER_LOGIN_MDM, result)
+        assertEquals("Force flag should win over ignored MDM signal (B4)",
+            FEATURE_BROWSER_LOGIN_FORCE_FLAG, result)
     }
 
     // endregion
@@ -202,33 +216,20 @@ class BrowserLoginTelemetryTest {
     }
 
     @Test
-    fun test_givenMyDomainServer_whenSelectLMarker_thenL3Returned() {
+    fun test_givenWelcomeDiscovery_whenSelectLMarker_thenL3Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
-        // My Domain is a non-pool, non-WD URL
-        val result = activity.selectLMarker(
-            usedWelcomeDiscovery = false,
-            loginServerUrl = "https://myorg.my.salesforce.com",
-        )
-        assertEquals("My Domain login server should yield L3",
-            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
-    }
-
-    @Test
-    fun test_givenWelcomeDiscovery_whenSelectLMarker_thenL4Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
-        // WD flag takes precedence regardless of the resolved server URL
+        // L3: Welcome Discovery flow — WD flag takes precedence regardless of the resolved URL
         val result = activity.selectLMarker(
             usedWelcomeDiscovery = true,
             loginServerUrl = "https://myorg.my.salesforce.com",
         )
-        assertEquals("Welcome Discovery should yield L4",
+        assertEquals("Welcome Discovery should yield L3",
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
     }
 
     @Test
-    fun test_givenWelcomeDiscoveryWithProductionUrl_whenSelectLMarker_thenL4Returned() {
+    fun test_givenWelcomeDiscoveryWithProductionUrl_whenSelectLMarker_thenL3Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
         // WD flag wins even when the resolved URL is production
@@ -236,20 +237,58 @@ class BrowserLoginTelemetryTest {
             usedWelcomeDiscovery = true,
             loginServerUrl = LoginServerManager.PRODUCTION_LOGIN_URL,
         )
-        assertEquals("WD flag should override production URL and yield L4",
+        assertEquals("WD flag should override production URL and yield L3",
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY, result)
+    }
+
+    @Test
+    fun test_givenMyDomainServer_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // L4: host ends with .my.salesforce.com
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.my.salesforce.com",
+        )
+        assertEquals("My Domain login server should yield L4",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
+    }
+
+    @Test
+    fun test_givenMyDomainSandboxServer_whenSelectLMarker_thenL4Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        // Sandbox My Domain also ends with .my.salesforce.com (L4, not L2, because URL != sandbox constant)
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://myorg.sandbox.my.salesforce.com",
+        )
+        assertEquals("My Domain sandbox server should yield L4",
+            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
     }
 
     @Test
     fun test_givenWelcomeLoginUrl_whenSelectLMarker_thenL5Returned() {
         every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
 
-        // The WD URL itself is a pool server, so when usedWelcomeDiscovery=false it falls to L5.
+        // The WD URL itself: when usedWelcomeDiscovery=false it falls to L5 (custom)
         val result = activity.selectLMarker(
             usedWelcomeDiscovery = false,
             loginServerUrl = LoginServerManager.WELCOME_LOGIN_URL,
         )
         assertEquals("WD URL without WD flag set should yield L5 (custom)",
+            FEATURE_LOGIN_SERVER_CUSTOM, result)
+    }
+
+    @Test
+    fun test_givenCustomServer_whenSelectLMarker_thenL5Returned() {
+        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
+
+        val result = activity.selectLMarker(
+            usedWelcomeDiscovery = false,
+            loginServerUrl = "https://custom.example.com",
+        )
+        assertEquals("Custom server should yield L5",
             FEATURE_LOGIN_SERVER_CUSTOM, result)
     }
 
@@ -260,8 +299,8 @@ class BrowserLoginTelemetryTest {
         val allLMarkers = listOf(
             FEATURE_LOGIN_SERVER_PRODUCTION,
             FEATURE_LOGIN_SERVER_SANDBOX,
-            FEATURE_LOGIN_SERVER_MY_DOMAIN,
             FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
+            FEATURE_LOGIN_SERVER_MY_DOMAIN,
             FEATURE_LOGIN_SERVER_CUSTOM,
         )
         val selected = activity.selectLMarker(
@@ -271,21 +310,6 @@ class BrowserLoginTelemetryTest {
         val selectedCount = allLMarkers.count { it == selected }
         assertEquals("Exactly one L marker should be selected", 1, selectedCount)
         assertEquals("The selected marker should be L1", FEATURE_LOGIN_SERVER_PRODUCTION, selected)
-    }
-
-    @Test
-    fun test_givenMyDomainWithTrailingSpace_whenSelectLMarker_thenL3Returned() {
-        every { activity.selectLMarker(any(), any()) } answers { callOriginal() }
-
-        // selectLMarker trims the URL, so trailing spaces should not affect the result.
-        // Note: the trimming is done in onAuthFlowSuccess before calling selectLMarker,
-        // but selectLMarker still receives pre-trimmed input here.
-        val result = activity.selectLMarker(
-            usedWelcomeDiscovery = false,
-            loginServerUrl = "https://myorg.my.salesforce.com",
-        )
-        assertEquals("My Domain URL should yield L3",
-            FEATURE_LOGIN_SERVER_MY_DOMAIN, result)
     }
 
     // endregion

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginServerManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginServerManagerTest.kt
@@ -840,4 +840,78 @@ class LoginServerManagerMockTest {
         assertEquals("https://mdm2.example.com/2", servers?.get(1)?.url)
         assertEquals(false, servers?.get(1)?.isCustom)
     }
+
+    // region isProductionLoginServer / isMyDomainServer / isPoolServer
+
+    @Test
+    fun test_givenProductionUrl_whenIsProductionLoginServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isProductionLoginServer("https://login.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenInternalProductionPoolUrl_whenIsProductionLoginServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isProductionLoginServer("https://login.test1.pc-rnd.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenMyDomainUrl_whenIsProductionLoginServer_thenFalse() {
+        assertEquals(false, LoginServerManager.isProductionLoginServer("https://myorg.my.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenInternalMyDomainUrl_whenIsProductionLoginServer_thenFalse() {
+        assertEquals(false, LoginServerManager.isProductionLoginServer("https://mobilesdksdb32.test1.my.pc-rnd.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenSandboxUrl_whenIsProductionLoginServer_thenFalse() {
+        assertEquals(false, LoginServerManager.isProductionLoginServer("https://test.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenMyDomainUrl_whenIsMyDomainServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isMyDomainServer("https://myorg.my.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenInternalMyDomainUrl_whenIsMyDomainServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isMyDomainServer("https://mobilesdksdb32.test1.my.pc-rnd.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenProductionUrl_whenIsMyDomainServer_thenFalse() {
+        assertEquals(false, LoginServerManager.isMyDomainServer("https://login.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenInternalProductionUrl_whenIsMyDomainServer_thenFalse() {
+        assertEquals(false, LoginServerManager.isMyDomainServer("https://login.test1.pc-rnd.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenProductionUrl_whenIsPoolServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isPoolServer(LoginServerManager.PRODUCTION_LOGIN_URL))
+    }
+
+    @Test
+    fun test_givenInternalProductionUrl_whenIsPoolServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isPoolServer("https://login.test1.pc-rnd.salesforce.com"))
+    }
+
+    @Test
+    fun test_givenSandboxUrl_whenIsPoolServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isPoolServer(LoginServerManager.SANDBOX_LOGIN_URL))
+    }
+
+    @Test
+    fun test_givenWelcomeUrl_whenIsPoolServer_thenTrue() {
+        assertEquals(true, LoginServerManager.isPoolServer(LoginServerManager.WELCOME_LOGIN_URL))
+    }
+
+    @Test
+    fun test_givenMyDomainUrl_whenIsPoolServer_thenFalse() {
+        assertEquals(false, LoginServerManager.isPoolServer("https://myorg.my.salesforce.com"))
+    }
+
+    // endregion
 }

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -85,7 +85,7 @@ Beacon app login tests for lightweight authentication use cases, covering both o
 | `testBeaconJwt_AllScopes` | Beacon JWT | All |
 
 #### AdvancedAuthBeaconLoginTests
-Tests for Beacon app login flows using advanced authentication with Chrome Custom Tabs. This class runs the same tests as BeaconLoginTests but uses the advanced_auth login host. Requires intent filters in AndroidManifest.xml matching the beacon redirect URIs (`beaconadvancedopaque://success/done` and `beaconadvancedjwt://success/done`).
+Tests for Beacon app login flows using advanced authentication with Chrome Custom Tabs. This class runs the same tests as BeaconLoginTests but uses the advanced_auth login host. Requires intent filters in AndroidManifest.xml matching the beacon redirect URIs (`beaconadvancedopaque://success/done` and `beaconadvancedjwt://success/done`). Each test validates that the B4 marker (`forceAdvancedAuthentication`) is present in the `ftr_` user-agent segment.
 
 | Test | App Config | Scopes | Login Host |
 |------|-----------|--------|------------|
@@ -177,6 +177,8 @@ Each `loginAndValidate` call performs the following checks:
 3. **Token format** — opaque tokens are exactly 112 characters; JWT tokens exceed that length; refresh tokens are 87 characters
 4. **API request** — a REST API call succeeds with the issued tokens
 5. **DPoP (DPoP apps only)** — `OAuth Token Type` is `"DPoP"` and the DPoP nonce is non-empty after login
+6. **Browser-login B-marker** — the `ftr_` segment of the user-agent string contains exactly one B-marker (B1–B4) when browser-based login was used, and none when it was not. See [B-marker semantics](#b-and-l-markers-in-ftr_) below.
+7. **Login-server L-marker** — the `ftr_` segment contains exactly one L-marker (L1–L5) on every non-refresh login. See [L-marker semantics](#b-and-l-markers-in-ftr_) below.
 
 `assertRevokeAndRefreshWorks` additionally verifies for DPoP apps:
 - **Token type preserved** — `OAuth Token Type` remains `"DPoP"` after refresh
@@ -193,8 +195,40 @@ Multi-user tests additionally verify:
 
 Restart tests additionally verify:
 - Session credentials are **reloaded from disk** after a cold process restart
-- Per-user feature flags (BW, WD) encoded in the user agent string **persist** across restarts via `hydratePerUserFeatures()`
+- Per-user feature flags (BW, WD, B-markers, L-markers) encoded in the user agent string **persist** across restarts via `hydratePerUserFeatures()`
 - DPoP EC key pairs stored in **AndroidKeyStore** survive a process kill and restart
+
+### B- and L-markers in `ftr_`
+
+The `ftr_` user-agent segment encodes per-user telemetry codes. Two code families are validated by `validateUserAgent`:
+
+#### B-markers — why browser login was used
+
+Registered once per user alongside the BW (browser-windows) flag. Exactly one is set when browser-based login occurred; none are set for in-app WebView login.
+
+| Code | Constant | Meaning | Priority |
+|------|----------|---------|----------|
+| B1 | `FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG` | Server auth-config required browser login | Lowest |
+| B3 | `FEATURE_BROWSER_LOGIN_FOR_ADMIN` | "Login for Admin" flow used | Highest |
+| B4 | `FEATURE_BROWSER_LOGIN_FORCE_FLAG` | `SalesforceSDKManager.forceAdvancedAuthentication` was set | — |
+
+> **Note:** B2 (MDM-required browser auth) is iOS-only and is never registered on Android.
+
+Priority order when multiple reasons apply: **B3 > B4 > B1**.
+
+#### L-markers — which login server type was used
+
+Registered on every non-refresh login. Exactly one is set per login.
+
+| Code | Constant | Meaning |
+|------|----------|---------|
+| L1 | `FEATURE_LOGIN_SERVER_PRODUCTION` | Production pool server (`login.salesforce.com` and internal pool equivalents) |
+| L2 | `FEATURE_LOGIN_SERVER_SANDBOX` | Sandbox (`test.salesforce.com`) |
+| L3 | `FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY` | Welcome Discovery flow was used |
+| L4 | `FEATURE_LOGIN_SERVER_MY_DOMAIN` | My Domain org (`.my.` in the host) |
+| L5 | `FEATURE_LOGIN_SERVER_OTHER` | Any other login server |
+
+L3 takes priority over the resolved domain: even if Welcome Discovery resolves to a My Domain org, the final L-marker is L3 (captured before the WD global flag is cleared).
 
 ## Architecture
 

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -22,18 +22,21 @@ Legacy login tests using the default Connected App (CA) opaque configuration fro
 | `testCAOpaque_DefaultScopes_UserAgentFlow_NotHybrid` | CA Opaque | Default | User Agent | No |
 
 #### CAScopeSelectionLoginTests
-Connected App login tests with explicit scope selection across web server and user agent flows, both hybrid and non-hybrid.
+Connected App login tests with explicit scope selection across web server and user agent flows, both hybrid and non-hybrid. Includes in-app WebView variants (`forceAdvancedAuthentication = false`) that exercise the legacy WKWebView path.
 
-| Test | Scopes | Flow | Hybrid |
-|------|--------|------|--------|
-| `testCAOpaque_SubsetScopes_WebServerFlow` | Subset | Web Server | No |
-| `testCAOpaque_AllScopes_WebServerFlow` | All | Web Server | Yes |
-| `testCAOpaque_SubsetScopes_WebServerFlow_NotHybrid` | Subset | Web Server | No |
-| `testCAOpaque_AllScopes_WebServerFlow_NotHybrid` | All | Web Server | No |
-| `testCAOpaque_SubsetScopes_UserAgentFlow` | Subset | User Agent | Yes |
-| `testCAOpaque_AllScopes_UserAgentFlow` | All | User Agent | Yes |
-| `testCAOpaque_SubsetScopes_UserAgentFlow_NotHybrid` | Subset | User Agent | No |
-| `testCAOpaque_AllScopes_UserAgentFlow_NotHybrid` | All | User Agent | No |
+| Test | Scopes | Flow | Auth Surface |
+|------|--------|------|--------------|
+| `testCAOpaque_SubsetScopes_WebServerFlow` | Subset | Web Server | Browser (default) |
+| `testCAOpaque_AllScopes_WebServerFlow` | All | Web Server | Browser (default) |
+| `testCAOpaque_DefaultScopes_WebServerFlow_InAppWebView` | Default | Web Server | In-App WebView |
+| `testCAOpaque_SubsetScopes_WebServerFlow_InAppWebView` | Subset | Web Server | In-App WebView |
+| `testCAOpaque_AllScopes_WebServerFlow_InAppWebView` | All | Web Server | In-App WebView |
+| `testCAOpaque_SubsetScopes_WebServerFlow_NotHybrid` | Subset | Web Server | Browser (default) |
+| `testCAOpaque_AllScopes_WebServerFlow_NotHybrid` | All | Web Server | Browser (default) |
+| `testCAOpaque_SubsetScopes_UserAgentFlow` | Subset | User Agent | In-App WebView |
+| `testCAOpaque_AllScopes_UserAgentFlow` | All | User Agent | In-App WebView |
+| `testCAOpaque_SubsetScopes_UserAgentFlow_NotHybrid` | Subset | User Agent | In-App WebView |
+| `testCAOpaque_AllScopes_UserAgentFlow_NotHybrid` | All | User Agent | In-App WebView |
 
 #### ECALoginTests
 External Client App (ECA) login tests for both opaque and JWT token formats with scope variations.

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/CAScopeSelectionLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/CAScopeSelectionLoginTests.kt
@@ -89,6 +89,38 @@ class CAScopeSelectionLoginTests: AuthFlowTest() {
     }
 
     // endregion
+    // region CA Web Server Flow Tests (In-App WebView)
+
+    // Login with CA opaque using default scopes, web server flow, and in-app WebView (advanced auth disabled).
+    @Test
+    fun testCAOpaque_DefaultScopes_WebServerFlow_InAppWebView() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            forceAdvancedAuthentication = false,
+        )
+    }
+
+    // Login with CA opaque using subset of scopes, web server flow, and in-app WebView (advanced auth disabled).
+    @Test
+    fun testCAOpaque_SubsetScopes_WebServerFlow_InAppWebView() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            scopeSelection = SUBSET,
+            forceAdvancedAuthentication = false,
+        )
+    }
+
+    // Login with CA opaque using all scopes, web server flow, and in-app WebView (advanced auth disabled).
+    @Test
+    fun testCAOpaque_AllScopes_WebServerFlow_InAppWebView() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            scopeSelection = ALL,
+            forceAdvancedAuthentication = false,
+        )
+    }
+
+    // endregion
     // region CA User Agent Flow Tests
 
     // Login with CA opaque using subset of scopes and user agent flow.

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -28,6 +28,7 @@ package com.salesforce.samples.authflowtester
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.salesforce.androidsdk.app.Features
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.HttpAccess
 import com.salesforce.androidsdk.auth.OAuth2
@@ -434,7 +435,7 @@ class MultiUserLoginTests: AuthFlowTest() {
         waitForUserCount(sdkManager.userAccountManager, expectedCount = 1)
 
         // Back on User A — MU gone, no BW
-        app.validateUserAgent(REGULAR_AUTH, isMultiUser = false)
+        app.validateUserAgent(REGULAR_AUTH, isMultiUser = false, expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -225,10 +225,11 @@ class MultiUserLoginTests: AuthFlowTest() {
         // Other user
         loginOtherUserAndValidate(knownAppConfig = CA_OPAQUE)
 
-        // Migrate current user
+        // Migrate current user (both users logged in → isMultiUser = true)
         migrateAndValidate(
             knownAppConfig = BEACON_OPAQUE,
             knownUserConfig = otherUser,
+            isMultiUser = true,
         )
 
         // Switch back to initial user and assert unaltered.
@@ -294,7 +295,8 @@ class MultiUserLoginTests: AuthFlowTest() {
         assertEquals(userAUsername, remainingUsers.first().username)
 
         // With User A, validate the original tokens are intact and a refresh still succeeds.
-        app.validateUser(REGULAR_AUTH, user)
+        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true,
+            expectedBMarker = Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG)
         app.validateOAuthValues(knownAppConfig = CA_OPAQUE, scopeSelection = EMPTY)
         val (userPostAccessToken, userPostRefreshToken) = app.getTokens()
         assertEquals(userAccessToken, userPostAccessToken)
@@ -323,7 +325,9 @@ class MultiUserLoginTests: AuthFlowTest() {
 
         // Validate nothing changed for "otherUser" before user switch
         val (otherUserPostAccessToken, otherUserPostRefreshToken) = app.getTokens()
-        app.validateUser(knownLoginHostConfig = REGULAR_AUTH, knownUserConfig = otherUser)
+        app.validateUser(knownLoginHostConfig = REGULAR_AUTH, knownUserConfig = otherUser,
+            isMultiUser = true, expectAdvancedAuth = true,
+            expectedBMarker = Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG)
         app.validateOAuthValues(knownAppConfig = ECA_OPAQUE, scopeSelection = EMPTY)
         assertEquals(otherUserAccessToken, otherUserPostAccessToken)
         assertEquals(otherUserRefreshToken, otherUserPostRefreshToken)
@@ -371,10 +375,14 @@ class MultiUserLoginTests: AuthFlowTest() {
     private fun switchToUserAndValidate(
         knownUserConfig: KnownUserConfig,
         knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+        expectAdvancedAuth: Boolean = true,
     ) {
         app.switchToUser(knownUserConfig)
         composeTestRule.waitForIdle()
-        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true)
+        val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
+        val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true,
+            expectAdvancedAuth = expectAdvancedAuth, expectedBMarker = expectedBMarker)
     }
 
     /**
@@ -433,9 +441,12 @@ class MultiUserLoginTests: AuthFlowTest() {
             showLoginPage = false,
         )
         waitForUserCount(sdkManager.userAccountManager, expectedCount = 1)
+        app.waitForAppLoad()
 
-        // Back on User A — MU gone, no BW
-        app.validateUserAgent(REGULAR_AUTH, isMultiUser = false, expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN)
+        // Back on User A — MU gone; BW+B4 present because forceAdvancedAuthentication=true was used at login
+        app.validateUserAgent(REGULAR_AUTH, isMultiUser = false, expectAdvancedAuth = true,
+            expectedBMarker = Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG,
+            expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN)
     }
 
     companion object {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/NegativeLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/NegativeLoginTests.kt
@@ -30,6 +30,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.salesforce.androidsdk.app.Features
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.samples.authflowtester.pageObjects.ChromeCustomTabPageObject
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
@@ -122,7 +123,8 @@ class NegativeLoginTests : AuthFlowTest() {
         // Verify the original user's tokens and config are still intact and
         // a refresh succeeds. navigateBackToApp() above already waited for
         // the AuthFlowTester main screen to reload.
-        app.validateUser(REGULAR_AUTH, user)
+        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true,
+            expectedBMarker = Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG)
         app.validateOAuthValues(knownAppConfig = CA_OPAQUE, scopeSelection = EMPTY)
         val (postAccessToken, postRefreshToken) = app.getTokens()
         assertEquals(userAccessToken, postAccessToken)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -45,6 +45,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.salesforce.androidsdk.accounts.UserAccountManager
+import com.salesforce.androidsdk.app.Features
 import com.salesforce.samples.authflowtester.ALERT_POSITIVE_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.ALERT_TITLE_CONTENT_DESC
 import com.salesforce.samples.authflowtester.CREDS_SECTION_CONTENT_DESC
@@ -290,6 +291,8 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         isMultiUser: Boolean = false,
         expectAdvancedAuth: Boolean = false,
         isDpop: Boolean = false,
+        expectedBMarker: String? = null,
+        expectedLMarker: String? = null,
     ) {
         val expected = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
 
@@ -326,7 +329,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
 
         // Validate feature flags — UI is already settled, reuse the existing layout traversal
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, isDpop = isDpop)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, isDpop = isDpop, expectedBMarker = expectedBMarker, expectedLMarker = expectedLMarker)
     }
 
     fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection) {
@@ -526,9 +529,11 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         expectAdvancedAuth: Boolean = false,
         isRtr: Boolean = false,
         isDpop: Boolean = false,
+        expectedBMarker: String? = null,
+        expectedLMarker: String? = null,
     ) {
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, isRtr, isDpop)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, isRtr, isDpop, expectedBMarker, expectedLMarker)
     }
 
     private fun validateUserAgent(
@@ -539,6 +544,8 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         expectAdvancedAuth: Boolean = false,
         isRtr: Boolean = false,
         isDpop: Boolean = false,
+        expectedBMarker: String? = null,
+        expectedLMarker: String? = null,
     ) {
         assert(ua.contains("SalesforceMobileSDK/")) {
             "User agent missing 'SalesforceMobileSDK/' prefix: $ua"
@@ -599,6 +606,46 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         } else {
             assert("DP" !in flags) {
                 "Expected no 'DP' flag for non-DPoP session in: $ua"
+            }
+        }
+
+        val allBMarkers = listOf(
+            Features.FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG,
+            Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN,
+            Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG,
+        )  // B2 excluded — never registered on Android
+        if (expectedBMarker != null) {
+            assert(expectedBMarker in flags) {
+                "Expected B-marker '$expectedBMarker' in ftr_ flags of: $ua"
+            }
+            allBMarkers.filter { it != expectedBMarker }.forEach { marker ->
+                assert(marker !in flags) {
+                    "Unexpected B-marker '$marker' in ftr_ flags of: $ua"
+                }
+            }
+        } else {
+            allBMarkers.forEach { marker ->
+                assert(marker !in flags) {
+                    "Unexpected B-marker '$marker' in ftr_ flags of: $ua"
+                }
+            }
+        }
+
+        val allLMarkers = listOf(
+            Features.FEATURE_LOGIN_SERVER_PRODUCTION,
+            Features.FEATURE_LOGIN_SERVER_SANDBOX,
+            Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY,
+            Features.FEATURE_LOGIN_SERVER_MY_DOMAIN,
+            Features.FEATURE_LOGIN_SERVER_OTHER,
+        )
+        if (expectedLMarker != null) {
+            assert(expectedLMarker in flags) {
+                "Expected L-marker '$expectedLMarker' in ftr_ flags of: $ua"
+            }
+            allLMarkers.filter { it != expectedLMarker }.forEach { marker ->
+                assert(marker !in flags) {
+                    "Unexpected L-marker '$marker' in ftr_ flags of: $ua"
+                }
             }
         }
     }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthorizationPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthorizationPageObject.kt
@@ -38,7 +38,6 @@ import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.RE
 import com.salesforce.androidsdk.R as sdkR
 
 private const val TAG = "AuthorizationPageObject"
-private const val MAX_RETRIES = 5
 /**
  * Short timeout for checking optional UI elements. Used for:
  * - Local Chrome UI (password save dialog) that appears immediately or not at all
@@ -95,12 +94,11 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
         val app = AuthFlowTesterPageObject(composeTestRule)
         swipeUp()
 
-        // Note: The Allow button is server-rendered on Salesforce's OAuth page.
-        // We use a short timeout (500ms) per check but loop MAX_RETRIES times,
-        // giving us 5 × 500ms = 2.5s of total polling. Combined with the
-        // SLEEP_TIME_MS (2.5s) before this method, we have ~5s total to find
-        // the button, balancing speed with reliability for server-side rendering.
-        repeat(MAX_RETRIES) {
+        // Poll for the full TIMEOUT_MS budget (15s on FTL, 10s locally). The Allow button is
+        // server-rendered and arrives at varying latency — a fixed retry count was too short for
+        // second-user logins where Chrome is in a different pre-warmed state.
+        val deadline = System.currentTimeMillis() + TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
             if (app.isAppLoaded()) {
                 Log.i(TAG, "Left login screen — no approval needed.")
                 return
@@ -112,16 +110,16 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
                 return
             }
         }
+        Log.w(TAG, "Allow button not found in Custom Tab within ${TIMEOUT_MS}ms.")
     }
 
     /** Original flow: scrolls and polls for Allow in the in-app WebView. */
     private fun tapAllowInWebView() {
         swipeUp()
 
-        // Note: Short timeout per check (500ms) × MAX_RETRIES = 2.5s total polling.
-        // Combined with SLEEP_TIME_MS (2.5s) before this method = ~5s total for
-        // server-rendered Allow button to appear.
-        repeat(MAX_RETRIES) {
+        // Poll for the full TIMEOUT_MS budget (15s on FTL, 10s locally).
+        val deadline = System.currentTimeMillis() + TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
             if (!loginActivityExists()) {
                 Log.i(TAG, "Left login screen — no approval needed.")
                 return
@@ -133,7 +131,7 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
                 return
             }
         }
-        Log.w(TAG, "Allow button not found after login within retry limit.")
+        Log.w(TAG, "Allow button not found in WebView within ${TIMEOUT_MS}ms.")
     }
 
     /**
@@ -142,13 +140,12 @@ class AuthorizationPageObject(composeTestRule: ComposeTestRule) : BasePageObject
      * and taps Allow.
      */
     fun tapAllowAfterMigration() {
-        // Wait for the page to load, swipe, then poll for the Allow button.
-        // Note: Short timeout (500ms) per check × MAX_RETRIES = 2.5s total
-        // polling for server-rendered Allow button.
         allowButton.waitForExists(QUICK_CHECK_TIMEOUT_MS)
         swipeUp()
 
-        repeat(MAX_RETRIES) {
+        // Poll for the full TIMEOUT_MS budget.
+        val deadline = System.currentTimeMillis() + TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
             // WebView dismissed means approval completed without us clicking
             val webView = device.findObject(UiSelector().className("android.webkit.WebView"))
             if (!webView.exists()) {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/BasePageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/BasePageObject.kt
@@ -44,7 +44,7 @@ abstract class BasePageObject(val composeTestRule: ComposeTestRule) {
             ) == "true"
         }
         val TIMEOUT_MS: Long by lazy {
-            if (isFtl) 15_000 else 5_000
+            if (isFtl) 15_000 else 10_000
         }
 
         val SLEEP_TIME_MS: Long by lazy {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -468,7 +468,7 @@ abstract class AuthFlowTest {
             else LoginPageObject(composeTestRule)
         val chromePage = ChromeCustomTabPageObject(composeTestRule)
 
-        ensureRegularAuthServer(expectCustomTab = useWebServerFlow)
+        ensureRegularAuthServer(expectCustomTab = useWebServerFlow, forceAdvancedAuthentication = useWebServerFlow)
 
         // Reach Login Options via the top bar (back-out is a no-op on the WebView path).
         topBarPage.backOutToLoginActivity()

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -428,7 +428,9 @@ abstract class AuthFlowTest {
     ) {
         app.switchToUser(knownUserConfig)
         composeTestRule.waitForIdle()
-        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop)
+        val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
+        val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = true, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop, expectedBMarker = expectedBMarker)
     }
 
     companion object {
@@ -595,7 +597,9 @@ abstract class AuthFlowTest {
         assert(preAccessToken != postAccessToken)
         assert(preRefreshToken != postRefreshToken)
 
-        app.validateUser(knownLoginHostConfig, knownUserConfig, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop)
+        val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
+        val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        app.validateUser(knownLoginHostConfig, knownUserConfig, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop, expectedBMarker = expectedBMarker)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
 
         // Assert new tokens work

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -588,6 +588,7 @@ abstract class AuthFlowTest {
         knownUserConfig: KnownUserConfig = user,
         expectAdvancedAuth: Boolean = true,
         isDpop: Boolean = false,
+        isMultiUser: Boolean = false,
     ) {
         val (preAccessToken, preRefreshToken) = app.getTokens()
         app.migrateToNewApp(knownAppConfig, scopeSelection)
@@ -599,7 +600,7 @@ abstract class AuthFlowTest {
 
         val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
         val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
-        app.validateUser(knownLoginHostConfig, knownUserConfig, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop, expectedBMarker = expectedBMarker)
+        app.validateUser(knownLoginHostConfig, knownUserConfig, isMultiUser = isMultiUser, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop, expectedBMarker = expectedBMarker)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
 
         // Assert new tokens work

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -383,7 +383,11 @@ abstract class AuthFlowTest {
         isDpop: Boolean = false,
     ) {
         restartApp()
-        app.validateUser(knownLoginHostConfig, knownUserConfig, usesWelcomeDiscovery, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop)
+        val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
+        val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        val expectedLMarker = if (usesWelcomeDiscovery) Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
+                              else Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
+        app.validateUser(knownLoginHostConfig, knownUserConfig, usesWelcomeDiscovery, expectAdvancedAuth = expectAdvancedAuth, isDpop = isDpop, expectedBMarker = expectedBMarker, expectedLMarker = expectedLMarker)
     }
 
     /**

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -35,6 +35,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
+import com.salesforce.androidsdk.app.Features
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.samples.authflowtester.AuthFlowTesterActivity
 import com.salesforce.samples.authflowtester.pageObjects.AuthFlowTesterPageObject
@@ -323,7 +324,11 @@ abstract class AuthFlowTest {
         app.waitForAppLoad()
 
         val isDpop = useDPoP
-        app.validateUser(knownLoginHostConfig, knownUserConfig, useWelcomeDiscovery, isMultiUser, expectAdvancedAuth = forceAdvancedAuthentication, isDpop = isDpop)
+        val shouldHaveBW = forceAdvancedAuthentication || knownLoginHostConfig == ADVANCED_AUTH
+        val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        val expectedLMarker = if (useWelcomeDiscovery) Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
+                              else Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
+        app.validateUser(knownLoginHostConfig, knownUserConfig, useWelcomeDiscovery, isMultiUser, expectAdvancedAuth = forceAdvancedAuthentication, isDpop = isDpop, expectedBMarker = expectedBMarker, expectedLMarker = expectedLMarker)
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
     }
@@ -490,7 +495,7 @@ abstract class AuthFlowTest {
         AuthorizationPageObject(composeTestRule).tapAllowAfterLogin(ADVANCED_AUTH)
 
         app.waitForAppLoad()
-        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true, isDpop = useDPoP)
+        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true, isDpop = useDPoP, expectedBMarker = Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN, expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN)
         app.validateOAuthValues(knownAppConfig, scopeSelection = EMPTY)
         app.validateApiRequest()
     }
@@ -619,6 +624,7 @@ abstract class AuthFlowTest {
             assert(postNonce.isNotEmpty()) { "DPoP nonce should be non-empty after refresh" }
         }
 
-        app.validateUserAgent(knownLoginHostConfig = knownLoginHostConfig, expectAdvancedAuth = expectAdvancedAuth, isMultiUser = isMultiUser, isRtr = isRtr, isDpop = isDpop)
+        val expectedBMarker = if (expectAdvancedAuth) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        app.validateUserAgent(knownLoginHostConfig = knownLoginHostConfig, expectAdvancedAuth = expectAdvancedAuth, isMultiUser = isMultiUser, isRtr = isRtr, isDpop = isDpop, expectedBMarker = expectedBMarker, expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN)
     }
 }


### PR DESCRIPTION
## Summary

Adds 8 new per-user \`ftr_\` telemetry markers to the SDK user-agent string (B2 deferred on Android):

- **B1, B3, B4**: explain *why* browser login (Advanced Auth / Custom Tabs) was used
- **L1–L5**: record *which login server type* was used on every non-refresh login

Follow-up to W-23126676 (Force Advanced Authentication flag). Spec and plan live in the Workspace repo under \`specs/W-23701450-W-23240736-browser-login-telemetry-markers/\`. Companion iOS PR: forcedotcom/SalesforceMobileSDK-iOS.

## B-markers — "why browser login was used"

Registered per-user alongside \`BW\`. Exactly one B-marker per user. Priority: **B3 > B4 > B1** (B2 deferred — no reliable MDM browser-login signal on Android).

| Code | Reason |
|------|--------|
| \`B1\` | Server auth-config opted in (\`UseAndroidNativeBrowserForAuthentication\`) |
| \`B3\` | "Login for Admin" flow (\`completedViaAdminCustomTab\`) |
| \`B4\` | \`forceAdvancedAuthentication\` SDK flag (W-23126676) |

## L-markers — "which login server type"

Registered per-user on every non-refresh login (browser or WebView). Exactly one L-marker per user.

| Code | Login server | Detection |
|------|-------------|-----------|
| \`L1\` | Production pool | host matches \`login.salesforce.com\` or \`login.*.salesforce.com\` (no \`.my.\`) — covers internal envs like \`login.test1.pc-rnd.salesforce.com\` |
| \`L2\` | Sandbox | exact match \`test.salesforce.com\` |
| \`L3\` | Welcome Discovery | WD global flag set at auth-completion time (checked before cleared) |
| \`L4\` | My Domain | host contains \`.my.\` and ends with \`.salesforce.com\` — covers \`*.my.salesforce.com\` and internal \`*.my.*.salesforce.com\` |
| \`L5\` | Other | fallthrough |

## Implementation

- **\`Features.java\`**: 8 new string constants (\`FEATURE_BROWSER_LOGIN_*\`, \`FEATURE_LOGIN_SERVER_*\`)
- **\`LoginServerManager.java\`**: new \`isProductionLoginServer()\` and \`isMyDomainServer()\` static helpers; \`isPoolServer()\` updated to delegate to \`isProductionLoginServer()\`
- **\`LoginActivity.kt\`**: \`completedViaAdminCustomTab\` field added; \`selectBMarker()\` and \`selectLMarker()\` internal functions (in companion object); both called in \`onAuthFlowSuccess()\` after BW promotion
- **\`AuthFlowTesterPageObject.kt\`**: \`validateUserAgent\` extended with \`expectedBMarker\`/\`expectedLMarker\` params and assertions; B/L marker computation threaded through \`restartAndValidateUser\`, \`switchToUserAndValidateUser\`, \`migrateAndValidate\`, and \`assertRevokeAndRefreshWorks\`

## Tests

- **\`BrowserLoginTelemetryTest.kt\`** (11 tests): unit tests for \`selectBMarker()\` / \`selectLMarker()\` including internal env URLs — no device required
- **\`LoginServerManagerTest.kt\`** (11 new tests): unit tests for \`isProductionLoginServer()\`, \`isMyDomainServer()\`, \`isPoolServer()\` including internal env URLs
- **\`CAScopeSelectionLoginTests.kt\`** (3 new tests): \`testCAOpaque_*_WebServerFlow_InAppWebView\` variants that exercise \`forceAdvancedAuthentication = false\` (in-app WebView path) and verify no B-markers are registered
- **\`AuthFlowTest.kt\`**: fixed B/L marker threading through \`restartAndValidateUser\`, \`switchToUserAndValidateUser\`, and \`migrateAndValidate\`; fixed missing \`expectedBMarker\` in \`NegativeLoginTests\` and \`MultiUserLoginTests\`

## Notes

- B2 (MDM) deferred on Android — no reliable signal distinguishes MDM-required browser login from other reasons