### PR TITLE
Add downgradeFromDPoP for in-place DPoP→Bearer migration

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManagerExtension.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManagerExtension.kt
@@ -35,7 +35,6 @@ import com.salesforce.androidsdk.auth.dpop.DPoPNonceCache
 import com.salesforce.androidsdk.config.OAuthConfig
 import com.salesforce.androidsdk.ui.TokenMigrationActivity
 import com.salesforce.androidsdk.util.SalesforceSDKLogger
-import com.salesforce.androidsdk.util.SalesforceSDKLogger.w
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Default
 import kotlinx.coroutines.launch
@@ -270,19 +269,17 @@ fun UserAccountManager.downgradeFromDPoP(
     // Capture the pre-migration credentials identifier now: migration mints a NEW identifier for
     // the account, so reading userAccount.credentialsIdentifier after the migration completes
     // would return the wrong (or a null) value. This is what obsolete-DPoP-state cleanup below is
-    // keyed on.
+    // keyed on. The account is guaranteed DPoP-bound here (the non-DPoP case returned early above),
+    // so cleanup always applies on success.
     val oldCredId = userAccount.credentialsIdentifier
-    val wasDPoPBound = userAccount.tokenType == DPoPKeyManager.DPOP_TOKEN_TYPE
 
     val onSuccessWithCleanup: (userAccount: UserAccount) -> Unit = { migratedUser ->
-        if (wasDPoPBound) {
-            oldCredId?.takeIf { it.isNotEmpty() }?.let { id ->
-                runCatching {
-                    DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(id))
-                    DPoPNonceCache.clear(id)
-                }.onFailure { e ->
-                    w(TAG, "Failed to delete obsolete DPoP state on downgrade", e)
-                }
+        oldCredId?.takeIf { it.isNotEmpty() }?.let { id ->
+            runCatching {
+                DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(id))
+                DPoPNonceCache.clear(id)
+            }.onFailure { e ->
+                SalesforceSDKLogger.w(TAG, "Failed to delete obsolete DPoP state on downgrade", e)
             }
         }
         onSuccess(migratedUser)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManagerExtension.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManagerExtension.kt
@@ -30,9 +30,12 @@ import android.content.Intent
 import com.salesforce.androidsdk.accounts.UserAccountManager.getInstance
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.ScopeParser.Companion.toScopeParser
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager
+import com.salesforce.androidsdk.auth.dpop.DPoPNonceCache
 import com.salesforce.androidsdk.config.OAuthConfig
 import com.salesforce.androidsdk.ui.TokenMigrationActivity
 import com.salesforce.androidsdk.util.SalesforceSDKLogger
+import com.salesforce.androidsdk.util.SalesforceSDKLogger.w
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Default
 import kotlinx.coroutines.launch
@@ -147,6 +150,9 @@ fun UserAccountManager.migrateRefreshToken(
  * null-check failure below runs on the caller's thread, but the OAuth-config resolution and
  * migration below it run on [Default]. Callers that touch UI from these callbacks must marshal
  * to the main thread themselves.
+ *
+ * No-op: if [userAccount] is already DPoP-bound, there's nothing to upgrade — [onSuccess] is
+ * invoked synchronously with the unchanged account and no migration is attempted.
  */
 @Suppress("UnusedReceiverParameter")
 fun UserAccountManager.upgradeToDPoP(
@@ -154,6 +160,11 @@ fun UserAccountManager.upgradeToDPoP(
     onSuccess: (userAccount: UserAccount) -> Unit,
     onFailure: (error: String, errorDesc: String?, e: Throwable?) -> Unit,
 ) {
+    if (userAccount.tokenType == DPoPKeyManager.DPOP_TOKEN_TYPE) {
+        onSuccess(userAccount)
+        return
+    }
+
     val clientId = userAccount.clientId
     val loginServer = userAccount.loginServer
 
@@ -193,6 +204,119 @@ fun UserAccountManager.upgradeToDPoP(
                     appConfig = appConfig,
                     useDPoP = true,
                     onMigrationSuccess = onSuccess,
+                    onMigrationError = onFailure,
+                )
+            },
+            onFailure = { e ->
+                val message = "Failed to resolve OAuth configuration for login server."
+                SalesforceSDKLogger.e(TAG, message, e)
+                onFailure(message, e.message, e)
+            },
+        )
+    }
+}
+
+/**
+ * Downgrades the [userAccount]'s existing DPoP-bound refresh token to a Bearer (non-DPoP) one,
+ * in place — same consumer key, redirect URI, and scopes the account already uses. This is a
+ * same-config convenience over [migrateRefreshToken] with `useDPoP = false`: no re-consent is
+ * expected because nothing about the connected app / External Client App configuration changes.
+ *
+ * This works regardless of the global [SalesforceSDKManager.useDPoP] flag: that flag only sets
+ * the default DPoP posture for brand-new logins, while this call is an explicit action on an
+ * already-authenticated session — an app can leave the global flag on and still roll one user
+ * back to Bearer. The connected app / External Client App must accept Bearer tokens for the
+ * downgrade to succeed; a DPoP-enforcing app will reject the resulting session.
+ *
+ * On success, the pre-downgrade DPoP key pair and DPoP nonce-cache entries (keyed by the
+ * account's pre-migration [UserAccount.credentialsIdentifier], since migration mints a new one)
+ * are deleted — mirroring the teardown [SalesforceSDKManager] performs on logout. On failure or
+ * cancellation, that state is left untouched so the original DPoP-bound session keeps working.
+ *
+ * Callers wanting to migrate to a *different* consumer key, redirect URI, or scopes (or to
+ * explicitly upgrade a Bearer session to DPoP) should call [migrateRefreshToken] directly with
+ * their own [OAuthConfig] and `useDPoP` value, or see [upgradeToDPoP].
+ *
+ * Note: [onFailure] (and [onSuccess]) may be invoked off the main thread — the synchronous
+ * null-check failure below runs on the caller's thread, but the OAuth-config resolution and
+ * migration below it run on [Default]. Callers that touch UI from these callbacks must marshal
+ * to the main thread themselves.
+ *
+ * No-op: if [userAccount] is already Bearer (non-DPoP), there's nothing to downgrade —
+ * [onSuccess] is invoked synchronously with the unchanged account, no migration is attempted,
+ * and no DPoP state cleanup runs (there's none to clean up).
+ */
+@Suppress("UnusedReceiverParameter")
+fun UserAccountManager.downgradeFromDPoP(
+    userAccount: UserAccount,
+    onSuccess: (userAccount: UserAccount) -> Unit,
+    onFailure: (error: String, errorDesc: String?, e: Throwable?) -> Unit,
+) {
+    if (userAccount.tokenType != DPoPKeyManager.DPOP_TOKEN_TYPE) {
+        onSuccess(userAccount)
+        return
+    }
+
+    val clientId = userAccount.clientId
+    val loginServer = userAccount.loginServer
+
+    if (clientId == null || loginServer == null) {
+        val message = "User account clientId or loginServer is null."
+        SalesforceSDKLogger.e(TAG, message)
+        onFailure(message, null, null)
+        return
+    }
+
+    // Capture the pre-migration credentials identifier now: migration mints a NEW identifier for
+    // the account, so reading userAccount.credentialsIdentifier after the migration completes
+    // would return the wrong (or a null) value. This is what obsolete-DPoP-state cleanup below is
+    // keyed on.
+    val oldCredId = userAccount.credentialsIdentifier
+    val wasDPoPBound = userAccount.tokenType == DPoPKeyManager.DPOP_TOKEN_TYPE
+
+    val onSuccessWithCleanup: (userAccount: UserAccount) -> Unit = { migratedUser ->
+        if (wasDPoPBound) {
+            oldCredId?.takeIf { it.isNotEmpty() }?.let { id ->
+                runCatching {
+                    DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(id))
+                    DPoPNonceCache.clear(id)
+                }.onFailure { e ->
+                    w(TAG, "Failed to delete obsolete DPoP state on downgrade", e)
+                }
+            }
+        }
+        onSuccess(migratedUser)
+    }
+
+    // Prefer the redirect URI persisted on the account at login time: it's the exact value the
+    // connected app / External Client App was configured with for this user, and it doesn't
+    // change over time. Only fall back to resolving the OAuth configuration for the user's login
+    // server (debug override, per-host app config, or boot config) for accounts persisted before
+    // redirect URI was captured on UserAccount. Either way, keep the user's own consumer key and
+    // scopes so the downgrade is a true same-config, in-place operation.
+    CoroutineScope(Default).launch {
+        runCatching {
+            val persistedRedirectUri = userAccount.redirectUri
+            val redirectUri = if (!persistedRedirectUri.isNullOrBlank()) {
+                persistedRedirectUri
+            } else {
+                SalesforceSDKManager.getInstance()
+                    .resolveOAuthConfigForLoginServer(loginServer)
+                    .redirectUri
+            }
+
+            OAuthConfig(
+                consumerKey = clientId,
+                redirectUri = redirectUri,
+                scopes = userAccount.scope?.toScopeParser()?.scopes?.toList(),
+            )
+        }.fold(
+            onSuccess = { appConfig ->
+                migrateRefreshToken(
+                    userAccount = userAccount,
+                    appConfig = appConfig,
+                    useDPoP = false,
+                    onMigrationSuccess = onSuccessWithCleanup,
                     onMigrationError = onFailure,
                 )
             },

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerMigrateTokenTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerMigrateTokenTest.kt
@@ -31,6 +31,8 @@ import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager
+import com.salesforce.androidsdk.auth.dpop.DPoPNonceCache
 import com.salesforce.androidsdk.config.OAuthConfig
 import com.salesforce.androidsdk.ui.TokenMigrationActivity
 import com.salesforce.androidsdk.util.SalesforceSDKLogger
@@ -51,6 +53,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Tests for UserAccountManager.migrateRefreshToken extension function.
@@ -355,5 +359,255 @@ class UserAccountManagerMigrateTokenTest {
             targetUserId,
             capturedIntent.getStringExtra(TokenMigrationActivity.EXTRA_USER_ID)
         )
+    }
+
+    /**
+     * Tests for UserAccountManager.downgradeFromDPoP extension function. Config resolution and
+     * the migrateRefreshToken delegation run on Dispatchers.Default (mirroring upgradeToDPoP), so
+     * tests that need to observe the resulting migration Intent synchronize on a CountDownLatch
+     * that mockContext.startActivity trips, rather than sleeping.
+     */
+
+    @Test
+    fun downgradeFromDPoP_withNullClientId_callsOnFailure() {
+        // Given
+        val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.clientId } returns null
+        every { mockUserAccount.loginServer } returns "login.example.com"
+
+        // When
+        mockUserAccountManager.downgradeFromDPoP(
+            userAccount = mockUserAccount,
+            onSuccess = onMigrationSuccess,
+            onFailure = onMigrationError,
+        )
+
+        // Then
+        verify(exactly = 1) {
+            onMigrationError.invoke("User account clientId or loginServer is null.", null, null)
+        }
+        verify(exactly = 0) { onMigrationSuccess.invoke(any()) }
+        verify(exactly = 0) { mockContext.startActivity(any()) }
+    }
+
+    @Test
+    fun downgradeFromDPoP_withNullLoginServer_callsOnFailure() {
+        // Given
+        val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.clientId } returns "testClientId"
+        every { mockUserAccount.loginServer } returns null
+
+        // When
+        mockUserAccountManager.downgradeFromDPoP(
+            userAccount = mockUserAccount,
+            onSuccess = onMigrationSuccess,
+            onFailure = onMigrationError,
+        )
+
+        // Then
+        verify(exactly = 1) {
+            onMigrationError.invoke("User account clientId or loginServer is null.", null, null)
+        }
+        verify(exactly = 0) { onMigrationSuccess.invoke(any()) }
+        verify(exactly = 0) { mockContext.startActivity(any()) }
+    }
+
+    @Test
+    fun downgradeFromDPoP_withValidAccount_migratesWithUseDPoPFalseAndSameConfig() {
+        // Given
+        val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.userId } returns "testUserId"
+        every { mockUserAccount.orgId } returns "testOrgId"
+        every { mockUserAccount.clientId } returns "testClientId"
+        every { mockUserAccount.loginServer } returns "login.example.com"
+        every { mockUserAccount.redirectUri } returns "testapp://callback"
+        every { mockUserAccount.scope } returns null
+        every { mockUserAccount.tokenType } returns DPoPKeyManager.DPOP_TOKEN_TYPE
+
+        every { MigrationCallbackRegistry.register(any()) } returns "callback-key"
+
+        val intentSlot = slot<Intent>()
+        val activityStarted = CountDownLatch(1)
+        every { mockContext.startActivity(capture(intentSlot)) } answers {
+            activityStarted.countDown()
+        }
+
+        // When
+        mockUserAccountManager.downgradeFromDPoP(
+            userAccount = mockUserAccount,
+            onSuccess = onMigrationSuccess,
+            onFailure = onMigrationError,
+        )
+
+        // Then
+        assertTrue("Migration activity should have been started",
+            activityStarted.await(5, TimeUnit.SECONDS))
+
+        val capturedIntent = intentSlot.captured
+        assertEquals("Downgrade must migrate with useDPoP=false, even with the global flag on",
+            false,
+            capturedIntent.getBooleanExtra(TokenMigrationActivity.EXTRA_USE_DPOP, true)
+        )
+        assertTrue("Intent should carry the same-config OAuthConfig",
+            capturedIntent.hasExtra(TokenMigrationActivity.EXTRA_OAUTH_CONFIG)
+        )
+        verify(exactly = 0) { onMigrationError.invoke(any(), any(), any()) }
+    }
+
+    @Test
+    fun downgradeFromDPoP_onSuccess_whenPreMigrationAccountWasDPoPBound_deletesObsoleteKeyAndNonce() {
+        // Given
+        mockkObject(DPoPKeyManager)
+        mockkObject(DPoPNonceCache)
+        every { DPoPKeyManager.aliasForCredentialsIdentifier(any()) } answers { callOriginal() }
+        every { DPoPKeyManager.deleteKeyPair(any()) } just runs
+        every { DPoPNonceCache.clear(any()) } just runs
+
+        val oldCredId = "old-dpop-cred-id"
+        val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.userId } returns "testUserId"
+        every { mockUserAccount.orgId } returns "testOrgId"
+        every { mockUserAccount.clientId } returns "testClientId"
+        every { mockUserAccount.loginServer } returns "login.example.com"
+        every { mockUserAccount.redirectUri } returns "testapp://callback"
+        every { mockUserAccount.scope } returns null
+        every { mockUserAccount.tokenType } returns DPoPKeyManager.DPOP_TOKEN_TYPE
+        every { mockUserAccount.credentialsIdentifier } returns oldCredId
+
+        val callbacksSlot = slot<MigrationCallbackRegistry.MigrationCallbacks>()
+        every { MigrationCallbackRegistry.register(capture(callbacksSlot)) } returns "callback-key"
+
+        val activityStarted = CountDownLatch(1)
+        every { mockContext.startActivity(any()) } answers { activityStarted.countDown() }
+
+        // When
+        mockUserAccountManager.downgradeFromDPoP(
+            userAccount = mockUserAccount,
+            onSuccess = onMigrationSuccess,
+            onFailure = onMigrationError,
+        )
+        assertTrue("Migration activity should have been started",
+            activityStarted.await(5, TimeUnit.SECONDS))
+
+        val migratedAccount: UserAccount = mockk(relaxed = true)
+        every { migratedAccount.username } returns "user@test.com"
+        every { migratedAccount.instanceServer } returns "https://test.instance"
+        callbacksSlot.captured.onMigrationSuccess(migratedAccount)
+
+        // Then - the OLD (pre-migration) identifier's key/nonce are reclaimed.
+        verify(exactly = 1) {
+            DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(oldCredId))
+        }
+        verify(exactly = 1) { DPoPNonceCache.clear(oldCredId) }
+        verify(exactly = 1) { onMigrationSuccess.invoke(migratedAccount) }
+    }
+
+    @Test
+    fun downgradeFromDPoP_onFailure_retainsDPoPKeyAndNonce() {
+        // Given
+        mockkObject(DPoPKeyManager)
+        mockkObject(DPoPNonceCache)
+        every { DPoPKeyManager.aliasForCredentialsIdentifier(any()) } answers { callOriginal() }
+        every { DPoPKeyManager.deleteKeyPair(any()) } just runs
+        every { DPoPNonceCache.clear(any()) } just runs
+
+        val oldCredId = "old-dpop-cred-id"
+        val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.userId } returns "testUserId"
+        every { mockUserAccount.orgId } returns "testOrgId"
+        every { mockUserAccount.clientId } returns "testClientId"
+        every { mockUserAccount.loginServer } returns "login.example.com"
+        every { mockUserAccount.redirectUri } returns "testapp://callback"
+        every { mockUserAccount.scope } returns null
+        every { mockUserAccount.tokenType } returns DPoPKeyManager.DPOP_TOKEN_TYPE
+        every { mockUserAccount.credentialsIdentifier } returns oldCredId
+
+        val callbacksSlot = slot<MigrationCallbackRegistry.MigrationCallbacks>()
+        every { MigrationCallbackRegistry.register(capture(callbacksSlot)) } returns "callback-key"
+
+        val activityStarted = CountDownLatch(1)
+        every { mockContext.startActivity(any()) } answers { activityStarted.countDown() }
+
+        // When
+        mockUserAccountManager.downgradeFromDPoP(
+            userAccount = mockUserAccount,
+            onSuccess = onMigrationSuccess,
+            onFailure = onMigrationError,
+        )
+        assertTrue("Migration activity should have been started",
+            activityStarted.await(5, TimeUnit.SECONDS))
+
+        // The migration failed/was cancelled: onMigrationError fires, onMigrationSuccess never does.
+        callbacksSlot.captured.onMigrationError("error", "desc", null)
+
+        // Then - the still-in-use DPoP key/nonce must NOT be torn down.
+        verify(exactly = 0) { DPoPKeyManager.deleteKeyPair(any()) }
+        verify(exactly = 0) { DPoPNonceCache.clear(any()) }
+        verify(exactly = 1) { onMigrationError.invoke("error", "desc", null) }
+    }
+
+    /**
+     * No-op guard for [UserAccountManager.upgradeToDPoP]: an already DPoP-bound account has
+     * nothing to upgrade, so the call must short-circuit before any migration is attempted.
+     */
+    @Test
+    fun testUpgradeToDPoP_alreadyDPoP_isNoOpAndUserUnchanged() {
+        // Given - an account already DPoP-bound.
+        val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.tokenType } returns DPoPKeyManager.DPOP_TOKEN_TYPE
+        every { mockUserAccount.clientId } returns "testClientId"
+        every { mockUserAccount.loginServer } returns "login.example.com"
+
+        // When
+        mockUserAccountManager.upgradeToDPoP(
+            userAccount = mockUserAccount,
+            onSuccess = onMigrationSuccess,
+            onFailure = onMigrationError,
+        )
+
+        // Then - onSuccess fires immediately with the unchanged account; no migration is started.
+        verify(exactly = 1) { onMigrationSuccess.invoke(mockUserAccount) }
+        verify(exactly = 0) { onMigrationError.invoke(any(), any(), any()) }
+        verify(exactly = 0) { MigrationCallbackRegistry.register(any()) }
+        verify(exactly = 0) { mockContext.startActivity(any()) }
+        assertEquals("tokenType must remain unchanged",
+            DPoPKeyManager.DPOP_TOKEN_TYPE, mockUserAccount.tokenType)
+    }
+
+    /**
+     * No-op guard for [UserAccountManager.downgradeFromDPoP]: an already Bearer (non-DPoP)
+     * account has nothing to downgrade, so the call must short-circuit before any migration is
+     * attempted or DPoP state cleanup is considered.
+     */
+    @Test
+    fun testDowngradeFromDPoP_alreadyBearer_isNoOpAndUserUnchanged() {
+        // Given - an account already Bearer (non-DPoP).
+        mockkObject(DPoPKeyManager)
+        mockkObject(DPoPNonceCache)
+        every { DPoPKeyManager.deleteKeyPair(any()) } just runs
+        every { DPoPNonceCache.clear(any()) } just runs
+
+        val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.tokenType } returns "Bearer"
+        every { mockUserAccount.clientId } returns "testClientId"
+        every { mockUserAccount.loginServer } returns "login.example.com"
+        every { mockUserAccount.credentialsIdentifier } returns "bearer-cred-id"
+
+        // When
+        mockUserAccountManager.downgradeFromDPoP(
+            userAccount = mockUserAccount,
+            onSuccess = onMigrationSuccess,
+            onFailure = onMigrationError,
+        )
+
+        // Then - onSuccess fires immediately with the unchanged account; no migration is started,
+        // and no DPoP key/nonce cleanup is attempted (there's no DPoP state to clean up).
+        verify(exactly = 1) { onMigrationSuccess.invoke(mockUserAccount) }
+        verify(exactly = 0) { onMigrationError.invoke(any(), any(), any()) }
+        verify(exactly = 0) { MigrationCallbackRegistry.register(any()) }
+        verify(exactly = 0) { mockContext.startActivity(any()) }
+        verify(exactly = 0) { DPoPKeyManager.deleteKeyPair(any()) }
+        verify(exactly = 0) { DPoPNonceCache.clear(any()) }
+        assertEquals("tokenType must remain unchanged", "Bearer", mockUserAccount.tokenType)
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -66,6 +66,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, server enf
 | `testMigrate_ECAJwtDPoP_To_ECAJwtDPoPRtr` | ECA JWT DPoP → ECA JWT DPoP RTR | — | Migrate from DPoP to DPoP+RTR |
 | `testLogin_DPoP_ECA_Without_DPoP_Fails` | ECA JWT DPoP | — | Server enforcement: DPoP-enforced ECA rejects login without DPoP (`useDPoP=false`); no account created |
 | `testUpgrade_NonDPoP_InPlace_ToDPoP` | ECA JWT → ECA JWT DPoP | — | Bearer → DPoP in-place upgrade; global `useDPoP` flag remains off; per-call `dpopOverride` triggers upgrade |
+| `testDowngrade_DPoP_InPlace_ToBearer` | ECA JWT | — | DPoP → Bearer in-place downgrade; session is established on the DPoP-optional ECA via per-call `useDPoP=true` (global flag stays on the whole time); downgrade deletes the obsolete DPoP key pair and nonce cache entry on success |
 | `testECAJwtDPoP_WithRestart` | ECA JWT DPoP | — | DPoP EC key pair survives process restart (AndroidKeyStore) |
 | `testECAJwtDPoP_ViaLoginPoolServer` | ECA JWT DPoP | — | `@Ignore` (W-23864247 — pool login server rejects valid `dpop_jkt` token exchange) |
 | `testLoginForAdmin_DPoP` | ECA JWT DPoP | — | Login for Admins hand-off to Custom Tab works with DPoP |

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -226,6 +226,21 @@ class DPoPLoginTests : AuthFlowTest() {
 
     // endregion
 
+    // region DPoP Downgrade Tests
+
+    // In-place downgrade: a DPoP-bound session on an unenforced ECA is rolled back to Bearer via
+    // the "Downgrade from DPoP" affordance, with the process-wide DPoP flag left ON the entire
+    // time. Proves the migration re-auth honors the per-call intent (LoginViewModel.dpopOverride)
+    // rather than SalesforceSDKManager.useDPoP, and that no re-consent is needed since the
+    // consumer key/redirect URI/scopes are unchanged.
+    @Test
+    fun testDowngrade_DPoP_InPlace_ToBearer() {
+        loginAndValidate(knownAppConfig = ECA_JWT, useDPoP = true)
+        downgradeFromDPoPAndValidate(knownAppConfig = ECA_JWT)
+    }
+
+    // endregion
+
     // region DPoP Restart Tests
 
     /**

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -58,6 +58,7 @@ import com.salesforce.androidsdk.app.Features.FEATURE_TOKEN_MIGRATION
 import com.salesforce.samples.authflowtester.ALERT_POSITIVE_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.ALERT_TITLE_CONTENT_DESC
 import com.salesforce.samples.authflowtester.CREDS_SECTION_CONTENT_DESC
+import com.salesforce.samples.authflowtester.DOWNGRADE_FROM_DPOP_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.MIGRATE_TOKEN_BUTTON_CONTENT_DESC
 import com.salesforce.samples.authflowtester.MIGRATE_USER_RADIO_CONTENT_DESC
 import com.salesforce.samples.authflowtester.UPGRADE_TO_DPOP_BUTTON_CONTENT_DESC
@@ -471,6 +472,46 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         // Tap the "Upgrade to DPoP" button.
         waitForNode(UPGRADE_TO_DPOP_BUTTON_CONTENT_DESC)
         composeTestRule.onNodeWithContentDescription(UPGRADE_TO_DPOP_BUTTON_CONTENT_DESC)
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        AuthorizationPageObject(composeTestRule).tapAllowAfterMigration()
+
+        // Wait for migration to complete and the sheet to auto-dismiss (see migrateToNewApp
+        // for the rationale behind the close-button fallback).
+        val closeDesc = getString(R.string.close_content_description)
+        try {
+            waitForNodeGone(closeDesc)
+        } catch (_: Exception) {
+            composeTestRule.onNodeWithContentDescription(closeDesc)
+                .performSemanticsAction(SemanticsActions.OnClick)
+            composeTestRule.waitForIdle()
+            waitForNodeGone(closeDesc)
+        }
+
+        // Wait for the app UI to refresh with new token data.
+        waitForAppLoad()
+    }
+
+    /**
+     * Opens the migration bottom sheet and taps "Downgrade from DPoP" for the current user — an
+     * in-place downgrade of the existing connected app (same consumer key/redirect URI/scopes)
+     * back to Bearer, independent of [SalesforceSDKManager.useDPoP]. No consent screen is
+     * expected because the consumer key, redirect URI, and scopes are unchanged, but
+     * [AuthorizationPageObject.tapAllowAfterMigration] is still consulted to tolerate a stray
+     * consent screen rather than asserting its strict absence. Mirrors [upgradeToDPoP] with the
+     * inverse button.
+     */
+    fun downgradeFromDPoP() {
+        // Tap "Migrate Access Token" bottom bar icon to open the sheet.
+        val migrateDesc = getString(R.string.migrate_access_token)
+        waitForNode(migrateDesc)
+        composeTestRule.onNodeWithContentDescription(migrateDesc)
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeTestRule.waitForIdle()
+
+        // Tap the "Downgrade from DPoP" button.
+        waitForNode(DOWNGRADE_FROM_DPOP_BUTTON_CONTENT_DESC)
+        composeTestRule.onNodeWithContentDescription(DOWNGRADE_FROM_DPOP_BUTTON_CONTENT_DESC)
             .performSemanticsAction(SemanticsActions.OnClick)
 
         AuthorizationPageObject(composeTestRule).tapAllowAfterMigration()

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/ChromeCustomTabPageObject.kt
@@ -69,8 +69,23 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
         skipGoogleSignIn()
         val (username, password) = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
         setUsername(username)
-        tapLogin()
+        // A combined Salesforce My Domain page renders username + password on ONE screen, so the
+        // password field is already present after typing the username. A two-step flow instead
+        // shows a username-only page and needs a Log In tap to advance to the password page.
+        // Only tap to advance in the two-step case: tapping Log In on a combined page submits an
+        // empty password, which triggers the client-side "Please enter your password" error and
+        // re-renders the form (previously this stray tap, combined with setPassword grabbing the
+        // first text field, caused the password to be typed into the username field).
+        val passwordAlreadyVisible = device
+            .findObject(UiSelector().className("android.widget.EditText").instance(1))
+            .waitForExists(QUICK_CHECK_TIMEOUT_MS)
+        if (!passwordAlreadyVisible) tapLogin()
         setPassword(password)
+        // On the combined page the Log In button sits directly below the password field, so the
+        // soft keyboard raised by setPassword covers it — a tap would land on the keyboard instead
+        // of the button and the form would never submit. Dismiss the keyboard first (Back closes
+        // the IME without leaving the Custom Tab) so the button is on-screen and clickable.
+        dismissKeyboard()
         tapLogin()
         // Under forced advanced authentication every login completes in the Custom Tab, so the
         // OAuth approval page is always rendered there regardless of the configured host.
@@ -176,8 +191,16 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
     }
 
     override fun setPassword(password: String) {
+        // resourceId("password") never resolves inside Chrome (HTML element IDs are not Android
+        // resource IDs — see setUsername), so the field must be located by position. The password
+        // input is the 2nd text field on a combined username+password page, or the only field on a
+        // two-step page's password screen. Prefer instance(1) (combined page) and fall back to
+        // instance(0) (two-step). Using instance(0) unconditionally would target the USERNAME field
+        // on a combined page, typing the password into it.
         val passwordField = device.findObject(UiSelector().resourceId(PASSWORD_ID))
             .takeIf { it.waitForExists(QUICK_CHECK_TIMEOUT_MS) }
+            ?: device.findObject(UiSelector().className("android.widget.EditText").instance(1))
+                .takeIf { it.waitForExists(QUICK_CHECK_TIMEOUT_MS) }
             ?: device.findObject(UiSelector().className("android.widget.EditText").instance(0))
                 .also {
                     if (!it.waitForExists(WEBVIEW_ACTION_TIMEOUT_MS)) {
@@ -198,6 +221,29 @@ class ChromeCustomTabPageObject(composeTestRule: ComposeTestRule): LoginPageObje
                     }
                 }
         loginButton.click()
+    }
+
+    /**
+     * Dismisses the soft keyboard if it is showing.
+     *
+     * Uses UiAutomator's [UiDevice.pressBack] (like [LoginOptionsPageObject]) rather than
+     * `Espresso.closeSoftKeyboard()`: the keyboard is raised over the Chrome Custom Tab, which runs
+     * in a separate process Espresso cannot reach. When the IME is visible, Back dismisses it
+     * without leaving the tab. The `dumpsys input_method` guard ensures we only press Back when the
+     * keyboard is actually shown, so this never accidentally navigates the tab when it is hidden.
+     */
+    private fun dismissKeyboard() {
+        // Default to true if the shell probe fails: the only caller invokes this right after typing
+        // into the password field, so the keyboard is reliably up and dismissing it is safe.
+        val keyboardShown = runCatching {
+            device.executeShellCommand("dumpsys input_method")
+                .replace(" ", "")
+                .contains("mInputShown=true")
+        }.getOrDefault(true)
+        if (keyboardShown) {
+            device.pressBack()
+            device.waitForIdle(QUICK_CHECK_TIMEOUT_MS)
+        }
     }
 
     /**

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -779,6 +779,53 @@ abstract class AuthFlowTest {
         assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, wasMigrated = true, isJwt = appConfig.issuesJwt)
     }
 
+    /**
+     * Drives the "Downgrade from DPoP" affordance for the current user's existing DPoP-bound
+     * session and validates the resulting Bearer credential — same consumer key, new tokens, no
+     * DPoP nonce. Mirrors [upgradeToDPoPAndValidate] but for the inverse, same-config
+     * [com.salesforce.androidsdk.accounts.downgradeFromDPoP] convenience, so it takes no target
+     * [KnownAppConfig]/scopes — the config is unchanged.
+     */
+    fun downgradeFromDPoPAndValidate(
+        knownAppConfig: KnownAppConfig,
+        knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
+        knownUserConfig: KnownUserConfig = user,
+        expectAdvancedAuth: Boolean = true,
+        expectedAMarker: String? = Features.FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
+    ) {
+        val (preAccessToken, preRefreshToken) = app.getTokens()
+        app.downgradeFromDPoP()
+        val (postAccessToken, postRefreshToken) = app.getTokens()
+
+        // Assert tokens are new.
+        assert(preAccessToken != postAccessToken)
+        assert(preRefreshToken != postRefreshToken)
+
+        val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
+        val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        val appConfig = testConfig.getApp(knownAppConfig)
+        app.validateUser(
+            knownLoginHostConfig,
+            knownUserConfig,
+            expectAdvancedAuth = expectAdvancedAuth,
+            isDpop = false,
+            expectedBMarker = expectedBMarker,
+            expectedAMarker = expectedAMarker,
+            wasMigrated = true,
+            isJwt = appConfig.issuesJwt,
+            isBeacon = appConfig.isBeacon,
+        )
+
+        // The consumer key is unchanged — same app, only the DPoP binding changed.
+        app.validateOAuthValues(knownAppConfig, scopeSelection = EMPTY)
+
+        // Assert the newly Bearer tokens work with no DPoP proof. downgradeFromDPoP delegates to
+        // the refresh-token migration path, so the "TM" (token-migration) UA feature flag is
+        // legitimately registered and persists across subsequent refreshes — the marker tracks the
+        // migration mechanism, not whether the connected app changed. Assert its presence.
+        assertRevokeAndRefreshWorks(isRtr = false, isDpop = false, wasMigrated = true, isJwt = appConfig.issuesJwt)
+    }
+
     fun assertRevokeAndRefreshWorks(
         isRtr: Boolean,
         isDpop: Boolean = false,

--- a/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/java/com/salesforce/samples/authflowtester/AuthFlowTesterActivity.kt
@@ -113,6 +113,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import com.salesforce.androidsdk.accounts.UserAccount
 import com.salesforce.androidsdk.accounts.UserAccountManager
+import com.salesforce.androidsdk.accounts.downgradeFromDPoP
 import com.salesforce.androidsdk.accounts.migrateRefreshToken
 import com.salesforce.androidsdk.accounts.upgradeToDPoP
 import com.salesforce.androidsdk.app.SalesforceSDKManager
@@ -162,6 +163,7 @@ const val JWT_SECTION_CONTENT_DESC = "jwt_section"
 const val OAUTH_SECTION_CONTENT_DESC = "oauth_config_section"
 const val MIGRATE_TOKEN_BUTTON_CONTENT_DESC = "migrate_refresh_token_button"
 const val UPGRADE_TO_DPOP_BUTTON_CONTENT_DESC = "upgrade_to_dpop_button"
+const val DOWNGRADE_FROM_DPOP_BUTTON_CONTENT_DESC = "downgrade_from_dpop_button"
 const val MIGRATE_USER_RADIO_CONTENT_DESC = "migrate_user_radio"
 const val ALERT_TITLE_CONTENT_DESC = "alert_title"
 const val ALERT_POSITIVE_BUTTON_CONTENT_DESC = "alert_positive"
@@ -718,6 +720,71 @@ class AuthFlowTesterActivity : SalesforceActivity() {
                         )
                     } else {
                         Text(text = stringResource(R.string.upgrade_to_dpop_button))
+                    }
+                }
+
+                // "Downgrade from DPoP": in-place downgrade of the selected user's own connected
+                // app back to Bearer, independent of SalesforceSDKManager.useDPoP — see
+                // UserAccountManager.downgradeFromDPoP. Inverse gate of the upgrade button above.
+                Text(
+                    text = stringResource(R.string.downgrade_from_dpop_title),
+                    fontSize = SECTION_TITLE_SIZE.sp,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(top = (INNER_CARD_PADDING/2).dp),
+                )
+                Text(
+                    text = stringResource(R.string.downgrade_from_dpop_description),
+                    fontSize = 12.sp,
+                    color = colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = (INNER_CARD_PADDING/2).dp),
+                )
+
+                Button(
+                    modifier = Modifier.fillMaxWidth()
+                        .padding(vertical = (INNER_CARD_PADDING/2).dp)
+                        .semantics { contentDescription = DOWNGRADE_FROM_DPOP_BUTTON_CONTENT_DESC },
+                    shape = RoundedCornerShape(CORNER_SHAPE.dp),
+                    enabled = alreadyDPoPBound && !migrateToDPoPInProgress && selectedUser != null,
+                    onClick = {
+                        val userToDowngrade = selectedUser ?: return@Button
+                        migrateToDPoPInProgress = true
+
+                        userAccountManager?.downgradeFromDPoP(
+                            userAccount = userToDowngrade,
+                            onSuccess = {
+                                runOnUiThread {
+                                    Toast.makeText(
+                                        this@AuthFlowTesterActivity,
+                                        resources.getString(R.string.migration_success),
+                                        Toast.LENGTH_LONG,
+                                    ).show()
+                                    migrateToDPoPInProgress = false
+                                    onDismiss.invoke()
+                                }
+                            },
+                            onFailure = { error, errorDesc, e ->
+                                runOnUiThread {
+                                    migrateToDPoPInProgress = false
+                                    migrateToDPoPError = error +
+                                            (errorDesc?.let { " \n\nDesc: $it" } ?: "") +
+                                            (e?.let { "\n\nThrowable: $it" } ?: "")
+                                }
+                            },
+                        )
+                    },
+                ) {
+                    if (migrateToDPoPInProgress) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(INNER_CARD_PADDING.dp),
+                            strokeWidth = SPINNER_STROKE_WIDTH.dp,
+                        )
+                        Spacer(Modifier.width(INNER_CARD_PADDING.dp))
+                        Text(
+                            text = stringResource(R.string.migration_in_progress),
+                            fontWeight = FontWeight.Medium,
+                        )
+                    } else {
+                        Text(text = stringResource(R.string.downgrade_from_dpop_button))
                     }
                 }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/main/res/values/strings.xml
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/res/values/strings.xml
@@ -34,6 +34,9 @@
     <string name="upgrade_to_dpop_title">Upgrade to DPoP</string>
     <string name="upgrade_to_dpop_description">Bind this user\'s existing refresh token to DPoP in place, using their current connected app, redirect URI, and scopes. No new consent is required.</string>
     <string name="upgrade_to_dpop_button">Upgrade to DPoP</string>
+    <string name="downgrade_from_dpop_title">Downgrade from DPoP</string>
+    <string name="downgrade_from_dpop_description">Roll this user\'s existing DPoP-bound refresh token back to Bearer in place, using their current connected app, redirect URI, and scopes. No new consent is required.</string>
+    <string name="downgrade_from_dpop_button">Downgrade from DPoP</string>
     <string name="change_connected_app_title">Change Connected App</string>
 
     <!-- BaseComponents -->

--- a/native/NativeSampleApps/AuthFlowTester/src/main/res/xml/servers.xml
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/res/xml/servers.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <servers>
-    <server name="DPoP" url="https://sdb6-2.test1.my.pc-rnd.salesforce.com" />
     <server name="UITests" url="https://authflowtestingmsdksdb38.test1.my.pc-rnd.salesforce.com" />
     <server name="UITests Adv Auth" url="https://advauthflowtestingmsdksdb38.test1.my.pc-rnd.salesforce.com" />
     <server name="Welcome Discovery" url="https://welcome.salesforce.com/discovery" />


### PR DESCRIPTION
## What

Adds `UserAccountManager.downgradeFromDPoP(userAccount, onSuccess, onFailure)`, the inverse of the existing `upgradeToDPoP`. It rolls a DPoP-bound session back to unbound Bearer **in place** — same connected app, redirect URI, and scopes — independent of the global `useDPoP` flag. It is a **no-op** (invokes `onSuccess` with the unchanged account) when the session is already Bearer.

## Why

Completes the in-place DPoP migration pair so apps can move a user off DPoP without a full logout/login, mirroring `upgradeToDPoP`.

## Changes

- **`UserAccountManagerExtension`** — new `downgradeFromDPoP` extension delegating to `migrateRefreshToken` with `useDPoP = false`; no-op guard when already Bearer. On success it deletes the obsolete DPoP key pair + nonce-cache entries keyed to the pre-downgrade credentials. Also adds a matching no-op guard to the existing `upgradeToDPoP` (returns the unchanged account when already DPoP-bound).
- **AuthFlowTester** — "Downgrade from DPoP" action (enabled only for a DPoP-bound session), downgrade UI test, and a downgrade validation helper. Removes an obsolete DPoP test-server entry.
- **Custom Tab login test fix** — a Salesforce My Domain page renders username + password on one screen; the previous unconditional "advance" tap submitted an empty password and the position-based lookup then typed the password into the username field. The helper now advances only on a genuine two-step page, targets the password field explicitly, and dismisses the soft keyboard before submitting.

## Review notes

- Touches a public API and the credential/login-UI surface — requesting maintainer (Wolf) review before merge; kept as **draft**.
- New user-facing strings are in AuthFlowTester's own `strings.xml` (sample-app labels for the downgrade button), not the SDK's `sf__strings.xml`.
