### PR TITLE
[Android] NativeLoginManager Basic-Auth header uses URL-safe Base64 instead of standard Base64, breaking login for some username/password combinations

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/NativeLoginManager.kt
@@ -33,9 +33,7 @@ import android.content.pm.PackageManager.FEATURE_FACE
 import android.content.pm.PackageManager.FEATURE_IRIS
 import android.net.Uri
 import android.os.Bundle
-import android.util.Base64.NO_PADDING
 import android.util.Base64.NO_WRAP
-import android.util.Base64.URL_SAFE
 import android.util.Base64.encodeToString
 import android.util.Patterns.EMAIL_ADDRESS
 import androidx.biometric.BiometricManager
@@ -722,7 +720,7 @@ internal class NativeLoginManager(
         value2: String
     ) = encodeToString(
         "$value1:$value2".toByteArray(),
-        URL_SAFE or NO_WRAP or NO_PADDING
+        NO_WRAP
     )
 
     /**

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
@@ -470,7 +470,7 @@ class NativeLoginManagerTest {
         verifyLoginRequestAuthorizationHeader(restClient, "Basic $expectedCreds")
     }
 
-    // region Helpers used by attestation tests
+    // region Helpers used by attestation and Authorization-header tests
 
     /**
      * Verifies that the REST client received a login request with the expected
@@ -505,7 +505,8 @@ class NativeLoginManagerTest {
      * `Authorization` header matches the expected value.
      *
      * @param restClient The REST client mock to verify
-     * @param expectedAuthorizationHeader The expected `Authorization` header value
+     * @param expectedAuthorizationHeader The expected `Authorization` header
+     * value
      */
     private fun verifyLoginRequestAuthorizationHeader(
         restClient: RestClient,
@@ -560,7 +561,7 @@ class NativeLoginManagerTest {
             restClient = restClient,
         )
 
-    // endregion Helpers used by attestation tests
+    // endregion Helpers used by attestation and Authorization-header tests
 
     private fun addUserAccount() {
         UserAccountManager.getInstance().createAccount(UserAccountTest.createTestAccount())

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
@@ -14,6 +14,7 @@ import com.salesforce.androidsdk.accounts.UserAccountManager
 import com.salesforce.androidsdk.accounts.UserAccountTest
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.auth.OAuth2.OAUTH_AUTH_PATH
+import com.salesforce.androidsdk.auth.interfaces.OtpVerificationMethod
 import com.salesforce.androidsdk.rest.ClientManager
 import com.salesforce.androidsdk.rest.RestClient
 import com.salesforce.androidsdk.rest.RestClient.OAuthRefreshInterceptor
@@ -419,6 +420,56 @@ class NativeLoginManagerTest {
         verifyLoginRequestAttestation(restClient, expectedAttestationValue = null)
     }
 
+    /**
+     * Tests that [NativeLoginManager.login] builds the Basic-Auth
+     * `Authorization` header using the standard Base64 alphabet with padding
+     * (RFC 4648 §4, as required by RFC 7617), rather than the URL-safe
+     * alphabet.  The password below is chosen so that the colon-concatenated,
+     * UTF-8-encoded username:password bytes Base64-encode differently under
+     * the standard and URL-safe alphabets (contains `/` and requires `=`
+     * padding under the standard alphabet), so a regression back to
+     * URL-safe encoding would be caught.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun nativeLoginManager_login_usesStandardBase64ForAuthorizationHeader() = runTest {
+        val restClient = createRestClientStubbingFailedLoginResponse()
+        mgr = createNativeLoginManagerForTest(restClient = restClient)
+
+        mgr.login(TEST_DIVERGING_USERNAME, TEST_DIVERGING_PASSWORD)
+        advanceUntilIdle()
+
+        val expectedCreds = java.util.Base64.getEncoder().encodeToString(
+            "$TEST_DIVERGING_USERNAME:$TEST_DIVERGING_PASSWORD".toByteArray()
+        )
+        verifyLoginRequestAuthorizationHeader(restClient, "Basic $expectedCreds")
+    }
+
+    /**
+     * Tests that [NativeLoginManager.submitPasswordlessAuthorizationRequest],
+     * which shares the same colon-concatenated Base64 encoding helper as
+     * [NativeLoginManager.login], also produces a standard-alphabet,
+     * padded Basic-Auth header rather than URL-safe encoding.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun nativeLoginManager_submitPasswordlessAuthorizationRequest_usesStandardBase64ForAuthorizationHeader() = runTest {
+        val restClient = createRestClientStubbingFailedLoginResponse()
+        mgr = createNativeLoginManagerForTest(restClient = restClient)
+
+        mgr.submitPasswordlessAuthorizationRequest(
+            otp = TEST_DIVERGING_PASSWORD,
+            otpIdentifier = TEST_DIVERGING_USERNAME,
+            otpVerificationMethod = OtpVerificationMethod.Email
+        )
+        advanceUntilIdle()
+
+        val expectedCreds = java.util.Base64.getEncoder().encodeToString(
+            "$TEST_DIVERGING_USERNAME:$TEST_DIVERGING_PASSWORD".toByteArray()
+        )
+        verifyLoginRequestAuthorizationHeader(restClient, "Basic $expectedCreds")
+    }
+
     // region Helpers used by attestation tests
 
     /**
@@ -445,6 +496,24 @@ class NativeLoginManagerTest {
                     !bodyString.contains("attestation=")
                 }
                 pathMatches && attestationMatches
+            }, any())
+        }
+    }
+
+    /**
+     * Verifies that the REST client received a login request whose
+     * `Authorization` header matches the expected value.
+     *
+     * @param restClient The REST client mock to verify
+     * @param expectedAuthorizationHeader The expected `Authorization` header value
+     */
+    private fun verifyLoginRequestAuthorizationHeader(
+        restClient: RestClient,
+        expectedAuthorizationHeader: String
+    ) {
+        verify(exactly = 1) {
+            restClient.sendAsync(match {
+                it.additionalHttpHeaders?.get("Authorization") == expectedAuthorizationHeader
             }, any())
         }
     }
@@ -513,5 +582,14 @@ class NativeLoginManagerTest {
         const val TEST_PASSWORD = "test123456"
         const val TEST_CHALLENGE_VALUE = "__TEST_CHALLENGE_VALUE__"
         const val TEST_APP_ATTESTATION = "__TEST_APP_ATTESTATION__"
+
+        /**
+         * A username/password pair whose colon-concatenated, UTF-8-encoded
+         * bytes Base64-encode to a value containing `/` and requiring `=`
+         * padding under the standard alphabet, diverging from the URL-safe
+         * alphabet's output for the same bytes.
+         */
+        const val TEST_DIVERGING_USERNAME = "regdemouser501@salesforce.com"
+        const val TEST_DIVERGING_PASSWORD = "Winter2026!?!"
     }
 }


### PR DESCRIPTION
## Summary

`NativeLoginManager`'s helper for building the Basic-Auth `Authorization` header encoded the colon-concatenated username and password with Android's URL-safe Base64 alphabet and no padding. HTTP Basic Authentication (RFC 7617) requires the standard Base64 alphabet with padding. For most credential pairs the two alphabets produce identical output, which is why this went unnoticed — they only diverge when the encoded bytes would contain `+`, `/`, or need `=` padding under the standard alphabet. When that happens, the org's edge rejects the malformed header with a generic error page instead of a normal OAuth error, making the failure look like an infra issue rather than a client-side encoding bug.

- Changed `generateColonConcatenatedBase64String()` to encode with the standard Base64 alphabet (`NO_WRAP` only, dropping `URL_SAFE` and `NO_PADDING`).
- This helper is shared by both `login()` (username/password) and `submitAuthorizationRequest()` (used by the OTP/passwordless flows), so both call sites are fixed by the one change.
- Removed the now-unused `URL_SAFE`/`NO_PADDING` imports.

## Scope note

This does not touch the other `URL_SAFE` usages elsewhere in the SDK (`SalesforceKeyGenerator`, `DPoPProofBuilder`) — those encode DPoP proofs / SHA-256 hashes / code verifiers, which correctly use URL-safe Base64 per their own specs and are unrelated to this HTTP Basic-Auth header.

## Test plan

- [x] Added a regression test covering `login()`, using a username/password pair whose combined UTF-8 bytes diverge between the standard and URL-safe alphabets (contains `/` and requires `=` padding under the standard alphabet); asserts the `Authorization` header matches standard Base64 output.
- [x] Added a regression test covering `submitPasswordlessAuthorizationRequest()` (the OTP/passwordless call site sharing the same helper), same divergent credential pair.
- [x] Ran `NativeLoginManagerTest` on a connected emulator — 23/23 passed, including both new tests.
- [x] Confirmed `SalesforceKeyGenerator.java` and `DPoPProofBuilder.kt`'s `URL_SAFE` usages are unmodified.

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*