### PR TITLE
fix(release): remove stale libs/SalesforceReact references from setversion.sh

### DIFF
--- a/setversion.sh
+++ b/setversion.sh
@@ -133,9 +133,6 @@ SHORT_VERSION=`echo ${OPT_VERSION} | cut -d. -f1,2`
 
 echo -e "${YELLOW}*** SETTING VERSION NAME TO ${OPT_VERSION}, VERSION CODE TO ${OPT_CODE}, IS DEV = ${OPT_IS_DEV} ***${NC}"
 
-echo "*** Updating react package.json ***"
-update_react_package_json "./libs/SalesforceReact/package.json" "${OPT_VERSION}" "${OPT_IS_DEV}"
-
 echo "*** Updating top build.gradle file ***"
 update_top_build_gradle "./build.gradle.kts" "${OPT_VERSION}"
 
@@ -145,7 +142,6 @@ update_build_gradle "./libs/SalesforceSDK/build.gradle.kts" "${OPT_VERSION}"
 update_build_gradle "./libs/SmartStore/build.gradle.kts" "${OPT_VERSION}"
 update_build_gradle "./libs/MobileSync/build.gradle.kts" "${OPT_VERSION}"
 update_build_gradle "./libs/SalesforceHybrid/build.gradle.kts" "${OPT_VERSION}"
-update_build_gradle "./libs/SalesforceReact/build.gradle.kts" "${OPT_VERSION}"
 
 echo "*** Updating manifests ***"
 update_manifest "./libs/SalesforceAnalytics/AndroidManifest.xml" "${VERSION_SUFFIXED}" "${OPT_CODE}"
@@ -153,7 +149,6 @@ update_manifest "./libs/SalesforceSDK/AndroidManifest.xml" "${VERSION_SUFFIXED}"
 update_manifest "./libs/SmartStore/AndroidManifest.xml" "${VERSION_SUFFIXED}" "${OPT_CODE}"
 update_manifest "./libs/MobileSync/AndroidManifest.xml" "${VERSION_SUFFIXED}" "${OPT_CODE}"
 update_manifest "./libs/SalesforceHybrid/AndroidManifest.xml" "${VERSION_SUFFIXED}" "${OPT_CODE}"
-update_manifest "./libs/SalesforceReact/AndroidManifest.xml" "${VERSION_SUFFIXED}" "${OPT_CODE}"
 
 echo "*** Updating config.xml files ***"
 update_config_xml "./libs/SalesforceHybrid/res/xml/config.xml" "${OPT_VERSION}"


### PR DESCRIPTION
## Summary

- `SalesforceReact` was removed from this repo in SDK 14.0 — all React Native code now lives in `SalesforceMobileSDK-ReactNative/android/`
- Three version-stamping calls targeting `libs/SalesforceReact/{package.json,build.gradle.kts,AndroidManifest.xml}` were silently no-op'ing on missing files during every `setversion.sh` run
- Version stamping for the React Native library is now handled by `setversion.sh` in the ReactNative repo

## Test plan

- [ ] Run `setversion.sh -v 14.1.0 -c 100 -d no` and verify it completes without errors and stamps all remaining `libs/` modules correctly
- [ ] Confirm `SalesforceMobileSDK-ReactNative/setversion.sh` stamps the React Native library version independently

Fixes W-23916089