### PR TITLE
fix(auth): pass LoginActivity's own viewModel into LoginView()

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/LoginActivity.kt
@@ -322,7 +322,7 @@ open class LoginActivity : FragmentActivity() {
         // Set content
         setContent {
             MaterialTheme(colorScheme = SalesforceSDKManager.getInstance().colorScheme()) {
-                LoginView()
+                LoginView(viewModel = viewModel)
             }
         }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/LoginView.kt
@@ -153,10 +153,10 @@ internal const val LOADING_INDICATOR_SIZE = 50
 internal const val SLOW_ANIMATION_MS = 500
 
 @Composable
-fun LoginView() {
+fun LoginView(
+    viewModel: LoginViewModel = viewModel(factory = SalesforceSDKManager.getInstance().loginViewModelFactory),
+) {
     val activity: LoginActivity = LocalContext.current.getActivity() as LoginActivity
-    val viewModel: LoginViewModel =
-        viewModel(factory = SalesforceSDKManager.getInstance().loginViewModelFactory)
     val frontDoorBridgeUrl = viewModel.frontDoorBridgeUrl.observeAsState()
     // Observe selectedServer and loginUrl AS COMPOSE STATE so that recomposition triggers when
     // either changes — and so titleText is read inside Compose's snapshot system, not via the


### PR DESCRIPTION
LoginActivity.onCreate() calls setContent { LoginView() } without an argument, so the composable builds a second, independent LoginViewModel via SalesforceSDKManager.loginViewModelFactory instead of reusing the Activity's own viewModel property.

This silently breaks advanced-auth login for any app that customizes LoginActivity.viewModel (e.g. to override singleServerCustomTabActivity): generateAuthorizationUrl() runs on the Compose-built instance and decides launchingCustomTab=true correctly, but the onBrowserCustomTabReady callback - wired in onCreate() onto the Activity's own instance - is null on the instance that actually invokes it, so the Custom Tab never launches. The WebView is left showing the intentional "about:blank" placeholder forever, with no error and no further log output.

Give LoginView() a viewModel parameter (defaulting to the previous factory-based construction, so callers that don't subclass LoginActivity are unaffected) and have LoginActivity pass its own viewModel explicitly.

Verified: reproduced the blank-screen hang on commit 638fbea and on the official v14.0.0-rc.0 tag (0049b454be) with a subclassed LoginActivity/LoginViewModel; confirmed this exact fix resolves it - real Chrome Custom Tab launches and the real login page renders. No automated test added: reproducing this specific defect requires either launching a real LoginActivity subclass (no precedent in this test suite - every existing Compose test here deliberately uses the generic ComponentActivity to avoid exactly that) or exercising onCreate() directly (not covered by the existing mockk-based LoginActivityTest pattern either). Flagging for discussion rather than introducing a new test-infra pattern unilaterally.