### PR TITLE
fix(dpop): retry resource-server 400 use_dpop_nonce once

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecorator.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecorator.kt
@@ -63,6 +63,17 @@ object DPoPRequestDecorator {
     }
 
     /**
+     * Stores [DPOP_NONCE_HEADER] from [response] in [DPoPNonceCache] when present.
+     * No-op if the header, [credentialsIdentifier], or [host] is missing or empty.
+     */
+    fun harvestNonce(response: Response, credentialsIdentifier: String?, host: String?) {
+        if (credentialsIdentifier.isNullOrEmpty() || host.isNullOrEmpty()) return
+        val nonce = response.header(DPOP_NONCE_HEADER) ?: return
+        if (nonce.isEmpty()) return
+        DPoPNonceCache.store(credentialsIdentifier, host, nonce)
+    }
+
+    /**
      * Returns true if [response] is a DPoP nonce challenge per RFC 9449 §8:
      * - 400 with body containing `error=use_dpop_nonce`
      * - 401 with a non-empty `DPoP-Nonce` response header

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -835,6 +835,18 @@ public class RestClient {
             request = buildAuthenticatedRequest(request);
             Response response = chain.proceed(request);
 
+            // Cold nonce cache (e.g. after process restart): resource server may return
+            // HTTP 400 use_dpop_nonce. Harvest once and rebuild the proof. Do not treat
+            // 401 as a nonce retry — that remains the token-refresh path.
+            if (credentialsIdentifier != null && !credentialsIdentifier.isEmpty()
+                    && response.code() == HttpURLConnection.HTTP_BAD_REQUEST
+                    && DPoPRequestDecorator.INSTANCE.isNonceChallenge(response)) {
+                DPoPRequestDecorator.INSTANCE.harvestNonce(response, credentialsIdentifier, request.url().host());
+                response.close();
+                request = buildAuthenticatedRequest(request);
+                response = chain.proceed(request);
+            }
+
             /*
              * Standard access token expiry returns 401 as the error code.
              */

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/rest/RestClient.java
@@ -839,6 +839,7 @@ public class RestClient {
             // HTTP 400 use_dpop_nonce. Harvest once and rebuild the proof. Do not treat
             // 401 as a nonce retry — that remains the token-refresh path.
             if (credentialsIdentifier != null && !credentialsIdentifier.isEmpty()
+                    && request.header("DPoP") != null
                     && response.code() == HttpURLConnection.HTTP_BAD_REQUEST
                     && DPoPRequestDecorator.INSTANCE.isNonceChallenge(response)) {
                 DPoPRequestDecorator.INSTANCE.harvestNonce(response, credentialsIdentifier, request.url().host());

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecoratorTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecoratorTest.kt
@@ -202,4 +202,45 @@ class DPoPRequestDecoratorTest {
     fun isNonceChallenge_401_noNonceHeader_returnsFalse() {
         assertFalse(DPoPRequestDecorator.isNonceChallenge(response(401, "{}")))
     }
+
+    @Test
+    fun harvestNonce_headerPresent_storesInCache() {
+        DPoPNonceCache.clearAll()
+        try {
+            DPoPRequestDecorator.harvestNonce(
+                response(400, """{"error":"use_dpop_nonce"}""", dpopNonce = "harvested-nonce"),
+                testScope,
+                "test.salesforce.com",
+            )
+            assertEquals("harvested-nonce", DPoPNonceCache.get(testScope, "test.salesforce.com"))
+        } finally {
+            DPoPNonceCache.clearAll()
+        }
+    }
+
+    @Test
+    fun harvestNonce_missingHeader_isNoOp() {
+        DPoPNonceCache.clearAll()
+        try {
+            DPoPRequestDecorator.harvestNonce(response(400, "{}"), testScope, "test.salesforce.com")
+            assertNull(DPoPNonceCache.get(testScope, "test.salesforce.com"))
+        } finally {
+            DPoPNonceCache.clearAll()
+        }
+    }
+
+    @Test
+    fun harvestNonce_nullCredentialsIdentifier_isNoOp() {
+        DPoPNonceCache.clearAll()
+        try {
+            DPoPRequestDecorator.harvestNonce(
+                response(400, "{}", dpopNonce = "n"),
+                null,
+                "test.salesforce.com",
+            )
+            assertNull(DPoPNonceCache.get(testScope, "test.salesforce.com"))
+        } finally {
+            DPoPNonceCache.clearAll()
+        }
+    }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/OAuthRefreshInterceptorNonceTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/OAuthRefreshInterceptorNonceTest.kt
@@ -220,6 +220,38 @@ class OAuthRefreshInterceptorNonceTest {
         assertNull(DPoPNonceCache.get(credentialsId, instanceHost))
     }
 
+    /**
+     * Bearer session receives 400 use_dpop_nonce. The nonce retry guard requires
+     * request.header("DPoP") != null — Bearer requests carry no DPoP header, so
+     * the harvest+retry branch must not fire.
+     */
+    @Test
+    fun test_givenBearerTokenType_when400UseDpopNonce_thenNoHarvestAndNoRetry() {
+        val request = buildRequest()
+        val interceptor = buildInterceptor(tokenType = "Bearer")
+        var callCount = 0
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } answers {
+                callCount++
+                Response.Builder()
+                    .request(firstArg())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(400)
+                    .message("Bad Request")
+                    .header("DPoP-Nonce", "should-not-be-harvested")
+                    .body("""{"error":"use_dpop_nonce"}""".toResponseBody("application/json".toMediaType()))
+                    .build()
+            }
+        }
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(1, callCount)
+        assertEquals(400, response.code)
+        assertNull(DPoPNonceCache.get(credentialsId, instanceHost))
+    }
+
     private fun nonceChallengeResponse(request: Request, nonce: String): Response =
         Response.Builder()
             .request(request)

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/OAuthRefreshInterceptorNonceTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/rest/OAuthRefreshInterceptorNonceTest.kt
@@ -53,10 +53,9 @@ import java.net.URI
 /**
  * Tests for DPoP nonce handling in OAuthRefreshInterceptor.
  *
- * Nonces are issued exclusively by the /token endpoint (during token exchange and refresh)
- * and cached by OAuth2.java. The interceptor's role is limited to proactively reading
- * the cached nonce when building each DPoP proof — it does not harvest nonces from
- * resource-server responses and does not retry on use_dpop_nonce challenges.
+ * The interceptor proactively includes a cached nonce in each DPoP proof. On HTTP 400
+ * use_dpop_nonce it harvests DPoP-Nonce and retries once. It does not harvest from
+ * successful resource-server responses and does not treat 401 as a nonce retry.
  */
 @SmallTest
 @RunWith(AndroidJUnit4::class)
@@ -179,8 +178,8 @@ class OAuthRefreshInterceptorNonceTest {
     }
 
     /**
-     * A DPoP-Nonce header in a resource-server response is not harvested by the interceptor.
-     * Only the token endpoint (OAuth2.java) populates the cache.
+     * A DPoP-Nonce header on a successful resource-server response is not harvested.
+     * Harvest happens only on HTTP 400 use_dpop_nonce.
      */
     @Test
     fun test_givenResourceServerResponseWithDPoPNonceHeader_whenRequestCompletes_thenNonceIsNotCached() {
@@ -220,4 +219,66 @@ class OAuthRefreshInterceptorNonceTest {
         assertEquals(1, callCount)
         assertNull(DPoPNonceCache.get(credentialsId, instanceHost))
     }
+
+    private fun nonceChallengeResponse(request: Request, nonce: String): Response =
+        Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(400)
+            .message("Bad Request")
+            .header("DPoP-Nonce", nonce)
+            .body("""{"error":"use_dpop_nonce"}""".toResponseBody("application/json".toMediaType()))
+            .build()
+
+    @Test
+    fun test_given400UseDpopNonce_whenIntercept_thenHarvestsNonceAndRetriesOnceWithProof() {
+        val request = buildRequest()
+        val interceptor = buildInterceptor()
+        val captured = mutableListOf<Request>()
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } answers {
+                val sent = firstArg<Request>()
+                captured.add(sent)
+                if (captured.size == 1) nonceChallengeResponse(sent, "n1")
+                else successResponse(sent)
+            }
+        }
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(200, response.code)
+        assertEquals(2, captured.size)
+        assertEquals("n1", DPoPNonceCache.get(credentialsId, instanceHost))
+        val retryProof = captured[1].header("DPoP")
+        assertNotNull(retryProof)
+        val payloadJson = String(
+            android.util.Base64.decode(
+                retryProof!!.split(".")[1],
+                android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING
+            ),
+            Charsets.UTF_8
+        )
+        assert(payloadJson.contains("n1")) { "Retry proof should contain harvested nonce. Payload: $payloadJson" }
+    }
+
+    @Test
+    fun test_given400UseDpopNonceTwice_whenIntercept_thenDoesNotLoop() {
+        val request = buildRequest()
+        val interceptor = buildInterceptor()
+        var callCount = 0
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns request
+            every { proceed(any()) } answers {
+                callCount++
+                nonceChallengeResponse(firstArg(), "n-loop")
+            }
+        }
+
+        val response = interceptor.intercept(chain)
+
+        assertEquals(2, callCount)
+        assertEquals(400, response.code)
+    }
+
 }


### PR DESCRIPTION
## Summary
`OAuthRefreshInterceptor` now detects HTTP 400 `use_dpop_nonce`, harvests `DPoP-Nonce`, rebuilds the DPoP proof, and retries once. 401 remains the token-refresh path. Matches iOS W-23501382 / #4145.

## Work item
W-23989400

## Tests
`OAuthRefreshInterceptorNonceTest` and `DPoPRequestDecoratorTest` passed on emulator.

## Spec
https://git.soma.salesforce.com/SalesforceMobileSDK/SalesforceMobileSDK-Workspace/pull/85