### PR TITLE
fix(setVersion.sh): support pre-release version formats (e.g. 14.0.0-rc.0)

### DIFF
--- a/setversion.sh
+++ b/setversion.sh
@@ -50,14 +50,14 @@ update_top_build_gradle ()
     local file=$1
     local versionName=$2
     # sed -i.bak works identically on both BSD sed (macOS) and GNU sed (Linux)
-    sed -i.bak "s/version = \"[0-9\.]*\"/version = \"${versionName}\"/g" "${file}" && rm -f "${file}.bak"
+    sed -i.bak "s/version = \"[0-9][0-9.a-zA-Z-]*\"/version = \"${versionName}\"/g" "${file}" && rm -f "${file}.bak"
 }
 
 update_build_gradle ()
 {
     local file=$1
     local versionName=$2
-    sed -i.bak "s/\[\"PUBLISH_VERSION\"\] = \"[0-9\.]*\"/\[\"PUBLISH_VERSION\"\] = \"${versionName}\"/g" "${file}" && rm -f "${file}.bak"
+    sed -i.bak "s/\[\"PUBLISH_VERSION\"\] = \"[0-9][0-9.a-zA-Z-]*\"/\[\"PUBLISH_VERSION\"\] = \"${versionName}\"/g" "${file}" && rm -f "${file}.bak"
 }
 
 update_manifest ()


### PR DESCRIPTION
## Summary

Widen the version-matching sed pattern in `update_top_build_gradle` and `update_build_gradle` from `[0-9\.]*` to `[0-9][0-9.a-zA-Z-]*`. The old pattern only matched digits and dots, so when a file already contained a pre-release version (e.g. `14.0.0-rc.0`) the substitution found no match and silently did nothing. This was particularly problematic for RC-to-RC updates (e.g. `rc.0` → `rc.1`).

GUS: W-23916131

## Test plan

- [ ] `./setVersion.sh -v 14.0.0-rc.0 -c 92` correctly sets version in all build.gradle.kts files
- [ ] Running `./setVersion.sh -v 14.0.0-rc.1 -c 92` after `rc.0` is already set also succeeds (round-trip)
- [ ] `./setVersion.sh -v 14.0.0 -c 92` continues to work as before