### PR TITLE
Remove plaintext token response log (W-23820720)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -1186,7 +1186,6 @@ public class OAuth2 {
         public TokenEndpointResponse(Response response, List<String> additionalOauthKeys) {
             try {
                 final JSONObject parsedResponse = (new RestResponse(response)).asJSONObject();
-                SalesforceSDKLogger.d(TAG, "parsedResponse-->" + parsedResponse);
                 authToken = parsedResponse.getString(ACCESS_TOKEN);
                 instanceUrl = parsedResponse.getString(INSTANCE_URL);
                 if (parsedResponse.has(API_INSTANCE_URL)) {


### PR DESCRIPTION
## Summary

- Removes a debug log statement in `OAuth2.TokenEndpointResponse` that serialized the full parsed token endpoint JSON object in plaintext to the device log.

## What was logged

The removed line (`OAuth2.java`, `TokenEndpointResponse(Response, List)` constructor) called `JSONObject.toString()` on the raw server response, which contains all of the following fields in plaintext:

- `access_token`
- `refresh_token`
- `id_token`
- `lightning_sid`, `vf_sid`, `content_sid`, `parent_sid`
- `csrf_token`
- `cookie_client_src`, `cookie_sid_client`
- All additional OAuth values

This is a regression of W-22027920. Any device with Android debug logging enabled (or log aggregation in debug/staging environments) would have exposed these tokens.

## Security audit of other `SalesforceSDKLogger.d` calls

During the fix, all other `SalesforceSDKLogger.d` calls in the SDK libraries were audited for similar sensitive-data exposure. Findings:

| File | Line | Message | Assessment |
|---|---|---|---|
| `SPAuthCodeHelper.kt` | 82 | `"getTokenResponse $tokenResponse"` | **Safe** — `TokenEndpointResponse` has no `toString()` override; logs class name + hashcode only |
| `SPAuthCodeHelper.kt` | 95 | `"onAuthFlowSuccess $userAccount"` | **Safe** — `UserAccount` has no `toString()` override; logs class name + hashcode only |
| `NativeLoginManager.kt` | 258 | `"onAuthFlowSuccess $userAccount"` | **Safe** — same `UserAccount` class, same result |
| `RestClient.java` | 824–825 | `"response request url: …"` / `"response code: …"` | **Safe** — logs the OAuth2 endpoint URL path and HTTP status code, no token values |
| `RestClient.java` | 846 | `"shouldRefresh() returned true"` | **Safe** — pure flow-control message |

No other changes required.

## Test plan

- [ ] Confirm `OAuth2.TokenEndpointResponse` constructor no longer emits a log line at debug level
- [ ] Run `SalesforceSDKTest` suite — no test changes expected since the removed line was purely diagnostic