### PR TITLE
[Android] cdvCompileSdkVersion=35 too low for current androidx transitive deps, blocks hybrid_remote generation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-cdvCompileSdkVersion=35
+cdvCompileSdkVersion=36
 cdvMinSdkVersion=31
 android.useAndroidX=true
 android.nonTransitiveRClass=true


### PR DESCRIPTION
## Problem

Generating a hybrid_remote Android app via `SalesforceMobileSDK-Package`'s `test_force.js` and
building it with Gradle fails with an `AAR metadata` compileSdk mismatch. The generated app ends
up compiled against `cdvCompileSdkVersion=35`, while several transitive androidx dependencies
pulled in by the SDK (`androidx.biometric`, `androidx.browser`, `androidx.activity`,
`androidx.core`, `androidx.navigationevent`) require `compileSdk 36+`. This blocks Android
hybrid_remote app generation entirely.

## Root cause

This repository's own `gradle.properties` still declared `cdvCompileSdkVersion=35`, out of step
with the `compileSdk = 36` already pinned across this repo's own SDK library modules
(`SalesforceSDK`, `SalesforceHybrid`, `SmartStore`, `MobileSync`, `SalesforceAnalytics`) for these
same androidx dependency versions. During Cordova plugin generation, the plugin's `update.sh`
copies this repo's `gradle.properties` into the generated app project — so the stale `35` always
wins regardless of the Cordova plugin repo's own (already-correct) copy of this setting.

## Fix

Bump `cdvCompileSdkVersion` from `35` to `36` in `gradle.properties`, matching the floor already
required by and verified against the current androidx dependency versions elsewhere in this repo.

## Test plan

- [x] Confirmed `androidx-core` (1.18.0), `androidx-activity` (1.13.0), `androidx-browser`
      (1.10.0), and `androidx-biometric` (1.4.0-alpha07) match the versions already built
      successfully against `compileSdk = 36` in this repo's own library modules.
- [x] Locally rebuilt `:libs:SalesforceHybrid:assembleDebug` before and after this change —
      succeeds both times.
- [ ] End-to-end verification: generate a hybrid_remote Android app via
      `SalesforceMobileSDK-Package`'s `test_force.js` pointed at this branch and confirm the
      Gradle build succeeds (pending a separate verification pass).

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*
