### PR TITLE
fix(test): handle non-dismissable login picker in Chrome Custom Tab page object

### DIFF
--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/BasePageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/BasePageObject.kt
@@ -53,8 +53,8 @@ abstract class BasePageObject(val composeTestRule: ComposeTestRule) {
 
         /**
          * Extended timeout for Espresso WebView actions ([retryWebAction]) that wait for
-         * server-rendered login page content. The Salesforce sandbox login page can take up to
-         * ~30 s to render interactive form elements after [onPageFinished] fires; this budget
+         * server-rendered login page content. The Salesforce sandbox login page can take
+         * 20–30 s to render interactive form elements after [onPageFinished] fires; this budget
          * covers that latency with headroom for both local emulators and Firebase Test Lab.
          */
         val WEBVIEW_ACTION_TIMEOUT_MS: Long by lazy {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/BasePageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/BasePageObject.kt
@@ -44,11 +44,21 @@ abstract class BasePageObject(val composeTestRule: ComposeTestRule) {
             ) == "true"
         }
         val TIMEOUT_MS: Long by lazy {
-            if (isFtl) 15_000 else 10_000
+            if (isFtl) 20_000 else 15_000
         }
 
         val SLEEP_TIME_MS: Long by lazy {
             if (isFtl) 5_000 else 2_500
+        }
+
+        /**
+         * Extended timeout for Espresso WebView actions ([retryWebAction]) that wait for
+         * server-rendered login page content. The Salesforce sandbox login page can take up to
+         * ~30 s to render interactive form elements after [onPageFinished] fires; this budget
+         * covers that latency with headroom for both local emulators and Firebase Test Lab.
+         */
+        val WEBVIEW_ACTION_TIMEOUT_MS: Long by lazy {
+            if (isFtl) 60_000 else 45_000
         }
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
@@ -84,9 +84,9 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
 
     /**
      * Surfaces the LoginActivity (or the server picker) by closing the Custom Tab that forced
-     * advanced auth auto-launches over it. Since W-23731759 the login picker is non-dismissable,
-     * so callers that need the top bar (e.g. [changeServerByUrl]) must select a server from the
-     * picker first; callers that need Login Options can use the picker's dev-support button via
+     * advanced auth auto-launches over it. The login picker is non-dismissable, so callers that
+     * need the top bar (e.g. [changeServerByUrl]) must select a server from the picker first;
+     * callers that need Login Options can use the picker's dev-support button via
      * [LoginPageObject.openLoginOptions]. This method only closes the tab and waits for Compose
      * to be ready — it does NOT attempt to dismiss the picker.
      */

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
@@ -28,13 +28,11 @@ package com.salesforce.samples.authflowtester.pageObjects
 
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onAllNodesWithContentDescription
-import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
-import com.salesforce.androidsdk.R
+import com.salesforce.androidsdk.ui.components.LoginViewTestTags
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
@@ -85,15 +83,14 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
     }
 
     /**
-     * Surfaces the LoginActivity by backing out of the Custom Tab that forced advanced auth
-     * auto-launches over it (the tab hides the Compose top bar the [LoginPageObject] actions need).
-     * Backing out returns `RESULT_CANCELED`, which the SDK handles by raising the server-picker
-     * bottom sheet; that is dismissed here too so a subsequent top-bar action can re-launch the tab.
-     * Waits up to [TIMEOUT_MS] for the async tab launch; no-op if no tab appears (already on the
-     * LoginActivity).
+     * Surfaces the LoginActivity (or the server picker) by closing the Custom Tab that forced
+     * advanced auth auto-launches over it. Since W-23731759 the login picker is non-dismissable,
+     * so callers that need the top bar (e.g. [changeServerByUrl]) must select a server from the
+     * picker first; callers that need Login Options can use the picker's dev-support button via
+     * [LoginPageObject.openLoginOptions]. This method only closes the tab and waits for Compose
+     * to be ready — it does NOT attempt to dismiss the picker.
      */
     override fun backOutToLoginActivity() {
-        // Clear the FRE first; until it is gone it covers the tab toolbar (the close button).
         skipGoogleSignIn()
         val closeButton = device.findObject(
             UiSelector().resourceId("com.android.chrome:id/close_button")
@@ -102,27 +99,18 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
             return
         }
         closeButton.click()
-        dismissServerPickerIfPresent()
-    }
-
-    /** Dismisses the login-server-picker bottom sheet via its Close button, if it is showing. */
-    private fun dismissServerPickerIfPresent() {
-        val closeDescription = getString(R.string.sf__server_close_button_content_description)
-        val appeared = try {
+        // Wait for either the picker or the top bar to be reachable.
+        try {
             composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-                composeTestRule.onAllNodesWithContentDescription(closeDescription)
+                composeTestRule.onAllNodesWithTag(LoginViewTestTags.SERVER_PICKER)
+                    .fetchSemanticsNodes().isNotEmpty() ||
+                composeTestRule.onAllNodesWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
                     .fetchSemanticsNodes().isNotEmpty()
             }
-            true
         } catch (_: ComposeTimeoutException) {
-            // The picker never appeared (e.g. shared browser session re-auth); nothing to dismiss.
-            false
+            // Best-effort; caller action will fail with a clear message if neither is reachable.
         }
-
-        if (appeared) {
-            composeTestRule.onNodeWithContentDescription(closeDescription).performClick()
-            composeTestRule.waitForIdle()
-        }
+        composeTestRule.waitForIdle()
     }
 
     override fun setUsername(name: String) {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
@@ -218,25 +218,35 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
      * Selects a server from the server picker bottom sheet by matching its URL substring.
      * Used for servers that aren't represented in `ui_test_config.json` (e.g.
      * `welcome.salesforce.com/discovery`).
+     *
+     * If the picker is already showing (e.g. because [backOutToLoginActivity] left it up after
+     * the tab closed), skip opening it and select directly.
      */
     fun changeServerByUrl(url: String) {
-        // Tap "More Options" three-dot menu (Compose IconButton)
-        composeTestRule.onNodeWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
-            .performClick()
-        composeTestRule.waitForIdle()
+        val pickerAlreadyShowing = composeTestRule
+            .onAllNodesWithTag(LoginViewTestTags.SERVER_PICKER)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
 
-        // Tap "Change Server" dropdown menu item
-        composeTestRule.onNodeWithTag(LoginViewTestTags.MENU_ITEM_PICK_SERVER)
-            .performClick()
+        if (!pickerAlreadyShowing) {
+            // Tap "More Options" three-dot menu (Compose IconButton)
+            composeTestRule.onNodeWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
+                .performClick()
+            composeTestRule.waitForIdle()
 
-        // Wait for server picker bottom sheet to appear
-        try {
-            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
-                composeTestRule.onAllNodesWithTag(LoginViewTestTags.SERVER_PICKER)
-                    .fetchSemanticsNodes().isNotEmpty()
+            // Tap "Change Server" dropdown menu item
+            composeTestRule.onNodeWithTag(LoginViewTestTags.MENU_ITEM_PICK_SERVER)
+                .performClick()
+
+            // Wait for server picker bottom sheet to appear
+            try {
+                composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+                    composeTestRule.onAllNodesWithTag(LoginViewTestTags.SERVER_PICKER)
+                        .fetchSemanticsNodes().isNotEmpty()
+                }
+            } catch (e: ComposeTimeoutException) {
+                throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for server picker bottom sheet to appear", e)
             }
-        } catch (e: ComposeTimeoutException) {
-            throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for server picker bottom sheet to appear", e)
         }
 
         // Select the server matching the URL (filter for clickable node if multiple matches)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
@@ -124,6 +124,7 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
         } catch (_: androidx.compose.ui.test.ComposeTimeoutException) {
             // Best-effort: if the top bar is not reachable within the timeout the caller's
             // subsequent actions will fail with descriptive messages.
+            android.util.Log.w("LoginPageObject", "waitForLoginScreen: timed out after ${TIMEOUT_MS}ms waiting for MORE_OPTIONS_BUTTON")
         }
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
@@ -116,14 +116,27 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
     }
 
     fun openLoginOptions() {
-        // Tap "More Options" three-dot menu (Compose IconButton)
-        composeTestRule.onNodeWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
-            .performClick()
-        composeTestRule.waitForIdle()
+        // If the login-server picker is showing, the top app bar is behind its modal scrim.
+        // In that case, tap the picker's own dev-support button instead (PICKER_DEV_SUPPORT_BUTTON
+        // is visible in the picker header for debug builds). Otherwise use the normal top-bar path.
+        val pickerShowing = composeTestRule
+            .onAllNodesWithTag(LoginViewTestTags.SERVER_PICKER)
+            .fetchSemanticsNodes()
+            .isNotEmpty()
 
-        // Tap "Developer Support" dropdown menu item
-        composeTestRule.onNodeWithTag(LoginViewTestTags.MENU_ITEM_DEV_SUPPORT)
-            .performClick()
+        if (pickerShowing) {
+            composeTestRule.onNodeWithTag(LoginViewTestTags.PICKER_DEV_SUPPORT_BUTTON)
+                .performClick()
+        } else {
+            // Tap "More Options" three-dot menu (Compose IconButton)
+            composeTestRule.onNodeWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
+                .performClick()
+            composeTestRule.waitForIdle()
+
+            // Tap "Developer Support" dropdown menu item
+            composeTestRule.onNodeWithTag(LoginViewTestTags.MENU_ITEM_DEV_SUPPORT)
+                .performClick()
+        }
         composeTestRule.waitForIdle()
 
         // Wait for the AlertDialog to be fully rendered and ready

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/LoginPageObject.kt
@@ -80,7 +80,12 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
 
     open fun login(knownLoginHostConfig: KnownLoginHostConfig, knownUserConfig: KnownUserConfig) {
         val (username, password) = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
-        setUsername(username)
+        waitForPageLoad()
+        retryWebAction(timeoutMs = WEBVIEW_ACTION_TIMEOUT_MS) {
+            onWebView().withElement(findElement(Locator.ID, USERNAME_ID))
+                .perform(clearElement())
+                .perform(webKeys(username))
+        }
         tapLogin()
         setPassword(password)
         tapLogin()
@@ -101,6 +106,76 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
         } catch (_: Throwable) {
             false
         }
+
+    /**
+     * Waits for the LoginActivity top bar to be visible (MORE_OPTIONS_BUTTON present and Compose
+     * idle). Used after [changeServerByUrl] dismisses the server picker: the picker close and
+     * subsequent WebView reload are asynchronous; waiting here ensures the LoginActivity Compose
+     * hierarchy is fully settled before the caller proceeds.
+     */
+    fun waitForLoginScreen() {
+        try {
+            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+                composeTestRule
+                    .onAllNodesWithTag(LoginViewTestTags.MORE_OPTIONS_BUTTON)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+        } catch (_: androidx.compose.ui.test.ComposeTimeoutException) {
+            // Best-effort: if the top bar is not reachable within the timeout the caller's
+            // subsequent actions will fail with descriptive messages.
+        }
+    }
+
+    /**
+     * Waits for the in-app WebView page to finish loading by watching the LOADING_INDICATOR:
+     * phase 1 waits for the indicator to appear (confirming a reload has started); phase 2 waits
+     * for it to disappear (confirming [LoginActivity.LoginWebViewClient.onPageFinished] has fired).
+     *
+     * This is called at the top of [login] to handle the case where a reload was triggered by
+     * [LoginOptionsPageObject.setOverrideBootConfig] → [LoginOptionsActivity.finish()] →
+     * [LoginActivity.onResume] → [LoginViewModel.reloadWebView]. The Salesforce sandbox page can
+     * take 20–30 s to render the login form, and [retryWebAction]'s 15 s budget would expire
+     * before the `username` element appears without this explicit wait.
+     *
+     * Best-effort on both phases so slow or already-loaded pages degrade gracefully: if the
+     * indicator never appears the page was already loaded (or loaded faster than we checked) and
+     * we proceed immediately; if phase 2 times out [retryWebAction] keeps retrying as a fallback.
+     */
+    private fun waitForPageLoad() {
+        // Phase 1: Wait for the LOADING_INDICATOR to appear, confirming a reload is in progress.
+        // Short timeout: if the reload was so fast we missed the indicator, proceed immediately.
+        val indicatorAppeared = try {
+            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS) {
+                composeTestRule
+                    .onAllNodesWithTag(LoginViewTestTags.LOADING_INDICATOR)
+                    .fetchSemanticsNodes()
+                    .isNotEmpty()
+            }
+            true
+        } catch (_: ComposeTimeoutException) {
+            false
+        }
+
+        if (!indicatorAppeared) {
+            // The indicator never showed: page was already loaded or the reload is still pending.
+            // Proceed — retryWebAction will handle any remaining wait.
+            return
+        }
+
+        // Phase 2: Wait for the LOADING_INDICATOR to disappear, confirming onPageFinished fired.
+        // Use a generous multiple of TIMEOUT_MS to accommodate slow sandbox pages (observed ~26 s).
+        try {
+            composeTestRule.waitUntil(timeoutMillis = TIMEOUT_MS * 3) {
+                composeTestRule
+                    .onAllNodesWithTag(LoginViewTestTags.LOADING_INDICATOR)
+                    .fetchSemanticsNodes()
+                    .isEmpty()
+            }
+        } catch (_: ComposeTimeoutException) {
+            // Best-effort: page is still loading but retryWebAction will keep trying.
+        }
+    }
 
     /**
      * Welcome Discovery login: the OAuth `login_hint` already pre-filled the username
@@ -291,7 +366,7 @@ open class LoginPageObject(composeTestRule: ComposeTestRule): BasePageObject(com
                 return action()
             } catch (e: Exception) {
                 lastException = e
-                Thread.sleep(TIMEOUT_MS / 4)
+                Thread.sleep(SLEEP_TIME_MS)
             }
         }
         throw AssertionError(

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -30,7 +30,9 @@ import android.Manifest
 import android.content.Intent
 import android.os.Build
 import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import com.salesforce.androidsdk.ui.components.LoginViewTestTags
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
@@ -198,7 +200,19 @@ abstract class AuthFlowTest {
         // login surface.
         val regularAuthServer = loginServerManager.getLoginServerFromURL(regularAuthUrl)
         if (regularAuthServer != null) {
-            loginServerManager.setSelectedLoginServer(regularAuthServer)
+            // If the picker is showing after backOutToLoginActivity(), dismiss it by tapping the
+            // regular-auth row — this triggers reloadWebView and closes the sheet. When the picker
+            // is not showing, call setSelectedLoginServer directly as before.
+            val loginPage = LoginPageObject(composeTestRule)
+            val pickerShowing = composeTestRule
+                .onAllNodesWithTag(LoginViewTestTags.SERVER_PICKER)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+            if (pickerShowing) {
+                loginPage.changeServerByUrl(regularAuthUrl)
+            } else {
+                loginServerManager.setSelectedLoginServer(regularAuthServer)
+            }
 
             if (expectCustomTab) {
                 // Reaching here means the server actually changed (a sticky ADVANCED_AUTH

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -222,9 +222,14 @@ abstract class AuthFlowTest {
                 // then generates the OAuth URL and launches the Custom Tab.  Wait for that tab to
                 // actually appear rather than sleeping a fixed interval.
                 chromePage.waitForCustomTab()
+            } else if (pickerShowing) {
+                // When the picker was showing, changeServerByUrl() tapped the server row which
+                // triggers an auth-config fetch and then reloads the WebView. Wait for the
+                // MORE_OPTIONS_BUTTON to confirm the LoginActivity's Compose is idle and the login
+                // screen is fully in front before returning — this ensures the WebView reload has
+                // begun and retryWebAction has the full timeout budget to wait for the login form.
+                loginPage.waitForLoginScreen()
             }
-            // For the WebView path there is nothing to wait for: the WebView page-object actions
-            // retry internally until the reloaded login form is ready.
         }
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
@@ -65,8 +65,10 @@ enum class KnownAppConfig {
     ECA_JWT_DPOP_RTR,
 }
 
+private val json = Json { ignoreUnknownKeys = true }
+
 val testConfig: UITestConfig by lazy {
-    Json.decodeFromString(
+    json.decodeFromString(
         string = ResourceReaderHelper.readAssetFile(
             InstrumentationRegistry.getInstrumentation().targetContext,
             /* assetFilePath = */ "ui_test_config.json",


### PR DESCRIPTION
## Summary

**Root cause**: PR #2983 (merged Aug 11) made the login-server picker non-dismissable — it removed the close button from \`LoginServerPicker\` and blocked swipe-to-dismiss. After a Chrome Custom Tab closes (via \`backOutToLoginActivity\`), the SDK raises the picker. Tests that then called \`openLoginOptions()\` or \`changeServerByUrl()\` were failing because both methods tried to tap \`MORE_OPTIONS_BUTTON\` in the top app bar, which is behind the picker's modal scrim.

**Fixes:**
- **\`ChromeCustomTabPageObject.backOutToLoginActivity()\`**: simplified — closes the tab and waits for either the picker or the top bar to be reachable, without trying to dismiss the picker (which is intentionally non-dismissable).
- **\`LoginPageObject.openLoginOptions()\`**: detects whether the picker is showing before tapping the top bar. If it is, routes through \`PICKER_DEV_SUPPORT_BUTTON\` (the debug-only "Developer Support" button in the picker header, added alongside the non-dismissable picker change) instead of the blocked \`MORE_OPTIONS_BUTTON\` path.
- **\`LoginPageObject.changeServerByUrl()\`**: detects whether the picker is already showing (e.g. left up by \`backOutToLoginActivity\`) and skips the open-picker steps, selecting the server directly.

## Test plan

- [x] \`testECAJwt_SubsetScopes_NotHybrid\` — previously failing, now passes (22s on Pixel 9 Pro XL AVD API 35)
- [ ] Broader test suite (other tests that exercise the \`backOutToLoginActivity → openLoginOptions/changeServerByUrl\` path) should be validated in CI