### PR TITLE
test(W-23836447): add non-DPoP pool server login test to ECALoginTests

### DIFF
--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -39,16 +39,17 @@ Connected App login tests with explicit scope selection across web server and us
 | `testCAOpaque_AllScopes_UserAgentFlow_NotHybrid` | All | User Agent | In-App WebView |
 
 #### ECALoginTests
-External Client App (ECA) login tests for both opaque and JWT token formats with scope variations.
+External Client App (ECA) login tests for both opaque and JWT token formats with scope variations. Also covers pool server login (non-DPoP).
 
-| Test | App Config | Scopes |
-|------|-----------|--------|
-| `testECAOpaque_DefaultScopes` | ECA Opaque | Default |
-| `testECAOpaque_SubsetScopes` | ECA Opaque | Subset |
-| `testECAOpaque_AllScopes` | ECA Opaque | All |
-| `testECAJwt_DefaultScopes` | ECA JWT | Default |
-| `testECAJwt_SubsetScopes_NotHybrid` | ECA JWT | Subset |
-| `testECAJwt_AllScopes` | ECA JWT | All |
+| Test | App Config | Scopes | Notes |
+|------|-----------|--------|-------|
+| `testECAOpaque_DefaultScopes` | ECA Opaque | Default | |
+| `testECAOpaque_SubsetScopes` | ECA Opaque | Subset | |
+| `testECAOpaque_AllScopes` | ECA Opaque | All | |
+| `testECAJwt_DefaultScopes` | ECA JWT | Default | |
+| `testECAJwt_SubsetScopes_NotHybrid` | ECA JWT | Subset | |
+| `testECAJwt_AllScopes` | ECA JWT | All | |
+| `testECAJwt_ViaLoginPoolServer` | ECA JWT | — | `@Ignore` (loginPoolHost not provisioned in CI config — add the key and re-enable) |
 
 #### DPoPLoginTests
 All DPoP tests live here — basic login, RTR, multi-user, migration, and restart. Verifies that DPoP-bound access tokens are issued (`token_type: "DPoP"`), API calls succeed with `ath`-bound proofs, the access token refreshes correctly, and the DPoP nonce rotates on every `/token` response. DPoP is toggled on via `LoginOptions` before each login; `cleanup()` resets it to `false` after each test. All DPoP tests use the `regular_auth` login host (sdb38) — DPoP is an ECA property, not an org property.

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -49,7 +49,7 @@ External Client App (ECA) login tests for both opaque and JWT token formats with
 | `testECAJwt_DefaultScopes` | ECA JWT | Default | |
 | `testECAJwt_SubsetScopes_NotHybrid` | ECA JWT | Subset | |
 | `testECAJwt_AllScopes` | ECA JWT | All | |
-| `testECAJwt_ViaLoginPoolServer` | ECA JWT | — | `@Ignore` (loginPoolHost not provisioned in CI config — add the key and re-enable) |
+| `testECAJwt_ViaLoginPoolServer` | ECA JWT | — | Pool server login without DPoP |
 
 #### DPoPLoginTests
 All DPoP tests live here — basic login, RTR, multi-user, migration, and restart. Verifies that DPoP-bound access tokens are issued (`token_type: "DPoP"`), API calls succeed with `ath`-bound proofs, the access token refreshes correctly, and the DPoP nonce rotates on every `/token` response. DPoP is toggled on via `LoginOptions` before each login; `cleanup()` resets it to `false` after each test. All DPoP tests use the `regular_auth` login host (sdb38) — DPoP is an ECA property, not an org property.

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/ECALoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/ECALoginTests.kt
@@ -88,10 +88,6 @@ fun testECAJwt_AllScopes() {
     // region ECA Pool Server Tests
 
     // Login via the pool server without DPoP and verify the session is valid.
-    //
-    // Skipped: loginPoolHost not yet provisioned in CI ui_test_config.json.
-    // Re-enable once the key is added and the CI environment can reach the pool server.
-    @Ignore("loginPoolHost not provisioned in CI config — add the key and re-enable")
     @Test
     fun testECAJwt_ViaLoginPoolServer() {
         loginAndValidate(knownAppConfig = ECA_JWT, useLoginPoolHost = true)


### PR DESCRIPTION
## Summary

- Adds `testECAJwt_ViaLoginPoolServer` to `ECALoginTests` — verifies that a plain ECA JWT login through the pool server produces a valid session (non-DPoP path)
- Updates `AuthFlowTester/README.md`: adds the new test to the ECALoginTests table, adds a Notes column, and updates the section description to mention pool server coverage

> **Note:** This commit should have been included in the main `dpop-jkt-pool-servers` PR. Opening as a separate PR to avoid rebasing the already-reviewed branch.

## Test plan

- [ ] AuthFlowTester: `testECAJwt_ViaLoginPoolServer` passes against `login.test1.pc-rnd.salesforce.com`