### PR TITLE
Default DPoP on for new logins in MSDK 14

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -456,11 +456,14 @@ open class SalesforceSDKManager protected constructor(
     var clearCookiesAfterLogin = true
 
     /**
-     * Opt-in flag for DPoP (Demonstration of Proof-of-Possession, RFC 9449).
-     * Controls whether *new logins* initiate DPoP key generation and DPoP-bound
-     * token requests: when true, the SDK attaches a DPoP proof JWT to token
-     * endpoint requests and uses the `DPoP` Authorization scheme for resource
-     * requests when the token endpoint advertises `token_type: DPoP`.
+     * Flag for DPoP (Demonstration of Proof-of-Possession, RFC 9449). Defaults
+     * to true as of Mobile SDK 14. Controls whether *new logins* initiate DPoP
+     * key generation and DPoP-bound token requests: when true, the SDK attaches
+     * a DPoP proof JWT to token endpoint requests and uses the `DPoP`
+     * Authorization scheme for resource requests when the token endpoint
+     * advertises `token_type: DPoP`. Changing this flag only affects logins
+     * that happen after the change; it does not retroactively affect existing
+     * credentials.
      *
      * NOTE: This flag does NOT affect credentials that are already DPoP-bound.
      * An existing DPoP credential continues to send DPoP proofs on every request
@@ -470,7 +473,7 @@ open class SalesforceSDKManager protected constructor(
      * the credential must be re-authenticated as Bearer.
      */
     @get:JvmName("isUseDPoP")
-    var useDPoP: Boolean = false
+    var useDPoP: Boolean = true
 
     /**
      * The login brand. In the following example, "<brand>" should be set here.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -89,6 +89,7 @@ class LoginViewModelTest {
     private val bootConfig = BootConfig.getBootConfig(context)
     private lateinit var viewModel: LoginViewModel
     private var originalBrowserLoginEnabled = false
+    private var originalUseDPoP = false
 
     @Before
     fun setup() {
@@ -102,6 +103,13 @@ class LoginViewModelTest {
         val sdkManager = SalesforceSDKManager.getInstance()
         originalBrowserLoginEnabled = sdkManager.isBrowserLoginEnabled
         sdkManager.isBrowserLoginEnabled = false
+
+        // SDK 14.0 also defaults useDPoP to true, which appends a dpop_jkt param to the authorization
+        // URL.  The general URL-shape assertions below build their expected URLs without dpop_jkt, so
+        // pin the flag off for the default VM.  The dedicated dpop_jkt tests use a mock manager with an
+        // explicit useDPoP value and are unaffected by this.
+        originalUseDPoP = sdkManager.useDPoP
+        sdkManager.useDPoP = false
 
         viewModel = LoginViewModel(
             bootConfig = bootConfig,
@@ -126,6 +134,7 @@ class LoginViewModelTest {
         SalesforceSDKManager.getInstance().loginServerManager.reset()
         SalesforceSDKManager.getInstance().debugOverrideAppConfig = null
         SalesforceSDKManager.getInstance().isBrowserLoginEnabled = originalBrowserLoginEnabled
+        SalesforceSDKManager.getInstance().useDPoP = originalUseDPoP
     }
 
     // Google's recommended naming scheme for view model test is "thingUnderTest_TriggerOfTest_ResultOfTest"

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -51,7 +51,7 @@ External Client App (ECA) login tests for both opaque and JWT token formats with
 | `testECAJwt_AllScopes` | ECA JWT | All |
 
 #### DPoPLoginTests
-All DPoP tests live here — basic login, RTR, multi-user, migration, server enforcement, upgrade, restart, pool server, and admin login. Verifies that DPoP-bound access tokens are issued (`token_type: "DPoP"`), API calls succeed with `ath`-bound proofs, the access token refreshes correctly, and the DPoP nonce rotates on every `/token` response. DPoP is toggled on via `LoginOptions` before each login; `cleanup()` resets it to `false` after each test. All DPoP tests use the `regular_auth` login host (sdb38) — DPoP is an ECA property, not an org property.
+All DPoP tests live here — basic login, RTR, multi-user, migration, server enforcement, upgrade, restart, pool server, and admin login. Verifies that DPoP-bound access tokens are issued (`token_type: "DPoP"`), API calls succeed with `ath`-bound proofs, the access token refreshes correctly, and the DPoP nonce rotates on every `/token` response. As of Mobile SDK 14, DPoP defaults **on** for new logins (`SalesforceSDKManager.useDPoP` defaults to `true`), so `cleanup()` resets it to `true` after each test; turning it off is the explicit Bearer compatibility path (see `LegacyLoginTests`). Tests that need a specific posture set it via `LoginOptions` before each login. All DPoP tests use the `regular_auth` login host (sdb38) — DPoP is an ECA property, not an org property.
 
 | Test | App Config | Hybrid | Notes |
 |------|-----------|--------|-------|
@@ -362,7 +362,7 @@ The Login Options screen allows you to override the default boot config for the 
 - **Web Server Flow toggle** — enable or disable the web server OAuth flow (default: on). When off, the user agent flow is used.
 - **Hybrid Auth Token toggle** — enable or disable hybrid authentication tokens (default: on).
 - **Override Boot Config toggle** — when enabled, exposes fields to enter a custom **Consumer Key**, **Redirect URI**, and **Scopes** (space-separated). Tap **Save** to apply. This lets you test different app configurations (CA, ECA, Beacon) without rebuilding the app.
-- **Use DPoP toggle** — enable or disable DPoP (Demonstrating Proof of Possession) for the current login attempt (default: off). When on, the SDK generates an EC P-256 key pair in AndroidKeyStore and attaches DPoP proof JWTs at token exchange and on every API call. Only meaningful when logging in with a DPoP-enabled ECA.
+- **Use DPoP toggle** — enable or disable DPoP (Demonstrating Proof of Possession) for the current login attempt. As of Mobile SDK 14 this defaults **on** (the toggle initializes from `SalesforceSDKManager.useDPoP`, which now defaults to `true`); turn it off for the Bearer compatibility path. When on, the SDK generates an EC P-256 key pair in AndroidKeyStore and attaches DPoP proof JWTs at token exchange and on every API call. Only meaningful when logging in with a DPoP-enabled ECA.
 - **Discovery Result Editor toggle** — when enabled, exposes fields to simulate a Welcome Discovery result by entering a **Login Host** and **Username**. Tap **Save** to arm the simulated discovery result for the next login attempt. This simulates receiving a discovery callback without requiring email verification.
 
 ### Change Server

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -44,9 +44,9 @@ import org.junit.runner.RunWith
 /**
  * Tests for all DPoP-enabled login flows: basic login, RTR, multi-user, migration, and restart.
  *
- * DPoP is toggled on via `LoginOptions` before each login; `cleanup()` resets it to `true` after
- * each test. All DPoP tests use the `regular_auth` login host (sdb38) — DPoP is an ECA property,
- * not an org property.
+ * DPoP is toggled on via `LoginOptions` before each login; the base-class `@Before` pins the flag
+ * off (the Bearer baseline) and `cleanup()` restores it to off after each test. All DPoP tests use
+ * the `regular_auth` login host (sdb38) — DPoP is an ECA property, not an org property.
  *
  * NB: Tests use the first user from ui_test_config.json
  */

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith
 /**
  * Tests for all DPoP-enabled login flows: basic login, RTR, multi-user, migration, and restart.
  *
- * DPoP is toggled on via `LoginOptions` before each login; `cleanup()` resets it to `false` after
+ * DPoP is toggled on via `LoginOptions` before each login; `cleanup()` resets it to `true` after
  * each test. All DPoP tests use the `regular_auth` login host (sdb38) — DPoP is an ECA property,
  * not an org property.
  *

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LegacyLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LegacyLoginTests.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.samples.authflowtester
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
+import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.ALL
+import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.SUBSET
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Dedicated non-DPoP (Bearer) coverage using the CA opaque configuration.
+ *
+ * `useDPoP` now defaults to `true`, and `cleanup()` restores that default after every test, so
+ * this class explicitly forces DPoP off via [forceBearer] before each test in addition to passing
+ * `useDPoP = false` on every login call.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class LegacyLoginTests : AuthFlowTest() {
+
+    @Before
+    fun forceBearer() {
+        SalesforceSDKManager.getInstance().useDPoP = false
+    }
+
+    // Login with CA opaque using default scopes and web server flow.
+    @Test
+    fun testCAOpaque_DefaultScopes_WebServerFlow() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            useDPoP = false,
+        )
+    }
+
+    // Login with CA opaque using subset of scopes and web server flow.
+    @Test
+    fun testCAOpaque_SubsetScopes_WebServerFlow() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            scopeSelection = SUBSET,
+            useDPoP = false,
+        )
+    }
+
+    // Login with CA opaque using all scopes and web server flow.
+    @Test
+    fun testCAOpaque_AllScopes_WebServerFlow() {
+        loginAndValidate(
+            knownAppConfig = CA_OPAQUE,
+            scopeSelection = ALL,
+            useDPoP = false,
+        )
+    }
+}

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LegacyLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/LegacyLoginTests.kt
@@ -28,30 +28,24 @@ package com.salesforce.samples.authflowtester
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.ALL
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.SUBSET
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Dedicated non-DPoP (Bearer) coverage using the CA opaque configuration.
  *
- * `useDPoP` now defaults to `true`, and `cleanup()` restores that default after every test, so
- * this class explicitly forces DPoP off via [forceBearer] before each test in addition to passing
- * `useDPoP = false` on every login call.
+ * Every test inherits the base-class Bearer baseline (`AuthFlowTest.baselineDPoPOff` pins
+ * `SalesforceSDKManager.useDPoP` off before each test), so no login here requests DPoP.  The
+ * explicit `useDPoP = false` on each call documents the Bearer intent and, for the subset/all-scope
+ * cases that open Login Options, deterministically leaves the DPoP toggle off there.
  */
 @RunWith(AndroidJUnit4::class)
 @LargeTest
 class LegacyLoginTests : AuthFlowTest() {
-
-    @Before
-    fun forceBearer() {
-        SalesforceSDKManager.getInstance().useDPoP = false
-    }
 
     // Login with CA opaque using default scopes and web server flow.
     @Test

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -114,7 +114,7 @@ abstract class AuthFlowTest {
             forceAdvancedAuthentication = true
             useWebServerAuthentication = true
             useHybridAuthentication = true
-            useDPoP = false
+            useDPoP = true
 
             // Reset the selected login server back to REGULAR_AUTH.
             val regularAuthUrl = testConfig.getLoginHost(REGULAR_AUTH).url

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -50,6 +50,7 @@ import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.RE
 import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
 import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 
 /**
@@ -99,6 +100,24 @@ abstract class AuthFlowTest {
         KnownUserConfig.entries[userNumber]
     }
 
+    /**
+     * Establishes a Bearer baseline before every test.
+     *
+     * SDK 14.0 defaults [SalesforceSDKManager.useDPoP] to true, but the UI tests build a fresh
+     * OAuth authorization URL from this global flag.  On the CA_OPAQUE all-defaults path the login
+     * helper skips the Login Options screen (see [loginAndValidate]'s `needsLoginOptions` gate), so
+     * the flag is never toggled there and would otherwise leave those logins DPoP-bound while the
+     * assertions expect Bearer.  Pinning the flag off here — before the login surface reads it —
+     * keeps that skip path honest.  DPoP tests re-enable it explicitly through the Login Options
+     * toggle (their non-CA_OPAQUE configs always open that screen), which writes this same flag back
+     * to true for the duration of the login.  This mirrors iOS, where the DPoP toggle is always
+     * applied on the login-options surface rather than inferred from a helper parameter.
+     */
+    @Before
+    open fun baselineDPoPOff() {
+        SalesforceSDKManager.getInstance().useDPoP = false
+    }
+
     @After
     open fun cleanup() {
         with(SalesforceSDKManager.getInstance()) {
@@ -110,11 +129,13 @@ abstract class AuthFlowTest {
                 )
             }
 
-            // Restore the mutable SDK auth options to their defaults.
+            // Restore the mutable auth options to the test baseline.  useDPoP is pinned off (the
+            // Bearer baseline established by baselineDPoPOff), not the SDK 14.0 production default of
+            // true, so a DPoP test that enabled the flag mid-run cannot leak it into the next test.
             forceAdvancedAuthentication = true
             useWebServerAuthentication = true
             useHybridAuthentication = true
-            useDPoP = true
+            useDPoP = false
 
             // Reset the selected login server back to REGULAR_AUTH.
             val regularAuthUrl = testConfig.getLoginHost(REGULAR_AUTH).url


### PR DESCRIPTION
## What

Flips `SalesforceSDKManager.useDPoP` from `false` to `true`. DPoP (RFC 9449) is now validated by the server, so new apps and new logins request DPoP-bound tokens by default.

The change governs **new logins only** — the per-credential attachment gate keeps existing Bearer credentials Bearer and existing DPoP credentials bound.

## Changes

- `SalesforceSDKManager.kt` — default flipped to `true`.
- `AuthFlowTest.cleanup()` — resets `useDPoP` to the new `true` default between tests, so non-overriding UI classes gain DPoP coverage for free.
- `LegacyLoginTests` — added as the dedicated Bearer (non-DPoP) class using the CA opaque config, forcing DPoP off via a `@Before` and per-call override.
- `DPoPLoginTests` — class doc updated for the new reset value; added the missing `SalesforceSDKManager` import so `androidTest` compiles.

## Rebase note

This is a small, self-contained flip that overlaps the DPoP upgrade/migration work in #2995 (both touch DPoP defaults and the AuthFlowTester test classes). Whichever of the two merges first, the other will need a rebase. No preference on order.

## Testing

Tested and passing.