### PR TITLE
fix(dpop): enable pool-server DPoP login; fix identity fetch for all DPoP flows

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -416,21 +416,19 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 /**
  * Fetches user identity, trying idUrlWithInstance first, then falling back to raw idUrl.
  *
- * Attempt 1 — idUrlWithInstance: the instance / My Domain URL. Works for both My Domain
- * logins (nonce keyed to My Domain host = idUrlWithInstance host) and pool-server logins
- * in the same environment (e.g. login.test1.pc-rnd.salesforce.com tokens are accepted by
- * authflowtesting.test1.my.pc-rnd.salesforce.com; the per-host nonce lookup misses but
- * getAny supplies the pool-server nonce which that environment accepts).
+ * Attempt 1 — idUrlWithInstance: the instance / My Domain URL. Works for My Domain logins
+ * and for pool-server logins where the org's My Domain is in the same environment as the
+ * pool server (the My Domain accepts the token and the pool-server nonce supplied via
+ * DPoPNonceCache.getAny).
  *
  * Attempt 2 — raw idUrl (only when idUrl differs from idUrlWithInstance): fallback for
- * pool-server DPoP logins where idUrlWithInstance points to a different-environment
- * production instance that rejects pool-server-issued tokens. The raw idUrl host matches
- * the pool server and has the correct nonce.
+ * cross-environment pool-server DPoP logins where idUrlWithInstance points to a
+ * production instance that rejects pool-server-issued tokens.
  *
- * Upfront URL selection based on LoginServerManager.isPoolServer was investigated but
- * rejected: pool-server login portals do not serve identity endpoint requests themselves,
- * so routing there would silently break identity fetches for pool-server logins where
- * idUrlWithInstance (the org's My Domain) accepts the token and nonce.
+ * Note: iOS uses raw idUrl exclusively (no idUrlWithInstance substitution). Android needs
+ * idUrlWithInstance first because some pool-server login portals in test environments do
+ * not serve the identity endpoint themselves — routing there fails, while the org's My
+ * Domain (idUrlWithInstance) accepts both the token and the nonce.
  *
  * No token refresh is attempted: the access token was just issued by the login flow,
  * so it is valid by construction. A refresh would also be unsafe under Refresh Token
@@ -452,8 +450,8 @@ private suspend fun fetchUserIdentityWithRetry(
 
 /**
  * Calls the identity service using either [TokenEndpointResponse.idUrlWithInstance]
- * (My Domain / instance host) or the raw [TokenEndpointResponse.idUrl] (pool-server host),
- * as selected by [fetchUserIdentityWithRetry].
+ * (My Domain / instance host) or the raw [TokenEndpointResponse.idUrl], as selected
+ * by [fetchUserIdentityWithRetry].
  */
 private suspend fun fetchUserIdentity(
     tokenResponse: TokenEndpointResponse,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -414,15 +414,21 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 }
 
 /**
- * Fetches user identity with a URL fallback for pool-server DPoP logins.
+ * Fetches user identity, trying idUrlWithInstance first, then falling back to raw idUrl.
  *
- * Attempt 1 — idUrlWithInstance: the normal path. Works for regular My Domain logins
- * where the instance host matches the token-exchange host and the DPoP nonce is found.
+ * Attempt 1 — idUrlWithInstance: works for My Domain logins where the DPoP nonce was
+ * issued at the My Domain host (which idUrlWithInstance resolves to). Also works for
+ * classic sandbox logins (test.salesforce.com idUrl) because the nonce is keyed to the
+ * My Domain / instance host, not the legacy id URL host.
  *
- * Attempt 2 — raw idUrl (only when different from idUrlWithInstance): pool-server DPoP
- * logins where idUrlWithInstance points to the production instance, which rejects
- * pool-server-issued tokens. The raw idUrl uses the pool-server host, which matches
- * the nonce harvested at the token endpoint and accepts the token.
+ * Attempt 2 — raw idUrl (only when idUrl differs from idUrlWithInstance): handles
+ * pool-server DPoP logins where the token and nonce were issued by the pool server.
+ * idUrlWithInstance substitutes the production instance host, which rejects pool-server
+ * tokens and has no matching nonce, so Attempt 1 fails and we retry with the raw idUrl.
+ *
+ * We cannot skip Attempt 1 and select the URL upfront based on idUrl != idUrlWithInstance
+ * because that condition also fires for classic-domain sandboxes (e.g. test.salesforce.com
+ * idUrl with a My Domain instanceUrl), where idUrlWithInstance is the correct URL.
  *
  * No token refresh is attempted: the access token was just issued by the login flow,
  * so it is valid by construction. A refresh would also be unsafe under Refresh Token

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -137,7 +137,7 @@ internal suspend fun onAuthFlowComplete(
     // Note: Can't use default parameter value for a suspended function parameter.
     val actualFetchUserIdentity: suspend (TokenEndpointResponse) -> OAuth2.IdServiceResponse? =
         fetchUserIdentity ?: { tr: TokenEndpointResponse ->
-            fetchUserIdentityWithRetry(tr)
+            fetchUserIdentityWithRetry(tr, loginServer)
         }
 
     if (blockIntegrationUser) {
@@ -414,23 +414,17 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 }
 
 /**
- * Fetches user identity, trying [TokenEndpointResponse.idUrlWithInstance] first, then
- * falling back to the raw [TokenEndpointResponse.idUrl].
+ * Fetches user identity using the URL appropriate for the login server.
  *
- * Two attempts are needed because Salesforce always puts the pool-server host
- * (e.g. login.test1.pc-rnd.salesforce.com) in the `id` field of the token response,
- * regardless of which server actually issued the token. [TokenEndpointResponse.idUrlWithInstance]
- * corrects this by replacing the `id` host with the issuing server's host.
+ * Salesforce always puts the pool-server host in the `id` field of the token response
+ * regardless of which server issued the token. [TokenEndpointResponse.idUrlWithInstance]
+ * corrects this by substituting the issuing server's host, which is correct for My Domain
+ * logins and for Bearer tokens on any server.
  *
- * Attempt 1 — [TokenEndpointResponse.idUrlWithInstance]: the instance / My Domain URL.
- * Works for My Domain logins (token was issued by My Domain; calling the pool server with
- * a My Domain-issued token returns Wrong_Org). Also works for pool-server logins in
- * same-environment setups.
- *
- * Attempt 2 — raw [TokenEndpointResponse.idUrl] (only when it differs from
- * [TokenEndpointResponse.idUrlWithInstance]): fallback for pool-server DPoP logins where
- * [TokenEndpointResponse.idUrlWithInstance] points to a production instance that returns
- * Wrong_Org for pool-server-issued tokens.
+ * For DPoP tokens issued by a pool server, [TokenEndpointResponse.idUrlWithInstance] points
+ * to My Domain, which rejects pool-server-issued DPoP tokens with `Bad_OAuth_Token` — it
+ * does not issue a nonce challenge the way data endpoints do. The raw
+ * [TokenEndpointResponse.idUrl] (pool-server host) must be used instead.
  *
  * No token refresh is attempted: the access token was just issued by the login flow,
  * so it is valid by construction. A refresh would also be unsafe under Refresh Token
@@ -438,23 +432,11 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
  */
 private suspend fun fetchUserIdentityWithRetry(
     tokenResponse: TokenEndpointResponse,
+    loginServer: String,
 ): OAuth2.IdServiceResponse? {
-    val initial = fetchUserIdentity(tokenResponse, useRawIdUrl = false)
-    if (initial?.username != null) return initial
-
-    if (!tokenResponse.idUrl.isNullOrEmpty() && tokenResponse.idUrl != tokenResponse.idUrlWithInstance) {
-        val rawResult = fetchUserIdentity(tokenResponse, useRawIdUrl = true)
-        if (rawResult?.username != null) return rawResult
-    }
-
-    return initial
-}
-
-private suspend fun fetchUserIdentity(
-    tokenResponse: TokenEndpointResponse,
-    useRawIdUrl: Boolean = false,
-): OAuth2.IdServiceResponse? {
-    val url = if (useRawIdUrl) tokenResponse.idUrl else tokenResponse.idUrlWithInstance
+    val url = if ("DPoP".equals(tokenResponse.tokenType, ignoreCase = true)
+        && LoginServerManager.isPoolServer(loginServer)
+    ) tokenResponse.idUrl else tokenResponse.idUrlWithInstance
     return runCatching {
         withContext(Default) {
             callIdentityService(

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -134,14 +134,10 @@ internal suspend fun onAuthFlowComplete(
     // Reset Dev Support LoginOptionsActivity override
     SalesforceSDKManager.getInstance().debugOverrideAppConfig = null
 
-    // Note: Can't use default parameter value for suspended function parameter fetchUserIdentity.
-    // When no override is provided, use fetchUserIdentityWithRetry, which matches iOS
-    // SFIdentityCoordinator behavior: on 401/403 from the identity endpoint, iOS refreshes
-    // the session and retries. The pool server sometimes returns "Wrong_Org" on the first
-    // identity call due to session-affinity issues; a refresh yields a new token that succeeds.
+    // Note: Can't use default parameter value for a suspended function parameter.
     val actualFetchUserIdentity: suspend (TokenEndpointResponse) -> OAuth2.IdServiceResponse? =
         fetchUserIdentity ?: { tr: TokenEndpointResponse ->
-            fetchUserIdentityWithRetry(tr, loginServer, consumerKey)
+            fetchUserIdentityWithRetry(tr)
         }
 
     if (blockIntegrationUser) {
@@ -418,58 +414,32 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 }
 
 /**
- * Fetches user identity with up to two fallback attempts.
+ * Fetches user identity with a URL fallback for pool-server DPoP logins.
  *
- * Attempt 1 — idUrlWithInstance: works for regular My Domain logins (instance host
- * matches the token-exchange host, so the DPoP nonce is found and the instance accepts
- * the token).
+ * Attempt 1 — idUrlWithInstance: the normal path. Works for regular My Domain logins
+ * where the instance host matches the token-exchange host and the DPoP nonce is found.
  *
- * Attempt 2 — raw idUrl (when different from idUrlWithInstance): handles pool-server
+ * Attempt 2 — raw idUrl (only when different from idUrlWithInstance): pool-server DPoP
  * logins where idUrlWithInstance points to the production instance, which rejects
- * pool-server-issued DPoP tokens with "Bad_OAuth_Token". The raw idUrl uses the pool
- * server host, matching the nonce that was harvested at the token endpoint.
+ * pool-server-issued tokens. The raw idUrl uses the pool-server host, which matches
+ * the nonce harvested at the token endpoint and accepts the token.
  *
- * Attempt 3 — token refresh + retry: handles transient "Wrong_Org" routing failures
- * from the pool server. Mirrors iOS SFIdentityCoordinator, which refreshes on 401/403
- * from the identity endpoint and then retries.
+ * No token refresh is attempted: the access token was just issued by the login flow,
+ * so it is valid by construction. A refresh would also be unsafe under Refresh Token
+ * Rotation — consuming the fresh token and discarding the rotated replacement.
  */
 private suspend fun fetchUserIdentityWithRetry(
     tokenResponse: TokenEndpointResponse,
-    loginServer: String,
-    consumerKey: String,
 ): OAuth2.IdServiceResponse? {
-    // Attempt 1: idUrlWithInstance (regular My Domain logins).
     val initial = fetchUserIdentity(tokenResponse, useRawIdUrl = false)
     if (initial?.username != null) return initial
 
-    // Attempt 2: raw idUrl fallback (pool-server DPoP logins).
     if (!tokenResponse.idUrl.isNullOrEmpty() && tokenResponse.idUrl != tokenResponse.idUrlWithInstance) {
         val rawResult = fetchUserIdentity(tokenResponse, useRawIdUrl = true)
         if (rawResult?.username != null) return rawResult
     }
 
-    // Attempt 3: token refresh + retry (handles Wrong_Org pool server routing issues).
-    val refreshToken = tokenResponse.refreshToken ?: return initial
-    val refreshed = runCatching {
-        withContext(Default) {
-            OAuth2.refreshAuthToken(
-                HttpAccess.DEFAULT,
-                URI(loginServer),
-                consumerKey,
-                refreshToken,
-                null,
-                tokenResponse.credentialsIdentifier,
-                tokenResponse.tokenType,
-            )
-        }
-    }.onFailure { t ->
-        w(TAG, "Token refresh for identity retry failed.", t)
-    }.getOrNull() ?: return initial
-
-    // After refresh, try idUrl first (pool server) then idUrlWithInstance (regular).
-    val refreshedRaw = fetchUserIdentity(refreshed, useRawIdUrl = true)
-    if (refreshedRaw?.username != null) return refreshedRaw
-    return fetchUserIdentity(refreshed, useRawIdUrl = false)
+    return initial
 }
 
 /**

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -418,20 +418,37 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 }
 
 /**
- * Fetches user identity, retrying once with a refreshed token if the first attempt
- * returns no username. Matches iOS SFIdentityCoordinator: on 401/403 from the identity
- * endpoint iOS refreshes the session and retries. The pool server sometimes returns
- * "Wrong_Org" on the first call due to session-affinity issues; a refresh yields a new
- * token (and DPoP nonce) that succeeds at the identity endpoint.
+ * Fetches user identity with up to two fallback attempts.
+ *
+ * Attempt 1 — idUrlWithInstance: works for regular My Domain logins (instance host
+ * matches the token-exchange host, so the DPoP nonce is found and the instance accepts
+ * the token).
+ *
+ * Attempt 2 — raw idUrl (when different from idUrlWithInstance): handles pool-server
+ * logins where idUrlWithInstance points to the production instance, which rejects
+ * pool-server-issued DPoP tokens with "Bad_OAuth_Token". The raw idUrl uses the pool
+ * server host, matching the nonce that was harvested at the token endpoint.
+ *
+ * Attempt 3 — token refresh + retry: handles transient "Wrong_Org" routing failures
+ * from the pool server. Mirrors iOS SFIdentityCoordinator, which refreshes on 401/403
+ * from the identity endpoint and then retries.
  */
 private suspend fun fetchUserIdentityWithRetry(
     tokenResponse: TokenEndpointResponse,
     loginServer: String,
     consumerKey: String,
 ): OAuth2.IdServiceResponse? {
-    val initial = fetchUserIdentity(tokenResponse)
+    // Attempt 1: idUrlWithInstance (regular My Domain logins).
+    val initial = fetchUserIdentity(tokenResponse, useRawIdUrl = false)
     if (initial?.username != null) return initial
 
+    // Attempt 2: raw idUrl fallback (pool-server DPoP logins).
+    if (!tokenResponse.idUrl.isNullOrEmpty() && tokenResponse.idUrl != tokenResponse.idUrlWithInstance) {
+        val rawResult = fetchUserIdentity(tokenResponse, useRawIdUrl = true)
+        if (rawResult?.username != null) return rawResult
+    }
+
+    // Attempt 3: token refresh + retry (handles Wrong_Org pool server routing issues).
     val refreshToken = tokenResponse.refreshToken ?: return initial
     val refreshed = runCatching {
         withContext(Default) {
@@ -449,27 +466,28 @@ private suspend fun fetchUserIdentityWithRetry(
         w(TAG, "Token refresh for identity retry failed.", t)
     }.getOrNull() ?: return initial
 
-    return fetchUserIdentity(refreshed)
+    // After refresh, try idUrl first (pool server) then idUrlWithInstance (regular).
+    val refreshedRaw = fetchUserIdentity(refreshed, useRawIdUrl = true)
+    if (refreshedRaw?.username != null) return refreshedRaw
+    return fetchUserIdentity(refreshed, useRawIdUrl = false)
 }
 
 /**
- * Helper method to fetch user identity from token response.
+ * Calls the identity service using either the instance-substituted URL or the raw URL
+ * from the token response. The [useRawIdUrl] flag distinguishes pool-server fallback
+ * (raw idUrl = pool server host, nonce found) from the default path (idUrlWithInstance
+ * = instance/My Domain host, nonce found for regular logins).
  */
 private suspend fun fetchUserIdentity(
-    tokenResponse: TokenEndpointResponse
+    tokenResponse: TokenEndpointResponse,
+    useRawIdUrl: Boolean = false,
 ): OAuth2.IdServiceResponse? {
-    // Use the raw identity URL from the token response, not the instance-substituted URL.
-    // This matches iOS (SFIdentityCoordinator uses credentials.identityUrl directly).
-    // idUrlWithInstance replaces the login/pool-server host with the instance host, which
-    // causes the identity fetch to go to a different server than the one that issued the
-    // token. For DPoP-bound tokens in particular this breaks: the production instance's
-    // identity endpoint rejects DPoP tokens issued by a pool server with "Bad_OAuth_Token"
-    // because the token is only valid at the issuing server's identity endpoint.
+    val url = if (useRawIdUrl) tokenResponse.idUrl else tokenResponse.idUrlWithInstance
     return runCatching {
         withContext(Default) {
             callIdentityService(
                 HttpAccess.DEFAULT,
-                tokenResponse.idUrl,
+                url,
                 tokenResponse.authToken,
                 tokenResponse.tokenType,
                 tokenResponse.credentialsIdentifier,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -416,19 +416,21 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 /**
  * Fetches user identity, trying idUrlWithInstance first, then falling back to raw idUrl.
  *
- * Attempt 1 — idUrlWithInstance: works for My Domain logins where the DPoP nonce was
- * issued at the My Domain host (which idUrlWithInstance resolves to). Also works for
- * classic sandbox logins (test.salesforce.com idUrl) because the nonce is keyed to the
- * My Domain / instance host, not the legacy id URL host.
+ * Attempt 1 — idUrlWithInstance: the instance / My Domain URL. Works for both My Domain
+ * logins (nonce keyed to My Domain host = idUrlWithInstance host) and pool-server logins
+ * in the same environment (e.g. login.test1.pc-rnd.salesforce.com tokens are accepted by
+ * authflowtesting.test1.my.pc-rnd.salesforce.com; the per-host nonce lookup misses but
+ * getAny supplies the pool-server nonce which that environment accepts).
  *
- * Attempt 2 — raw idUrl (only when idUrl differs from idUrlWithInstance): handles
- * pool-server DPoP logins where the token and nonce were issued by the pool server.
- * idUrlWithInstance substitutes the production instance host, which rejects pool-server
- * tokens and has no matching nonce, so Attempt 1 fails and we retry with the raw idUrl.
+ * Attempt 2 — raw idUrl (only when idUrl differs from idUrlWithInstance): fallback for
+ * pool-server DPoP logins where idUrlWithInstance points to a different-environment
+ * production instance that rejects pool-server-issued tokens. The raw idUrl host matches
+ * the pool server and has the correct nonce.
  *
- * We cannot skip Attempt 1 and select the URL upfront based on idUrl != idUrlWithInstance
- * because that condition also fires for classic-domain sandboxes (e.g. test.salesforce.com
- * idUrl with a My Domain instanceUrl), where idUrlWithInstance is the correct URL.
+ * Upfront URL selection based on LoginServerManager.isPoolServer was investigated but
+ * rejected: pool-server login portals do not serve identity endpoint requests themselves,
+ * so routing there would silently break identity fetches for pool-server logins where
+ * idUrlWithInstance (the org's My Domain) accepts the token and nonce.
  *
  * No token refresh is attempted: the access token was just issued by the login flow,
  * so it is valid by construction. A refresh would also be unsafe under Refresh Token
@@ -449,10 +451,9 @@ private suspend fun fetchUserIdentityWithRetry(
 }
 
 /**
- * Calls the identity service using either the instance-substituted URL or the raw URL
- * from the token response. The [useRawIdUrl] flag distinguishes pool-server fallback
- * (raw idUrl = pool server host, nonce found) from the default path (idUrlWithInstance
- * = instance/My Domain host, nonce found for regular logins).
+ * Calls the identity service using either [TokenEndpointResponse.idUrlWithInstance]
+ * (My Domain / instance host) or the raw [TokenEndpointResponse.idUrl] (pool-server host),
+ * as selected by [fetchUserIdentityWithRetry].
  */
 private suspend fun fetchUserIdentity(
     tokenResponse: TokenEndpointResponse,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -134,8 +134,15 @@ internal suspend fun onAuthFlowComplete(
     // Reset Dev Support LoginOptionsActivity override
     SalesforceSDKManager.getInstance().debugOverrideAppConfig = null
 
-    // Note: Can't use default parameter value for suspended function parameter fetchUserIdentity
-    val actualFetchUserIdentity = fetchUserIdentity ?: ::fetchUserIdentity
+    // Note: Can't use default parameter value for suspended function parameter fetchUserIdentity.
+    // When no override is provided, use fetchUserIdentityWithRetry, which matches iOS
+    // SFIdentityCoordinator behavior: on 401/403 from the identity endpoint, iOS refreshes
+    // the session and retries. The pool server sometimes returns "Wrong_Org" on the first
+    // identity call due to session-affinity issues; a refresh yields a new token that succeeds.
+    val actualFetchUserIdentity: suspend (TokenEndpointResponse) -> OAuth2.IdServiceResponse? =
+        fetchUserIdentity ?: { tr: TokenEndpointResponse ->
+            fetchUserIdentityWithRetry(tr, loginServer, consumerKey)
+        }
 
     if (blockIntegrationUser) {
         /*
@@ -411,16 +418,58 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 }
 
 /**
+ * Fetches user identity, retrying once with a refreshed token if the first attempt
+ * returns no username. Matches iOS SFIdentityCoordinator: on 401/403 from the identity
+ * endpoint iOS refreshes the session and retries. The pool server sometimes returns
+ * "Wrong_Org" on the first call due to session-affinity issues; a refresh yields a new
+ * token (and DPoP nonce) that succeeds at the identity endpoint.
+ */
+private suspend fun fetchUserIdentityWithRetry(
+    tokenResponse: TokenEndpointResponse,
+    loginServer: String,
+    consumerKey: String,
+): OAuth2.IdServiceResponse? {
+    val initial = fetchUserIdentity(tokenResponse)
+    if (initial?.username != null) return initial
+
+    val refreshToken = tokenResponse.refreshToken ?: return initial
+    val refreshed = runCatching {
+        withContext(Default) {
+            OAuth2.refreshAuthToken(
+                HttpAccess.DEFAULT,
+                URI(loginServer),
+                consumerKey,
+                refreshToken,
+                null,
+                tokenResponse.credentialsIdentifier,
+                tokenResponse.tokenType,
+            )
+        }
+    }.onFailure { t ->
+        w(TAG, "Token refresh for identity retry failed.", t)
+    }.getOrNull() ?: return initial
+
+    return fetchUserIdentity(refreshed)
+}
+
+/**
  * Helper method to fetch user identity from token response.
  */
 private suspend fun fetchUserIdentity(
     tokenResponse: TokenEndpointResponse
 ): OAuth2.IdServiceResponse? {
+    // Use the raw identity URL from the token response, not the instance-substituted URL.
+    // This matches iOS (SFIdentityCoordinator uses credentials.identityUrl directly).
+    // idUrlWithInstance replaces the login/pool-server host with the instance host, which
+    // causes the identity fetch to go to a different server than the one that issued the
+    // token. For DPoP-bound tokens in particular this breaks: the production instance's
+    // identity endpoint rejects DPoP tokens issued by a pool server with "Bad_OAuth_Token"
+    // because the token is only valid at the issuing server's identity endpoint.
     return runCatching {
         withContext(Default) {
             callIdentityService(
                 HttpAccess.DEFAULT,
-                tokenResponse.idUrlWithInstance,
+                tokenResponse.idUrl,
                 tokenResponse.authToken,
                 tokenResponse.tokenType,
                 tokenResponse.credentialsIdentifier,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -414,21 +414,23 @@ private fun logAddAccount(account: UserAccount?, loginServerManager: LoginServer
 }
 
 /**
- * Fetches user identity, trying idUrlWithInstance first, then falling back to raw idUrl.
+ * Fetches user identity, trying [TokenEndpointResponse.idUrlWithInstance] first, then
+ * falling back to the raw [TokenEndpointResponse.idUrl].
  *
- * Attempt 1 — idUrlWithInstance: the instance / My Domain URL. Works for My Domain logins
- * and for pool-server logins where the org's My Domain is in the same environment as the
- * pool server (the My Domain accepts the token and the pool-server nonce supplied via
- * DPoPNonceCache.getAny).
+ * Two attempts are needed because Salesforce always puts the pool-server host
+ * (e.g. login.test1.pc-rnd.salesforce.com) in the `id` field of the token response,
+ * regardless of which server actually issued the token. [TokenEndpointResponse.idUrlWithInstance]
+ * corrects this by replacing the `id` host with the issuing server's host.
  *
- * Attempt 2 — raw idUrl (only when idUrl differs from idUrlWithInstance): fallback for
- * cross-environment pool-server DPoP logins where idUrlWithInstance points to a
- * production instance that rejects pool-server-issued tokens.
+ * Attempt 1 — [TokenEndpointResponse.idUrlWithInstance]: the instance / My Domain URL.
+ * Works for My Domain logins (token was issued by My Domain; calling the pool server with
+ * a My Domain-issued token returns Wrong_Org). Also works for pool-server logins in
+ * same-environment setups.
  *
- * Note: iOS uses raw idUrl exclusively (no idUrlWithInstance substitution). Android needs
- * idUrlWithInstance first because some pool-server login portals in test environments do
- * not serve the identity endpoint themselves — routing there fails, while the org's My
- * Domain (idUrlWithInstance) accepts both the token and the nonce.
+ * Attempt 2 — raw [TokenEndpointResponse.idUrl] (only when it differs from
+ * [TokenEndpointResponse.idUrlWithInstance]): fallback for pool-server DPoP logins where
+ * [TokenEndpointResponse.idUrlWithInstance] points to a production instance that returns
+ * Wrong_Org for pool-server-issued tokens.
  *
  * No token refresh is attempted: the access token was just issued by the login flow,
  * so it is valid by construction. A refresh would also be unsafe under Refresh Token
@@ -448,11 +450,6 @@ private suspend fun fetchUserIdentityWithRetry(
     return initial
 }
 
-/**
- * Calls the identity service using either [TokenEndpointResponse.idUrlWithInstance]
- * (My Domain / instance host) or the raw [TokenEndpointResponse.idUrl], as selected
- * by [fetchUserIdentityWithRetry].
- */
 private suspend fun fetchUserIdentity(
     tokenResponse: TokenEndpointResponse,
     useRawIdUrl: Boolean = false,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -657,10 +657,10 @@ public class OAuth2 {
                 final String host = HttpUrl.get(identityServiceIdUrl).host();
                 String nonce = DPoPNonceCache.INSTANCE.get(credentialsIdentifier, host);
                 if (nonce == null) {
-                    // Fallback: use any nonce for this credential. Mirrors iOS latest(forScope:).
-                    // Needed when the identity URL host differs from the token-exchange host
-                    // (e.g. non-My-Domain sandbox: token at test.salesforce.com, identity at instance).
-                    nonce = DPoPNonceCache.INSTANCE.getLatest(credentialsIdentifier);
+                    // Fallback: use any nonce for this credential when the identity URL host
+                    // differs from the token-exchange host (e.g. non-My-Domain sandbox: token
+                    // at test.salesforce.com, identity at instance host).
+                    nonce = DPoPNonceCache.INSTANCE.getAny(credentialsIdentifier);
                 }
                 final String proof = DPoPProofBuilder.INSTANCE.buildProof("GET", htu, keyPair, nonce, authToken);
                 builder.header(DPOP, proof);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -654,7 +654,14 @@ public class OAuth2 {
                 final String htu = DPoPURLHelper.INSTANCE.canonicalize(identityServiceIdUrl);
                 final String alias = DPoPKeyManager.INSTANCE.aliasForCredentialsIdentifier(credentialsIdentifier);
                 final KeyPair keyPair = DPoPKeyManager.INSTANCE.generateOrLoadKeyPair(alias);
-                final String nonce = DPoPNonceCache.INSTANCE.get(credentialsIdentifier, HttpUrl.get(identityServiceIdUrl).host());
+                final String host = HttpUrl.get(identityServiceIdUrl).host();
+                String nonce = DPoPNonceCache.INSTANCE.get(credentialsIdentifier, host);
+                if (nonce == null) {
+                    // Fallback: use any nonce for this credential. Mirrors iOS latest(forScope:).
+                    // Needed when the identity URL host differs from the token-exchange host
+                    // (e.g. non-My-Domain sandbox: token at test.salesforce.com, identity at instance).
+                    nonce = DPoPNonceCache.INSTANCE.getLatest(credentialsIdentifier);
+                }
                 final String proof = DPoPProofBuilder.INSTANCE.buildProof("GET", htu, keyPair, nonce, authToken);
                 builder.header(DPOP, proof);
             } catch (Exception e) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -655,13 +655,7 @@ public class OAuth2 {
                 final String alias = DPoPKeyManager.INSTANCE.aliasForCredentialsIdentifier(credentialsIdentifier);
                 final KeyPair keyPair = DPoPKeyManager.INSTANCE.generateOrLoadKeyPair(alias);
                 final String host = HttpUrl.get(identityServiceIdUrl).host();
-                String nonce = DPoPNonceCache.INSTANCE.get(credentialsIdentifier, host);
-                if (nonce == null) {
-                    // Fallback: use any nonce for this credential when the identity URL host
-                    // differs from the token-exchange host (e.g. non-My-Domain sandbox: token
-                    // at test.salesforce.com, identity at instance host).
-                    nonce = DPoPNonceCache.INSTANCE.getAny(credentialsIdentifier);
-                }
+                final String nonce = DPoPNonceCache.INSTANCE.get(credentialsIdentifier, host);
                 final String proof = DPoPProofBuilder.INSTANCE.buildProof("GET", htu, keyPair, nonce, authToken);
                 builder.header(DPOP, proof);
             } catch (Exception e) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPNonceCache.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPNonceCache.kt
@@ -48,6 +48,17 @@ object DPoPNonceCache {
     fun get(credentialsIdentifier: String, host: String): String? =
         cache[cacheKey(credentialsIdentifier, host)]
 
+    /**
+     * Returns any cached nonce for the given credentials identifier, regardless of host.
+     *
+     * This mirrors iOS `DPoPNonceCache.latest(forScope:)`. It is used as a fallback when
+     * the per-host lookup misses — for example, when calling the identity endpoint at the
+     * instance URL but the nonce was harvested at the token endpoint on a different host
+     * (e.g. a pool server or a non-My-Domain sandbox login URL).
+     */
+    fun getLatest(credentialsIdentifier: String): String? =
+        cache.entries.firstOrNull { it.key.startsWith("$credentialsIdentifier|") }?.value
+
     fun store(credentialsIdentifier: String, host: String, nonce: String) {
         cache[cacheKey(credentialsIdentifier, host)] = nonce
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPNonceCache.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPNonceCache.kt
@@ -48,16 +48,6 @@ object DPoPNonceCache {
     fun get(credentialsIdentifier: String, host: String): String? =
         cache[cacheKey(credentialsIdentifier, host)]
 
-    /**
-     * Returns any cached nonce for the given credentials identifier, regardless of host.
-     *
-     * Used as a fallback when the per-host lookup misses — for example, when calling the
-     * identity endpoint at the instance URL but the nonce was harvested at the token
-     * endpoint on a different host (e.g. a pool server or a non-My-Domain sandbox login URL).
-     */
-    fun getAny(credentialsIdentifier: String): String? =
-        cache.entries.firstOrNull { it.key.startsWith("$credentialsIdentifier|") }?.value
-
     fun store(credentialsIdentifier: String, host: String, nonce: String) {
         cache[cacheKey(credentialsIdentifier, host)] = nonce
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPNonceCache.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPNonceCache.kt
@@ -51,12 +51,11 @@ object DPoPNonceCache {
     /**
      * Returns any cached nonce for the given credentials identifier, regardless of host.
      *
-     * This mirrors iOS `DPoPNonceCache.latest(forScope:)`. It is used as a fallback when
-     * the per-host lookup misses — for example, when calling the identity endpoint at the
-     * instance URL but the nonce was harvested at the token endpoint on a different host
-     * (e.g. a pool server or a non-My-Domain sandbox login URL).
+     * Used as a fallback when the per-host lookup misses — for example, when calling the
+     * identity endpoint at the instance URL but the nonce was harvested at the token
+     * endpoint on a different host (e.g. a pool server or a non-My-Domain sandbox login URL).
      */
-    fun getLatest(credentialsIdentifier: String): String? =
+    fun getAny(credentialsIdentifier: String): String? =
         cache.entries.firstOrNull { it.key.startsWith("$credentialsIdentifier|") }?.value
 
     fun store(credentialsIdentifier: String, host: String, nonce: String) {

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -69,6 +69,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, server enf
 | `testDowngrade_DPoP_InPlace_ToBearer` | ECA JWT | — | DPoP → Bearer in-place downgrade; session is established on the DPoP-optional ECA via per-call `useDPoP=true` (global flag stays on the whole time); downgrade deletes the obsolete DPoP key pair and nonce cache entry on success |
 | `testECAJwtDPoP_WithRestart` | ECA JWT DPoP | — | DPoP EC key pair survives process restart (AndroidKeyStore) |
 | `testECAJwtDPoP_ViaLoginPoolServer` | ECA JWT DPoP | — | Pool server login with DPoP; `dpop_jkt` accepted; L1 (production) marker in UA |
+| `testECAJwtDPoP_ViaLoginPoolServer_Rtr` | ECA JWT DPoP RTR | — | Pool server + DPoP + RTR; safety net: refresh token must survive the post-login identity fetch (W-23991713) |
 | `testLoginForAdmin_DPoP` | ECA JWT DPoP | — | Login for Admins hand-off to Custom Tab works with DPoP |
 
 #### RTRLoginTests

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -67,7 +67,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, server enf
 | `testLogin_DPoP_ECA_Without_DPoP_Fails` | ECA JWT DPoP | — | Server enforcement: DPoP-enforced ECA rejects login without DPoP (`useDPoP=false`); no account created |
 | `testUpgrade_NonDPoP_InPlace_ToDPoP` | ECA JWT → ECA JWT DPoP | — | Bearer → DPoP in-place upgrade; global `useDPoP` flag remains off; per-call `dpopOverride` triggers upgrade |
 | `testECAJwtDPoP_WithRestart` | ECA JWT DPoP | — | DPoP EC key pair survives process restart (AndroidKeyStore) |
-| `testECAJwtDPoP_ViaLoginPoolServer` | ECA JWT DPoP | — | `@Ignore` (W-23864247 — pool login server rejects valid `dpop_jkt` token exchange) |
+| `testECAJwtDPoP_ViaLoginPoolServer` | ECA JWT DPoP | — | Pool server login with DPoP; `dpop_jkt` accepted; L1 (production) marker in UA |
 | `testLoginForAdmin_DPoP` | ECA JWT DPoP | — | Login for Admins hand-off to Custom Tab works with DPoP |
 
 #### RTRLoginTests

--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -69,7 +69,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, server enf
 | `testDowngrade_DPoP_InPlace_ToBearer` | ECA JWT | — | DPoP → Bearer in-place downgrade; session is established on the DPoP-optional ECA via per-call `useDPoP=true` (global flag stays on the whole time); downgrade deletes the obsolete DPoP key pair and nonce cache entry on success |
 | `testECAJwtDPoP_WithRestart` | ECA JWT DPoP | — | DPoP EC key pair survives process restart (AndroidKeyStore) |
 | `testECAJwtDPoP_ViaLoginPoolServer` | ECA JWT DPoP | — | Pool server login with DPoP; `dpop_jkt` accepted; L1 (production) marker in UA |
-| `testECAJwtDPoP_ViaLoginPoolServer_Rtr` | ECA JWT DPoP RTR | — | Pool server + DPoP + RTR; safety net: refresh token must survive the post-login identity fetch (W-23991713) |
+| `testECAJwtDPoP_ViaLoginPoolServer_Rtr` | ECA JWT DPoP RTR | — | Pool server + DPoP + RTR; safety net: refresh token must survive the post-login identity fetch |
 | `testLoginForAdmin_DPoP` | ECA JWT DPoP | — | Login for Admins hand-off to Custom Tab works with DPoP |
 
 #### RTRLoginTests

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -289,6 +289,24 @@ class DPoPLoginTests : AuthFlowTest() {
         assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isJwt = true, useLoginPoolHost = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
     }
 
+    // Login via the pool server with DPoP + RTR and verify refresh token rotation holds after login.
+    // This is a safety net for the RTR-unsafe credential-refresh pattern seen on iOS: if the
+    // identity fetch were to consume the refresh token (e.g. by triggering a credential refresh
+    // to resolve a Wrong_Org routing error), assertRevokeAndRefreshWorks below would fail because
+    // the refresh token would already be spent. Android's two-attempt URL strategy avoids that by
+    // resolving the routing problem with the still-valid access token, never touching the refresh
+    // token. W-23991713 tracks the equivalent iOS investigation.
+    @Test
+    fun testECAJwtDPoP_ViaLoginPoolServer_Rtr() {
+        loginAndValidate(
+            knownAppConfig = ECA_JWT_DPOP_RTR,
+            useHybridAuthToken = false,
+            useDPoP = true,
+            useLoginPoolHost = true,
+        )
+        assertRevokeAndRefreshWorks(isRtr = true, isDpop = true, isJwt = true, useLoginPoolHost = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
+    }
+
     // endregion
 
     // region DPoP Login for Admins Tests

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -260,14 +260,9 @@ class DPoPLoginTests : AuthFlowTest() {
 
     // region DPoP Pool Server Tests
 
-    // Login via the pool server (login.test1.pc-rnd.salesforce.com) with DPoP enabled
-    // and verify dpop_jkt was accepted and DPoP binding holds after a revoke+refresh.
-    //
-    // Skipped: server-side bug W-23864247 — the pool login server returns
-    // invalid_dpop_proof on the authorization-code token exchange even though the
-    // DPoP proof is cryptographically valid and the JWK thumbprint exactly matches
-    // the dpop_jkt sent in /authorize.  Re-enable when the server fix is confirmed.
-    @Ignore("W-23864247: pool login server rejects valid dpop_jkt token exchange")
+    // Login via the pool server with DPoP enabled and verify dpop_jkt was accepted
+    // and DPoP binding holds after a revoke+refresh. The pool server routes through
+    // production login infrastructure, so the user agent carries L1 (production), not L4.
     @Test
     fun testECAJwtDPoP_ViaLoginPoolServer() {
         loginAndValidate(
@@ -276,7 +271,7 @@ class DPoPLoginTests : AuthFlowTest() {
             useDPoP = true,
             useLoginPoolHost = true,
         )
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isJwt = true)
+        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isJwt = true, useLoginPoolHost = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
     }
 
     // endregion

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -316,7 +316,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         // Wait for the UI to update asynchronously after login or user switch.
         // The view may be recreated and collapsed when the current user state updates.
         try {
-            composeTestRule.waitUntil(TIMEOUT_MS) {
+            composeTestRule.waitUntil(APP_LOAD_TIMEOUT_MS) {
                 try {
                     val nodes = composeTestRule.onAllNodesWithContentDescription(USERNAME).fetchSemanticsNodes()
                     val isVisible = nodes.isNotEmpty()
@@ -338,7 +338,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
                 }
             }
         } catch (e: ComposeTimeoutException) {
-            throw AssertionError("Timed out after ${TIMEOUT_MS}ms waiting for username to show \"${expected.username}\"", e)
+            throw AssertionError("Timed out after ${APP_LOAD_TIMEOUT_MS}ms waiting for username to show \"${expected.username}\"", e)
         }
         assertEquals(expected.username, getText(USERNAME))
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -290,7 +290,13 @@ abstract class AuthFlowTest {
 
         ensureRegularAuthServer(expectCustomTab = forceAdvancedAuthentication, forceAdvancedAuthentication = forceAdvancedAuthentication)
 
-        val needsLoginOptions = !useWebServerFlow || !useHybridAuthToken || useDPoP ||
+        // SDK 14.0 defaults useDPoP=true. On the CA_OPAQUE all-defaults path the Login Options
+        // screen is otherwise skipped, so the OAuth URL built at app startup (with useDPoP=true)
+        // would contain dpop_jkt even for Bearer tests. Opening and dismissing Login Options
+        // triggers loginDevMenuReload, which causes LoginActivity to regenerate the URL with the
+        // current useDPoP=false value before login proceeds.
+        val needsDPoPUrlReset = !useDPoP && knownAppConfig == CA_OPAQUE && scopeSelection == EMPTY
+        val needsLoginOptions = !useWebServerFlow || !useHybridAuthToken || useDPoP || needsDPoPUrlReset ||
                 !forceAdvancedAuthentication || knownAppConfig != CA_OPAQUE ||
                 scopeSelection != EMPTY || useWelcomeDiscovery
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -788,6 +788,7 @@ abstract class AuthFlowTest {
         expectedAMarker: String? = Features.FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         wasMigrated: Boolean = false,
         isJwt: Boolean = false,
+        useLoginPoolHost: Boolean = false,
     ) {
         val (preAccessToken, preRefreshToken) = app.getTokens()
         app.revokeAccessToken()
@@ -811,6 +812,11 @@ abstract class AuthFlowTest {
         } else {
             null
         }
+        val expectedLMarker = if (useLoginPoolHost) {
+            Features.FEATURE_LOGIN_SERVER_PRODUCTION
+        } else {
+            Features.FEATURE_LOGIN_SERVER_MY_DOMAIN
+        }
         app.validateUserAgent(
             knownLoginHostConfig = knownLoginHostConfig,
             expectAdvancedAuth = expectAdvancedAuth,
@@ -818,7 +824,7 @@ abstract class AuthFlowTest {
             isRtr = isRtr,
             isDpop = isDpop,
             expectedBMarker = expectedBMarker,
-            expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN,
+            expectedLMarker = expectedLMarker,
             expectedAMarker = expectedAMarker,
             wasMigrated = wasMigrated,
             isJwt = isJwt,


### PR DESCRIPTION
## Summary

- Re-enables \`testECAJwtDPoP_ViaLoginPoolServer\` (W-23864247 resolved — server now accepts \`dpop_jkt\` from pool-server logins)
- Fixes DPoP identity-fetch URL strategy so all 13 \`DPoPLoginTests\` pass
- Fixes pre-existing \`LegacyLoginTests\` Bearer baseline failure introduced in \`5d974172\`: CA_OPAQUE all-defaults path now opens Login Options to trigger \`loginDevMenuReload\`, regenerating the OAuth URL without \`dpop_jkt\`

## Root cause (DPoP identity fetch)

Salesforce always returns the pool-server host (e.g. \`login.test1.pc-rnd.salesforce.com\`) in the \`id\` field of every token response, regardless of which server actually issued the token. \`idUrlWithInstance\` corrects this by replacing the \`id\` host with the issuing server's host.

For **My Domain logins**, the token was issued by My Domain. The correct identity URL is \`idUrlWithInstance\` (My Domain host).

For **pool-server DPoP logins**, \`idUrlWithInstance\` points to My Domain, which rejects the pool-server-issued DPoP token with \`Bad_OAuth_Token\` — it does not issue a \`401 use_dpop_nonce\` challenge the way data endpoints do. The correct URL is raw \`idUrl\` (pool-server host). Bearer tokens are unaffected: My Domain accepts pool-server-issued Bearer tokens at the identity endpoint regardless.

This server-side inconsistency is tracked in **W-23992239** (Auth Protocols team).

## Fix (DPoP identity fetch)

\`fetchUserIdentityWithRetry\` uses \`LoginServerManager.isPoolServer\` to select the URL upfront — a single call, no retry:

- **DPoP + pool-server login** → raw \`idUrl\` (pool-server identity endpoint accepts its own token)
- **All other cases** → \`idUrlWithInstance\` (My Domain; correct for My Domain logins and all Bearer tokens)

**Why not the iOS approach?** \`SFIdentityCoordinator\` on iOS handles identity 401/403 by triggering a full credential refresh and retrying. That works because the refresh response resets \`credentials.identityUrl\` to the My Domain host as a side effect. But it is RTR-unsafe — it consumes the refresh token unnecessarily to fix a routing error, and the rotated replacement is discarded. The \`isPoolServer\` selection avoids any token refresh entirely.

**Why not a two-attempt retry?** An earlier iteration tried \`idUrlWithInstance\` first and fell back to \`idUrl\`. The \`isPoolServer\` check makes the intent explicit, eliminates the speculative first attempt for pool-server DPoP logins, and is simpler to reason about.

## Additional changes

- **\`DPoPNonceCache.getAny()\` removed**: was a host-agnostic fallback initially added for the identity endpoint. Salesforce only issues \`DPoP-Nonce\` on token-endpoint responses, so the per-host cache is always correctly populated before the identity call. \`getAny()\` was redundant.
- **RTR safety-net test added** (\`testECAJwtDPoP_ViaLoginPoolServer_Rtr\`): verifies that after a pool-server DPoP + RTR login the refresh token is still valid, confirming the identity fetch never touches the refresh token. See W-23991713 for the equivalent iOS investigation.

## Root cause (LegacyLoginTests Bearer baseline)

SDK 14.0 defaults \`useDPoP=true\`. The CA_OPAQUE all-defaults path skipped Login Options, so the OAuth URL built at app startup (with \`dpop_jkt\`) was used for Bearer tests. Opening and dismissing Login Options triggers \`loginDevMenuReload\`, causing \`LoginActivity.onResume\` to regenerate the URL with \`useDPoP=false\`.

## Test results

All 14 AuthFlowTester UI test suites run on emulator (Pixel 9 Pro XL, API 36). **All non-Beacon tests pass.** Beacon tests (\`BEACON_OPAQUE\` / \`BEACON_JWT\`) fail pre-existing across all suites; the same failures are seen on iOS, pointing to an environment or server-side issue with the Beacon app configuration in the test sandbox rather than a code regression.

In \`MultiUserLoginTests\`, 2 non-Beacon tests (\`testFirstDynamic_SecondStatic_DifferentApps\`, \`testMultiUser_revokeOtherUserRefreshToken\`) showed instrumentation crashes when run as part of the full suite after preceding Beacon failures. Both pass when run in isolation.

## Test plan

- [x] All 13 runnable \`DPoPLoginTests\` pass (1 \`@Ignored\` W-22512846 — server-side RTR+JWT blocker)
- [x] \`testECAJwtDPoP_ViaLoginPoolServer\` passes end-to-end (pool-server login with \`dpop_jkt\`, L1 marker, revoke+refresh with DPoP binding)
- [x] \`testECAJwtDPoP_ViaLoginPoolServer_Rtr\` passes (RTR safety net — refresh token survives the identity fetch)
- [x] \`testECAJwtDPoP_Hybrid\` passes (My Domain DPoP — confirms \`idUrlWithInstance\` path)
- [x] All non-Beacon tests pass across all 14 suites
- [x] Beacon failures confirmed pre-existing and cross-platform; the 2 non-Beacon instrumentation crashes in \`MultiUserLoginTests\` pass when run in isolation