### PR TITLE
fix(AuthFlowTesterUITests): remove beacon RTR workaround (W-24028119)

### DIFF
--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/AuthFlowTest.kt
@@ -30,25 +30,25 @@ import android.Manifest
 import android.content.Intent
 import android.os.Build
 import androidx.annotation.VisibleForTesting
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
-import com.salesforce.androidsdk.ui.components.LoginViewTestTags
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import com.salesforce.androidsdk.app.Features
 import com.salesforce.androidsdk.app.SalesforceSDKManager
+import com.salesforce.androidsdk.ui.components.LoginViewTestTags
 import com.salesforce.samples.authflowtester.AuthFlowTesterActivity
 import com.salesforce.samples.authflowtester.pageObjects.AuthFlowTesterPageObject
 import com.salesforce.samples.authflowtester.pageObjects.AuthorizationPageObject
+import com.salesforce.samples.authflowtester.pageObjects.ChromeCustomTabPageObject
 import com.salesforce.samples.authflowtester.pageObjects.LoginOptionsPageObject
 import com.salesforce.samples.authflowtester.pageObjects.LoginPageObject
-import com.salesforce.samples.authflowtester.pageObjects.ChromeCustomTabPageObject
-import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.EMPTY
-import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
-import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
 import com.salesforce.samples.authflowtester.testUtility.KnownAppConfig.CA_OPAQUE
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.ADVANCED_AUTH
+import com.salesforce.samples.authflowtester.testUtility.KnownLoginHostConfig.REGULAR_AUTH
+import com.salesforce.samples.authflowtester.testUtility.ScopeSelection.EMPTY
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -786,8 +786,7 @@ abstract class AuthFlowTest {
         app.validateOAuthValues(knownAppConfig, scopeSelection)
 
         // Assert new tokens work. This revoke forces a normal refresh through the session refresher —
-        // the one path that registers the sticky RT marker — so a beacon app that rotates its refresh
-        // token here (W-23971480) will legitimately carry RT on the next validation.
+        // the one path that registers the sticky RT marker.
         app.revokeAccessToken()
         app.validateApiRequest()
         val (_, refreshedRefreshToken) = app.getTokens()

--- a/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
+++ b/native/NativeSampleApps/AuthFlowTester/src/androidTest/java/com/salesforce/samples/authflowtester/testUtility/UITestConfig.kt
@@ -125,8 +125,7 @@ data class AppConfig(
     val isBeacon = name.startsWith("beacon_")
     // Config-level capability: does this app configuration rotate the refresh token on refresh?
     // Distinct from the per-user, observed RT feature marker tracked in the test base class.
-    // W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed
-    val expectsRefreshTokenRotation = name.contains("_rtr") || name.startsWith("beacon_")
+    val expectsRefreshTokenRotation = name.contains("_rtr")
     val isDpop = name.contains("_dpop")
     val expectedTokenFormat = if (issuesJwt) "jwt" else "Opaque"
     val scopeList = scopes.split(" ")


### PR DESCRIPTION
## Summary

Removes the `beacon_` clause from `expectsRefreshTokenRotation` in `UITestConfig.kt` and cleans up the related comment in `AuthFlowTest.kt`.

The server bug (W-23971480) that caused beacon apps to unconditionally rotate the refresh token on every refresh has been fixed in sdb38. The workaround and its comment are no longer needed — `beacon_opaque` and `beacon_jwt` tests should now pass without the special-case RTR expectation.

## Test plan

- [x] `BeaconLoginTests.testBeaconOpaque_DefaultScopes` — was failing with RTR mismatch, now passes
- [ ] Full beacon test suite on a connected emulator/device