### PR TITLE
[Android] Move mainSid calculation to UserAccount

### DIFF
--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewCookieManager.kt
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceWebViewCookieManager.kt
@@ -52,7 +52,7 @@ class SalesforceWebViewCookieManager {
         val lightningSid = userAccount.lightningSid
         val contentDomain = userAccount.contentDomain
         val contentSid = userAccount.contentSid
-        val mainSid = if (userAccount.tokenFormat == "jwt") userAccount.parentSid else userAccount.authToken
+        val mainSid = userAccount.mainSid
         val vfDomain = userAccount.vfDomain
         val vfSid = userAccount.vfSid
         val clientSrc = userAccount.cookieClientSrc

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -740,6 +740,16 @@ public class UserAccount {
 	}
 
 	/**
+	 * Returns the session ID to use as the main SID cookie.
+	 * For JWT token format, this is the parent SID; otherwise it is the auth token.
+	 *
+	 * @return main SID string
+	 */
+	public String getMainSid() {
+		return "jwt".equals(tokenFormat) ? parentSid : authToken;
+	}
+
+	/**
 	 * Returns the token format.
 	 *
 	 * @return token format.

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -878,6 +878,30 @@ public class UserAccountTest {
         Assert.assertEquals(rotationTime, account.getLastTokenRotationTime());
     }
 
+    @Test
+    public void test_givenAccessTokenFormat_whenGetMainSid_thenReturnsAuthToken() {
+        final UserAccount account = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(createTestAccount())
+                .authToken("test_auth_token")
+                .parentSid("test_parent_sid")
+                .tokenFormat("access_token")
+                .build();
+
+        Assert.assertEquals("test_auth_token", account.getMainSid());
+    }
+
+    @Test
+    public void test_givenJwtTokenFormat_whenGetMainSid_thenReturnsParentSid() {
+        final UserAccount account = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(createTestAccount())
+                .authToken("test_auth_token")
+                .parentSid("test_parent_sid")
+                .tokenFormat("jwt")
+                .build();
+
+        Assert.assertEquals("test_parent_sid", account.getMainSid());
+    }
+
     /**
      * Check the user accounts are the same
      * @param expected Expected UserAccount


### PR DESCRIPTION
## Summary

- Adds `getMainSid()` to `UserAccount.java` — returns `parentSid` for JWT token format, `authToken` otherwise
- Updates `SalesforceWebViewCookieManager.kt` to use `userAccount.mainSid` instead of the inline ternary
- Adds 2 unit tests to `UserAccountTest.java` covering both branches of the logic

## GUS

- W-24023806

## Test plan

- [ ] `test_givenAccessTokenFormat_whenGetMainSid_thenReturnsAuthToken` — passes (new)
- [ ] `test_givenJwtTokenFormat_whenGetMainSid_thenReturnsParentSid` — passes (new)
- [ ] `:libs:SalesforceSDK:connectedAndroidTest` — no regressions
- [ ] `:libs:SalesforceHybrid:connectedAndroidTest` — no regressions