### PR TITLE
fix(W-23622931): escape single quotes in SmartSQL json_extract path and FTS MATCH value

### DIFF
--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/QuerySpec.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/QuerySpec.java
@@ -381,7 +381,7 @@ public class QuerySpec {
             case match:
                 pred = computeFieldReference(SmartStore.SOUP_ENTRY_ID) + " IN ("
                         + SELECT + SmartStore.ROWID_COL + " " + FROM + computeSoupFtsReference() + " " + WHERE
-                        + computeSoupFtsReference() + " MATCH '" + qualifyMatchKey(field, matchKey) + "'"
+                        + computeSoupFtsReference() + " MATCH '" + qualifyMatchKey(field, matchKey).replace("'", "''") + "'"
                         // statement arg binding doesn't seem to work so inlining matchKey
                         + ") ";
                 break;

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartSqlHelper.java
@@ -173,7 +173,7 @@ public class SmartSqlHelper  {
 
 		if (!indexed) {
 			// Thanks to the json1 extension we can query the data even if it is not indexed
-			columnName = "json_extract(" + SmartStore.SOUP_COL + ", '$." + path + "')";
+			columnName = "json_extract(" + SmartStore.SOUP_COL + ", '$." + path.replace("'", "''") + "')";
 		} else {
 			try {
 				columnName = DBHelper.getInstance(db).getColumnNameForPath(db, soupName, path);

--- a/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
+++ b/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java
@@ -376,7 +376,7 @@ public class SmartStore  {
             // Column name or expression the db index is on
             String columnName = soupTableName + "_" + i;
             if (TypeGroup.value_indexed_with_json_extract.isMember(indexSpec.type)) {
-                columnName = "json_extract(" + SOUP_COL + ", '$." + indexSpec.path + "')";
+                columnName = "json_extract(" + SOUP_COL + ", '$." + indexSpec.path.replace("'", "''") + "')";
             }
 
             // for create table

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/QuerySpecTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/QuerySpecTest.java
@@ -167,6 +167,15 @@ public class QuerySpecTest {
     }
 
     @Test
+    public void testMatchQuerySmartSqlWithSingleQuoteInMatchKey() {
+        // Single quotes in matchKey must be doubled so they don't break the surrounding MATCH '...' literal.
+        QuerySpec querySpec = QuerySpec.buildMatchQuerySpec("employees", "lastName", "O'Brien", "firstName", QuerySpec.Order.ascending, 1);
+        Assert.assertEquals("Wrong smart sql for match query spec with single quote in matchKey",
+            "SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees}_fts MATCH '{employees:lastName}:O''Brien') ORDER BY {employees:firstName} ASC ",
+            querySpec.smartSql);
+    }
+
+    @Test
     public void testQualifyMatchKey() {
         Assert.assertEquals("Wrong qualified match query", "abc", QuerySpec.qualifyMatchKey(null, "abc"));
         Assert.assertEquals("Wrong qualified match query", "{soup:path}:abc", QuerySpec.qualifyMatchKey("{soup:path}", "abc"));

--- a/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlTest.java
+++ b/libs/test/SmartStoreTest/src/com/salesforce/androidsdk/smartstore/store/SmartSqlTest.java
@@ -232,6 +232,14 @@ public class SmartSqlTest extends SmartStoreTestCase {
 	}
 
 	@Test
+	public void testConvertSmartSqlForNonIndexedColumnWithSingleQuoteInPath() {
+		// Single quotes in non-indexed paths must be doubled so they don't break the surrounding json_extract(soup, '$.path') literal.
+		// The path with ' is in the WHERE clause so that the FROM {employees} token is resolved before any single-quote appears in beforeStr.
+		Assert.assertEquals("select TABLE_1_3 from TABLE_1 where json_extract(soup, '$.user''s.address') = 'foo'",
+			store.convertSmartSql("select {employees:employeeId} from {employees} where {employees:user's.address} = 'foo'"));
+	}
+
+	@Test
 	public void testConvertSmartSqlWithQuotedCurlyBraces() {
     	Assert.assertEquals("select json_extract(soup, '$.education') from TABLE_1 where json_extract(soup, '$.education') like 'Account(where: {Name: {eq: \"Jason\"}})'",
 			store.convertSmartSql("select {employees:education} from {employees} where {employees:education} like 'Account(where: {Name: {eq: \"Jason\"}})'"));


### PR DESCRIPTION
## Summary
- **Sink 1 — `json_extract` path** (`SmartSqlHelper.java:176`): escapes `'` → `''` in the soup path before building `json_extract(soup, '$.path')`. A quote in the path broke out of the SQL string literal, allowing SmartSQL injection via a non-indexed query path (CWE-89).
- **Sink 2 — FTS MATCH value** (`QuerySpec.java:384`): escapes `'` → `''` in the qualified match key before inlining into `MATCH 'value'`. Statement arg binding doesn't work for FTS MATCH so inlining is unavoidable; escaping prevents breaking out of the surrounding string literal.
- Both sinks are reachable from the SmartStore Cordova bridge in hybrid apps (W-23622931).

## Test plan
- [ ] Build SmartStore: `./gradlew :libs:SmartStore:build` — confirmed passing
- [ ] Run SmartStore tests: `./gradlew :libs:SmartStore:connectedAndroidTest` — confirmed all passing