### PR TITLE
Remove server-bug workarounds from AuthFlowTester

### DIFF
--- a/native/NativeSampleApps/AuthFlowTester/README.md
+++ b/native/NativeSampleApps/AuthFlowTester/README.md
@@ -58,7 +58,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, server enf
 |------|-----------|--------|-------|
 | `testECAJwtDPoP_Hybrid` | ECA JWT DPoP | Yes | |
 | `testECAJwtDPoP_NoHybrid` | ECA JWT DPoP | No | |
-| `testECAJwtDPoPRtr_Hybrid` | ECA JWT DPoP RTR | Yes | `@Ignore` (W-22512846 — server does not yet support Named JWTs for Hybrid Flows) |
+| `testECAJwtDPoPRtr_Hybrid` | ECA JWT DPoP RTR | Yes | DPoP + refresh token rotation, hybrid auth token |
 | `testECAJwtDPoPRtr_NoHybrid` | ECA JWT DPoP RTR | No | DPoP + refresh token rotation |
 | `testECAJwtDPoP_MultiUser_UniqueTokens` | ECA JWT DPoP | — | Two users; unique tokens; independent revoke+refresh per user |
 | `testECAJwtDPoP_And_NonDPoP_MultiUser_FlagOff_IndependentProofs` | ECA JWT DPoP + ECA JWT | — | DPoP and non-DPoP users coexist; toggling DPoP off for second user does not affect first |
@@ -77,7 +77,7 @@ Tests for ECA configurations with Refresh Token Rotation (RTR) enabled. Verifies
 
 | Test | App Config | Hybrid | Notes |
 |------|-----------|--------|-------|
-| `testECAJwtRtr_Hybrid` | ECA JWT RTR | Yes | `@Ignore` (W-22512846 — server does not yet support Named JWTs for Hybrid Flows) |
+| `testECAJwtRtr_Hybrid` | ECA JWT RTR | Yes | |
 | `testECAJwtRtr_NoHybrid` | ECA JWT RTR | No | |
 | `testECAOpaqueRtr_Hybrid` | ECA Opaque RTR | Yes | |
 | `testECAOpaqueRtr_NoHybrid` | ECA Opaque RTR | No | |

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -59,16 +59,16 @@ class DPoPLoginTests : AuthFlowTest() {
     @Test
     fun testECAJwtDPoP_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_DPOP, useDPoP = true)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isJwt = true)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, isJwt = true)
     }
 
     // Login with ECA JWT DPoP without hybrid auth token.
     @Test
     fun testECAJwtDPoP_NoHybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_DPOP, useHybridAuthToken = false, useDPoP = true)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
     }
 
     // endregion
@@ -79,16 +79,16 @@ class DPoPLoginTests : AuthFlowTest() {
     @Test
     fun testECAJwtDPoPRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_DPOP_RTR, useDPoP = true)
-        assertRevokeAndRefreshWorks(isRtr = true, isDpop = true, isJwt = true)
-        assertRevokeAndRefreshWorks(isRtr = true, isDpop = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, isDpop = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, isDpop = true, isJwt = true)
     }
 
     // Login with ECA JWT DPoP RTR without hybrid auth token.
     @Test
     fun testECAJwtDPoPRtr_NoHybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_DPOP_RTR, useHybridAuthToken = false, useDPoP = true)
-        assertRevokeAndRefreshWorks(isRtr = true, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
-        assertRevokeAndRefreshWorks(isRtr = true, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, isDpop = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
     }
 
     // endregion
@@ -113,12 +113,12 @@ class DPoPLoginTests : AuthFlowTest() {
         // Switch back to initial user; revoke + refresh must work with DPoP nonce rotation
         switchToUserAndValidateUser(user, isDpop = true, isJwt = true)
         app.validateOAuthValues(knownAppConfig = ECA_JWT_DPOP, scopeSelection = ScopeSelection.EMPTY)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isMultiUser = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, isMultiUser = true, isJwt = true)
 
         // Switch to other user; revoke + refresh must work independently with its own nonce
         switchToUserAndValidateUser(otherUser, isDpop = true, isJwt = true)
         app.validateOAuthValues(knownAppConfig = ECA_JWT_DPOP, scopeSelection = ScopeSelection.EMPTY)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isMultiUser = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, isMultiUser = true, isJwt = true)
     }
 
     // Mixed DPoP + non-DPoP users with the process-wide DPoP flag flipped off after both are
@@ -144,13 +144,13 @@ class DPoPLoginTests : AuthFlowTest() {
         // ECA_JWT_DPOP issues JWT tokens, so isJwt=true is required to expect JT in the UA.
         switchToUserAndValidateUser(user, isDpop = true, isJwt = true)
         app.validateOAuthValues(knownAppConfig = ECA_JWT_DPOP, scopeSelection = ScopeSelection.EMPTY)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isMultiUser = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, isMultiUser = true, isJwt = true)
 
         // Switch to user B (Bearer). Refresh + REST GET must NOT attach DPoP anywhere.
         // ECA_JWT issues JWT tokens, so isJwt=true is required to expect JT (not OT) in the UA.
         switchToUserAndValidateUser(otherUser, isDpop = false, isJwt = true)
         app.validateOAuthValues(knownAppConfig = ECA_JWT, scopeSelection = ScopeSelection.EMPTY)
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = false, isMultiUser = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = false, isMultiUser = true, isJwt = true)
     }
 
     // endregion
@@ -259,7 +259,7 @@ class DPoPLoginTests : AuthFlowTest() {
         // After restart the key pair must still be valid — revoke+refresh proves it.
         // The nonce-change assertion also confirms the server accepted the DPoP proof
         // built with the key pair loaded from AndroidKeyStore after restart.
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, isJwt = true)
     }
 
     // endregion
@@ -279,7 +279,7 @@ class DPoPLoginTests : AuthFlowTest() {
             useDPoP = true,
             useLoginPoolHost = true,
         )
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, isJwt = true, useLoginPoolHost = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, isJwt = true, useLoginPoolHost = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
     }
 
     // Login via the pool server with DPoP + RTR and verify refresh token rotation holds after login.
@@ -297,7 +297,7 @@ class DPoPLoginTests : AuthFlowTest() {
             useDPoP = true,
             useLoginPoolHost = true,
         )
-        assertRevokeAndRefreshWorks(isRtr = true, isDpop = true, isJwt = true, useLoginPoolHost = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, isDpop = true, isJwt = true, useLoginPoolHost = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
     }
 
     // endregion

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/DPoPLoginTests.kt
@@ -37,7 +37,6 @@ import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT_
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection
 import com.salesforce.samples.authflowtester.testUtility.testConfig
 import org.junit.Assert.assertNotEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -76,9 +75,7 @@ class DPoPLoginTests : AuthFlowTest() {
 
     // region ECA JWT DPoP RTR Tests
 
-    // TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows.
-    // Server currently returns invalid_grant for RTR + JWT tokens in hybrid flow.
-    @Ignore("TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows")
+    // Login with ECA JWT DPoP RTR using hybrid auth token flow.
     @Test
     fun testECAJwtDPoPRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_DPOP_RTR, useDPoP = true)
@@ -176,19 +173,15 @@ class DPoPLoginTests : AuthFlowTest() {
     }
 
     // Login with DPoP ECA, migrate to DPoP+RTR ECA — refresh token rotation now enabled.
-    // Uses useHybridAuthToken = false: the server rejects hybrid grants with RTR + JWT enabled
-    // (W-22512846), so the non-hybrid path is used as a workaround.
     @Test
     fun testMigrate_ECAJwtDPoP_To_ECAJwtDPoPRtr() {
         loginAndValidate(
             knownAppConfig = ECA_JWT_DPOP,
-            useHybridAuthToken = false,
             useDPoP = true,
         )
         migrateAndValidate(
             ECA_JWT_DPOP_RTR,
             isDpop = true,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
         )
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
@@ -32,7 +32,6 @@ import com.salesforce.androidsdk.app.Features.FEATURE_AUTH_TYPE_WEB_SERVER_NON_H
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_JWT_RTR
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.ECA_OPAQUE_RTR
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -47,9 +46,7 @@ class RTRLoginTests : AuthFlowTest() {
 
     // region ECA JWT RTR Tests
 
-    // TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows.
-    // Server currently returns invalid_grant for RTR + JWT tokens in hybrid flow.
-    @Ignore("TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows")
+    // Login with ECA JWT RTR using hybrid auth token flow.
     @Test
     fun testECAJwtRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR)

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RTRLoginTests.kt
@@ -50,16 +50,16 @@ class RTRLoginTests : AuthFlowTest() {
     @Test
     fun testECAJwtRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR)
-        assertRevokeAndRefreshWorks(isRtr = true, isJwt = true)
-        assertRevokeAndRefreshWorks(isRtr = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, isJwt = true)
     }
 
     // Login with ECA JWT RTR without hybrid auth token.
     @Test
     fun testECAJwtRtr_NoHybrid() {
         loginAndValidate(knownAppConfig = ECA_JWT_RTR, useHybridAuthToken = false)
-        assertRevokeAndRefreshWorks(isRtr = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
-        assertRevokeAndRefreshWorks(isRtr = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID, isJwt = true)
     }
 
     // endregion
@@ -70,16 +70,16 @@ class RTRLoginTests : AuthFlowTest() {
     @Test
     fun testECAOpaqueRtr_Hybrid() {
         loginAndValidate(knownAppConfig = ECA_OPAQUE_RTR)
-        assertRevokeAndRefreshWorks(isRtr = true)
-        assertRevokeAndRefreshWorks(isRtr = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true)
     }
 
     // Login with ECA Opaque RTR without hybrid auth token.
     @Test
     fun testECAOpaqueRtr_NoHybrid() {
         loginAndValidate(knownAppConfig = ECA_OPAQUE_RTR, useHybridAuthToken = false)
-        assertRevokeAndRefreshWorks(isRtr = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
-        assertRevokeAndRefreshWorks(isRtr = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = true, expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID)
     }
 
     // endregion

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RefreshTokenMigrationTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/RefreshTokenMigrationTests.kt
@@ -28,17 +28,13 @@ package com.salesforce.samples.authflowtester
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import com.salesforce.androidsdk.app.Features.FEATURE_AUTH_TYPE_USER_AGENT_NON_HYBRID
-import com.salesforce.androidsdk.app.Features.FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID
+import com.salesforce.androidsdk.app.Features.FEATURE_AUTH_TYPE_USER_AGENT_HYBRID
+import com.salesforce.androidsdk.app.Features.FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID
 import com.salesforce.samples.authflowtester.testUtility.AuthFlowTest
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig
-import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig
-import com.salesforce.samples.authflowtester.testUtility.KnownUserConfig
 import com.salesforce.samples.authflowtester.testUtility.ScopeSelection
 import org.junit.Test
 import org.junit.runner.RunWith
-
-// TODO: remove loginAndValidate override when W-20524841 is fixed.
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -57,7 +53,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         migrateAndValidate(
             KnownAppConfig.CA_JWT,
             scopeSelection = ScopeSelection.ALL,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -72,7 +68,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         migrateAndValidate(
             KnownAppConfig.ECA_JWT,
             scopeSelection = ScopeSelection.ALL,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -87,7 +83,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         migrateAndValidate(
             KnownAppConfig.BEACON_JWT,
             scopeSelection = ScopeSelection.ALL,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -102,7 +98,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         )
         migrateAndValidate(
             KnownAppConfig.BEACON_OPAQUE,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -114,7 +110,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         )
         migrateAndValidate(
             KnownAppConfig.CA_OPAQUE,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -129,11 +125,11 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         )
         migrateAndValidate(
             KnownAppConfig.ECA_OPAQUE,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
         migrateAndValidate(
             KnownAppConfig.CA_OPAQUE,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -145,11 +141,11 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         )
         migrateAndValidate(
             KnownAppConfig.BEACON_OPAQUE,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
         migrateAndValidate(
             KnownAppConfig.CA_OPAQUE,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -161,11 +157,11 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
         )
         migrateAndValidate(
             KnownAppConfig.BEACON_JWT,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
         migrateAndValidate(
             KnownAppConfig.BEACON_OPAQUE,
-            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID,
         )
     }
 
@@ -190,7 +186,7 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
             knownAppConfig = KnownAppConfig.ECA_OPAQUE,
             scopeSelection = ScopeSelection.ALL,
             expectAdvancedAuth = false,
-            expectedAMarker = FEATURE_AUTH_TYPE_USER_AGENT_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_USER_AGENT_HYBRID,
         )
     }
 
@@ -210,37 +206,9 @@ class RefreshTokenMigrationTests: AuthFlowTest() {
             knownAppConfig = KnownAppConfig.BEACON_OPAQUE,
             scopeSelection = ScopeSelection.ALL,
             expectAdvancedAuth = false,
-            expectedAMarker = FEATURE_AUTH_TYPE_USER_AGENT_NON_HYBRID,
+            expectedAMarker = FEATURE_AUTH_TYPE_USER_AGENT_HYBRID,
         )
     }
 
     // endregion
-
-    override fun loginAndValidate(
-        knownAppConfig: KnownAppConfig,
-        scopeSelection: ScopeSelection,
-        useWebServerFlow: Boolean,
-        useHybridAuthToken: Boolean,
-        useDPoP: Boolean,
-        knownLoginHostConfig: KnownLoginHostConfig,
-        knownUserConfig: KnownUserConfig,
-        forceAdvancedAuthentication: Boolean,
-        useWelcomeDiscovery: Boolean,
-        isMultiUser: Boolean,
-        useLoginPoolHost: Boolean,
-    ) {
-        super.loginAndValidate(
-            knownAppConfig = knownAppConfig,
-            scopeSelection = scopeSelection,
-            useWebServerFlow = useWebServerFlow,
-            useHybridAuthToken = false, // TODO: W-20524841 — Pass useHybridAuthToken once server bug is fixed.
-            useDPoP = useDPoP,
-            forceAdvancedAuthentication = forceAdvancedAuthentication,
-            knownLoginHostConfig = knownLoginHostConfig,
-            knownUserConfig = user,
-            useWelcomeDiscovery = useWelcomeDiscovery,
-            isMultiUser = isMultiUser,
-            useLoginPoolHost = useLoginPoolHost,
-        )
-    }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -309,6 +309,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         wasMigrated: Boolean = false,
         isJwt: Boolean = false,
         isBeacon: Boolean = false,
+        expectedRtMarker: Boolean = false,
     ) {
         val expected = testConfig.getUser(knownLoginHostConfig, knownUserConfig)
 
@@ -345,7 +346,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
 
         // Validate feature flags — UI is already settled, reuse the existing layout traversal
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, isDpop = isDpop, expectedBMarker = expectedBMarker, expectedLMarker = expectedLMarker, expectedAMarker = expectedAMarker, wasMigrated = wasMigrated, isJwt = isJwt, isBeacon = isBeacon)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, expectedRtMarker = expectedRtMarker, isDpop = isDpop, expectedBMarker = expectedBMarker, expectedLMarker = expectedLMarker, expectedAMarker = expectedAMarker, wasMigrated = wasMigrated, isJwt = isJwt, isBeacon = isBeacon)
     }
 
     fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection) {
@@ -622,7 +623,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
         expectAdvancedAuth: Boolean = false,
-        isRtr: Boolean = false,
+        expectedRtMarker: Boolean = false,
         isDpop: Boolean = false,
         expectedBMarker: String? = null,
         expectedLMarker: String? = null,
@@ -632,7 +633,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         isBeacon: Boolean = false,
     ) {
         expandUserCredentialsSection(targetNode = USER_AGENT_CONTENT_DESC)
-        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, isRtr, isDpop, expectedBMarker, expectedLMarker, expectedAMarker, wasMigrated, isJwt, isBeacon)
+        validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, expectedRtMarker, isDpop, expectedBMarker, expectedLMarker, expectedAMarker, wasMigrated, isJwt, isBeacon)
     }
 
     private fun validateUserAgent(
@@ -641,7 +642,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         usesWelcomeDiscovery: Boolean = false,
         isMultiUser: Boolean = false,
         expectAdvancedAuth: Boolean = false,
-        isRtr: Boolean = false,
+        expectedRtMarker: Boolean = false,
         isDpop: Boolean = false,
         expectedBMarker: String? = null,
         expectedLMarker: String? = null,
@@ -692,7 +693,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
             }
         }
 
-        if (isRtr) {
+        if (expectedRtMarker) {
             assert("RT" in flags) {
                 "Expected 'RT' flag after Refresh Token Rotation in: $ua"
             }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -101,6 +101,37 @@ abstract class AuthFlowTest {
     }
 
     /**
+     * Per-user, observed RT feature-marker state.
+     *
+     * RT is a sticky SDK marker: it starts absent after login and is registered only when a normal
+     * refresh (through the session refresher) observes a changed refresh token. Login, migration,
+     * and restart never advance it. A config that *can* rotate ([AppConfig.expectsRefreshTokenRotation])
+     * is not the same as a user that *has* been observed rotating — so UA assertions must consult
+     * this observed state rather than the config capability, otherwise migrations that follow a
+     * rotating refresh would falsely expect RT to be absent (or present). Mirrors iOS
+     * `BaseAuthFlowTester.expectedRTRFeatureMarkerByUsername`.
+     */
+    private val expectedRtMarkerByUsername = mutableMapOf<String, Boolean>()
+
+    private fun usernameFor(
+        knownLoginHostConfig: KnownLoginHostConfig,
+        knownUserConfig: KnownUserConfig,
+    ): String = testConfig.getUser(knownLoginHostConfig, knownUserConfig).username
+
+    private fun currentUsername(): String =
+        SalesforceSDKManager.getInstance().userAccountManager.currentUser?.username
+            ?: throw AssertionError("No current user to read the RT feature-marker state for")
+
+    private fun expectedRtMarker(username: String): Boolean =
+        expectedRtMarkerByUsername[username]
+            ?: throw AssertionError("No RT feature-marker state recorded for user $username")
+
+    /** Sticky update: once a user has been observed rotating, RT stays expected. */
+    private fun recordRefreshTokenRotation(username: String, rotated: Boolean) {
+        expectedRtMarkerByUsername[username] = (expectedRtMarkerByUsername[username] ?: false) || rotated
+    }
+
+    /**
      * Establishes a Bearer baseline before every test.
      *
      * SDK 14.0 defaults [SalesforceSDKManager.useDPoP] to true, but the UI tests build a fresh
@@ -116,6 +147,9 @@ abstract class AuthFlowTest {
     @Before
     open fun baselineDPoPOff() {
         SalesforceSDKManager.getInstance().useDPoP = false
+        // Each test logs in fresh users; cleanup() logs everyone out, clearing the SDK's per-user
+        // markers. Reset the mirrored observed-RT state so it cannot leak across tests.
+        expectedRtMarkerByUsername.clear()
     }
 
     @After
@@ -395,6 +429,11 @@ abstract class AuthFlowTest {
             else -> Features.FEATURE_AUTH_TYPE_USER_AGENT_NON_HYBRID
         }
         val appConfig = testConfig.getApp(knownAppConfig)
+        // An authorization-code login never runs the session refresher, so it cannot set RT.
+        // Record this explicitly: later migration/switch/restart checks preserve it until a
+        // test-triggered normal refresh observes token rotation.
+        val username = usernameFor(knownLoginHostConfig, knownUserConfig)
+        expectedRtMarkerByUsername[username] = false
         app.validateUser(
             knownLoginHostConfig,
             knownUserConfig,
@@ -407,6 +446,7 @@ abstract class AuthFlowTest {
             expectedAMarker = expectedAMarker,
             isJwt = appConfig.issuesJwt,
             isBeacon = appConfig.isBeacon,
+            expectedRtMarker = expectedRtMarker(username),
         )
         app.validateOAuthValues(knownAppConfig, scopeSelection)
         app.validateApiRequest()
@@ -478,6 +518,9 @@ abstract class AuthFlowTest {
             else -> Features.FEATURE_AUTH_TYPE_USER_AGENT_NON_HYBRID
         }
         val appConfig = testConfig.getApp(knownAppConfig)
+        // A restart reloads persisted state; it never runs the session refresher, so the RT marker is
+        // unchanged. Assert with the RT state carried across the restart.
+        val username = usernameFor(knownLoginHostConfig, knownUserConfig)
         app.validateUser(
             knownLoginHostConfig,
             knownUserConfig,
@@ -489,6 +532,7 @@ abstract class AuthFlowTest {
             expectedAMarker = expectedAMarker,
             isJwt = appConfig.issuesJwt,
             isBeacon = appConfig.isBeacon,
+            expectedRtMarker = expectedRtMarker(username),
         )
     }
 
@@ -594,7 +638,10 @@ abstract class AuthFlowTest {
 
         app.waitForAppLoad()
         val appConfig = testConfig.getApp(knownAppConfig)
-        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true, isDpop = useDPoP, expectedBMarker = Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN, expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN, expectedAMarker = Features.FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID, isJwt = appConfig.issuesJwt, isBeacon = appConfig.isBeacon)
+        // Admin login is still an authorization-code login, so RT starts absent for this user.
+        // Reuse the username already resolved above for the Chrome login.
+        expectedRtMarkerByUsername[username] = false
+        app.validateUser(REGULAR_AUTH, user, expectAdvancedAuth = true, isDpop = useDPoP, expectedBMarker = Features.FEATURE_BROWSER_LOGIN_FOR_ADMIN, expectedLMarker = Features.FEATURE_LOGIN_SERVER_MY_DOMAIN, expectedAMarker = Features.FEATURE_AUTH_TYPE_WEB_SERVER_HYBRID, isJwt = appConfig.issuesJwt, isBeacon = appConfig.isBeacon, expectedRtMarker = expectedRtMarker(username))
         app.validateOAuthValues(knownAppConfig, scopeSelection = EMPTY)
         app.validateApiRequest()
     }
@@ -719,6 +766,10 @@ abstract class AuthFlowTest {
         val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
         val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
         val appConfig = testConfig.getApp(knownAppConfig)
+        // Migration re-issues tokens through the token-migration path, not the session refresher, so
+        // it never advances the RT marker. Assert with the RT state carried over from before this
+        // migration (a rotation from an earlier normal refresh stays sticky).
+        val username = usernameFor(knownLoginHostConfig, knownUserConfig)
         app.validateUser(
             knownLoginHostConfig,
             knownUserConfig,
@@ -730,12 +781,17 @@ abstract class AuthFlowTest {
             wasMigrated = true,
             isJwt = appConfig.issuesJwt,
             isBeacon = appConfig.isBeacon,
+            expectedRtMarker = expectedRtMarker(username),
         )
         app.validateOAuthValues(knownAppConfig, scopeSelection)
 
-        // Assert new tokens work
+        // Assert new tokens work. This revoke forces a normal refresh through the session refresher —
+        // the one path that registers the sticky RT marker — so a beacon app that rotates its refresh
+        // token here (W-23971480) will legitimately carry RT on the next validation.
         app.revokeAccessToken()
         app.validateApiRequest()
+        val (_, refreshedRefreshToken) = app.getTokens()
+        recordRefreshTokenRotation(username, rotated = refreshedRefreshToken != postRefreshToken)
     }
 
     /**
@@ -782,7 +838,7 @@ abstract class AuthFlowTest {
         // migration path, so the "TM" (token-migration) UA feature flag is legitimately registered
         // and persists across subsequent refreshes — the marker tracks the migration mechanism, not
         // whether the connected app changed. Assert its presence.
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = true, wasMigrated = true, isJwt = appConfig.issuesJwt)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = true, wasMigrated = true, isJwt = appConfig.issuesJwt)
     }
 
     /**
@@ -829,11 +885,11 @@ abstract class AuthFlowTest {
         // the refresh-token migration path, so the "TM" (token-migration) UA feature flag is
         // legitimately registered and persists across subsequent refreshes — the marker tracks the
         // migration mechanism, not whether the connected app changed. Assert its presence.
-        assertRevokeAndRefreshWorks(isRtr = false, isDpop = false, wasMigrated = true, isJwt = appConfig.issuesJwt)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation = false, isDpop = false, wasMigrated = true, isJwt = appConfig.issuesJwt)
     }
 
     fun assertRevokeAndRefreshWorks(
-        isRtr: Boolean,
+        expectsRefreshTokenRotation: Boolean,
         isDpop: Boolean = false,
         knownLoginHostConfig: KnownLoginHostConfig = REGULAR_AUTH,
         expectAdvancedAuth: Boolean = true,
@@ -850,11 +906,18 @@ abstract class AuthFlowTest {
 
         assert(preAccessToken != postAccessToken) { "Access token should have been refreshed" }
 
-        if (isRtr) {
-            assert(preRefreshToken != postRefreshToken) { "Refresh token should have rotated (RTR app)" }
+        val refreshTokenRotated = preRefreshToken != postRefreshToken
+        if (expectsRefreshTokenRotation) {
+            assert(refreshTokenRotated) { "Refresh token should have rotated (RTR app)" }
         } else {
-            assert(preRefreshToken == postRefreshToken) { "Refresh token should not have changed (non-RTR app)" }
+            assert(!refreshTokenRotated) { "Refresh token should not have changed (non-RTR app)" }
         }
+
+        // This is a normal refresh through the session refresher, the only path that registers the
+        // sticky RT marker. Record the observation for the current user *before* reading it back for
+        // the UA assertion, so a rotation seen here is reflected in what we expect the UA to carry.
+        val username = currentUsername()
+        recordRefreshTokenRotation(username, rotated = refreshTokenRotated)
 
         if (isDpop) {
             val postNonce = app.getDpopInfo().nonce
@@ -874,7 +937,7 @@ abstract class AuthFlowTest {
             knownLoginHostConfig = knownLoginHostConfig,
             expectAdvancedAuth = expectAdvancedAuth,
             isMultiUser = isMultiUser,
-            isRtr = isRtr,
+            expectedRtMarker = expectedRtMarker(username),
             isDpop = isDpop,
             expectedBMarker = expectedBMarker,
             expectedLMarker = expectedLMarker,
@@ -899,6 +962,9 @@ abstract class AuthFlowTest {
         composeTestRule.waitForIdle()
         val shouldHaveBW = expectAdvancedAuth || knownLoginHostConfig == ADVANCED_AUTH
         val expectedBMarker = if (shouldHaveBW) Features.FEATURE_BROWSER_LOGIN_FORCE_FLAG else null
+        // Switching users only changes which credential is active; it never runs the session
+        // refresher, so assert with the target user's own carried-over RT state.
+        val username = usernameFor(knownLoginHostConfig, knownUserConfig)
         app.validateUser(
             knownLoginHostConfig,
             knownUserConfig,
@@ -908,6 +974,7 @@ abstract class AuthFlowTest {
             expectedBMarker = expectedBMarker,
             expectedAMarker = expectedAMarker,
             isJwt = isJwt,
+            expectedRtMarker = expectedRtMarker(username),
         )
     }
 }

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
@@ -123,8 +123,10 @@ data class AppConfig(
 ) {
     val issuesJwt = name.contains("_jwt")
     val isBeacon = name.startsWith("beacon_")
+    // Config-level capability: does this app configuration rotate the refresh token on refresh?
+    // Distinct from the per-user, observed RT feature marker tracked in the test base class.
     // W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed
-    val isRtr = name.contains("_rtr") || name.startsWith("beacon_")
+    val expectsRefreshTokenRotation = name.contains("_rtr") || name.startsWith("beacon_")
     val isDpop = name.contains("_dpop")
     val expectedTokenFormat = if (issuesJwt) "jwt" else "Opaque"
     val scopeList = scopes.split(" ")


### PR DESCRIPTION
## Summary
Two server bugs are confirmed resolved, so their AuthFlowTester test workarounds are removed:
- **W-22512846** ("Enable Named JWTs for Hybrid Flows") — fixed in build 266
- **W-20524841** ("Hybrid token flow without requesting hybrid scopes works but hybrid refresh token flow does not") — closed in build 264

Changes:
- Re-enable `testECAJwtRtr_Hybrid` (RTRLoginTests) — remove `@Ignore` (W-22512846)
- Re-enable `testECAJwtDPoPRtr_Hybrid` (DPoPLoginTests) — remove `@Ignore` (W-22512846)
- Remove the `useHybridAuthToken = false` workaround in `testMigrate_ECAJwtDPoP_To_ECAJwtDPoPRtr`; the migration A-marker assertion returns to the default `WEB_SERVER_HYBRID`
- Remove the class-level `loginAndValidate` override in `RefreshTokenMigrationTests` that forced `useHybridAuthToken = false` (W-20524841). Logins are now hybrid, so every migration A-marker assertion flips from `*_NON_HYBRID` to `*_HYBRID` (the migration A-marker persists from the initial login; it is not recomputed at migration time)
- Drop now-unused imports (`org.junit.Ignore`, `KnownLoginHostConfig`, `KnownUserConfig`) and update the AuthFlowTester README

## Test plan
Verified on a local emulator (API 36) against the internal test org:
- [x] `RTRLoginTests#testECAJwtRtr_Hybrid` passes
- [x] `DPoPLoginTests#testECAJwtDPoPRtr_Hybrid` passes
- [x] `DPoPLoginTests#testMigrate_ECAJwtDPoP_To_ECAJwtDPoPRtr` passes
- [x] `RefreshTokenMigrationTests#testMigrate_ECA_AddMoreScopes` passes (WEB_SERVER_HYBRID)
- [x] `RefreshTokenMigrationTests#testMigrateCAUserAgent_To_ECAExtendedWebServer` passes (USER_AGENT_HYBRID)