### PR TITLE
Fix DPoP token type comparisons to be case-insensitive

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManagerExtension.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManagerExtension.kt
@@ -159,7 +159,7 @@ fun UserAccountManager.upgradeToDPoP(
     onSuccess: (userAccount: UserAccount) -> Unit,
     onFailure: (error: String, errorDesc: String?, e: Throwable?) -> Unit,
 ) {
-    if (userAccount.tokenType == DPoPKeyManager.DPOP_TOKEN_TYPE) {
+    if (DPoPKeyManager.isDPoPTokenType(userAccount.tokenType)) {
         onSuccess(userAccount)
         return
     }
@@ -251,7 +251,7 @@ fun UserAccountManager.downgradeFromDPoP(
     onSuccess: (userAccount: UserAccount) -> Unit,
     onFailure: (error: String, errorDesc: String?, e: Throwable?) -> Unit,
 ) {
-    if (userAccount.tokenType != DPoPKeyManager.DPOP_TOKEN_TYPE) {
+    if (!DPoPKeyManager.isDPoPTokenType(userAccount.tokenType)) {
         onSuccess(userAccount)
         return
     }

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt
@@ -58,6 +58,7 @@ import com.salesforce.androidsdk.app.Features.FEATURE_TOKEN_FORMAT_OPAQUE
 import com.salesforce.androidsdk.app.Features.FEATURE_TOKEN_MIGRATION
 import com.salesforce.androidsdk.app.SalesforceSDKManager
 import com.salesforce.androidsdk.app.SalesforceSDKManager.Companion.encryptionKey
+import com.salesforce.androidsdk.auth.dpop.DPoPKeyManager
 import com.salesforce.androidsdk.auth.OAuth2.TokenEndpointResponse
 import com.salesforce.androidsdk.auth.OAuth2.addAuthorizationHeader
 import com.salesforce.androidsdk.auth.OAuth2.callIdentityService
@@ -220,7 +221,7 @@ internal suspend fun onAuthFlowComplete(
         // DP: DPoP-bound session. Token migration bypasses LoginActivity.onAuthFlowSuccess (the
         // usual site of this marker), so an in-place upgrade to DPoP would otherwise never advertise
         // the flag. tokenType is a per-session property, so mirror it onto the migrated account here.
-        if ("DPoP" == account.tokenType) {
+        if (DPoPKeyManager.isDPoPTokenType(account.tokenType)) {
             SalesforceSDKManager.getInstance().registerUsedAppFeature(FEATURE_DPOP, account)
         } else {
             SalesforceSDKManager.getInstance().unregisterUsedAppFeature(FEATURE_DPOP, account)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -692,7 +692,7 @@ public class OAuth2 {
      * @param tokenType Token type (e.g. "Bearer" or "DPoP"), or null for default Bearer.
      */
     public static Request.Builder addAuthorizationHeader(Request.Builder builder, String authToken, @Nullable String tokenType) {
-        final String scheme = DPoPKeyManager.DPOP_TOKEN_TYPE.equals(tokenType) ? DPoPKeyManager.DPOP_TOKEN_TYPE + " " : BEARER;
+        final String scheme = DPoPKeyManager.isDPoPTokenType(tokenType) ? DPoPKeyManager.DPOP_TOKEN_TYPE + " " : BEARER;
         return builder.header(AUTHORIZATION, scheme + authToken);
     }
 
@@ -1204,7 +1204,7 @@ public class OAuth2 {
                 tokenFormat = callbackUrlParams.getOrDefault(TOKEN_FORMAT, "");
                 scope = callbackUrlParams.get(SCOPE);
                 tokenType = callbackUrlParams.get(TOKEN_TYPE);
-                uiSid = DPoPKeyManager.DPOP_TOKEN_TYPE.equals(tokenType) ? callbackUrlParams.get(UI_SID) : null;
+                uiSid = DPoPKeyManager.isDPoPTokenType(tokenType) ?callbackUrlParams.get(UI_SID) : null;
 
                 // NB: beacon apps not supported with user agent flow so no beacon child fields expected
 
@@ -1288,7 +1288,7 @@ public class OAuth2 {
                 }
                 scope = parsedResponse.optString(SCOPE);
                 tokenType = parsedResponse.optString(TOKEN_TYPE, null);
-                uiSid = DPoPKeyManager.DPOP_TOKEN_TYPE.equals(tokenType) ? parsedResponse.optString(UI_SID, null) : null;
+                uiSid = DPoPKeyManager.isDPoPTokenType(tokenType) ?parsedResponse.optString(UI_SID, null) : null;
 
             } catch (Exception e) {
                 SalesforceSDKLogger.w(TAG, "Could not parse token endpoint response", e);

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManager.kt
@@ -41,10 +41,18 @@ object DPoPKeyManager {
     private const val ANDROID_KEYSTORE = "AndroidKeyStore"
 
     /**
-     * RFC 9449 token type string. Case-sensitive per the spec. Single source of truth —
-     * `OAuth2.java` references this constant rather than redefining the literal.
+     * RFC 9449 token type string. Canonical casing — compare via [isDPoPTokenType] since
+     * RFC 6749 §5.1 does not mandate casing; servers may return `"dpop"`, `"DPoP"`, or any variant.
      */
     const val DPOP_TOKEN_TYPE = "DPoP"
+
+    /**
+     * Returns true iff [tokenType] matches `"DPoP"` case-insensitively (RFC 6749 §5.1).
+     * Handles null/empty safely — never returns true for those.
+     */
+    @JvmStatic
+    fun isDPoPTokenType(tokenType: String?): Boolean =
+        tokenType?.equals(DPOP_TOKEN_TYPE, ignoreCase = true) == true
 
     private const val TAG = "DPoPKeyManager"
 
@@ -108,7 +116,7 @@ object DPoPKeyManager {
      * by `credentialsIdentifier`.
      *
      * An explicit `tokenType` is authoritative:
-     * - `tokenType == "DPoP"` → attach.
+     * - `tokenType` matches `"DPoP"` case-insensitively (RFC 6749 §5.1) → attach.
      * - any other non-null type (e.g. "Bearer") → do NOT attach, and fast-exit before any
      *   KeyStore I/O. This protects the DPoP→Bearer migration / Bearer re-auth path: a Bearer
      *   credential that reuses a `credentialsIdentifier` still holding a stale DPoP key pair
@@ -120,7 +128,7 @@ object DPoPKeyManager {
      */
     fun shouldAttachDPoP(credentialsIdentifier: String?, tokenType: String?): Boolean {
         if (credentialsIdentifier.isNullOrEmpty()) return false
-        if (DPOP_TOKEN_TYPE == tokenType) return true
+        if (isDPoPTokenType(tokenType)) return true
         if (tokenType != null) return false // explicit non-DPoP type — fast exit, no KeyStore I/O
         // tokenType is null — transition window between /authorize and /token.
         return hasKeyPairForCredentialsIdentifier(credentialsIdentifier)

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/developer/support/DevSupportInfo.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/developer/support/DevSupportInfo.kt
@@ -116,7 +116,7 @@ data class DevSupportInfo(
                 "Beacon Child Consumer Key" to (currentUser.beaconChildConsumerKey ?: "None"),
                 "OAuth Token Type" to (currentUser.tokenType?.ifBlank { "Bearer" } ?: "Bearer"),
             )
-            if (currentUser.tokenType == "DPoP") {
+            if (DPoPKeyManager.isDPoPTokenType(currentUser.tokenType)) {
                 val credId = currentUser.credentialsIdentifier
                 val host = currentUser.instanceServer
                     ?.toHttpUrlOrNull()?.host ?: ""

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPKeyManagerTest.kt
@@ -163,4 +163,26 @@ class DPoPKeyManagerTest {
         assertFalse(DPoPKeyManager.shouldAttachDPoP(id, "Bearer"))
         assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "DPoP"))
     }
+
+    @Test
+    fun test_isDPoPTokenType_matchesCaseInsensitivelyAndRejectsNilEmpty() {
+        // RFC 6749 §5.1 does not mandate casing — servers may return "dpop" or "DPoP".
+        assertTrue(DPoPKeyManager.isDPoPTokenType("DPoP"))
+        assertTrue(DPoPKeyManager.isDPoPTokenType("dpop"))
+        assertTrue(DPoPKeyManager.isDPoPTokenType("DPOP"))
+
+        assertFalse(DPoPKeyManager.isDPoPTokenType(null))
+        assertFalse(DPoPKeyManager.isDPoPTokenType(""))
+        assertFalse(DPoPKeyManager.isDPoPTokenType("Bearer"))
+        assertFalse(DPoPKeyManager.isDPoPTokenType("bearer"))
+    }
+
+    @Test
+    fun test_shouldAttachDPoP_lowercaseDPoPTokenType_returnsTrue() {
+        // Regression for W-24027018: server returns lowercase "dpop" in refresh responses.
+        val id = "lowercase_dpop_${UUID.randomUUID()}"
+        aliasesToCleanUp.add(DPoPKeyManager.aliasForCredentialsIdentifier(id))
+        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "dpop"))
+        assertTrue(DPoPKeyManager.shouldAttachDPoP(id, "DPOP"))
+    }
 }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecoratorTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/dpop/DPoPRequestDecoratorTest.kt
@@ -243,4 +243,20 @@ class DPoPRequestDecoratorTest {
             DPoPNonceCache.clearAll()
         }
     }
+
+    @Test
+    fun applyAuthHeaders_lowercaseDPoPTokenType_stampsDPoPSchemeNotBearer() {
+        // Regression for W-24027018: server returns lowercase "dpop" in token refresh responses.
+        // Prior case-sensitive comparison caused addAuthorizationHeader to use Bearer on replay.
+        seedKeyPair(testScope)
+        val builder = requestBuilder()
+
+        DPoPRequestDecorator.applyAuthHeaders(builder, userAccount(tokenType = "dpop"))
+
+        val request = builder.build()
+        val auth = request.header("Authorization")
+        assertNotNull(auth)
+        assertTrue("lowercase 'dpop' must produce Authorization: DPoP …, got: $auth", auth!!.startsWith("DPoP "))
+        assertNotNull("lowercase 'dpop' must attach a DPoP proof header", request.header(DPoPRequestDecorator.DPOP_HEADER))
+    }
 }


### PR DESCRIPTION
## Summary

- **What**: Several DPoP token type comparisons across the Android SDK used case-sensitive equality (`==` in Kotlin, `.equals()` in Java) against the literal `"DPoP"`. RFC 6749 §5.1 defines `token_type` as case-insensitive; servers are permitted to return any casing. The fix adds an `isDPoPTokenType()` helper (using `equalsIgnoreCase`) to `DPoPKeyManager` and applies it to all five call sites.
- **Why**: Correctness/robustness fix per RFC 6749 §5.1. This is not confirmed as the root cause of any specific INVALID_AUTH_HEADER incident — debug logging showed the test org returns uppercase `"DPoP"` in refresh responses. The fix eliminates a latent failure mode for orgs/server versions that may return lowercase.
- **Scope**: 5 production files + 2 test files. No behaviour change for orgs returning uppercase `"DPoP"`.

## Files changed

| File | Fix |
|------|-----|
| `DPoPKeyManager.kt` | Add `isDPoPTokenType()` helper; use in `shouldAttachDPoP` |
| `OAuth2.java` | `addAuthorizationHeader` scheme + both `uiSid` assignments |
| `UserAccountManagerExtension.kt` | `upgradeToDPoP` / `downgradeFromDPoP` early-exits |
| `AuthenticationUtilities.kt` | `FEATURE_DPOP` telemetry registration |
| `DevSupportInfo.kt` | Dev support DPoP nonce display |

## Test plan

- [x] `test_isDPoPTokenType_matchesCaseInsensitivelyAndRejectsNilEmpty` passes
- [x] `test_shouldAttachDPoP_lowercaseDPoPTokenType_returnsTrue` passes
- [x] `applyAuthHeaders_lowercaseDPoPTokenType_stampsDPoPSchemeNotBearer` passes
- [x] Full `SalesforceSDK` connected suite: 423/423 pass on emulator
- [ ] Manual verification against a DPoP-enabled org

## Related

GUS: W-24027018
iOS counterpart: forcedotcom/SalesforceMobileSDK-iOS#4159