### PR TITLE
Add auth_trigger and sdkInfo params to Custom Tab authorize URL

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -1032,8 +1032,7 @@ open class LoginActivity : FragmentActivity() {
             customTabsIntent.intent.setPackage(customTabBrowser)
         }
 
-        // Add prompt=login to prevent the browser cookie from bypassing login if it exists.
-        val urlString = if (sharedBrowserSession) loginUrl else loginUrl + PROMPT_LOGIN
+        val urlString = buildCustomTabAuthorizeUrl(loginUrl, completedViaAdminCustomTab)
 
         runCatching {
             customTabsIntent.intent.setData(urlString.toUri())
@@ -1045,6 +1044,30 @@ open class LoginActivity : FragmentActivity() {
             }
             clearWebView()
         }
+    }
+
+    /**
+     * Appends `sdkInfo` and `auth_trigger` to the authorize URL for the native browser (Custom
+     * Tab) path only — the WebView path's real `User-Agent` header already carries this
+     * information, so [LoginViewModel.generateAuthorizationUrl]'s WebView URL is left untouched.
+     * Also appends `prompt=login` (unless a shared browser session is in use) to prevent the
+     * browser cookie from bypassing login if it exists.
+     */
+    @VisibleForTesting
+    internal fun buildCustomTabAuthorizeUrl(
+        loginUrl: String,
+        isAdminLogin: Boolean,
+        sdkManager: SalesforceSDKManager = SalesforceSDKManager.getInstance(),
+    ): String {
+        @Suppress("DEPRECATION")
+        val authTrigger = selectAuthTrigger(
+            isAdminLogin,
+            isMdmForcedBrowserLogin(),
+            sdkManager.forceAdvancedAuthentication,
+        )
+        val sdkInfo = Uri.encode(sdkManager.getUserAgent(""))
+        val urlWithSdkInfo = "$loginUrl&sdkInfo=$sdkInfo&auth_trigger=$authTrigger"
+        return if (sharedBrowserSession) urlWithSdkInfo else urlWithSdkInfo + PROMPT_LOGIN
     }
 
     private fun doesBrowserExist(customTabBrowser: String?) =
@@ -1484,6 +1507,18 @@ open class LoginActivity : FragmentActivity() {
         private const val SETUP_REQUEST_CODE = 72
         private const val TAG = "LoginActivity"
         private const val PROMPT_LOGIN = "&prompt=login"
+
+        // `auth_trigger` values sent to /services/oauth2/authorize on the native browser (Custom
+        // Tab) path. Same string literals as iOS's kSFOAuthAuthTrigger* constants.
+        @VisibleForTesting
+        internal const val AUTH_TRIGGER_ORG_CONFIG = "org_config"
+        @VisibleForTesting
+        internal const val AUTH_TRIGGER_MDM = "mdm"
+        @VisibleForTesting
+        internal const val AUTH_TRIGGER_FORCE_ADVANCED_AUTH = "force_advanced_auth"
+        @VisibleForTesting
+        internal const val AUTH_TRIGGER_LOGIN_FOR_ADMIN = "login_for_admin"
+
         private const val AUTHENTICATION_FAILED_INTENT = "com.salesforce.auth.intent.AUTHENTICATION_ERROR"
         private const val HTTP_ERROR_RESPONSE_CODE_INTENT = "com.salesforce.auth.intent.HTTP_RESPONSE_CODE"
         private const val RESPONSE_ERROR_INTENT = "com.salesforce.auth.intent.RESPONSE_ERROR"
@@ -1571,6 +1606,31 @@ open class LoginActivity : FragmentActivity() {
             completedViaAdminCustomTab -> FEATURE_BROWSER_LOGIN_FOR_ADMIN   // B3
             forceAdvancedAuth -> FEATURE_BROWSER_LOGIN_FORCE_FLAG           // B4
             else -> FEATURE_BROWSER_LOGIN_SERVER_AUTH_CONFIG                // B1 fallthrough
+        }
+
+        /**
+         * Selects the `auth_trigger` value sent to `/services/oauth2/authorize` on the native
+         * browser (Custom Tab) path, telling the server why browser login was chosen.
+         * Priority: login_for_admin > mdm > force_advanced_auth > org_config, mirroring
+         * [selectBMarker]'s B3 > B2 > B4 > B1 priority.
+         *
+         * @param isAdminLogin Whether this Custom Tab launch is the "Login for Admin" flow
+         * @param isMdmForced Unused on Android — reserved for future use (always pass false).
+         * See [selectBMarker]'s identically-named parameter: MDM forces cert auth via a
+         * different code path that never reaches the Custom Tab launch.
+         * @param forceAdvancedAuth Whether the [SalesforceSDKManager.forceAdvancedAuthentication] flag is set
+         * @return The `auth_trigger` value to send with the authorize request
+         */
+        @VisibleForTesting
+        internal fun selectAuthTrigger(
+            isAdminLogin: Boolean,
+            @Suppress("UNUSED_PARAMETER") isMdmForced: Boolean,
+            forceAdvancedAuth: Boolean,
+        ): String = when {
+            isAdminLogin -> AUTH_TRIGGER_LOGIN_FOR_ADMIN         // B3 — highest priority
+            forceAdvancedAuth -> AUTH_TRIGGER_FORCE_ADVANCED_AUTH // B4
+            else -> AUTH_TRIGGER_ORG_CONFIG                       // B1 — fallback
+            // B2/mdm unreachable here — MDM forces cert auth on Android, see selectBMarker
         }
 
         // endregion

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/app/BrowserLoginTelemetryTest.kt
@@ -38,18 +38,22 @@ import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_SANDBOX
 import com.salesforce.androidsdk.app.Features.FEATURE_LOGIN_SERVER_WELCOME_DISCOVERY
 import com.salesforce.androidsdk.config.LoginServerManager
 import com.salesforce.androidsdk.ui.LoginActivity
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.AUTH_TRIGGER_FORCE_ADVANCED_AUTH
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.AUTH_TRIGGER_LOGIN_FOR_ADMIN
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.AUTH_TRIGGER_ORG_CONFIG
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Unit tests for the B-marker (browser login reason) and L-marker (login server type)
- * telemetry selection logic in [LoginActivity].
+ * Unit tests for the B-marker (browser login reason), L-marker (login server type), and
+ * auth_trigger telemetry selection logic in [LoginActivity].
  *
- * The logic under test lives in [LoginActivity.selectBMarker] and [LoginActivity.selectLMarker],
- * which are companion object helpers annotated `@VisibleForTesting`. They are pure functions
- * that require no Activity context, so they are called directly without mocking.
+ * The logic under test lives in [LoginActivity.selectBMarker], [LoginActivity.selectLMarker], and
+ * [LoginActivity.selectAuthTrigger], which are companion object helpers annotated
+ * `@VisibleForTesting`. They are pure functions that require no Activity context, so they are
+ * called directly without mocking.
  *
  * L-marker mapping:
  *   L1 = Production server
@@ -159,6 +163,81 @@ class BrowserLoginTelemetryTest {
         )
         assertEquals("Force flag should win over ignored MDM signal (B4)",
             FEATURE_BROWSER_LOGIN_FORCE_FLAG, result)
+    }
+
+    // endregion
+    // region auth_trigger tests
+
+    @Test
+    fun test_givenAdminLogin_whenSelectAuthTrigger_thenLoginForAdminReturned() {
+        // Highest priority, mirrors B3
+        val result = LoginActivity.selectAuthTrigger(
+            isAdminLogin = true,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("Admin login should yield login_for_admin",
+            AUTH_TRIGGER_LOGIN_FOR_ADMIN, result)
+    }
+
+    @Test
+    fun test_givenForceAdvancedAuth_whenSelectAuthTrigger_thenForceAdvancedAuthReturned() {
+        // Mirrors B4
+        val result = LoginActivity.selectAuthTrigger(
+            isAdminLogin = false,
+            isMdmForced = false,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("Force-advanced-auth should yield force_advanced_auth",
+            AUTH_TRIGGER_FORCE_ADVANCED_AUTH, result)
+    }
+
+    @Test
+    fun test_givenNeitherAdminNorForceFlag_whenSelectAuthTrigger_thenOrgConfigReturned() {
+        // Fallthrough, mirrors B1
+        val result = LoginActivity.selectAuthTrigger(
+            isAdminLogin = false,
+            isMdmForced = false,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("Neither admin nor force flag should yield org_config fallback",
+            AUTH_TRIGGER_ORG_CONFIG, result)
+    }
+
+    @Test
+    fun test_givenAdminLoginAndForceAdvancedAuth_whenSelectAuthTrigger_thenLoginForAdminWins() {
+        // Priority: login_for_admin > force_advanced_auth
+        val result = LoginActivity.selectAuthTrigger(
+            isAdminLogin = true,
+            isMdmForced = false,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("Admin login should take priority over force-advanced-auth",
+            AUTH_TRIGGER_LOGIN_FOR_ADMIN, result)
+    }
+
+    @Test
+    fun test_givenMdmForcedIgnored_whenSelectAuthTrigger_thenFallsThroughToOrgConfig() {
+        // Mirrors selectBMarker's documented MDM no-op: isMdmForced is ignored on Android.
+        val result = LoginActivity.selectAuthTrigger(
+            isAdminLogin = false,
+            isMdmForced = true,
+            forceAdvancedAuth = false,
+        )
+        assertEquals("MDM flag is ignored on Android; should fall through to org_config",
+            AUTH_TRIGGER_ORG_CONFIG, result)
+    }
+
+    @Test
+    fun test_givenMdmForcedAndForceAdvancedAuth_whenSelectAuthTrigger_thenForceAdvancedAuthWins() {
+        // MDM ignored; force flag should still win over the org_config fallthrough
+        val result = LoginActivity.selectAuthTrigger(
+            isAdminLogin = false,
+            isMdmForced = true,
+            forceAdvancedAuth = true,
+        )
+        assertEquals("Force flag should win over ignored MDM signal",
+            AUTH_TRIGGER_FORCE_ADVANCED_AUTH, result)
     }
 
     // endregion

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
@@ -31,6 +31,7 @@ import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+import android.net.Uri
 import androidx.activity.result.ActivityResult
 import androidx.compose.ui.graphics.Color
 import androidx.core.net.toUri
@@ -42,6 +43,9 @@ import com.salesforce.androidsdk.rest.ClientManager
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.OAuthRefreshInterceptor
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.ABOUT_BLANK
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.AUTH_TRIGGER_FORCE_ADVANCED_AUTH
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.AUTH_TRIGGER_LOGIN_FOR_ADMIN
+import com.salesforce.androidsdk.ui.LoginActivity.Companion.AUTH_TRIGGER_ORG_CONFIG
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.EXTRA_KEY_LOGIN_HINT
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.EXTRA_KEY_LOGIN_HOST
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.SALESFORCE_WELCOME_DISCOVERY_MOBILE_URL_QUERY_PARAMETER_KEY_CALLBACK_URL
@@ -335,6 +339,91 @@ class LoginActivityTest {
     fun customTabToolbarColor_withTopBarColor_usesAppProvidedColor() {
         val appColor = Color(red = 10, green = 20, blue = 30)
         assertEquals(appColor, LoginActivity.customTabToolbarColor(topBarColor = appColor))
+    }
+
+    // endregion
+
+    // region buildCustomTabAuthorizeUrl
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun buildCustomTabAuthorizeUrl_forRegularLogin_appendsSdkInfoAndOrgConfigTrigger() {
+        val loginUrl = "https://example.com/services/oauth2/authorize?client_id=abc"
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.forceAdvancedAuthentication } returns false
+        every { sdkManager.getUserAgent("") } returns "SalesforceMobileSDK/test"
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.sharedBrowserSession } returns false
+        every {
+            activity.buildCustomTabAuthorizeUrl(any(), any(), any())
+        } answers { callOriginal() }
+
+        val result = activity.buildCustomTabAuthorizeUrl(loginUrl, false, sdkManager)
+
+        assertTrue("Should append sdkInfo",
+            result.contains("&sdkInfo=${Uri.encode("SalesforceMobileSDK/test")}"))
+        assertTrue("Should append org_config trigger (no admin/force flag)",
+            result.contains("&auth_trigger=$AUTH_TRIGGER_ORG_CONFIG"))
+        assertTrue("Should append prompt=login when not sharing browser session",
+            result.endsWith("&prompt=login"))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun buildCustomTabAuthorizeUrl_withForceAdvancedAuth_appendsForceAdvancedAuthTrigger() {
+        val loginUrl = "https://example.com/services/oauth2/authorize?client_id=abc"
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.forceAdvancedAuthentication } returns true
+        every { sdkManager.getUserAgent("") } returns "SalesforceMobileSDK/test"
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.sharedBrowserSession } returns false
+        every {
+            activity.buildCustomTabAuthorizeUrl(any(), any(), any())
+        } answers { callOriginal() }
+
+        val result = activity.buildCustomTabAuthorizeUrl(loginUrl, false, sdkManager)
+
+        assertTrue("Should append force_advanced_auth trigger",
+            result.contains("&auth_trigger=$AUTH_TRIGGER_FORCE_ADVANCED_AUTH"))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun buildCustomTabAuthorizeUrl_forAdminLogin_appendsLoginForAdminTriggerEvenWithForceFlag() {
+        val loginUrl = "https://example.com/services/oauth2/authorize?client_id=abc"
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        // Force flag is also set, but admin login should still take priority.
+        every { sdkManager.forceAdvancedAuthentication } returns true
+        every { sdkManager.getUserAgent("") } returns "SalesforceMobileSDK/test"
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.sharedBrowserSession } returns false
+        every {
+            activity.buildCustomTabAuthorizeUrl(any(), any(), any())
+        } answers { callOriginal() }
+
+        val result = activity.buildCustomTabAuthorizeUrl(loginUrl, true, sdkManager)
+
+        assertTrue("Admin login should take priority and append login_for_admin trigger",
+            result.contains("&auth_trigger=$AUTH_TRIGGER_LOGIN_FOR_ADMIN"))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun buildCustomTabAuthorizeUrl_withSharedBrowserSession_omitsPromptLogin() {
+        val loginUrl = "https://example.com/services/oauth2/authorize?client_id=abc"
+        val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
+        every { sdkManager.forceAdvancedAuthentication } returns false
+        every { sdkManager.getUserAgent("") } returns "SalesforceMobileSDK/test"
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.sharedBrowserSession } returns true
+        every {
+            activity.buildCustomTabAuthorizeUrl(any(), any(), any())
+        } answers { callOriginal() }
+
+        val result = activity.buildCustomTabAuthorizeUrl(loginUrl, false, sdkManager)
+
+        assertFalse("prompt=login should be omitted for a shared browser session",
+            result.contains("prompt=login"))
     }
 
     // endregion

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -29,6 +29,7 @@ package com.salesforce.samples.authflowtester
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.salesforce.androidsdk.app.Features.FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID
+import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT_DPOP


### PR DESCRIPTION
## Summary
- Appends `sdkInfo` (SDK user-agent string) and `auth_trigger` (why native browser login was chosen) query params to the OAuth authorize URL, Chrome Custom Tab path only
- WebView path is unchanged — it already sends the real User-Agent header
- `auth_trigger` priority: `login_for_admin` > `force_advanced_auth` > `org_config` (MDM forces cert auth via a different code path on Android, so `mdm` is unreachable here)

## Test plan
- [ ] `LoginActivityTest` / `BrowserLoginTelemetryTest` pass
- [ ] Manual login via Custom Tab confirms both params present in the authorize request

GUS: W-23789315