### PR TITLE
feat(W-23815428): add DPoPRequestDecorator with applyAuthHeaders convenience API

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecorator.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecorator.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.auth.OAuth2
+import com.salesforce.androidsdk.util.SalesforceSDKLogger
+import okhttp3.Request
+import okhttp3.Response
+
+/**
+ * Public convenience API for app developers stamping DPoP/Bearer authorization
+ * headers on HTTP requests built outside the SDK's RestClient.
+ *
+ * Gating is per-credential via [DPoPKeyManager.shouldAttachDPoP], not the global
+ * [com.salesforce.androidsdk.app.SalesforceSDKManager.useDPoP] flag. A DPoP-bound
+ * credential carries proofs on every request regardless of that flag.
+ */
+object DPoPRequestDecorator {
+
+    private const val TAG = "DPoPRequestDecorator"
+    const val DPOP_HEADER = "DPoP"
+    const val DPOP_NONCE_HEADER = "DPoP-Nonce"
+    private const val NONCE_ERROR_VALUE = "use_dpop_nonce"
+
+    /**
+     * Stamps [Authorization] and, if the account is DPoP-bound, a [DPoP] proof header
+     * on [builder]. No-op when [UserAccount.getAuthToken] is null or empty.
+     */
+    fun applyAuthHeaders(builder: Request.Builder, userAccount: UserAccount) {
+        val authToken = userAccount.authToken ?: return
+        if (authToken.isEmpty()) return
+
+        val tokenType = userAccount.tokenType
+        val credentialsIdentifier = userAccount.credentialsIdentifier
+
+        OAuth2.addAuthorizationHeader(builder, authToken, tokenType)
+        attachProof(builder, credentialsIdentifier, tokenType, authToken)
+    }
+
+    /**
+     * Returns true if [response] is a DPoP nonce challenge per RFC 9449 §8:
+     * - 400 with body containing `error=use_dpop_nonce`
+     * - 401 with a non-empty `DPoP-Nonce` response header
+     */
+    fun isNonceChallenge(response: Response): Boolean {
+        val code = response.code
+        if (code != 400 && code != 401) return false
+        if (code == 401) {
+            val nonce = response.header(DPOP_NONCE_HEADER)
+            if (!nonce.isNullOrEmpty()) return true
+        }
+        val body = response.peekBody(Long.MAX_VALUE).string()
+        return body.contains(NONCE_ERROR_VALUE)
+    }
+
+    /**
+     * Package-private helper used by RestClient.OAuthRefreshInterceptor to delegate
+     * the proof-building step without constructing a UserAccount.
+     */
+    @JvmName("attachProof")
+    internal fun attachProof(
+        builder: Request.Builder,
+        credentialsIdentifier: String?,
+        tokenType: String?,
+        authToken: String?
+    ) {
+        if (!DPoPKeyManager.shouldAttachDPoP(credentialsIdentifier, tokenType)) return
+        try {
+            val request = builder.build()
+            val url = request.url.toString()
+            val method = request.method
+            val htu = DPoPURLHelper.canonicalize(url)
+            val host = request.url.host
+            val alias = DPoPKeyManager.aliasForCredentialsIdentifier(credentialsIdentifier!!)
+            val keyPair = DPoPKeyManager.generateOrLoadKeyPair(alias)
+            val nonce = DPoPNonceCache.get(credentialsIdentifier, host)
+            val proof = DPoPProofBuilder.buildProof(method, htu, keyPair, nonce, authToken)
+            builder.header(DPOP_HEADER, proof)
+        } catch (e: Exception) {
+            SalesforceSDKLogger.e(TAG, "Failed to attach DPoP proof", e)
+        }
+    }
+}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -30,10 +30,7 @@ import com.salesforce.androidsdk.accounts.UserAccount;
 import com.salesforce.androidsdk.app.SalesforceSDKManager;
 import com.salesforce.androidsdk.auth.HttpAccess;
 import com.salesforce.androidsdk.auth.OAuth2;
-import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager;
-import com.salesforce.androidsdk.auth.dpop.DPoPNonceCache;
-import com.salesforce.androidsdk.auth.dpop.DPoPProofBuilder;
-import com.salesforce.androidsdk.auth.dpop.DPoPURLHelper;
+import com.salesforce.androidsdk.auth.dpop.DPoPRequestDecorator;
 import com.salesforce.androidsdk.security.BiometricAuthenticationManager;
 import com.salesforce.androidsdk.util.SalesforceSDKLogger;
 
@@ -73,7 +70,6 @@ public class RestClient {
     private static final String COMMUNITY_ID = "communityId";
     private static final String COMMUNITY_URL = "communityUrl";
     private static final String TAG = "RestClient";
-    private static final String DPOP = "DPoP";
 
     private static final Map<String, OAuthRefreshInterceptor> OAUTH_REFRESH_INTERCEPTORS = new HashMap<>();
     private static final Map<String, OkHttpClient.Builder> OK_CLIENT_BUILDERS = new HashMap<>();
@@ -915,18 +911,7 @@ public class RestClient {
         }
 
         private void attachDPoPProofIfNeeded(Request.Builder builder, String method, String url) {
-            if (!DPoPKeyManager.INSTANCE.shouldAttachDPoP(credentialsIdentifier, tokenType)) return;
-            try {
-                final String htu = DPoPURLHelper.INSTANCE.canonicalize(url);
-                final String host = HttpUrl.get(url).host();
-                final String alias = DPoPKeyManager.INSTANCE.aliasForCredentialsIdentifier(credentialsIdentifier);
-                final java.security.KeyPair keyPair = DPoPKeyManager.INSTANCE.generateOrLoadKeyPair(alias);
-                final String nonce = DPoPNonceCache.INSTANCE.get(credentialsIdentifier, host);
-                final String proof = DPoPProofBuilder.INSTANCE.buildProof(method, htu, keyPair, nonce, authToken);
-                builder.header(DPOP, proof);
-            } catch (Exception e) {
-                SalesforceSDKLogger.e(TAG, "Failed to attach DPoP proof", e);
-            }
+            DPoPRequestDecorator.INSTANCE.attachProof(builder, credentialsIdentifier, tokenType, authToken);
         }
 
         /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecoratorTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecoratorTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.auth.dpop
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.salesforce.androidsdk.accounts.UserAccount
+import com.salesforce.androidsdk.accounts.UserAccountBuilder
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Unit tests for [DPoPRequestDecorator], the public convenience API for stamping
+ * Authorization and DPoP proof headers on requests built outside RestClient.
+ */
+@RunWith(AndroidJUnit4::class)
+class DPoPRequestDecoratorTest {
+
+    private val testScope = "test_dpop_decorator_scope_${System.currentTimeMillis()}"
+    private val aliasesToCleanUp = mutableListOf<String>()
+
+    @After
+    fun tearDown() {
+        DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(testScope))
+        aliasesToCleanUp.forEach { DPoPKeyManager.deleteKeyPair(it) }
+        aliasesToCleanUp.clear()
+    }
+
+    private fun seedKeyPair(scope: String) {
+        DPoPKeyManager.generateOrLoadKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(scope))
+    }
+
+    private fun requestBuilder(): Request.Builder =
+        Request.Builder()
+            .url("https://test.salesforce.com/services/data")
+            .get()
+
+    private fun userAccount(
+        authToken: String? = "__ACCESS_TOKEN__",
+        tokenType: String?,
+        credentialsIdentifier: String? = testScope,
+    ): UserAccount = UserAccountBuilder.getInstance()
+        .accountName("account")
+        .username("user@example.com")
+        .authToken(authToken)
+        .refreshToken("__REFRESH_TOKEN__")
+        .instanceServer("https://test.salesforce.com")
+        .loginServer("https://login.salesforce.com")
+        .idUrl("https://login.salesforce.com/id/orgId/userId")
+        .clientId("client-id")
+        .orgId("orgId")
+        .userId("userId")
+        .tokenType(tokenType)
+        .credentialsIdentifier(credentialsIdentifier)
+        .build()
+
+    private fun response(
+        code: Int,
+        body: String = "",
+        dpopNonce: String? = null,
+    ): Response {
+        val builder = Response.Builder()
+            .request(requestBuilder().build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("msg")
+            .body(body.toResponseBody("application/json".toMediaType()))
+        if (dpopNonce != null) builder.header(DPoPRequestDecorator.DPOP_NONCE_HEADER, dpopNonce)
+        return builder.build()
+    }
+
+    @Test
+    fun applyAuthHeaders_dpopAccount_bothHeadersSet() {
+        seedKeyPair(testScope)
+        val builder = requestBuilder()
+
+        DPoPRequestDecorator.applyAuthHeaders(builder, userAccount(tokenType = "DPoP"))
+
+        val request = builder.build()
+        val auth = request.header("Authorization")
+        assertNotNull(auth)
+        assertTrue("Expected DPoP scheme but got: $auth", auth!!.startsWith("DPoP "))
+        val dpop = request.header(DPoPRequestDecorator.DPOP_HEADER)
+        assertNotNull("Expected DPoP proof header", dpop)
+        assertEquals("Expected a 3-part JWT proof", 3, dpop!!.split(".").size)
+    }
+
+    @Test
+    fun applyAuthHeaders_bearerAccount_onlyAuthorizationHeader() {
+        val builder = requestBuilder()
+
+        DPoPRequestDecorator.applyAuthHeaders(builder, userAccount(tokenType = "Bearer"))
+
+        val request = builder.build()
+        val auth = request.header("Authorization")
+        assertNotNull(auth)
+        assertTrue("Expected Bearer scheme but got: $auth", auth!!.startsWith("Bearer "))
+        assertNull(request.header(DPoPRequestDecorator.DPOP_HEADER))
+    }
+
+    @Test
+    fun applyAuthHeaders_dpopAccount_isUseDPoPFalse_proofStillAttached() {
+        val sdkManager = com.salesforce.androidsdk.app.SalesforceSDKManager.getInstance()
+        val original = sdkManager.useDPoP
+        try {
+            sdkManager.useDPoP = false
+            seedKeyPair(testScope)
+            val builder = requestBuilder()
+
+            DPoPRequestDecorator.applyAuthHeaders(builder, userAccount(tokenType = "DPoP"))
+
+            assertNotNull(
+                "DPoP proof must be attached for a DPoP-bound credential regardless of useDPoP",
+                builder.build().header(DPoPRequestDecorator.DPOP_HEADER),
+            )
+        } finally {
+            sdkManager.useDPoP = original
+        }
+    }
+
+    @Test
+    fun applyAuthHeaders_nullTokenType_withKeypair_proofAttached() {
+        seedKeyPair(testScope)
+        val builder = requestBuilder()
+
+        DPoPRequestDecorator.applyAuthHeaders(builder, userAccount(tokenType = null))
+
+        assertNotNull(
+            "DPoP proof must be attached when a key pair exists and tokenType is null",
+            builder.build().header(DPoPRequestDecorator.DPOP_HEADER),
+        )
+    }
+
+    @Test
+    fun applyAuthHeaders_nullTokenType_noKeypair_bearerOnly() {
+        val scope = "test_dpop_decorator_nokey_${System.currentTimeMillis()}"
+        aliasesToCleanUp.add(DPoPKeyManager.aliasForCredentialsIdentifier(scope))
+        val builder = requestBuilder()
+
+        DPoPRequestDecorator.applyAuthHeaders(
+            builder,
+            userAccount(tokenType = null, credentialsIdentifier = scope),
+        )
+
+        val request = builder.build()
+        val auth = request.header("Authorization")
+        assertNotNull(auth)
+        assertTrue("Expected Bearer scheme but got: $auth", auth!!.startsWith("Bearer "))
+        assertNull(request.header(DPoPRequestDecorator.DPOP_HEADER))
+    }
+
+    @Test
+    fun isNonceChallenge_400_useDpopNonceBody_returnsTrue() {
+        assertTrue(DPoPRequestDecorator.isNonceChallenge(response(400, """{"error":"use_dpop_nonce"}""")))
+    }
+
+    @Test
+    fun isNonceChallenge_401_dpopNonceHeader_returnsTrue() {
+        assertTrue(DPoPRequestDecorator.isNonceChallenge(response(401, dpopNonce = "somevalue")))
+    }
+
+    @Test
+    fun isNonceChallenge_200_returnsFalse() {
+        assertFalse(DPoPRequestDecorator.isNonceChallenge(response(200, "{}")))
+    }
+
+    @Test
+    fun isNonceChallenge_401_noNonceHeader_returnsFalse() {
+        assertFalse(DPoPRequestDecorator.isNonceChallenge(response(401, "{}")))
+    }
+}


### PR DESCRIPTION
## Summary

Adds a public convenience API, `DPoPRequestDecorator`, that lets app developers stamp DPoP/Bearer authorization headers on HTTP requests built outside the SDK's `RestClient`.

- **New `DPoPRequestDecorator` (Kotlin object)** in `com.salesforce.androidsdk.auth.dpop`:
  - `applyAuthHeaders(builder, userAccount)` — sets the `Authorization` header (DPoP or Bearer scheme via `OAuth2.addAuthorizationHeader`) and, when the credential is DPoP-bound, attaches a `DPoP` proof header. No-op when the account's auth token is null/empty.
  - `isNonceChallenge(response)` — detects an RFC 9449 §8 nonce challenge (400 with `use_dpop_nonce` in the body, or 401 with a non-empty `DPoP-Nonce` header).
  - `attachProof(...)` — internal helper (exposed to Java via `@JvmName`) that builds and attaches the proof; gated by `DPoPKeyManager.shouldAttachDPoP`.
- **`RestClient` refactor**: `OAuthRefreshInterceptor.attachDPoPProofIfNeeded` now delegates to `DPoPRequestDecorator.attachProof(...)`, removing the duplicated proof-building logic (and the now-unused `DPOP` constant / DPoP imports).

Gating remains per-credential (via `DPoPKeyManager.shouldAttachDPoP`), **not** the global `SalesforceSDKManager.useDPoP` flag — a DPoP-bound credential carries proofs on every request regardless of that flag.

## GUS

W-23815428

## Test plan

- New `DPoPRequestDecoratorTest` (9 instrumented tests): DPoP account stamps both headers; Bearer account gets Authorization only; proof attached even when `useDPoP=false`; null tokenType with/without a key pair; and the four `isNonceChallenge` cases. All pass.
- Existing `RestClientDPoPGateTests` and `OAuthRefreshInterceptorNonceTest` remain green — the interceptor refactor is behavior-preserving.