### PR TITLE
fix(test): repair three downgradeFromDPoP test failures in nightly CI

### DIFF
--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerMigrateTokenTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerMigrateTokenTest.kt
@@ -372,6 +372,7 @@ class UserAccountManagerMigrateTokenTest {
     fun downgradeFromDPoP_withNullClientId_callsOnFailure() {
         // Given
         val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.tokenType } returns DPoPKeyManager.DPOP_TOKEN_TYPE
         every { mockUserAccount.clientId } returns null
         every { mockUserAccount.loginServer } returns "login.example.com"
 
@@ -394,6 +395,7 @@ class UserAccountManagerMigrateTokenTest {
     fun downgradeFromDPoP_withNullLoginServer_callsOnFailure() {
         // Given
         val mockUserAccount: UserAccount = mockk(relaxed = true)
+        every { mockUserAccount.tokenType } returns DPoPKeyManager.DPOP_TOKEN_TYPE
         every { mockUserAccount.clientId } returns "testClientId"
         every { mockUserAccount.loginServer } returns null
 
@@ -495,8 +497,12 @@ class UserAccountManagerMigrateTokenTest {
         callbacksSlot.captured.onMigrationSuccess(migratedAccount)
 
         // Then - the OLD (pre-migration) identifier's key/nonce are reclaimed.
+        // Compute the expected alias outside the verify block: in MockK verify mode, calls to
+        // mocked functions return default values rather than executing callOriginal(), so
+        // aliasForCredentialsIdentifier() would return "" inside verify {} and produce a wrong matcher.
+        val expectedAlias = DPoPKeyManager.aliasForCredentialsIdentifier(oldCredId)
         verify(exactly = 1) {
-            DPoPKeyManager.deleteKeyPair(DPoPKeyManager.aliasForCredentialsIdentifier(oldCredId))
+            DPoPKeyManager.deleteKeyPair(expectedAlias)
         }
         verify(exactly = 1) { DPoPNonceCache.clear(oldCredId) }
         verify(exactly = 1) { onMigrationSuccess.invoke(migratedAccount) }


### PR DESCRIPTION
## Summary

- Three tests in `UserAccountManagerMigrateTokenTest` were broken since introduced (first caught by nightly CI on 2026-08-27, run [#33059386798](https://github.com/forcedotcom/SalesforceMobileSDK-Android/actions/runs/33059386798/job/98474092989))
- All three are **test bugs** — no production code changes

## Root Causes & Fixes

**Tests 1 & 2**: `downgradeFromDPoP_withNullClientId_callsOnFailure` / `downgradeFromDPoP_withNullLoginServer_callsOnFailure`

The mocks used `relaxed = true` without stubbing `tokenType`, so it defaulted to `""`. `downgradeFromDPoP()` checks `tokenType != DPOP_TOKEN_TYPE` first and returns early via `onSuccess` — the `clientId`/`loginServer` null-checks were never reached, so `onFailure` was never invoked.

Fix: add `every { mockUserAccount.tokenType } returns DPoPKeyManager.DPOP_TOKEN_TYPE` to both tests.

**Test 3**: `downgradeFromDPoP_onSuccess_whenPreMigrationAccountWasDPoPBound_deletesObsoleteKeyAndNonce`

`DPoPKeyManager.aliasForCredentialsIdentifier(oldCredId)` was called *inside* a `verify {}` block. In MockK verify mode, calls to mocked functions return default values (`""`) rather than executing `callOriginal()`, so the expected argument matcher became `eq("")` instead of `eq("dpop_old-dpop-cred-id")`. The production code had actually called `deleteKeyPair` correctly — the verification was broken.

Fix: compute `val expectedAlias = DPoPKeyManager.aliasForCredentialsIdentifier(oldCredId)` outside the `verify {}` block, then reference `expectedAlias` inside.

## Test Plan

- [x] All 3 previously-failing tests now pass locally (API 34 + API 36 emulators)
- [x] Full `UserAccountManagerMigrateTokenTest` class (15 tests) passes