### PR TITLE
Add Firebase Test Lab API 37 coverage

### DIFF
--- a/.github/workflows/reusable-lib-workflow.yaml
+++ b/.github/workflows/reusable-lib-workflow.yaml
@@ -24,6 +24,10 @@ jobs:
     runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
+      # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
+      PR_API_VERSION: "36"
+      FULL_API_RANGE: "31 32 33 34 35 36 37"
+      PS16K_MIN_API_VERSION: "36"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
@@ -126,9 +130,6 @@ jobs:
         continue-on-error: true
         if: success() || failure()
         env:
-          # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          PR_API_VERSION: "36"
-          FULL_API_RANGE: "31 32 33 34 35 36"
           IS_PR: ${{ inputs.is_pr }}
           LIB: ${{ inputs.lib }}
           RUN_NUMBER: ${{ github.run_number }}
@@ -160,13 +161,17 @@ jobs:
           for LEVEL in $LEVELS_TO_TEST
             do
               GCLOUD_RESULTS_DIR="${LIB}-api-${LEVEL}-build-${RUN_NUMBER}"
+              DEVICE_MODEL="MediumPhone.arm"
+              if [ "$PS16K_MIN_API_VERSION" -le "$LEVEL" ]; then
+                DEVICE_MODEL="MediumPhone_ps16k.arm"
+              fi
 
               eval gcloud beta firebase test android run \
                 --project mobile-apps-firebase-test \
                 --type instrumentation \
                 --app "native/NativeSampleApps/RestExplorer/build/outputs/apk/debug/RestExplorer-debug.apk" \
                 --test="libs/${LIB}/build/outputs/apk/androidTest/debug/${LIB}-debug-androidTest.apk" \
-                --device "model=MediumPhone.arm,version=${LEVEL},locale=en,orientation=portrait" \
+                --device "model=${DEVICE_MODEL},version=${LEVEL},locale=en,orientation=portrait" \
                 --environment-variables coverage=true,coverageFile="/sdcard/coverage.ec" \
                 --directories-to-pull=/sdcard \
                 --results-dir="${GCLOUD_RESULTS_DIR}" \
@@ -179,9 +184,6 @@ jobs:
         continue-on-error: true
         if: success() || failure()
         env:
-          # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          PR_API_VERSION: "36"
-          FULL_API_RANGE: "31 32 33 34 35 36"
           IS_PR: ${{ inputs.is_pr }}
           LIB: ${{ inputs.lib }}
           RUN_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/reusable-ui-workflow.yaml
+++ b/.github/workflows/reusable-ui-workflow.yaml
@@ -28,6 +28,11 @@ jobs:
     runs-on: forcedotcom-ubuntu  # forks: use ubuntu-latest (org-scoped runner)
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
+      # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
+      PR_API_VERSION: "36"
+      PR_DEVICE_MODEL: "MediumPhone_ps16k.arm"
+      FULL_API_RANGE: "31 32 33 34 35 36 37"
+      PS16K_MIN_API_VERSION: "36"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
@@ -92,8 +97,6 @@ jobs:
         continue-on-error: true
         if: ${{ inputs.is_pr && !inputs.run_all_ui_tests }}
         env:
-          # Most used according to https://gs.statcounter.com/android-version-market-share/mobile-tablet/worldwide
-          PR_API_VERSION: "36"
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           GCLOUD_RESULTS_DIR="authflowtester-pr-build-${RUN_NUMBER}"
@@ -114,7 +117,7 @@ jobs:
             --environment-variables clearPackageData=true \
             --app "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/debug/AuthFlowTester-debug.apk" \
             --test "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/androidTest/debug/AuthFlowTester-debug-androidTest.apk" \
-            --device "model=MediumPhone.arm,version=${PR_API_VERSION},locale=en,orientation=portrait" \
+            --device "model=${PR_DEVICE_MODEL},version=${PR_API_VERSION},locale=en,orientation=portrait" \
             --directories-to-pull=/sdcard \
             --results-dir="${GCLOUD_RESULTS_DIR}" \
             --results-history-name=AuthFlowTester \
@@ -126,7 +129,6 @@ jobs:
         continue-on-error: true
         if: ${{ inputs.is_pr && inputs.run_all_ui_tests }}
         env:
-          PR_API_VERSION: "36"
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           GCLOUD_RESULTS_DIR="authflowtester-pr-build-${RUN_NUMBER}"
@@ -138,7 +140,7 @@ jobs:
             --environment-variables clearPackageData=true \
             --app "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/debug/AuthFlowTester-debug.apk" \
             --test "native/NativeSampleApps/AuthFlowTester/build/outputs/apk/androidTest/debug/AuthFlowTester-debug-androidTest.apk" \
-            --device "model=MediumPhone.arm,version=${PR_API_VERSION},locale=en,orientation=portrait" \
+            --device "model=${PR_DEVICE_MODEL},version=${PR_API_VERSION},locale=en,orientation=portrait" \
             --directories-to-pull=/sdcard \
             --results-dir="${GCLOUD_RESULTS_DIR}" \
             --results-history-name=AuthFlowTester \
@@ -149,13 +151,16 @@ jobs:
         continue-on-error: true
         if: ${{ ! inputs.is_pr }}
         env:
-          FULL_API_RANGE: "31 32 33 34 35 36"
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           GCLOUD_RESULTS_DIR="authflowtester-single-user-build-${RUN_NUMBER}"
           DEVICE_ARGS=()
           for LEVEL in $FULL_API_RANGE; do
-            DEVICE_ARGS+=(--device "model=MediumPhone.arm,version=${LEVEL},locale=en,orientation=portrait")
+            DEVICE_MODEL="MediumPhone.arm"
+            if [ "$PS16K_MIN_API_VERSION" -le "$LEVEL" ]; then
+              DEVICE_MODEL="MediumPhone_ps16k.arm"
+            fi
+            DEVICE_ARGS+=(--device "model=${DEVICE_MODEL},version=${LEVEL},locale=en,orientation=portrait")
           done
 
           gcloud firebase test android run \
@@ -177,13 +182,16 @@ jobs:
         continue-on-error: true
         if: ${{ ! inputs.is_pr }}
         env:
-          FULL_API_RANGE: "31 32 33 34 35 36"
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           GCLOUD_RESULTS_DIR="authflowtester-multi-user-build-${RUN_NUMBER}"
           DEVICE_ARGS=()
           for LEVEL in $FULL_API_RANGE; do
-            DEVICE_ARGS+=(--device "model=MediumPhone.arm,version=${LEVEL},locale=en,orientation=portrait")
+            DEVICE_MODEL="MediumPhone.arm"
+            if [ "$PS16K_MIN_API_VERSION" -le "$LEVEL" ]; then
+              DEVICE_MODEL="MediumPhone_ps16k.arm"
+            fi
+            DEVICE_ARGS+=(--device "model=${DEVICE_MODEL},version=${LEVEL},locale=en,orientation=portrait")
           done
 
           gcloud firebase test android run \


### PR DESCRIPTION
## Summary

- Add API 37 to full Firebase Test Lab runs while keeping PR coverage on API 36
- Use the 16 KB page-size Arm emulator for APIs 36 and 37
- Run Android UI tests across APIs 31 through 37 in one device matrix
- Centralize the shared API and device configuration at the job level

## Validation

- Parsed the changed workflow YAML
- Validated every workflow run block with bash -n
- Ran git diff --check

No Firebase Test Lab matrices were launched locally.