### PR TITLE
Fix license metadata to BSD-3-Clause

### DIFF
--- a/buildSrc/src/main/kotlin/publish-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish-module.gradle.kts
@@ -31,8 +31,9 @@ if (rootProject.name == "SalesforceMobileSDK-Android") {
                             url.set("https://github.com/forcedotcom/SalesforceMobileSDK-Android")
                             licenses {
                                 license {
-                                    name.set("The Apache Software License, Version 2.0")
-                                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                                    name.set("BSD-3-Clause")
+                                    url.set("https://opensource.org/license/bsd-3-clause")
+                                    distribution.set("repo")
                                 }
                             }
                             developers {


### PR DESCRIPTION
## What

Corrects the license declared in the Maven Central POM metadata. The `publish-module` convention plugin declared **Apache 2.0**, but the SDK is licensed under **BSD-3-Clause** (see `LICENSE.md`). This makes the published POM's license match the repository's actual license.

## Change

`buildSrc/src/main/kotlin/publish-module.gradle.kts`:

```kotlin
licenses {
    license {
        name.set("BSD-3-Clause")
        url.set("https://opensource.org/license/bsd-3-clause")
        distribution.set("repo")
    }
}
```

## Note

The same fix is being made for the `SalesforceReact` artifact in SalesforceMobileSDK-ReactNative (forcedotcom/SalesforceMobileSDK-ReactNative#492).