### PR TITLE
fix(AuthFlowTester): fix beacon app tests — missing intent filters and isRtr (W-23971480)

### DIFF
--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/AdvancedAuthBeaconLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/AdvancedAuthBeaconLoginTests.kt
@@ -37,9 +37,9 @@ import org.junit.runner.RunWith
  * This class runs the same tests as BeaconLoginTests but uses the advanced_auth login host
  * with Chrome Custom Tabs instead of the in-app WebView.
  *
- * NB: Requires intent filters in AndroidManifest.xml matching the beacon redirect URIs:
- * - beaconadvancedopaque://success/done (for Beacon Opaque)
- * - beaconadvancedjwt://success/done (for Beacon JWT)
+ * NB: Requires intent filters in AndroidManifest.xml for the beacon redirect URIs
+ * (beaconopaque://success/done and beaconjwt://success/done) — same URIs as BeaconLoginTests
+ * since both classes use forceAdvancedAuthentication=true (Custom Tabs) by default.
  *
  * NB: Tests use the second user from ui_test_config.json (advanced_auth host) to avoid
  * login conflicts when running in parallel with regular auth tests.

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
@@ -123,7 +123,8 @@ data class AppConfig(
 ) {
     val issuesJwt = name.contains("_jwt")
     val isBeacon = name.startsWith("beacon_")
-    val isRtr = name.contains("_rtr")
+    // W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed
+    val isRtr = name.contains("_rtr") || name.startsWith("beacon_")
     val isDpop = name.contains("_dpop")
     val expectedTokenFormat = if (issuesJwt) "jwt" else "Opaque"
     val scopeList = scopes.split(" ")

--- a/native/NativeSampleApps/AuthFlowTester/src/main/AndroidManifest.xml
+++ b/native/NativeSampleApps/AuthFlowTester/src/main/AndroidManifest.xml
@@ -33,9 +33,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
-            <!-- Intent filter for advanced authentication with Beacon Opaque app -->
+            <!-- Intent filter for Beacon Opaque app -->
             <intent-filter>
-                <data android:scheme="beaconadvancedopaque"
+                <data android:scheme="beaconopaque"
                     android:host="success"
                     android:path="/done" />
                 <action android:name="android.intent.action.VIEW" />
@@ -43,9 +43,9 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
-            <!-- Intent filter for advanced authentication with Beacon JWT app -->
+            <!-- Intent filter for Beacon JWT app -->
             <intent-filter>
-                <data android:scheme="beaconadvancedjwt"
+                <data android:scheme="beaconjwt"
                     android:host="success"
                     android:path="/done" />
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
## Summary

- **Add missing `AndroidManifest.xml` intent filters** for `beaconjwt://success/done` and `beaconopaque://success/done`. Without these, Chrome Custom Tab OAuth redirects for standard beacon logins were silently dropped — the app never received the callback, causing all `BeaconLoginTests` to time out.
- **Update `isRtr` in `UITestConfig.kt`** to treat `beacon_` apps as RTR: `name.contains("_rtr") || name.startsWith("beacon_")`. This is needed due to a server-side bug (W-23971480) where beacon apps rotate the refresh token even though their name does not contain `"_rtr"`. The `beacon_` clause should be dropped once W-23971480 is fixed on the server side.

## Server-side bug

W-23971480 tracks a server bug where beacon apps behave like RTR (refresh token rotation is applied) despite the app config name not containing `"_rtr"`. Until that is fixed, the test infrastructure needs to know that beacon apps rotate their refresh token so that `assertRevokeAndRefreshWorks` passes correctly.

## Tests run locally

All beacon test suites passed locally on Pixel 9 Pro XL (AVD) API 16:

| Suite | Result |
|-------|--------|
| `BeaconLoginTests` (6 tests) | All passed |
| `AdvancedAuthBeaconLoginTests` (6 tests) | All passed |


## Re-created beacon apps on sdb38
That's the reason for the new intents.
The environment had been reset a while back. Updated UI_TEST_CONFIG secret.