### PR TITLE
fix(dpop): gate proof attachment on per-credential state

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -457,9 +457,17 @@ open class SalesforceSDKManager protected constructor(
 
     /**
      * Opt-in flag for DPoP (Demonstration of Proof-of-Possession, RFC 9449).
-     * When true, the SDK will attach a DPoP proof JWT to token endpoint
-     * requests and use the `DPoP` Authorization scheme for resource requests
-     * when the token endpoint advertises `token_type: DPoP`.
+     * Controls whether *new logins* initiate DPoP key generation and DPoP-bound
+     * token requests: when true, the SDK attaches a DPoP proof JWT to token
+     * endpoint requests and uses the `DPoP` Authorization scheme for resource
+     * requests when the token endpoint advertises `token_type: DPoP`.
+     *
+     * NOTE: This flag does NOT affect credentials that are already DPoP-bound.
+     * An existing DPoP credential continues to send DPoP proofs on every request
+     * regardless of this flag's value, because the server holds a DPoP-bound token
+     * and requires a proof on every request. Flipping this off is therefore not a
+     * global kill switch for in-flight sessions — to fully disable DPoP for a user,
+     * the credential must be re-authenticated as Bearer.
      */
     @get:JvmName("isUseDPoP")
     var useDPoP: Boolean = false

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -140,7 +140,7 @@ public class AuthenticatorService extends Service {
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final OAuth2.TokenEndpointResponse tr = OAuth2.refreshAuthToken(HttpAccess.DEFAULT,
                         tokenServer, originalUserAccount.getClientIdForRefresh(), originalUserAccount.getRefreshToken(), addlParamsMap,
-                        originalUserAccount.getCredentialsIdentifier());
+                        originalUserAccount.getCredentialsIdentifier(), originalUserAccount.getTokenType());
 
                 UserAccount updatedUserAccount = UserAccountBuilder.getInstance()
                         .populateFromUserAccount(originalUserAccount)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -498,7 +498,8 @@ public class OAuth2 {
 
     /**
      * Gets a new auth token using the refresh token. Overload that accepts a
-     * credentials identifier so DPoP proof can be attached when enabled.
+     * credentials identifier so DPoP proof can be attached when enabled. Delegates
+     * to the fully-parameterized overload with a null token type.
      *
      * @param httpAccessor HttpAccess instance.
      * @param loginServer Login server.
@@ -516,6 +517,34 @@ public class OAuth2 {
                                                          Map<String,String> addlParams,
                                                          @Nullable String credentialsIdentifier)
             throws OAuthFailedException, IOException {
+        return refreshAuthToken(httpAccessor, loginServer, clientId, refreshToken, addlParams,
+                credentialsIdentifier, null);
+    }
+
+    /**
+     * Gets a new auth token using the refresh token. Fully-parameterized overload
+     * that accepts the credential's persisted token type. When the credential is
+     * DPoP-bound the refresh request carries a DPoP proof — independent of the
+     * global {@code isUseDPoP} switch, which only gates new logins.
+     *
+     * @param httpAccessor HttpAccess instance.
+     * @param loginServer Login server.
+     * @param clientId Client ID.
+     * @param refreshToken Refresh token.
+     * @param addlParams Additional parameters.
+     * @param credentialsIdentifier Identifier used to look up the DPoP keypair, or null.
+     * @param tokenType Token type persisted on the credential (e.g. "DPoP" or null / "Bearer").
+     * @return Token response.
+     *
+     * @throws OAuthFailedException See {@link OAuthFailedException}.
+     * @throws IOException See {@link IOException}.
+     */
+    public static TokenEndpointResponse refreshAuthToken(HttpAccess httpAccessor, URI loginServer,
+                                                         String clientId, String refreshToken,
+                                                         Map<String,String> addlParams,
+                                                         @Nullable String credentialsIdentifier,
+                                                         @Nullable String tokenType)
+            throws OAuthFailedException, IOException {
         final FormBody.Builder builder = new FormBody.Builder();
         final boolean useHybridAuthentication = SalesforceSDKManager.getInstance().shouldUseHybridAuthentication();
         final String grantType = useHybridAuthentication ? HYBRID_REFRESH : REFRESH_TOKEN;
@@ -531,7 +560,7 @@ public class OAuth2 {
                 }
             }
         }
-        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, SalesforceSDKManager.getInstance(), credentialsIdentifier);
+        return makeTokenEndpointRequest(httpAccessor, loginServer, builder, SalesforceSDKManager.getInstance(), credentialsIdentifier, tokenType);
     }
 
     /**
@@ -620,7 +649,7 @@ public class OAuth2 {
             throws IOException {
         final Request.Builder builder = new Request.Builder().url(identityServiceIdUrl).get();
         addAuthorizationHeader(builder, authToken, tokenType);
-        if (DPOP.equals(tokenType) && credentialsIdentifier != null && SalesforceSDKManager.getInstance().isUseDPoP()) {
+        if (DPoPKeyManager.INSTANCE.shouldAttachDPoP(credentialsIdentifier, tokenType)) {
             try {
                 final String htu = DPoPURLHelper.INSTANCE.canonicalize(identityServiceIdUrl);
                 final String alias = DPoPKeyManager.INSTANCE.aliasForCredentialsIdentifier(credentialsIdentifier);
@@ -672,7 +701,7 @@ public class OAuth2 {
                                                                  FormBody.Builder formBodyBuilder,
                                                                  SalesforceSDKManager salesforceSdkManager)
             throws OAuthFailedException, IOException {
-        return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder, salesforceSdkManager, null);
+        return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder, salesforceSdkManager, null, null);
     }
 
     @VisibleForTesting
@@ -682,6 +711,18 @@ public class OAuth2 {
                                                                  FormBody.Builder formBodyBuilder,
                                                                  SalesforceSDKManager salesforceSdkManager,
                                                                  @Nullable String credentialsIdentifier)
+            throws OAuthFailedException, IOException {
+        return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder, salesforceSdkManager, credentialsIdentifier, null);
+    }
+
+    @VisibleForTesting
+    @WorkerThread
+    public static TokenEndpointResponse makeTokenEndpointRequest(HttpAccess httpAccessor,
+                                                                 URI loginServer,
+                                                                 FormBody.Builder formBodyBuilder,
+                                                                 SalesforceSDKManager salesforceSdkManager,
+                                                                 @Nullable String credentialsIdentifier,
+                                                                 @Nullable String tokenType)
             throws OAuthFailedException, IOException {
 
         final StringBuilder sb = new StringBuilder(loginServer.toString());
@@ -705,8 +746,9 @@ public class OAuth2 {
         final String tokenHost = HttpUrl.get(refreshPath).host();
         final RequestBody body = formBodyBuilder.build();
         final Request.Builder requestBuilder = new Request.Builder().url(refreshPath).post(body);
+        final boolean attachDPoP = DPoPKeyManager.INSTANCE.shouldAttachDPoP(credentialsIdentifier, tokenType);
 
-        if (credentialsIdentifier != null && salesforceSdkManager.isUseDPoP()) {
+        if (attachDPoP) {
             try {
                 final String htu = DPoPURLHelper.INSTANCE.canonicalize(refreshPath);
                 final String alias = DPoPKeyManager.INSTANCE.aliasForCredentialsIdentifier(credentialsIdentifier);
@@ -723,7 +765,7 @@ public class OAuth2 {
         Response response = httpAccessor.getOkHttpClient().newCall(request).execute();
 
         // Harvest nonce from every response (proactive caching for next call).
-        if (credentialsIdentifier != null && salesforceSdkManager.isUseDPoP()) {
+        if (attachDPoP) {
             final String responseNonce = response.header("DPoP-Nonce");
             if (!TextUtils.isEmpty(responseNonce)) {
                 DPoPNonceCache.INSTANCE.store(credentialsIdentifier, tokenHost, responseNonce);
@@ -731,8 +773,7 @@ public class OAuth2 {
         }
 
         // Nonce challenge: server requires a nonce. Retry once with the harvested nonce.
-        if (credentialsIdentifier != null && salesforceSdkManager.isUseDPoP()
-                && isNonceChallenge(response)) {
+        if (attachDPoP && isNonceChallenge(response)) {
             response.close();
             try {
                 final String htu = DPoPURLHelper.INSTANCE.canonicalize(refreshPath);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -690,7 +690,7 @@ public class OAuth2 {
      * @param tokenType Token type (e.g. "Bearer" or "DPoP"), or null for default Bearer.
      */
     public static Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken, @Nullable String tokenType) {
-        final String scheme = DPOP.equals(tokenType) ? DPOP + " " : BEARER;
+        final String scheme = DPoPKeyManager.DPOP_TOKEN_TYPE.equals(tokenType) ? DPoPKeyManager.DPOP_TOKEN_TYPE + " " : BEARER;
         return builder.header(AUTHORIZATION, scheme + authToken);
     }
 
@@ -715,7 +715,12 @@ public class OAuth2 {
         return makeTokenEndpointRequest(httpAccessor, loginServer, formBodyBuilder, salesforceSdkManager, credentialsIdentifier, null);
     }
 
-    @VisibleForTesting
+    /**
+     * Canonical implementation of the token-endpoint request. This is the primary production
+     * entry point — {@link #refreshAuthToken} calls it directly. Prefer the shorter overloads
+     * unless a caller genuinely needs to supply {@code credentialsIdentifier} and
+     * {@code tokenType}.
+     */
     @WorkerThread
     public static TokenEndpointResponse makeTokenEndpointRequest(HttpAccess httpAccessor,
                                                                  URI loginServer,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
@@ -38,6 +38,7 @@ import java.security.spec.ECGenParameterSpec
 object DPoPKeyManager {
 
     private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    private const val DPOP_TOKEN_TYPE = "DPoP"
 
     fun generateOrLoadKeyPair(alias: String): KeyPair {
         val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
@@ -69,4 +70,38 @@ object DPoPKeyManager {
     }
 
     fun aliasForCredentialsIdentifier(id: String): String = "dpop_$id"
+
+    /**
+     * Returns true iff a key pair is already present in the AndroidKeyStore for the given alias.
+     * Side-effect-free — does NOT mint a key pair on miss.
+     */
+    fun hasKeyPair(alias: String): Boolean {
+        if (alias.isEmpty()) return false
+        return try {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+            keyStore.containsAlias(alias)
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /** Convenience overload — computes the alias for `credentialsIdentifier` and calls `hasKeyPair`. */
+    fun hasKeyPairForCredentialsIdentifier(credentialsIdentifier: String?): Boolean {
+        if (credentialsIdentifier.isNullOrEmpty()) return false
+        return hasKeyPair(aliasForCredentialsIdentifier(credentialsIdentifier))
+    }
+
+    /**
+     * Decides whether a DPoP proof should be attached to a request for a credential identified
+     * by `credentialsIdentifier`. Returns true when either the credential's tokenType is "DPoP"
+     * or a DPoP key pair has already been minted for the credential. Either signal alone is
+     * sufficient — they cover the transient window between `/authorize` (which mints the key
+     * pair before tokenType is written) and `/token` (which writes tokenType after the key pair
+     * has been used to sign the proof).
+     */
+    fun shouldAttachDPoP(credentialsIdentifier: String?, tokenType: String?): Boolean {
+        if (credentialsIdentifier.isNullOrEmpty()) return false
+        if (DPOP_TOKEN_TYPE == tokenType) return true
+        return hasKeyPairForCredentialsIdentifier(credentialsIdentifier)
+    }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
@@ -28,6 +28,7 @@ package com.salesforce.androidsdk.auth.dpop
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import com.salesforce.androidsdk.util.SalesforceSDKLogger
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
@@ -38,7 +39,14 @@ import java.security.spec.ECGenParameterSpec
 object DPoPKeyManager {
 
     private const val ANDROID_KEYSTORE = "AndroidKeyStore"
-    private const val DPOP_TOKEN_TYPE = "DPoP"
+
+    /**
+     * RFC 9449 token type string. Case-sensitive per the spec. Single source of truth —
+     * `OAuth2.java` references this constant rather than redefining the literal.
+     */
+    const val DPOP_TOKEN_TYPE = "DPoP"
+
+    private const val TAG = "DPoPKeyManager"
 
     fun generateOrLoadKeyPair(alias: String): KeyPair {
         val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
@@ -81,6 +89,10 @@ object DPoPKeyManager {
             val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
             keyStore.containsAlias(alias)
         } catch (e: Exception) {
+            // A failure here (device lock, entitlement error, KeyStoreException) is NOT the
+            // same as "key not present." Returning false means "proceed without a proof," so
+            // surface the failure for diagnostics rather than swallowing it silently.
+            SalesforceSDKLogger.w(TAG, "DPoPKeyManager: KeyStore lookup failed for $alias", e)
             false
         }
     }
@@ -93,15 +105,24 @@ object DPoPKeyManager {
 
     /**
      * Decides whether a DPoP proof should be attached to a request for a credential identified
-     * by `credentialsIdentifier`. Returns true when either the credential's tokenType is "DPoP"
-     * or a DPoP key pair has already been minted for the credential. Either signal alone is
-     * sufficient — they cover the transient window between `/authorize` (which mints the key
-     * pair before tokenType is written) and `/token` (which writes tokenType after the key pair
-     * has been used to sign the proof).
+     * by `credentialsIdentifier`.
+     *
+     * An explicit `tokenType` is authoritative:
+     * - `tokenType == "DPoP"` → attach.
+     * - any other non-null type (e.g. "Bearer") → do NOT attach, and fast-exit before any
+     *   KeyStore I/O. This protects the DPoP→Bearer migration / Bearer re-auth path: a Bearer
+     *   credential that reuses a `credentialsIdentifier` still holding a stale DPoP key pair
+     *   must never get an unexpected proof.
+     *
+     * A null `tokenType` is the transient window between `/authorize` (which mints the key pair
+     * before tokenType is written) and `/token` (which writes tokenType after the key pair has
+     * been used to sign the proof); only then do we fall back to the key-material signal.
      */
     fun shouldAttachDPoP(credentialsIdentifier: String?, tokenType: String?): Boolean {
         if (credentialsIdentifier.isNullOrEmpty()) return false
         if (DPOP_TOKEN_TYPE == tokenType) return true
+        if (tokenType != null) return false // explicit non-DPoP type — fast exit, no KeyStore I/O
+        // tokenType is null — transition window between /authorize and /token.
         return hasKeyPairForCredentialsIdentifier(credentialsIdentifier)
     }
 }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/ClientManager.java
@@ -706,7 +706,7 @@ public class ClientManager {
                 SalesforceSDKLogger.i(TAG, "Initiating token refresh to host: " + tokenServer.getHost());
                 final TokenEndpointResponse tr = refreshAuthToken(HttpAccess.DEFAULT,
                         tokenServer, originalUserAccount.getClientIdForRefresh(), currentRefreshToken, addlParamsMap,
-                        originalUserAccount.getCredentialsIdentifier());
+                        originalUserAccount.getCredentialsIdentifier(), originalUserAccount.getTokenType());
 
                 if (tr.authToken == null) {
                     throw new MalformedTokenException("Token endpoint returned null access token");

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -915,9 +915,7 @@ public class RestClient {
         }
 
         private void attachDPoPProofIfNeeded(Request.Builder builder, String method, String url) {
-            if (!DPOP.equals(tokenType)) return;
-            if (!SalesforceSDKManager.getInstance().isUseDPoP()) return;
-            if (credentialsIdentifier == null || credentialsIdentifier.isEmpty()) return;
+            if (!DPoPKeyManager.INSTANCE.shouldAttachDPoP(credentialsIdentifier, tokenType)) return;
             try {
                 final String htu = DPoPURLHelper.INSTANCE.canonicalize(url);
                 final String host = HttpUrl.get(url).host();

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2DPoPTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2DPoPTest.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth
+
+import android.app.Instrumentation
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.salesforce.androidsdk.TestForceApp
+import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager
+import com.salesforce.androidsdk.auth.dpop.DPoPNonceCache
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.net.URI
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests that OAuth2 attaches a DPoP proof header on the refresh, nonce-retry, and
+ * identity-service paths based on per-credential state — not the process-wide
+ * `SalesforceSDKManager.isUseDPoP()` flag.
+ */
+@RunWith(AndroidJUnit4::class)
+class OAuth2DPoPTest {
+
+    private lateinit var httpAccess: CapturingHttpAccess
+    private lateinit var credentialsIdentifier: String
+    private lateinit var alias: String
+    private var originalUseDPoP: Boolean = false
+
+    @Before
+    fun setUp() {
+        val app = Instrumentation.newApplication(
+            TestForceApp::class.java,
+            InstrumentationRegistry.getInstrumentation().context
+        )
+        InstrumentationRegistry.getInstrumentation().callApplicationOnCreate(app)
+
+        originalUseDPoP = SalesforceSDKManager.getInstance().useDPoP
+        httpAccess = CapturingHttpAccess()
+        credentialsIdentifier = "oauth2-dpop-test-${UUID.randomUUID()}"
+        alias = DPoPKeyManager.aliasForCredentialsIdentifier(credentialsIdentifier)
+    }
+
+    @After
+    fun tearDown() {
+        SalesforceSDKManager.getInstance().useDPoP = originalUseDPoP
+        DPoPKeyManager.deleteKeyPair(alias)
+    }
+
+    /** Post-flip refresh for a DPoP-bound credential still attaches a proof. */
+    @Test
+    fun test_refreshAuthToken_flagOff_credentialDPoPBound_attachesProof() {
+        SalesforceSDKManager.getInstance().useDPoP = false
+        DPoPKeyManager.generateOrLoadKeyPair(alias)
+        httpAccess.enqueueTokenSuccess()
+
+        OAuth2.refreshAuthToken(
+            httpAccess,
+            URI.create("https://example-token.test/"),
+            "test-client-id",
+            "test-refresh-token",
+            null,
+            credentialsIdentifier,
+            "DPoP"
+        )
+
+        val recorded = httpAccess.lastRequest()
+        assertNotNull("refresh request should have been sent", recorded)
+        assertNotNull(
+            "DPoP header must be attached on refresh when credential is DPoP-bound",
+            recorded!!.header("DPoP")
+        )
+    }
+
+    /** Bearer credential must never carry DPoP on refresh, regardless of flag. */
+    @Test
+    fun test_refreshAuthToken_bearerCredential_flagOffOrOn_neverAttachesProof() {
+        SalesforceSDKManager.getInstance().useDPoP = false
+        httpAccess.enqueueTokenSuccess()
+
+        OAuth2.refreshAuthToken(
+            httpAccess,
+            URI.create("https://example-token.test/"),
+            "test-client-id",
+            "test-refresh-token",
+            null,
+            credentialsIdentifier,
+            null
+        )
+        assertNull(
+            "Bearer credential must not carry DPoP header (flag off)",
+            httpAccess.lastRequest()!!.header("DPoP")
+        )
+
+        SalesforceSDKManager.getInstance().useDPoP = true
+        httpAccess.enqueueTokenSuccess()
+        OAuth2.refreshAuthToken(
+            httpAccess,
+            URI.create("https://example-token.test/"),
+            "test-client-id",
+            "test-refresh-token",
+            null,
+            credentialsIdentifier,
+            null
+        )
+        assertNull(
+            "Bearer credential must not carry DPoP header (flag on)",
+            httpAccess.lastRequest()!!.header("DPoP")
+        )
+    }
+
+    /** `use_dpop_nonce` retry re-attaches a proof and consumes the harvested nonce. */
+    @Test
+    fun test_refreshAuthToken_nonceChallenge_retryAttachesProof_flagOff() {
+        SalesforceSDKManager.getInstance().useDPoP = false
+        DPoPKeyManager.generateOrLoadKeyPair(alias)
+
+        val host = "example-nonce.test"
+        DPoPNonceCache.clear(credentialsIdentifier)
+
+        // First response: 400 use_dpop_nonce + DPoP-Nonce header for harvest.
+        httpAccess.enqueue(
+            code = 400,
+            body = "{\"error\":\"use_dpop_nonce\"}",
+            headers = mapOf("DPoP-Nonce" to "srv-nonce-abc")
+        )
+        // Second response: 200 success — expected after nonce retry.
+        httpAccess.enqueueTokenSuccess()
+
+        OAuth2.refreshAuthToken(
+            httpAccess,
+            URI.create("https://$host/"),
+            "test-client-id",
+            "test-refresh-token",
+            null,
+            credentialsIdentifier,
+            "DPoP"
+        )
+
+        val requests = httpAccess.allRequests()
+        assertEquals("Expected exactly two token endpoint requests", 2, requests.size)
+        assertNotNull("Initial request should carry a DPoP proof", requests[0].header("DPoP"))
+        assertNotNull("Retry request should carry a DPoP proof", requests[1].header("DPoP"))
+        // The retry proof is minted after the nonce is harvested, so it must differ from the first.
+        assertTrue(
+            "Retry proof header should be re-minted (i.e. differ from the initial one)",
+            requests[0].header("DPoP") != requests[1].header("DPoP")
+        )
+    }
+
+    /** Identity-service call attaches DPoP for a DPoP-bound credential even with flag off. */
+    @Test
+    fun test_callIdentityService_flagOff_credentialDPoPBound_attachesProof() {
+        SalesforceSDKManager.getInstance().useDPoP = false
+        DPoPKeyManager.generateOrLoadKeyPair(alias)
+        httpAccess.enqueueIdentitySuccess()
+
+        OAuth2.callIdentityService(
+            httpAccess,
+            "https://example-id.test/id/orgId/userId",
+            "test-access-token",
+            "DPoP",
+            credentialsIdentifier
+        )
+
+        val recorded = httpAccess.lastRequest()
+        assertNotNull("identity request should have been sent", recorded)
+        assertNotNull(
+            "DPoP header must be attached on identity fetch when credential is DPoP-bound",
+            recorded!!.header("DPoP")
+        )
+        assertEquals(
+            "Authorization scheme should be DPoP when tokenType==\"DPoP\"",
+            "DPoP test-access-token",
+            recorded.header("Authorization")
+        )
+    }
+
+    /**
+     * Bearer credential must not carry DPoP header on the identity endpoint.
+     */
+    @Test
+    fun test_callIdentityService_bearerCredential_neverAttachesProof() {
+        SalesforceSDKManager.getInstance().useDPoP = false
+        httpAccess.enqueueIdentitySuccess()
+
+        OAuth2.callIdentityService(
+            httpAccess,
+            "https://example-id.test/id/orgId/userId",
+            "test-access-token",
+            null,
+            credentialsIdentifier
+        )
+
+        val recorded = httpAccess.lastRequest()
+        assertNotNull(recorded)
+        assertNull("Bearer identity call must not carry DPoP header", recorded!!.header("DPoP"))
+        assertEquals(
+            "Authorization scheme should be Bearer when tokenType is null",
+            "Bearer test-access-token",
+            recorded.header("Authorization")
+        )
+    }
+
+    /**
+     * A HttpAccess subclass that installs an OkHttp interceptor to (a) capture every outbound
+     * request and (b) return canned responses without touching the network. Avoids the need for
+     * the MockWebServer dependency, which is not on this module's test classpath.
+     */
+    private class CapturingHttpAccess : HttpAccess(null, "dummy-agent") {
+
+        private val recordedRequests = mutableListOf<Request>()
+        private val enqueuedResponses = ArrayDeque<CannedResponse>()
+        private val cursor = AtomicInteger(0)
+
+        private val capturingInterceptor = Interceptor { chain ->
+            val req = chain.request()
+            synchronized(recordedRequests) { recordedRequests += req }
+            val canned = synchronized(enqueuedResponses) {
+                enqueuedResponses.removeFirstOrNull()
+            } ?: CannedResponse(200, "{}", emptyMap())
+            val builder = Response.Builder()
+                .request(req)
+                .protocol(Protocol.HTTP_1_1)
+                .code(canned.code)
+                .message(if (canned.code < 300) "OK" else "ERR")
+                .body(canned.body.toResponseBody("application/json".toMediaType()))
+            canned.headers.forEach { (k, v) -> builder.addHeader(k, v) }
+            builder.build()
+        }
+
+        override fun createNewClientBuilder(): OkHttpClient.Builder =
+            OkHttpClient.Builder().addInterceptor(capturingInterceptor)
+
+        fun enqueue(code: Int, body: String, headers: Map<String, String> = emptyMap()) {
+            synchronized(enqueuedResponses) { enqueuedResponses.addLast(CannedResponse(code, body, headers)) }
+        }
+
+        fun enqueueTokenSuccess() {
+            enqueue(
+                200,
+                """{"access_token":"new-access-token","instance_url":"https://instance.test",
+                    "id":"https://example-id.test/id/00Dxxxxx/005xxxxx",
+                    "token_type":"Bearer"}""".trimIndent(),
+                mapOf("DPoP-Nonce" to "srv-nonce-post-success")
+            )
+        }
+
+        fun enqueueIdentitySuccess() {
+            // Minimal identity response — enough JSON keys for IdServiceResponse to parse without NPE.
+            enqueue(
+                200,
+                """{"id":"https://example-id.test/id/00Dxxxxx/005xxxxx",
+                    "user_id":"005xxxxx","organization_id":"00Dxxxxx",
+                    "username":"unit@test.example","display_name":"unit","email":"unit@test.example",
+                    "urls":{},"active":true,"user_type":"STANDARD",
+                    "language":"en_US","locale":"en_US","utcOffset":0}""".trimIndent()
+            )
+        }
+
+        fun lastRequest(): Request? = synchronized(recordedRequests) {
+            recordedRequests.lastOrNull()
+        }
+
+        fun allRequests(): List<Request> = synchronized(recordedRequests) {
+            recordedRequests.toList()
+        }
+
+        private data class CannedResponse(val code: Int, val body: String, val headers: Map<String, String>)
+    }
+}

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2MockTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/OAuth2MockTests.kt
@@ -222,11 +222,10 @@ class OAuth2MockTests {
     // region DPoP tests
 
     @Test
-    fun test_givenUseDPoPTrueAndCredentialsIdentifier_whenMakeTokenEndpointRequest_thenDPoPHeaderPresent() {
+    fun test_givenDPoPTokenTypeAndCredentialsIdentifier_whenMakeTokenEndpointRequest_thenDPoPHeaderPresent() {
         val salesforceSdkManager = mockk<SalesforceSDKManager>(relaxed = true) {
             every { appAttestationClient } returns null
             every { deviceId } returns "__DEVICE_ID__"
-            every { useDPoP } returns true
         }
 
         val responseBody = """{"access_token":"t","instance_url":"https://i","id":"https://i/id/o/u"}"""
@@ -250,6 +249,7 @@ class OAuth2MockTests {
             FormBody.Builder(),
             salesforceSdkManager,
             "test-scope-id",
+            "DPoP",
         )
 
         val dpopHeader = requestSlot.captured.header("DPoP")

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
@@ -150,10 +150,11 @@ class DPoPKeyManagerTest {
         assertFalse(DPoPKeyManager.shouldAttachDPoP(id, null))
         assertFalse(DPoPKeyManager.shouldAttachDPoP(id, "Bearer"))
 
-        // Once a key pair exists, hasKeyPair leg kicks in for null / Bearer tokenType.
+        // Once a key pair exists, the hasKeyPair leg kicks in only for a null tokenType.
         DPoPKeyManager.generateOrLoadKeyPair(alias)
         assertTrue(DPoPKeyManager.shouldAttachDPoP(id, null))
-        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "Bearer"))
+        // Key material present, but an explicit "Bearer" tokenType takes priority — no proof.
+        assertFalse(DPoPKeyManager.shouldAttachDPoP(id, "Bearer"))
         assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "DPoP"))
 
         // After deletion the predicate falls back to tokenType-only.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
@@ -29,11 +29,13 @@ package com.salesforce.androidsdk.auth.dpop
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.security.interfaces.ECPublicKey
+import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class DPoPKeyManagerTest {
@@ -98,5 +100,66 @@ class DPoPKeyManagerTest {
     @Test
     fun test_givenCredentialsIdentifier_whenComputingAlias_thenPrefixedWithDpop() {
         assertEquals("dpop_user-123", DPoPKeyManager.aliasForCredentialsIdentifier("user-123"))
+    }
+
+    @Test
+    fun test_hasKeyPair_falseBeforeCreation_trueAfter_falseAfterDeletion() {
+        val alias = trackedAlias("has_keypair_${UUID.randomUUID()}")
+        assertFalse(DPoPKeyManager.hasKeyPair(alias))
+        DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertTrue(DPoPKeyManager.hasKeyPair(alias))
+        DPoPKeyManager.deleteKeyPair(alias)
+        assertFalse(DPoPKeyManager.hasKeyPair(alias))
+    }
+
+    @Test
+    fun test_hasKeyPair_emptyAlias_returnsFalse() {
+        assertFalse(DPoPKeyManager.hasKeyPair(""))
+    }
+
+    @Test
+    fun test_hasKeyPairForCredentialsIdentifier_nullOrEmpty_returnsFalse() {
+        assertFalse(DPoPKeyManager.hasKeyPairForCredentialsIdentifier(null))
+        assertFalse(DPoPKeyManager.hasKeyPairForCredentialsIdentifier(""))
+    }
+
+    @Test
+    fun test_hasKeyPairForCredentialsIdentifier_matchesHasKeyPairForComputedAlias() {
+        val id = "pred_${UUID.randomUUID()}"
+        val alias = DPoPKeyManager.aliasForCredentialsIdentifier(id)
+        aliasesToCleanUp.add(alias)
+        assertFalse(DPoPKeyManager.hasKeyPairForCredentialsIdentifier(id))
+        DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertTrue(DPoPKeyManager.hasKeyPairForCredentialsIdentifier(id))
+    }
+
+    @Test
+    fun test_shouldAttachDPoP_predicate_covers_all_cases() {
+        val id = "predicate_${UUID.randomUUID()}"
+        val alias = DPoPKeyManager.aliasForCredentialsIdentifier(id)
+        aliasesToCleanUp.add(alias)
+
+        // Null or empty id short-circuits to false regardless of tokenType.
+        assertFalse(DPoPKeyManager.shouldAttachDPoP(null, "DPoP"))
+        assertFalse(DPoPKeyManager.shouldAttachDPoP("", "DPoP"))
+
+        // Valid id, tokenType="DPoP", no key material yet → true (tokenType alone is sufficient).
+        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "DPoP"))
+
+        // Valid id, no tokenType, no key material → false.
+        assertFalse(DPoPKeyManager.shouldAttachDPoP(id, null))
+        assertFalse(DPoPKeyManager.shouldAttachDPoP(id, "Bearer"))
+
+        // Once a key pair exists, hasKeyPair leg kicks in for null / Bearer tokenType.
+        DPoPKeyManager.generateOrLoadKeyPair(alias)
+        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, null))
+        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "Bearer"))
+        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "DPoP"))
+
+        // After deletion the predicate falls back to tokenType-only.
+        DPoPKeyManager.deleteKeyPair(alias)
+        assertFalse(DPoPKeyManager.shouldAttachDPoP(id, null))
+        assertFalse(DPoPKeyManager.shouldAttachDPoP(id, "Bearer"))
+        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "DPoP"))
     }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientDPoPGateTests.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/RestClientDPoPGateTests.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.rest
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+/**
+ * Unit tests for RestClient's per-request DPoP gate at API-call time.
+ *
+ * Exercises OAuthRefreshInterceptor.buildAuthenticatedRequest via
+ * a mocked OkHttp Chain, capturing the outbound Request to assert
+ * on Authorization scheme and presence/absence of the DPoP header.
+ */
+@RunWith(AndroidJUnit4::class)
+class RestClientDPoPGateTests {
+
+    private val aliasesToCleanUp = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        aliasesToCleanUp.forEach { DPoPKeyManager.deleteKeyPair(it) }
+        aliasesToCleanUp.clear()
+    }
+
+    private fun trackId(name: String): String {
+        val id = "restclient_${name}_${UUID.randomUUID()}"
+        aliasesToCleanUp.add(DPoPKeyManager.aliasForCredentialsIdentifier(id))
+        return id
+    }
+
+    private fun captureAuthenticatedRequest(interceptor: RestClient.OAuthRefreshInterceptor): Request {
+        val outbound = Request.Builder()
+            .url("https://instance.example.com/services/data/v65.0/query")
+            .get()
+            .build()
+        val outboundSlot = slot<Request>()
+        val response = Response.Builder()
+            .request(outbound)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .build()
+        val chain = mockk<Interceptor.Chain>(relaxed = true) {
+            every { request() } returns outbound
+            every { proceed(capture(outboundSlot)) } returns response
+        }
+        interceptor.intercept(chain)
+        return outboundSlot.captured
+    }
+
+    // Credential is DPoP-bound (tokenType="DPoP") — outbound API request
+    // carries a DPoP header AND uses the DPoP Authorization scheme.
+    @Test
+    fun test_givenDPoPBoundCredential_whenIntercept_thenAttachesProofAndDPoPScheme() {
+        val id = trackId("sc2_dpop_bound")
+        val interceptor = RestClient.OAuthRefreshInterceptor(
+            null,
+            "__ACCESS_TOKEN__",
+            "DPoP",
+            id,
+            null,
+        )
+
+        val captured = captureAuthenticatedRequest(interceptor)
+
+        assertNotNull("Expected DPoP header on outbound request", captured.header("DPoP"))
+        assertTrue(
+            "Expected DPoP header to be non-blank",
+            !captured.header("DPoP").isNullOrBlank(),
+        )
+        val auth = captured.header("Authorization")
+        assertNotNull(auth)
+        assertTrue(
+            "Expected Authorization to use DPoP scheme but got: $auth",
+            auth!!.startsWith("DPoP "),
+        )
+    }
+
+    // Bearer credential — no DPoP header, Bearer Authorization scheme.
+    @Test
+    fun test_givenBearerCredential_whenIntercept_thenNoDPoPHeaderAndBearerScheme() {
+        val id = trackId("sc3_bearer")
+        val interceptor = RestClient.OAuthRefreshInterceptor(
+            null,
+            "__ACCESS_TOKEN__",
+            "Bearer",
+            id,
+            null,
+        )
+
+        val captured = captureAuthenticatedRequest(interceptor)
+
+        assertNull(
+            "Did not expect DPoP header for Bearer credential",
+            captured.header("DPoP"),
+        )
+        val auth = captured.header("Authorization")
+        assertNotNull(auth)
+        assertTrue(
+            "Expected Authorization to use Bearer scheme but got: $auth",
+            auth!!.startsWith("Bearer "),
+        )
+    }
+
+    // Belt-and-suspenders: no tokenType, but a key pair exists for the credential
+    // → interceptor still attaches a DPoP proof (Authorization stays Bearer
+    // because setAuthHeader keys off exact tokenType match — this asymmetry
+    // is intentional and documented).
+    @Test
+    fun test_givenNoTokenTypeButExistingKeyPair_whenIntercept_thenAttachesProof() {
+        val id = trackId("belt_haskeypair")
+        DPoPKeyManager.generateOrLoadKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(id))
+        val interceptor = RestClient.OAuthRefreshInterceptor(
+            null,
+            "__ACCESS_TOKEN__",
+            null,
+            id,
+            null,
+        )
+
+        val captured = captureAuthenticatedRequest(interceptor)
+
+        assertNotNull(
+            "Expected DPoP header when a key pair exists for the credential",
+            captured.header("DPoP"),
+        )
+    }
+
+    // Null credentialsIdentifier short-circuits — no DPoP header regardless of tokenType.
+    @Test
+    fun test_givenNullCredentialsIdentifier_whenIntercept_thenNoDPoPHeader() {
+        val interceptor = RestClient.OAuthRefreshInterceptor(
+            null,
+            "__ACCESS_TOKEN__",
+            "DPoP",
+            null,
+            null,
+        )
+
+        val captured = captureAuthenticatedRequest(interceptor)
+
+        assertNull(
+            "Did not expect DPoP header when credentialsIdentifier is null",
+            captured.header("DPoP"),
+        )
+    }
+}

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -30,6 +30,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.salesforce.androidsdk.app.Features.FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT_DPOP
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT_DPOP_RTR
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection
@@ -119,6 +120,36 @@ class DPoPLoginTests : AuthFlowTest() {
         switchToUserAndValidateUser(otherUser, isDpop = true, isJwt = true)
         app.validateOAuthValues(knownAppConfig = ECA_JWT_DPOP, scopeSelection = ScopeSelection.EMPTY)
         assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isMultiUser = true, isJwt = true)
+    }
+
+    // Mixed DPoP + non-DPoP users with the process-wide DPoP flag flipped off after both are
+    // logged in. Each user's post-flip refresh + revoke must use its own auth scheme
+    // independently — DPoP for the DPoP-bound credential, Bearer for the non-DPoP one — gated by
+    // per-credential state (tokenType or persisted key material), not the global flag.
+    @Test
+    fun testECAJwtDPoP_And_NonDPoP_MultiUser_FlagOff_IndependentProofs() {
+        // User A: DPoP ECA. useDPoP=true at login-time so /authorize gets dpop_jkt and the
+        // credential is persisted with tokenType="DPoP" plus a key pair in AndroidKeyStore.
+        loginAndValidate(knownAppConfig = ECA_JWT_DPOP, useDPoP = true)
+
+        // User B: non-DPoP ECA (Bearer). useDPoP=false at login-time so the credential is
+        // persisted with tokenType absent/"Bearer" and no key material.
+        addOtherUserAndValidate(knownAppConfig = ECA_JWT, useDPoP = false)
+
+        // Simulate an app upgrade or config change that flips the process-wide flag OFF.
+        // Existing DPoP-bound credentials must survive; new logins from now on would be Bearer.
+        SalesforceSDKManager.getInstance().useDPoP = false
+
+        // Switch to user A (DPoP-bound). Refresh + REST GET must attach a DPoP proof —
+        // gated by credential state, not the global flag.
+        switchToUserAndValidateUser(user, isDpop = true)
+        app.validateOAuthValues(knownAppConfig = ECA_JWT_DPOP, scopeSelection = ScopeSelection.EMPTY)
+        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isMultiUser = true)
+
+        // Switch to user B (Bearer). Refresh + REST GET must NOT attach DPoP anywhere.
+        switchToUserAndValidateUser(otherUser, isDpop = false)
+        app.validateOAuthValues(knownAppConfig = ECA_JWT, scopeSelection = ScopeSelection.EMPTY)
+        assertRevokeAndRefreshWorks(isRtr = false, isDpop = false, isMultiUser = true)
     }
 
     // endregion


### PR DESCRIPTION
## Summary

DPoP proof attachment was gated by the process-wide `SalesforceSDKManager.isUseDPoP()` flag. When the flag was flipped off while a DPoP-bound credential was still in use, subsequent refresh calls and REST/identity requests silently dropped the proof, producing a 401 loop.

Gate on `tokenType == "DPoP"` **or** `DPoPKeyManager.hasKeyPair(alias)` instead. The global flag continues to govern *new* logins only; once a credential is bound, every request for it carries a proof regardless of flag state (belt-and-suspenders).

## Changes

**SDK**
- `DPoPKeyManager` — new `hasKeyPair(alias)` side-effect-free presence check; new `shouldAttachDPoP(alias, tokenType)` belt-and-suspenders predicate.
- `OAuth2` — `refreshAuthToken` widened with a `tokenType` parameter (backwards-compat overload preserved); flag guards at the refresh, `use_dpop_nonce` retry, and identity-service paths replaced with the new predicate.
- `RestClient` / `ClientManager` / `AuthenticatorService` — thread `tokenType` through so the outbound-API guard honors bound credentials.

**Tests**
- `OAuth2DPoPTest` — new unit tests: post-flip refresh still attaches proof; Bearer never attaches; `use_dpop_nonce` retry re-attaches proof and consumes the harvested nonce; identity-service call attaches DPoP even with flag off; Bearer identity call never carries DPoP.
- `RestClientDPoPGateTests` — new unit tests: DPoP-bound credential attaches proof on outbound API request; Bearer credential does not.
- `DPoPKeyManagerTest` — coverage for the `hasKeyPair` presence check.
- `DPoPLoginTests` (`AuthFlowTester` androidTest) — UI test locking in flag-off-then-refresh end-to-end.

## Backwards compatibility

- Public API additions only. Existing `refreshAuthToken` overload without `tokenType` is preserved and delegates to the widened signature.
- The global `SalesforceSDKManager.isUseDPoP()` flag continues to work as before for new logins.

## Test plan

- [x] `:libs:SalesforceSDK:connectedAndroidTest` — 401/411 pass; the 11 baseline failures are pre-existing (10 need `test_credentials.json`, 1 MockK stub setup) and unrelated.
- [x] New DPoP-gate unit tests pass under `connectedAndroidTest`.
- [ ] UI test (`AuthFlowTester DPoPLoginTests`) — pending clean-device run (blocked locally on a Chrome Custom Tabs rendering flake unrelated to this change).
- [ ] Full-suite CI regression on merge.