### PR TITLE
[Android] Capture ui_sid from DPoP token response and use it in mainSid

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccount.java
@@ -109,6 +109,7 @@ public class UserAccount {
 	public static final String CREDENTIALS_IDENTIFIER = "credentialsIdentifier";
 	public static final String TOKEN_TYPE = "tokenType";
 	public static final String LAST_TOKEN_ROTATION_TIME = "lastTokenRotationTime";
+	public static final String UI_SID = "uiSid";
 
 	private static final String TAG = "UserAccount";
 	private static final String FORWARD_SLASH = "/";
@@ -160,6 +161,7 @@ public class UserAccount {
 	private String credentialsIdentifier;
 	private String tokenType;
 	private String lastTokenRotationTime;
+	private String uiSid;
 	private Set<String> featureFlags = new java.util.HashSet<>();
 
 	/**
@@ -309,6 +311,7 @@ public class UserAccount {
 			credentialsIdentifier = object.optString(CREDENTIALS_IDENTIFIER, null);
 			tokenType = object.optString(TOKEN_TYPE, null);
 			lastTokenRotationTime = object.optString(LAST_TOKEN_ROTATION_TIME, null);
+			uiSid = object.optString(UI_SID, null);
 			additionalOauthValues = MapUtil.addJSONObjectToMap(object, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -370,6 +373,7 @@ public class UserAccount {
 			credentialsIdentifier = bundle.getString(CREDENTIALS_IDENTIFIER);
 			tokenType = bundle.getString(TOKEN_TYPE);
 			lastTokenRotationTime = bundle.getString(LAST_TOKEN_ROTATION_TIME);
+			uiSid = bundle.getString(UI_SID);
 			additionalOauthValues = MapUtil.addBundleToMap(bundle, additionalOauthKeys, additionalOauthValues);
 		}
 	}
@@ -741,12 +745,31 @@ public class UserAccount {
 
 	/**
 	 * Returns the session ID to use as the main SID cookie.
-	 * For JWT token format, this is the parent SID; otherwise it is the auth token.
+	 * Returns uiSid when present (DPoP flows); for JWT token format returns parentSid; otherwise returns authToken.
 	 *
 	 * @return main SID string
 	 */
 	public String getMainSid() {
+		if (uiSid != null) return uiSid;
 		return "jwt".equals(tokenFormat) ? parentSid : authToken;
+	}
+
+	/**
+	 * Returns the UI session ID provided by the server for DPoP flows.
+	 *
+	 * @return ui SID string, or null if not present.
+	 */
+	public String getUiSid() {
+		return uiSid;
+	}
+
+	/**
+	 * Sets the UI session ID.
+	 *
+	 * @param uiSid UI session ID.
+	 */
+	public void setUiSid(String uiSid) {
+		this.uiSid = uiSid;
 	}
 
 	/**
@@ -1150,6 +1173,7 @@ public class UserAccount {
 			if (credentialsIdentifier != null) object.put(CREDENTIALS_IDENTIFIER, credentialsIdentifier);
 			if (tokenType != null) object.put(TOKEN_TYPE, tokenType);
 			if (lastTokenRotationTime != null) object.put(LAST_TOKEN_ROTATION_TIME, lastTokenRotationTime);
+			if (uiSid != null) object.put(UI_SID, uiSid);
 			if (!featureFlags.isEmpty()) {
 				org.json.JSONArray flagsArray = new org.json.JSONArray();
 				for (String f : featureFlags) flagsArray.put(f);
@@ -1220,6 +1244,7 @@ public class UserAccount {
 		if (credentialsIdentifier != null) object.putString(CREDENTIALS_IDENTIFIER, credentialsIdentifier);
 		if (tokenType != null) object.putString(TOKEN_TYPE, tokenType);
 		if (lastTokenRotationTime != null) object.putString(LAST_TOKEN_ROTATION_TIME, lastTokenRotationTime);
+		if (uiSid != null) object.putString(UI_SID, uiSid);
 		object = MapUtil.addMapToBundle(additionalOauthValues, additionalOauthKeys, object);
 		return object;
 	}

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountBuilder.kt
@@ -76,6 +76,7 @@ class UserAccountBuilder private constructor() {
     private var credentialsIdentifier: String? = null
     private var tokenType: String? = null
     private var lastTokenRotationTime: String? = null
+    private var uiSid: String? = null
 
     /**
      * Set fields from token end point response
@@ -113,6 +114,7 @@ class UserAccountBuilder private constructor() {
             .beaconChildConsumerSecret(tr.beaconChildConsumerSecret)
             .scope(tr.scope)
             .tokenType(tr.tokenType)
+            .uiSid(tr.uiSid)
     }
 
     /**
@@ -185,6 +187,7 @@ class UserAccountBuilder private constructor() {
             .credentialsIdentifier(userAccount.credentialsIdentifier)
             .tokenType(userAccount.tokenType)
             .lastTokenRotationTime(userAccount.lastTokenRotationTime)
+            .uiSid(userAccount.uiSid)
     }
 
     /**
@@ -637,6 +640,16 @@ class UserAccountBuilder private constructor() {
     }
 
     /**
+     * Sets the UI session ID (present in DPoP flows).
+     *
+     * @param uiSid UI session ID.
+     * @return Instance of this class.
+     */
+    fun uiSid(uiSid: String?): UserAccountBuilder {
+        return if (!allowUnset && uiSid == null) this else apply { this.uiSid = uiSid }
+    }
+
+    /**
      * Builds and returns a UserAccount object.
      *
      * @return UserAccount object.
@@ -686,6 +699,7 @@ class UserAccountBuilder private constructor() {
         account.credentialsIdentifier = credentialsIdentifier
         account.tokenType = tokenType
         account.lastTokenRotationTime = lastTokenRotationTime
+        account.uiSid = uiSid
         return account
     }
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -576,7 +576,6 @@ public class UserAccountManager {
 		final String tokenType = decryptUserData(account, AuthenticatorService.KEY_TOKEN_TYPE, encryptionKey);
 		final String lastTokenRotationTime = decryptUserData(account, AuthenticatorService.KEY_LAST_TOKEN_ROTATION_TIME, encryptionKey);
 		final String uiSid = decryptUserData(account, AuthenticatorService.KEY_UI_SID, encryptionKey);
-		final String uiSid = decryptUserData(account, AuthenticatorService.KEY_UI_SID, encryptionKey);
 		final String featureFlagsRaw = decryptUserData(account, AuthenticatorService.KEY_FEATURE_FLAGS, encryptionKey);
 
 		Map<String, String> additionalOauthValues = null;

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -785,9 +785,10 @@ public class UserAccountManager {
 		if (userAccount.getLastTokenRotationTime() != null) {
 			extras.putString(AuthenticatorService.KEY_LAST_TOKEN_ROTATION_TIME, SalesforceSDKManager.encrypt(userAccount.getLastTokenRotationTime(), encryptionKey));
 		}
-		if (userAccount.getUiSid() != null) {
-			extras.putString(AuthenticatorService.KEY_UI_SID, SalesforceSDKManager.encrypt(userAccount.getUiSid(), encryptionKey));
-		}
+		// Always write KEY_UI_SID: a null value calls setUserData(key, null) which clears any
+		// stale DPoP uiSid left in AccountManager after a DPoP-to-Bearer downgrade.
+		extras.putString(AuthenticatorService.KEY_UI_SID,
+			userAccount.getUiSid() != null ? SalesforceSDKManager.encrypt(userAccount.getUiSid(), encryptionKey) : null);
 		final Set<String> featureFlags = userAccount.getFeatureFlags();
 		if (!featureFlags.isEmpty()) {
 			extras.putString(AuthenticatorService.KEY_FEATURE_FLAGS,

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -575,6 +575,8 @@ public class UserAccountManager {
 		final String credentialsIdentifier = decryptUserData(account, AuthenticatorService.KEY_CREDENTIALS_IDENTIFIER, encryptionKey);
 		final String tokenType = decryptUserData(account, AuthenticatorService.KEY_TOKEN_TYPE, encryptionKey);
 		final String lastTokenRotationTime = decryptUserData(account, AuthenticatorService.KEY_LAST_TOKEN_ROTATION_TIME, encryptionKey);
+		final String uiSid = decryptUserData(account, AuthenticatorService.KEY_UI_SID, encryptionKey);
+		final String uiSid = decryptUserData(account, AuthenticatorService.KEY_UI_SID, encryptionKey);
 		final String featureFlagsRaw = decryptUserData(account, AuthenticatorService.KEY_FEATURE_FLAGS, encryptionKey);
 
 		Map<String, String> additionalOauthValues = null;
@@ -635,6 +637,7 @@ public class UserAccountManager {
 					.credentialsIdentifier(credentialsIdentifier)
 					.tokenType(tokenType)
 					.lastTokenRotationTime(lastTokenRotationTime)
+					.uiSid(uiSid)
 					.additionalOauthValues(additionalOauthValues)
 					.build();
 			if (!TextUtils.isEmpty(featureFlagsRaw)) {
@@ -782,6 +785,9 @@ public class UserAccountManager {
 		}
 		if (userAccount.getLastTokenRotationTime() != null) {
 			extras.putString(AuthenticatorService.KEY_LAST_TOKEN_ROTATION_TIME, SalesforceSDKManager.encrypt(userAccount.getLastTokenRotationTime(), encryptionKey));
+		}
+		if (userAccount.getUiSid() != null) {
+			extras.putString(AuthenticatorService.KEY_UI_SID, SalesforceSDKManager.encrypt(userAccount.getUiSid(), encryptionKey));
 		}
 		final Set<String> featureFlags = userAccount.getFeatureFlags();
 		if (!featureFlags.isEmpty()) {

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticatorService.java
@@ -95,6 +95,7 @@ public class AuthenticatorService extends Service {
     public static final String KEY_CREDENTIALS_IDENTIFIER = "credentialsIdentifier";
     public static final String KEY_TOKEN_TYPE = "tokenType";
     public static final String KEY_LAST_TOKEN_ROTATION_TIME = "lastTokenRotationTime";
+    public static final String KEY_UI_SID = "uiSid";
 
     private static final String TAG = "AuthenticatorService";
 

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -217,6 +217,7 @@ public class OAuth2 {
     private static final String COOKIE_SID_CLIENT = "cookie-sid_Client";
     private static final String SID_COOKIE_NAME = "sidCookieName";
     private static final String PARENT_SID = "parent_sid";
+    private static final String UI_SID = "ui_sid";
     private static final String TOKEN_FORMAT = "token_format";
     private static final String BEACON_CHILD_CONSUMER_SECRET = "auto_installed_app_org_consumer_secret";
     private static final String BEACON_CHILD_CONSUMER_KEY = "auto_installed_app_org_consumer_key";
@@ -1154,6 +1155,7 @@ public class OAuth2 {
         public String cookieSidClient;
         public String sidCookieName;
         public String parentSid;
+        public String uiSid;
         public String tokenFormat;
         public String beaconChildConsumerKey;
         public String beaconChildConsumerSecret;
@@ -1202,6 +1204,7 @@ public class OAuth2 {
                 tokenFormat = callbackUrlParams.getOrDefault(TOKEN_FORMAT, "");
                 scope = callbackUrlParams.get(SCOPE);
                 tokenType = callbackUrlParams.get(TOKEN_TYPE);
+                uiSid = DPoPKeyManager.DPOP_TOKEN_TYPE.equals(tokenType) ? callbackUrlParams.get(UI_SID) : null;
 
                 // NB: beacon apps not supported with user agent flow so no beacon child fields expected
 
@@ -1285,6 +1288,7 @@ public class OAuth2 {
                 }
                 scope = parsedResponse.optString(SCOPE);
                 tokenType = parsedResponse.optString(TOKEN_TYPE, null);
+                uiSid = DPoPKeyManager.DPOP_TOKEN_TYPE.equals(tokenType) ? parsedResponse.optString(UI_SID, null) : null;
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
@@ -275,6 +275,39 @@ public class UserAccountManagerTest {
                 rotationTime, restored.getLastTokenRotationTime());
     }
 
+    /*
+     * Regression test: uiSid stored during a DPoP session must be cleared when the account is
+     * updated with a Bearer token response (e.g. DPoP-to-Bearer downgrade). Without the fix,
+     * buildAuthBundle skips KEY_UI_SID when uiSid is null, leaving the old encrypted value in
+     * AccountManager. The next buildUserAccount reload then restores the stale uiSid, causing
+     * getMainSid() to return a DPoP session ID instead of the Bearer access token.
+     */
+    @Test
+    public void test_givenDPoPAccountWithUiSid_whenUpdateAccountWithBearerAccount_thenUiSidClearedAfterReload() {
+        UserAccount dpopAccount = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(UserAccountTest.createTestAccount())
+                .tokenType("DPoP")
+                .uiSid("dpop-ui-sid")
+                .build();
+        userAccMgr.createAccount(dpopAccount);
+        Account account = userAccMgr.getCurrentAccount();
+
+        Assert.assertEquals("Precondition: uiSid must be set on the DPoP account",
+                "dpop-ui-sid", userAccMgr.buildUserAccount(account).getUiSid());
+
+        UserAccount bearerAccount = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(dpopAccount)
+                .tokenType("Bearer")
+                .uiSid(null)
+                .build();
+        userAccMgr.updateAccount(account, bearerAccount);
+
+        UserAccount restored = userAccMgr.buildUserAccount(account);
+        Assert.assertNull("uiSid must be cleared after DPoP-to-Bearer downgrade", restored.getUiSid());
+        Assert.assertEquals("getMainSid must return authToken after uiSid is cleared",
+                UserAccountTest.TEST_AUTH_TOKEN, restored.getMainSid());
+    }
+
     /**
      * Test to get all authenticated users.
      */

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -903,22 +903,31 @@ public class UserAccountTest {
     }
 
     @Test
-    public void test_givenDPoPTokenType_whenBuildAccount_thenUiSidCaptured() {
+    public void test_givenDPoPTokenType_whenBuildFromTokenEndpointResponse_thenUiSidCaptured() {
+        Map<String, String> params = new HashMap<>(createTokenEndpointParams());
+        params.put("token_type", "DPoP");
+        params.put("ui_sid", "test_ui_sid");
+        OAuth2.TokenEndpointResponse tr = new OAuth2.TokenEndpointResponse(params, createAdditionalOauthKeys());
+
         final UserAccount account = UserAccountBuilder.getInstance()
-                .populateFromUserAccount(createTestAccount())
-                .uiSid("test_ui_sid")
+                .populateFromTokenEndpointResponse(tr)
                 .build();
 
-        Assert.assertEquals("test_ui_sid", account.getUiSid());
+        Assert.assertEquals("ui_sid must be captured when token_type is DPoP", "test_ui_sid", account.getUiSid());
     }
 
     @Test
-    public void test_givenNoDPoPTokenType_whenBuildAccount_thenUiSidIsNull() {
+    public void test_givenBearerTokenType_whenBuildFromTokenEndpointResponse_thenUiSidNotCaptured() {
+        Map<String, String> params = new HashMap<>(createTokenEndpointParams());
+        params.put("token_type", "Bearer");
+        params.put("ui_sid", "test_ui_sid");
+        OAuth2.TokenEndpointResponse tr = new OAuth2.TokenEndpointResponse(params, createAdditionalOauthKeys());
+
         final UserAccount account = UserAccountBuilder.getInstance()
-                .populateFromUserAccount(createTestAccount())
+                .populateFromTokenEndpointResponse(tr)
                 .build();
 
-        Assert.assertNull(account.getUiSid());
+        Assert.assertNull("ui_sid must be ignored when token_type is not DPoP", account.getUiSid());
     }
 
     @Test

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -902,6 +902,51 @@ public class UserAccountTest {
         Assert.assertEquals("test_parent_sid", account.getMainSid());
     }
 
+    @Test
+    public void test_givenDPoPTokenType_whenBuildAccount_thenUiSidCaptured() {
+        final UserAccount account = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(createTestAccount())
+                .uiSid("test_ui_sid")
+                .build();
+
+        Assert.assertEquals("test_ui_sid", account.getUiSid());
+    }
+
+    @Test
+    public void test_givenNoDPoPTokenType_whenBuildAccount_thenUiSidIsNull() {
+        final UserAccount account = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(createTestAccount())
+                .build();
+
+        Assert.assertNull(account.getUiSid());
+    }
+
+    @Test
+    public void test_givenUiSidPresent_whenGetMainSid_thenReturnsUiSid() {
+        final UserAccount account = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(createTestAccount())
+                .authToken("test_auth_token")
+                .parentSid("test_parent_sid")
+                .tokenFormat("jwt")
+                .uiSid("test_ui_sid")
+                .build();
+
+        Assert.assertEquals("test_ui_sid", account.getMainSid());
+    }
+
+    @Test
+    public void test_givenUiSidAbsent_whenGetMainSid_thenFallsBackToExistingLogic() {
+        final UserAccount account = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(createTestAccount())
+                .authToken("test_auth_token")
+                .parentSid("test_parent_sid")
+                .tokenFormat("jwt")
+                .build();
+
+        Assert.assertNull(account.getUiSid());
+        Assert.assertEquals("test_parent_sid", account.getMainSid());
+    }
+
     /**
      * Check the user accounts are the same
      * @param expected Expected UserAccount


### PR DESCRIPTION
## Summary

- Adds `private static final String UI_SID = "ui_sid"` constant to `OAuth2.java`
- Adds `uiSid` field to `OAuth2.TokenEndpointResponse`, read from the token endpoint response and guarded on `tokenType == "dpop"`
- Adds `uiSid` field, getter, and constant to `UserAccount.java`, serialized to/from JSON and Bundle
- Wires `uiSid` through `UserAccountBuilder.kt` (`populateFromTokenEndpointResponse`, `populateFromUserAccount`, `build()`)
- Encrypts and persists `uiSid` in `UserAccountManager` under `AuthenticatorService.KEY_UI_SID`
- Updates `getMainSid()` in `UserAccount.java`: returns `uiSid` if present, otherwise falls back to existing logic (`parentSid` for jwt, `authToken` otherwise)
- Adds 4 unit tests in `UserAccountTest.java`

## Dependencies

**This PR depends on (already merged):**
- [SalesforceMobileSDK-Android#3017](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/3017) — [Android] Move mainSid calculation to UserAccount ✅

**Related PRs (same feature):**
- [SalesforceMobileSDK-iOS#4154](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/4154) — [iOS] Capture ui_sid from DPoP token response and use it in mainSid
- [SalesforceMobileSDK-iOS-Hybrid#323](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid/pull/323) — [iOS-Hybrid] Use creds.mainSid in SalesforceWebViewCookieManager

## Tracking
- W-24024986 — [Android] Capture ui_sid from token endpoint and use it in mainSid
- Fixes W-23984602