### PR TITLE
Deprecate useWebServerAuthentication (OAuth user agent flow)

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/app/SalesforceSDKManager.kt
@@ -513,13 +513,25 @@ open class SalesforceSDKManager protected constructor(
     @set:Synchronized
     var customTabBrowser: String? = "com.android.chrome"
 
+    // Backing field for [useWebServerAuthentication].  The SDK reads this directly so its own
+    // internal use of the flag doesn't trigger the deprecation warning on the public property.
+    @Volatile
+    private var _useWebServerAuthentication = true
+
     /**
      * Optionally enables the web server flow for web view log on.  Defaults to
      * true
      */
+    @Deprecated("The OAuth user agent flow is being retired; the web server flow will be used for " +
+            "WebView login going forward. This flag will be removed in 15.0, or sooner if the server " +
+            "no longer supports the user agent flow.")
     @get:JvmName("shouldUseWebServerAuthentication")
     @set:Synchronized
-    var useWebServerAuthentication = true
+    var useWebServerAuthentication: Boolean
+        get() = _useWebServerAuthentication
+        set(value) {
+            _useWebServerAuthentication = value
+        }
 
     /**
      * Optionally, enables the hybrid authentication flow.  Defaults to true
@@ -1775,7 +1787,7 @@ open class SalesforceSDKManager protected constructor(
                 "Authenticated Users" to (userList ?: "None"),
             )
             val authConfig = listOf(
-                "Use Web Server Authentication" to "$useWebServerAuthentication",
+                "Use Web Server Authentication" to "$_useWebServerAuthentication",
                 "Use Hybrid Authentication Token" to "$useHybridAuthentication",
                 "Force Advanced Authentication" to "$_forceAdvancedAuthentication",
                 "My Domain Browser Login Enabled" to "$isBrowserLoginEnabled",

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginOptionsActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginOptionsActivity.kt
@@ -93,6 +93,9 @@ import com.salesforce.androidsdk.ui.theme.hintTextColor
 import com.salesforce.androidsdk.util.test.ExcludeFromJacocoGeneratedReport
 
 class LoginOptionsActivity: ComponentActivity() {
+    // This dev-menu toggle is the intended consumer of the deprecated web-server-auth flag, so
+    // suppress the deprecation nudge here (it fires on the public property from outside the SDK).
+    @Suppress("DEPRECATION")
     val useWebServer = MutableLiveData(SalesforceSDKManager.getInstance().useWebServerAuthentication)
     val useHybridToken = MutableLiveData(SalesforceSDKManager.getInstance().useHybridAuthentication)
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginViewModel.kt
@@ -256,6 +256,7 @@ open class LoginViewModel(
      * @return True if Web Server Flow is enabled, false if User-Agent Flow is
      * enabled.
      */
+    @Suppress("DEPRECATION") // Reads the deprecated useWebServerAuthentication flag until it is removed in 15.0.
     internal fun useWebServerFlow(
         sdkManager: SalesforceSDKManager = SalesforceSDKManager.getInstance(),
     ): Boolean = with(sdkManager) {
@@ -408,7 +409,9 @@ open class LoginViewModel(
             selectedServer.value?.let { server ->
                 // The Web Server Flow code challenge makes the authorization url unique each time,
                 // which triggers recomposition.  For User Agent Flow, change it to blank.
-                if (!SalesforceSDKManager.getInstance().useWebServerAuthentication) {
+                @Suppress("DEPRECATION") // Reads the deprecated useWebServerAuthentication flag until it is removed in 15.0.
+                val useWebServer = SalesforceSDKManager.getInstance().useWebServerAuthentication
+                if (!useWebServer) {
                     loginUrl.value = ABOUT_BLANK
                 }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/LoginViewModelTest.kt
@@ -213,7 +213,7 @@ class LoginViewModelTest {
     }
 
     @Test
-    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication and useWebServerAuthentication flags.
     fun browserCustomTabUrl_UsesWebServerFlow_EvenWhenUserAgentFlowIsActive() {
         viewModel.browserCustomTabUrl.observeForever { }
         viewModel.loginUrl.observeForever { }
@@ -270,7 +270,7 @@ class LoginViewModelTest {
     }
 
     @Test
-    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication and useWebServerAuthentication flags.
     fun browserCustomTabUrl_UsesWebServerFlow_WhenForceFlagOnAndWebServerAuthDisabled() {
         viewModel.browserCustomTabUrl.observeForever { }
         viewModel.loginUrl.observeForever { }
@@ -953,6 +953,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun generateAuthorizationUrl_ReleaseBuildIgnoresDebugOverrideAppConfig_OverAppConfigForLoginHost() {
         val sdkManagerMock = mockk<SalesforceSDKManager>(relaxed = false)
         val appConfigConsumerKey = "app_config_key_should_not_be_used"
@@ -1310,6 +1311,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun reloadWebView_WithUserAgentFlow_SetsAboutBlankFirst() {
         try {
             // Set to User Agent Flow (not Web Server Flow)
@@ -1344,6 +1346,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun reloadWebView_WithWebServerFlow_DoesNotSetAboutBlank() {
         assert(SalesforceSDKManager.getInstance().useWebServerAuthentication)
         // Ensure we're not using front door bridge
@@ -1423,6 +1426,7 @@ class LoginViewModelTest {
     // region useWebServerFlow Tests
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun useWebServerFlow_ReturnsTrue_WhenAppAttestationClientIsNotNull() {
         val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
         every { sdkManager.appAttestationClient } returns mockk()
@@ -1434,6 +1438,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun useWebServerFlow_ReturnsFalse_WhenNoAttestationAndWebServerAuthDisabled() {
         val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
         every { sdkManager.appAttestationClient } returns null
@@ -1445,6 +1450,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun useWebServerFlow_ReturnsTrue_WhenUseWebServerAuthenticationIsTrue() {
         val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
         every { sdkManager.useWebServerAuthentication } returns true
@@ -1456,6 +1462,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun useWebServerFlow_ReturnsTrue_WhenBrowserLoginIsEnabled() {
         val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
         every { sdkManager.useWebServerAuthentication } returns false
@@ -1467,6 +1474,7 @@ class LoginViewModelTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun useWebServerFlow_ReturnsTrue_WhenSingleServerCustomTabActivity() {
         val sdkManager = mockk<SalesforceSDKManager>(relaxed = true)
         every { sdkManager.useWebServerAuthentication } returns false

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityScenarioTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginActivityScenarioTest.kt
@@ -229,7 +229,7 @@ class LoginActivityScenarioTest {
     }
 
     @Test
-    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication and useWebServerAuthentication flags.
     fun loginActivity_ReloadsWebview_OnResumeWithLoginOptionChanges() {
         // This test drives the in-app WebView reload path, which only exists when advanced
         // authentication is NOT forced.  With the force flag on (the default) the login server's

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginOptionsActivityTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/ui/LoginOptionsActivityTest.kt
@@ -88,7 +88,7 @@ class LoginOptionsActivityTest {
     private lateinit var saveButton: SemanticsNodeInteraction
 
     @Before
-    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication and useWebServerAuthentication flags.
     fun setup() {
         // Save original values
         originalUseWebServer = SalesforceSDKManager.getInstance().useWebServerAuthentication
@@ -123,7 +123,7 @@ class LoginOptionsActivityTest {
     }
 
     @After
-    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication flag.
+    @Suppress("DEPRECATION") // Exercises the deprecated forceAdvancedAuthentication and useWebServerAuthentication flags.
     fun teardown() {
         // Restore original values
         SalesforceSDKManager.getInstance().useWebServerAuthentication = originalUseWebServer
@@ -148,6 +148,7 @@ class LoginOptionsActivityTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun loginOptionsActivity_WebServerFlowToggle_UpdatesSdkManager() {
         // Set initial state via the activity's LiveData
         composeTestRule.activity.runOnUiThread {
@@ -223,6 +224,7 @@ class LoginOptionsActivityTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun loginOptionsActivity_InitialToggleStates_ReflectSdkManagerValues() {
         // Set known states via the activity's LiveData
         composeTestRule.activity.runOnUiThread {
@@ -330,6 +332,7 @@ class LoginOptionsActivityTest {
     }
 
     @Test
+    @Suppress("DEPRECATION") // Exercises the deprecated useWebServerAuthentication flag.
     fun loginOptionsActivity_MultipleToggles_WorkIndependently() {
         // Set initial states
         composeTestRule.activity.runOnUiThread {


### PR DESCRIPTION
Deprecates `useWebServerAuthentication` on `SalesforceSDKManager` (14.0, for removal in 15.0). The OAuth user agent flow is being retired; the web server flow will be used for WebView login going forward. The flag will be removed in 15.0, or sooner if the server no longer supports the user agent flow.

- Public property annotated `@Deprecated`; backed by a `@Volatile private var _useWebServerAuthentication` field.
- Internal SDK code reads the backing field directly; the two dev-menu/login consumers use a localized `@Suppress("DEPRECATION")` so no internal usage trips a deprecation warning.
- Tests annotated `@Suppress("DEPRECATION")` with explanatory comments to stay warning-free.