### PR TITLE
fix(AuthFlowTesterUITests): fix mainSid/uiSid assertions and validateOAuthValues for non-hybrid and DPoP flows

### DIFF
--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/MultiUserLoginTests.kt
@@ -561,7 +561,7 @@ class MultiUserLoginTests: AuthFlowTest() {
             expectedAMarker = FEATURE_AUTH_TYPE_WEB_SERVER_NON_HYBRID,
             isJwt = false,
         )
-        app.validateOAuthValues(knownAppConfig = ECA_OPAQUE, scopeSelection = EMPTY)
+        app.validateOAuthValues(knownAppConfig = ECA_OPAQUE, scopeSelection = EMPTY, useHybridAuthToken = false)
 
         // Switch back to User B — must still have A2, JT
         switchToUserAndValidate(
@@ -604,7 +604,7 @@ class MultiUserLoginTests: AuthFlowTest() {
             isJwt = false,
             isBeacon = false,
         )
-        app.validateOAuthValues(knownAppConfig = ECA_OPAQUE, scopeSelection = EMPTY)
+        app.validateOAuthValues(knownAppConfig = ECA_OPAQUE, scopeSelection = EMPTY, useHybridAuthToken = false)
     }
 
     /**
@@ -785,7 +785,7 @@ class MultiUserLoginTests: AuthFlowTest() {
             isJwt = false,
             isBeacon = false,
         )
-        app.validateOAuthValues(knownAppConfig = CA_OPAQUE, scopeSelection = EMPTY)
+        app.validateOAuthValues(knownAppConfig = CA_OPAQUE, scopeSelection = EMPTY, useHybridAuthToken = false)
 
         // Switch back to User B — must still have A2, JT
         switchToUserAndValidate(

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -358,7 +358,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         validateUserAgent(getText(USER_AGENT_CONTENT_DESC), knownLoginHostConfig, usesWelcomeDiscovery, isMultiUser, expectAdvancedAuth, expectedRtMarker = expectedRtMarker, isDpop = isDpop, expectedBMarker = expectedBMarker, expectedLMarker = expectedLMarker, expectedAMarker = expectedAMarker, wasMigrated = wasMigrated, isJwt = isJwt, isBeacon = isBeacon)
     }
 
-    fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection, useHybridAuthToken: Boolean = true) {
+    fun validateOAuthValues(knownAppConfig: KnownAppConfig, scopeSelection: ScopeSelection, useHybridAuthToken: Boolean = true, isDpop: Boolean? = null) {
         val expected = testConfig.getApp(knownAppConfig)
         val (accessToken, refreshToken) = getTokens()
 
@@ -384,7 +384,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
             }
         }
 
-        validateSIDs(isDpop = expected.isDpop, accessToken = accessToken, isJwt = expected.issuesJwt, useHybrid = useHybridAuthToken, scopeList = expected.scopeList)
+        validateSIDs(isDpop = isDpop ?: expected.isDpop, accessToken = accessToken, isJwt = expected.issuesJwt, useHybrid = useHybridAuthToken, scopeList = expected.scopeList)
     }
 
     private fun validateSIDs(isDpop: Boolean, accessToken: String, isJwt: Boolean, useHybrid: Boolean, scopeList: List<String>) {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -411,7 +411,7 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         assertNotEmpty(vfDomain, shouldNotBeEmpty = hasVisualforceScope && useHybrid, "VF domain")
         assertNotEmpty(vfSid, shouldNotBeEmpty = hasVisualforceScope && useHybrid, "VF SID")
         assertNotEmpty(parentSid, shouldNotBeEmpty = isJwt && useHybrid, "Parent SID")
-        assertNotEmpty(uiSid, shouldNotBeEmpty = isDpop, "UI SID")
+        assertNotEmpty(uiSid, shouldNotBeEmpty = isDpop && useHybrid, "UI SID")
 
         if (useHybrid) {
             if (isDpop) {

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/pageObjects/AuthFlowTesterPageObject.kt
@@ -411,15 +411,16 @@ class AuthFlowTesterPageObject(composeTestRule: ComposeTestRule): BasePageObject
         assertNotEmpty(vfDomain, shouldNotBeEmpty = hasVisualforceScope && useHybrid, "VF domain")
         assertNotEmpty(vfSid, shouldNotBeEmpty = hasVisualforceScope && useHybrid, "VF SID")
         assertNotEmpty(parentSid, shouldNotBeEmpty = isJwt && useHybrid, "Parent SID")
-        assertNotEmpty(mainSid, shouldNotBeEmpty = true, "Main SID")
         assertNotEmpty(uiSid, shouldNotBeEmpty = isDpop, "UI SID")
 
-        if (uiSid.isNotEmpty()) {
-            assertEquals("Main SID should equal UI SID when UI SID is present", uiSid, mainSid)
-        } else if (parentSid.isNotEmpty()) {
-            assertEquals("Main SID should equal Parent SID when UI SID is absent and Parent SID is present", parentSid, mainSid)
-        } else {
-            assertEquals("Main SID should equal Access Token when neither UI SID nor Parent SID is present", accessToken, mainSid)
+        if (useHybrid) {
+            if (isDpop) {
+                assertEquals("Main SID should equal UI SID in DPoP hybrid flow", uiSid, mainSid)
+            } else if (isJwt) {
+                assertEquals("Main SID should equal Parent SID in JWT hybrid flow", parentSid, mainSid)
+            } else {
+                assertEquals("Main SID should equal Access Token in opaque hybrid flow", accessToken, mainSid)
+            }
         }
     }
 

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -448,7 +448,7 @@ abstract class AuthFlowTest {
             isBeacon = appConfig.isBeacon,
             expectedRtMarker = expectedRtMarker(username),
         )
-        app.validateOAuthValues(knownAppConfig, scopeSelection, useHybridAuthToken = useHybridAuthToken)
+        app.validateOAuthValues(knownAppConfig, scopeSelection, useHybridAuthToken = useHybridAuthToken, isDpop = useDPoP)
         app.validateApiRequest()
     }
 
@@ -832,7 +832,7 @@ abstract class AuthFlowTest {
         )
 
         // The consumer key is unchanged — same app, only the DPoP binding changed.
-        app.validateOAuthValues(knownAppConfig, scopeSelection = EMPTY)
+        app.validateOAuthValues(knownAppConfig, scopeSelection = EMPTY, isDpop = true)
 
         // Assert the newly DPoP-bound tokens work. upgradeToDPoP delegates to the refresh-token
         // migration path, so the "TM" (token-migration) UA feature flag is legitimately registered
@@ -879,7 +879,7 @@ abstract class AuthFlowTest {
         )
 
         // The consumer key is unchanged — same app, only the DPoP binding changed.
-        app.validateOAuthValues(knownAppConfig, scopeSelection = EMPTY)
+        app.validateOAuthValues(knownAppConfig, scopeSelection = EMPTY, isDpop = false)
 
         // Assert the newly Bearer tokens work with no DPoP proof. downgradeFromDPoP delegates to
         // the refresh-token migration path, so the "TM" (token-migration) UA feature flag is


### PR DESCRIPTION
## Summary

### Fix 1: `mainSid` assertion scoped to hybrid flows only
- Removes the unconditional `assertNotEmpty` on `mainSid` in `validateSIDs`
- Replaces the flat `if/else if/else` cascade with a `useHybrid`-gated block: DPoP→`uiSid`, JWT→`parentSid`, opaque→`accessToken`
- Non-hybrid flows skip `mainSid` assertion entirely — `mainSid` is only semantically meaningful in hybrid flows (WebView cookie injection). In non-hybrid JWT flows, `parentSid` is not returned by the server so `mainSid` is correctly empty.

### Fix 2: `uiSid` assertNotEmpty scoped to hybrid flows only
- Adds `&& useHybrid` guard to the `uiSid` assertion so non-hybrid DPoP flows no longer require a UI SID.

### Fix 3: Correct `validateOAuthValues` calls for non-hybrid and DPoP upgrade/downgrade flows
- **`MultiUserLoginTests`**: adds `useHybridAuthToken = false` to three `validateOAuthValues` calls where the user is logged in with non-hybrid auth, fixing false "Content domain should not be empty" assertion failures.
- **`AuthFlowTesterPageObject`**: adds an optional `isDpop: Boolean?` override to `validateOAuthValues`, defaulting to `null` (falls back to `expected.isDpop`), so callers can supply the runtime DPoP state.
- **`AuthFlowTest`**: passes `isDpop = useDPoP` in `loginAndValidate`, `isDpop = true` in `upgradeToDPoPAndValidate`, and `isDpop = false` in `downgradeFromDPoPAndValidate`, fixing false "UI SID should be empty" assertion failures in `DPoPLoginTests`.

## Test plan

- [x] `RTRLoginTests.testECAJwtRtr_NoHybrid` — was failing, now passes
- [ ] `MultiUserLoginTests.testFlagDiversity_*` — three tests fixed, awaiting emulator run
- [ ] `DPoPLoginTests.testUpgrade_NonDPoP_InPlace_ToDPoP` / `testDowngrade_DPoP_InPlace_ToBearer` — two tests fixed, awaiting emulator run
- [ ] Full `AuthFlowTester` UI test suite on a connected emulator/device