### PR TITLE
[Android][BLITZ] Native Login WebView fallback does not show back button

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -261,7 +261,19 @@ open class LoginViewModel(
 
     /** Value representing if the back button should be shown on the login view. */
     open val shouldShowBackButton = with(SalesforceSDKManager.getInstance()) {
-        !(userAccountManager.authenticatedUsers.isNullOrEmpty() || biometricAuthenticationManager?.locked ?: false)
+        when {
+            // Never show back while biometric-locked; user must authenticate.
+            biometricAuthenticationManager?.locked == true -> false
+            /*
+             * Native Login uses this WebView LoginActivity as a dismissible
+             * fallback: handleBackBehavior() finishes and returns to the native
+             * login activity, so show the back affordance to match — even with
+             * no authenticated users yet.
+             */
+            nativeLoginActivity != null -> true
+            // Otherwise show back only when an authenticated user exists.
+            else -> !userAccountManager.authenticatedUsers.isNullOrEmpty()
+        }
     }
 
     // The default, locally generated code verifier

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -38,6 +38,7 @@ import com.salesforce.androidsdk.config.BootConfig
 import com.salesforce.androidsdk.config.LoginServerManager.LoginServer
 import com.salesforce.androidsdk.config.LoginServerManager.WELCOME_LOGIN_URL
 import com.salesforce.androidsdk.config.OAuthConfig
+import com.salesforce.androidsdk.security.BiometricAuthenticationManager
 import com.salesforce.androidsdk.security.SalesforceKeyGenerator.getSHA256Hash
 import com.salesforce.androidsdk.ui.LoginActivity
 import com.salesforce.androidsdk.ui.LoginActivity.Companion.ABOUT_BLANK
@@ -46,7 +47,10 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -1471,6 +1475,83 @@ class LoginViewModelTest {
             )
         } finally {
             sdkManager.forceAdvancedAuthentication = originalForceAdvancedAuth
+        }
+    }
+
+    /**
+     * Builds a [LoginViewModel] whose [SalesforceSDKManager] is a spy that
+     * reports the app is using Native Login, so the WebView LoginActivity is
+     * the dismissible fallback, then runs [block] against it. The spy also
+     * reports no authenticated users, so the fallback scenario is deterministic
+     * regardless of any account state other suite tests leave on the shared
+     * SalesforceSDKManager singleton. [configureSpy] may further stub the spy
+     * (e.g. a locked biometric manager) before the view model is constructed.
+     * The object mock is always torn down.
+     */
+    private fun withNativeLoginFallbackViewModel(
+        configureSpy: (SalesforceSDKManager) -> Unit = {},
+        block: (LoginViewModel) -> Unit,
+    ) {
+        val spySdkManager = spyk(SalesforceSDKManager.getInstance())
+        // Any non-null Activity class works; only nativeLoginActivity's
+        // nullness gates the fallback, and its concrete type is never read.
+        every { spySdkManager.nativeLoginActivity } returns LoginActivity::class.java
+        // Pin the no-authenticated-users precondition on the spy rather than
+        // asserting on the shared singleton, which sibling tests can pollute.
+        every { spySdkManager.userAccountManager.authenticatedUsers } returns emptyList()
+        configureSpy(spySdkManager)
+        mockkObject(SalesforceSDKManager)
+        try {
+            every { SalesforceSDKManager.getInstance() } returns spySdkManager
+            block(
+                LoginViewModel(
+                    bootConfig = bootConfig,
+                    backgroundContext = testDispatcher,
+                )
+            )
+        } finally {
+            unmockkObject(SalesforceSDKManager)
+        }
+    }
+
+    /**
+     * When the app uses Native Login, the WebView LoginActivity is a
+     * dismissible fallback whose hardware-back already finishes and returns to
+     * the native login activity. The visible back affordance must be shown to
+     * match — even with no authenticated users — so the user is never stranded
+     * on the fallback WebView.
+     */
+    @Test
+    fun test_shouldShowBackButton_isTrueForNativeLoginFallbackWithNoUsers() {
+        withNativeLoginFallbackViewModel { nativeLoginViewModel ->
+            assertTrue(
+                "Back button must be shown for the Native Login WebView fallback.",
+                nativeLoginViewModel.shouldShowBackButton,
+            )
+        }
+    }
+
+    /**
+     * The Native Login fallback back affordance must still yield to the
+     * biometric lock — a locked user must authenticate rather than navigate
+     * back. The helper pins the no-authenticated-users precondition, so the
+     * only branch that could show the button is the Native Login one, proving
+     * the biometric lock takes precedence over it.
+     */
+    @Test
+    fun test_shouldShowBackButton_isFalseForNativeLoginFallbackWhenBiometricLocked() {
+        val lockedBioAuthManager = mockk<BiometricAuthenticationManager> {
+            every { locked } returns true
+        }
+        withNativeLoginFallbackViewModel(
+            configureSpy = { spy ->
+                every { spy.biometricAuthenticationManager } returns lockedBioAuthManager
+            },
+        ) { nativeLoginViewModel ->
+            assertFalse(
+                "Back button must remain hidden while biometric-locked, even for Native Login.",
+                nativeLoginViewModel.shouldShowBackButton,
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
When an app uses **Native Login**, the WebView-based `LoginActivity` acts as a *dismissible fallback* login
surface. Hardware/gesture back already worked there — `LoginActivity.handleBackBehavior()` finishes the activity
and returns to the native login activity when `nativeLoginActivity != null`. But the **visible** top-bar back
affordance never appeared, so a user who reached the fallback WebView had no on-screen way back and could get
stranded.

The visible affordance is bound to `LoginViewModel.shouldShowBackButton`, which previously gated *only* on
whether there were authenticated users. This change makes the visible button match the already-correct back
behavior in the Native Login fallback case.

## Root cause
`LoginViewModel.shouldShowBackButton` returned
`!(authenticatedUsers.isNullOrEmpty() || biometricAuthenticationManager?.locked)`. In Native Login fallback
mode there are typically no authenticated users yet, so the button was suppressed — even though
`handleBackBehavior()` would have dismissed the screen.

## Fix
`libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt` — rewrote the property as a `when`:

```kotlin
open val shouldShowBackButton = with(SalesforceSDKManager.getInstance()) {
    when {
        // Never show back while biometric-locked; user must authenticate.
        biometricAuthenticationManager?.locked == true -> false
        /*
         * Native Login uses this WebView LoginActivity as a dismissible
         * fallback: handleBackBehavior() finishes and returns to the native
         * login activity, so show the back affordance to match — even with
         * no authenticated users yet.
         */
        nativeLoginActivity != null -> true
        // Otherwise show back only when an authenticated user exists.
        else -> !userAccountManager.authenticatedUsers.isNullOrEmpty()
    }
}
```

Behavior preserved:
- **Biometric-locked** still suppresses the button (user must authenticate).
- **Standard login-without-accounts** flow (`moveTaskToBack`) is unchanged.
- `NativeLoginManager.shouldShowBackButton` (the app's own native login screen) is a *different* surface and is
  intentionally **not** touched — it correctly continues to gate on authenticated users.

## Tests
`libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt` — 2 new tests:
- `test_shouldShowBackButton_isTrueForNativeLoginFallbackWithNoUsers` — asserts the button shows when
  `nativeLoginActivity != null` and there are no authenticated users. **Fails on the pre-fix code** (failing-test-first).
- `test_shouldShowBackButton_isFalseForNativeLoginFallbackWhenBiometricLocked` — asserts biometric-locked still suppresses the button even in fallback mode. Pins the no-authenticated-users precondition so the biometric branch is the only thing that could show the button, proving the lock takes precedence.

Both tests share a small `withNativeLoginFallbackViewModel { … }` helper that spies `SalesforceSDKManager` to report Native Login is enabled and always tears the object mock down in a `finally`.

## Verification

### 1. Instrumented unit tests (API 36 emulator)
- Branch base == latest `dev` tip `c6fa97b03` (no drift).
- **Failing-test-first:** with the production fix reverted, `test_shouldShowBackButton_isTrueForNativeLoginFallbackWithNoUsers`
  FAILS ("Back button must be shown for the Native Login WebView fallback") — confirms the bug is real and still
  present on latest dev.
- With the fix: both new tests pass; `NativeLoginManagerTest` 21/0.
- **Suite flakiness note (pre-existing, not introduced by this PR):** repeated full `LoginViewModelTest` runs
  show occasional order-dependent failures in unrelated tests (`generateAuthorizationUrl_*`,
  `codeVerifier_UpdatesOn_WebViewRefresh`). The pristine `dev` suite flakes at the same ~10% rate and on a
  *different* unrelated test, so this is pre-existing suite instability, not caused by this change. All such
  tests pass in isolation. Out of scope for this bugfix.

### 2. End-to-end feature verification against the real Native Login feature (API 36 emulator)
The unit tests above exercise the `LoginViewModel` in isolation with mocks. To prove the *actual user-facing
behavior*, I also ran the **`AndroidNativeLoginTemplate`** (from the MSDK Templates repo) against a real
Experience Cloud org with Headless Identity, wired to this branch via a Gradle composite build, and drove the
exact repro on-device: launch → native login screen → tap **"Looking for Salesforce Log In?"** → WebView
fallback `com.salesforce.androidsdk.ui.LoginActivity`, with **zero authenticated users** (the reported broken
scenario). I captured both the screenshot and the `uiautomator` view hierarchy for each side:

| Build | WebView `LoginActivity` toolbar | `content-desc="Back"` node |
|---|---|---|
| **WITHOUT this fix** (tip of `dev`) | only ⋮ overflow — **no back button**; user is stranded (the bug) | **absent (0)** |
| **WITH this fix** (this branch) | **← back button present**; user can dismiss back to native login | **present (1)** at `[43,181][106,244]` |

The before/after difference is exactly the affordance this PR restores, confirmed both visually and in the
`uiautomator` accessibility hierarchy. The template clone used real test-org credentials that are **not**
committed anywhere.

#### Before — WebView fallback `LoginActivity`, no authenticated users (tip of `dev`, without this fix)
Toolbar shows only the ⋮ overflow; there is no back affordance, so the user is stranded.

<img width="1080" height="2400" alt="BEFORE_no-back-button" src="https://github.com/user-attachments/assets/8eedfbc2-adf1-4a0d-9f89-f6e3cffcaf80" />

_BEFORE screenshot: no back button in the top-left of the WebView fallback toolbar._

#### After — same screen, same conditions, with this fix
The ← back affordance is present in the top-left and returns the user to the native login screen.

<img width="1080" height="2400" alt="AFTER_back-button-present" src="https://github.com/user-attachments/assets/910423d5-e6f4-4dc9-9382-c28ae6c2c27f" />

_AFTER screenshot: ← back button present in the top-left of the WebView fallback toolbar._

## Regression risk

**Low, and bounded to Native-Login apps.** The rewrite is behavior-preserving for every path except the one
being fixed. Reasoning, per input:

- **The only value that changes is the Native-Login-fallback case.** The new `when` adds exactly one arm keyed on
  `nativeLoginActivity != null`. That condition is true *only* when an app has opted into Native Login via
  `useNativeLogin(...)`; apps that don't are completely unaffected.
- **Biometric-locked is evaluated first and still returns `false`** — a locked user can never be shown the
  affordance. Equivalent to the old expression's `biometricAuthenticationManager?.locked` term, and covered by
  `test_shouldShowBackButton_isFalseForNativeLoginFallbackWhenBiometricLocked`.
- **Standard login (no Native Login) is unchanged.** The `else` arm is the original predicate
  `!userAccountManager.authenticatedUsers.isNullOrEmpty()`, so the standard host-picker / login-without-accounts
  flow (which relies on `moveTaskToBack`) behaves exactly as before.
- **No change to back *handling*, only to back *visibility*.** `LoginActivity.handleBackBehavior()` already
  finished the activity and returned to the native login activity in this case; hardware/gesture back already
  worked. This PR only makes the *visible* affordance agree with behavior that already shipped — it does not add
  a new navigation path.
- **`NativeLoginManager.shouldShowBackButton` (the app's own native login screen) is a different surface and is
  not touched** — it continues to gate on authenticated users.
- **Adjacent recent change is safe.** The recent server-picker-non-dismissable change
  (https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2983) added a pre-existing guard test,
  `test_shouldShowBackButton_isFlagIndependent`, asserting the property does not depend on the deprecated
  `forceAdvancedAuthentication` flag. This change keeps that test green — the flag never enters the new `when`.
- **No public API signature change.** `shouldShowBackButton` remains an `open val` of the same type; only its
  computed value changes in the fallback case. No semver/deprecation impact.

## Checklist
- [x] **Backward compatibility:** no public API signature change (see Regression risk).
- [x] **Tests included:** 2 new tests in the correct target; failing-test-first proven; pre-existing
      `isFlagIndependent` guard still green.
- [x] **No regressions:** biometric-locked and standard flows unchanged and covered by tests.
- [x] **Multi-user:** unaffected — the new branch is keyed on `nativeLoginActivity`, orthogonal to account count.
- [x] **Localization:** no new user-facing strings.
- [x] **Security:** no credential/token handling change; no logging added.
- [x] **Both platforms:** Android-only — no matching iOS change is needed for this bug.

---

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*


