### PR TITLE
[Android] Fail fast when CCT callback URI scheme is missing from AndroidManifest

### DIFF
--- a/libs/SalesforceSDK/res/values/sf__strings.xml
+++ b/libs/SalesforceSDK/res/values/sf__strings.xml
@@ -142,4 +142,8 @@
     <string name="sf__login_options_discovery_login_host_field_content_description" translatable="false">Discovery Login Host Field</string>
     <string name="sf__login_options_discovery_username_field_content_description" translatable="false">Discovery Username Field</string>
     <string name="sf__login_options_discovery_save_button_content_description" translatable="false">Save Simulated Result Button</string>
+
+    <!-- Advanced auth manifest misconfiguration alert (debug builds only) -->
+    <string name="sf__advanced_auth_manifest_error_title">Advanced Auth Setup Error</string>
+    <string name="sf__advanced_auth_manifest_error_message">The redirect URI scheme \'%1$s\' is not registered in this app\'s AndroidManifest.xml.\n\nAdd an intent-filter with scheme \'%1$s\' to LoginActivity to complete the advanced auth flow.</string>
 </resources>

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -35,8 +35,12 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+import android.app.AlertDialog
+import android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE
+import android.content.pm.PackageManager
 import android.content.pm.PackageManager.FEATURE_FACE
 import android.content.pm.PackageManager.FEATURE_IRIS
+import android.content.pm.PackageManager.MATCH_DEFAULT_ONLY
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory.decodeResource
 import android.net.Uri
@@ -109,6 +113,8 @@ import androidx.lifecycle.Observer
 import com.salesforce.androidsdk.R.color.sf__background
 import com.salesforce.androidsdk.R.color.sf__background_dark
 import com.salesforce.androidsdk.R.drawable.sf__action_back
+import com.salesforce.androidsdk.R.string.sf__advanced_auth_manifest_error_message
+import com.salesforce.androidsdk.R.string.sf__advanced_auth_manifest_error_title
 import com.salesforce.androidsdk.R.string.cannot_use_another_apps_login_qr_code
 import com.salesforce.androidsdk.R.string.sf__app_blocked_error
 import com.salesforce.androidsdk.R.string.sf__biometric_opt_in_title
@@ -1176,6 +1182,22 @@ open class LoginActivity : FragmentActivity() {
 
         val urlString = buildCustomTabAuthorizeUrl(loginUrl, completedViaAdminCustomTab)
 
+        if (!isCallbackSchemeRegistered(viewModel.oAuthConfig.redirectUri)) {
+            val scheme = Uri.parse(viewModel.oAuthConfig.redirectUri).scheme
+                ?: viewModel.oAuthConfig.redirectUri
+            e(TAG, "Advanced auth misconfiguration: redirect URI scheme '$scheme' has no " +
+                    "matching intent-filter in this app's AndroidManifest.xml. " +
+                    "Add an intent-filter with scheme '$scheme' to LoginActivity.")
+            if (applicationInfo.flags and FLAG_DEBUGGABLE != 0) {
+                AlertDialog.Builder(this@LoginActivity)
+                    .setTitle(sf__advanced_auth_manifest_error_title)
+                    .setMessage(getString(sf__advanced_auth_manifest_error_message, scheme))
+                    .setPositiveButton(android.R.string.ok) { _, _ -> }
+                    .show()
+            }
+            return
+        }
+
         runCatching {
             customTabsIntent.intent.setData(urlString.toUri())
             customTabLauncher.launch(customTabsIntent.intent)
@@ -1221,6 +1243,23 @@ open class LoginActivity : FragmentActivity() {
                 w(TAG, "$customTabBrowser does not exist on this device", throwable)
             }.getOrDefault(false)
         }
+
+    /**
+     * Returns true if the app's manifest contains an intent-filter that handles [redirectUri],
+     * false otherwise.  A missing registration causes the CCT redirect to be silently dropped by
+     * Android, leaving the user on a blank screen at the end of the advanced-auth flow.
+     */
+    @VisibleForTesting
+    @Suppress("DEPRECATION")
+    internal fun isCallbackSchemeRegistered(redirectUri: String): Boolean {
+        val probeIntent = Intent(Intent.ACTION_VIEW, Uri.parse(redirectUri)).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+        return packageManager
+            ?.queryIntentActivities(probeIntent, MATCH_DEFAULT_ONLY)
+            .isNullOrEmpty()
+            .not()
+    }
 
     // endregion
     // region Log In Via Salesforce Identity API UI Bridge Front Door URL Private Implementation

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -1183,7 +1183,7 @@ open class LoginActivity : FragmentActivity() {
         val urlString = buildCustomTabAuthorizeUrl(loginUrl, completedViaAdminCustomTab)
 
         if (!isCallbackSchemeRegistered(viewModel.oAuthConfig.redirectUri)) {
-            val scheme = Uri.parse(viewModel.oAuthConfig.redirectUri).scheme
+            val scheme = viewModel.oAuthConfig.redirectUri.toUri().scheme
                 ?: viewModel.oAuthConfig.redirectUri
             e(TAG, "Advanced auth misconfiguration: redirect URI scheme '$scheme' has no " +
                     "matching intent-filter in this app's AndroidManifest.xml. " +
@@ -1252,8 +1252,9 @@ open class LoginActivity : FragmentActivity() {
     @VisibleForTesting
     @Suppress("DEPRECATION")
     internal fun isCallbackSchemeRegistered(redirectUri: String): Boolean {
-        val probeIntent = Intent(Intent.ACTION_VIEW, Uri.parse(redirectUri)).apply {
+        val probeIntent = Intent(Intent.ACTION_VIEW, redirectUri.toUri()).apply {
             addCategory(Intent.CATEGORY_BROWSABLE)
+            setPackage(packageName)  // scope to this app; avoids <queries> requirement
         }
         return packageManager
             ?.queryIntentActivities(probeIntent, MATCH_DEFAULT_ONLY)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -1246,8 +1246,8 @@ open class LoginActivity : FragmentActivity() {
 
     /**
      * Returns true if the app's manifest contains an intent-filter that handles [redirectUri],
-     * false otherwise.  A missing registration causes the CCT redirect to be silently dropped by
-     * Android, leaving the user on a blank screen at the end of the advanced-auth flow.
+     * false otherwise.  A missing registration causes the custom tab redirect to be silently
+     * dropped by Android, leaving the user on a blank screen at the end of the advanced-auth flow.
      */
     @VisibleForTesting
     @Suppress("DEPRECATION")

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityTest.kt
@@ -31,6 +31,7 @@ import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.activity.result.ActivityResult
 import androidx.biometric.BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
@@ -1240,6 +1241,34 @@ class LoginActivityTest {
             // And Advanced Auth is shown immediately.
             verify(exactly = 1) { activity.onBiometricPromptDismissedWithoutSuccess() }
         }
+    }
+
+    // endregion
+
+    // region isCallbackSchemeRegistered
+
+    @Test
+    fun test_givenRegisteredScheme_whenIsCallbackSchemeRegistered_thenReturnsTrue() {
+        val pm = mockk<PackageManager>()
+        @Suppress("DEPRECATION")
+        every { pm.queryIntentActivities(any(), any<Int>()) } returns listOf(mockk())
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.packageManager } returns pm
+        every { activity.isCallbackSchemeRegistered(any()) } answers { callOriginal() }
+
+        assertTrue(activity.isCallbackSchemeRegistered("testsfdc://success/done"))
+    }
+
+    @Test
+    fun test_givenUnregisteredScheme_whenIsCallbackSchemeRegistered_thenReturnsFalse() {
+        val pm = mockk<PackageManager>()
+        @Suppress("DEPRECATION")
+        every { pm.queryIntentActivities(any(), any<Int>()) } returns emptyList()
+        val activity = mockk<LoginActivity>(relaxed = true)
+        every { activity.packageManager } returns pm
+        every { activity.isCallbackSchemeRegistered(any()) } answers { callOriginal() }
+
+        assertFalse(activity.isCallbackSchemeRegistered("unregistered://callback/path"))
     }
 
     // endregion


### PR DESCRIPTION
## Summary

- Adds a `isCallbackSchemeRegistered()` preflight check in `LoginActivity.loadLoginPageInCustomTab()` that probes `PackageManager` for a matching intent-filter before launching the Chrome Custom Tab (CCT).
- When the redirect URI scheme is unregistered: logs an ERROR naming the missing scheme; in debug builds shows a localizable `AlertDialog` with remediation instructions and aborts the CCT launch cleanly.
- Adds two localizable strings to `sf__strings.xml` (`sf__advanced_auth_manifest_error_title`, `sf__advanced_auth_manifest_error_message`).
- Two new instrumented unit tests in `LoginActivityTest` verify the registered and unregistered cases.

Fixes the silent blank-screen hang that occurs when an app enables advanced auth but omits the callback URI `<intent-filter>` from its `AndroidManifest.xml`.

GUS: W-24000206

## Test plan

- [ ] `./gradlew :libs:SalesforceSDK:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.salesforce.androidsdk.ui.LoginActivityTest#test_givenRegisteredScheme_whenIsCallbackSchemeRegistered_thenReturnsTrue` passes
- [ ] `./gradlew :libs:SalesforceSDK:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.salesforce.androidsdk.ui.LoginActivityTest#test_givenUnregisteredScheme_whenIsCallbackSchemeRegistered_thenReturnsFalse` passes
- [ ] In a debug build with an app that has no CCT callback intent-filter, starting the login flow shows the AlertDialog before any CCT is opened
- [ ] In the same scenario, logcat shows the ERROR line naming the missing scheme
- [ ] Apps that already have the correct intent-filter registered see no change in behavior (happy path)