### PR TITLE
Stabilize flaky Android tests and harden API 37 logout handling

### DIFF
--- a/.github/workflows/reusable-lib-workflow.yaml
+++ b/.github/workflows/reusable-lib-workflow.yaml
@@ -210,12 +210,13 @@ jobs:
                   for RESULT_FILE in $(gsutil ls "${BUCKET_PATH}/*/test_result_1.xml" 2>/dev/null | grep -v "rerun"); do
                     gsutil cp "${RESULT_FILE}" "firebase_results/api_${LEVEL}_test_result.xml"
                   done
-                  # Pass 2: merge rerun testcases into originals so check_retries detects flaky tests
-                  for RESULT_FILE in $(gsutil ls "${BUCKET_PATH}/*/test_result_1.xml" 2>/dev/null | grep "rerun"); do
-                    RERUN_TMP="firebase_results/api_${LEVEL}_rerun_tmp.xml"
-                    ORIG_FILE="firebase_results/api_${LEVEL}_test_result.xml"
-                    gsutil cp "${RESULT_FILE}" "${RERUN_TMP}"
-                    python3 - "${ORIG_FILE}" "${RERUN_TMP}" "${ORIG_FILE}" << 'PYEOF'
+                fi
+                # Pass 2: merge rerun testcases into originals so check_retries detects flaky tests
+                for RESULT_FILE in $(gsutil ls "${BUCKET_PATH}/*/test_result_1.xml" 2>/dev/null | grep "rerun"); do
+                  RERUN_TMP="firebase_results/api_${LEVEL}_rerun_tmp.xml"
+                  ORIG_FILE="firebase_results/api_${LEVEL}_test_result.xml"
+                  gsutil cp "${RESULT_FILE}" "${RERUN_TMP}"
+                  python3 - "${ORIG_FILE}" "${RERUN_TMP}" "${ORIG_FILE}" << 'PYEOF'
           import sys, xml.etree.ElementTree as ET
           orig = ET.parse(sys.argv[1])
           rerun = ET.parse(sys.argv[2])
@@ -236,9 +237,8 @@ jobs:
           with open(sys.argv[3], 'w') as f:
             f.write(ET.tostring(orig.getroot(), encoding='unicode'))
           PYEOF
-                    rm "${RERUN_TMP}"
-                  done
-                fi
+                  rm "${RERUN_TMP}"
+                done
 
                 # Copy all shard data for code coverage (only needed for one level)
                 if [ "$LEVEL" == "$PR_API_VERSION" ] ; then

--- a/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/TestRunnerPlugin.java
+++ b/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/plugin/TestRunnerPlugin.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * PhoneGap plugin to run javascript tests.
@@ -51,7 +52,7 @@ public class TestRunnerPlugin extends ForcePlugin {
 	
 	// To synchronize with the tests
 	public final static BlockingQueue<Boolean> readyForTests = new ArrayBlockingQueue<Boolean>(1);
-	public final static BlockingQueue<TestResult> testResults = new ArrayBlockingQueue<TestResult>(1);
+	public final static BlockingQueue<TestResult> testResults = new LinkedBlockingQueue<TestResult>();
 	
 	/**
 	 * Supported plugin actions that the client can take.

--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/accounts/UserAccountManager.java
@@ -394,8 +394,11 @@ public class UserAccountManager {
 	 * @param reason The reason for the logout.
 	 */
 	public void signoutCurrentUser(Activity frontActivity, boolean showLoginPage, OAuth2.LogoutReason reason) {
-		SalesforceSDKManager.getInstance().logout(
-				getCurrentAccount(), frontActivity, showLoginPage, reason);
+		final Account currentAccount = getCurrentAccount();
+		if (currentAccount != null) {
+			SalesforceSDKManager.getInstance().logout(
+					currentAccount, frontActivity, showLoginPage, reason);
+		}
 	}
 
 	/**

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JSTestCase.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JSTestCase.java
@@ -44,6 +44,7 @@ import org.junit.Assert;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -72,6 +73,8 @@ public abstract class JSTestCase {
 
             // Start main activity
             Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+            TestRunnerPlugin.readyForTests.clear();
+            TestRunnerPlugin.testResults.clear();
             final Intent intent = new Intent(Intent.ACTION_MAIN);
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setClassName(instrumentation.getTargetContext(), SalesforceSDKManager.getInstance().getMainActivityClass().getName());
@@ -90,7 +93,12 @@ public abstract class JSTestCase {
                 // Block until test completes or times out
                 TestResult result;
                 try {
-                    result = TestRunnerPlugin.testResults.poll(timeout, TimeUnit.SECONDS);
+                    result = pollForTestResult(
+                            TestRunnerPlugin.testResults,
+                            testName,
+                            timeout,
+                            TimeUnit.SECONDS
+                    );
                     if (result == null) {
                         result = new TestResult(testName, false, "Timeout (" + timeout + " seconds) exceeded", timeout);
                     }
@@ -108,6 +116,28 @@ public abstract class JSTestCase {
             eq.tearDown();
             activity.finish();
         }
+    }
+
+    static TestResult pollForTestResult(
+            BlockingQueue<TestResult> results,
+            String expectedTestName,
+            long timeout,
+            TimeUnit timeUnit
+    ) throws InterruptedException {
+        final long deadline = System.nanoTime() + timeUnit.toNanos(timeout);
+        long remainingNanos = deadline - System.nanoTime();
+        while (remainingNanos > 0) {
+            final TestResult result = results.poll(remainingNanos, TimeUnit.NANOSECONDS);
+            if (result == null || expectedTestName.equals(result.testName)) {
+                return result;
+            }
+            SalesforceHybridLogger.w(
+                    TAG,
+                    "Ignoring late result for " + result.testName + " while waiting for " + expectedTestName
+            );
+            remainingNanos = deadline - System.nanoTime();
+        }
+        return null;
     }
 
     /**

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JSTestCaseTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/JSTestCaseTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.androidsdk.phonegap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.salesforce.androidsdk.phonegap.plugin.TestRunnerPlugin;
+import com.salesforce.androidsdk.phonegap.plugin.TestRunnerPlugin.TestResult;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class JSTestCaseTest {
+
+    @After
+    public void tearDown() {
+        TestRunnerPlugin.testResults.clear();
+    }
+
+    @Test
+    public void testResultQueueAcceptsLateAndCurrentResults() {
+        TestResult lateResult = new TestResult("timedOutTest", true, "", 31);
+        TestResult currentResult = new TestResult("currentTest", true, "", 1);
+
+        assertTrue(TestRunnerPlugin.testResults.offer(lateResult));
+        assertTrue(TestRunnerPlugin.testResults.offer(currentResult));
+    }
+
+    @Test
+    public void pollForTestResultIgnoresLateResultFromTimedOutTest() throws InterruptedException {
+        LinkedBlockingQueue<TestResult> results = new LinkedBlockingQueue<>();
+        results.add(new TestResult("timedOutTest", true, "", 31));
+        results.add(new TestResult("currentTest", true, "", 1));
+
+        TestResult result = JSTestCase.pollForTestResult(
+                results,
+                "currentTest",
+                1,
+                TimeUnit.SECONDS
+        );
+
+        assertEquals("currentTest", result.testName);
+    }
+}

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/MobileSyncJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/MobileSyncJSTest.java
@@ -115,7 +115,7 @@ public class MobileSyncJSTest extends JSTestCase {
 
     @BeforeClass
     public static void runJSTestSuite() throws InterruptedException {
-        JSTestCase.runJSTestSuite(JS_SUITE, data(), 60);
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 180);
     }
 
     @Test

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreJSTest.java
@@ -104,7 +104,7 @@ public class SmartStoreJSTest extends JSTestCase {
 
     @BeforeClass
     public static void runJSTestSuite() throws InterruptedException {
-        JSTestCase.runJSTestSuite(JS_SUITE, data(), 30);
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 60);
     }
 
     @Test

--- a/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreLoadJSTest.java
+++ b/libs/test/SalesforceHybridTest/src/com/salesforce/androidsdk/phonegap/SmartStoreLoadJSTest.java
@@ -63,7 +63,7 @@ public class SmartStoreLoadJSTest extends JSTestCase {
 
     @BeforeClass
     public static void runJSTestSuite() throws InterruptedException {
-        JSTestCase.runJSTestSuite(JS_SUITE, data(), 60);
+        JSTestCase.runJSTestSuite(JS_SUITE, data(), 180);
     }
 
     @Test

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountManagerTest.java
@@ -60,6 +60,7 @@ import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for UserAccountManager.
@@ -390,6 +391,20 @@ public class UserAccountManagerTest {
     }
 
     /**
+     * Test that signing out the current user is a no-op when there is no current account.
+     */
+    @Test
+    public void testSignoutCurrentUserDoesNothingWithoutCurrentAccount() throws InterruptedException {
+        Assert.assertNull("There should be no current account", userAccMgr.getCurrentAccount());
+
+        userAccMgr.signoutCurrentUser(null, false, OAuth2.LogoutReason.USER_LOGOUT);
+
+        Assert.assertFalse(
+                "Logout completion should not be broadcast when there is no current account",
+                logoutCompleteReceiver.awaitCompletion(1, TimeUnit.SECONDS));
+    }
+
+    /**
      * Test to signout of the current user.
      */
     @Test
@@ -626,6 +641,10 @@ public class UserAccountManagerTest {
             }
             completionSemaphore.release();
             return lastUserAccountReceived;
+        }
+
+        public boolean awaitCompletion(long timeout, TimeUnit timeUnit) throws InterruptedException {
+            return completionSemaphore.tryAcquire(timeout, timeUnit);
         }
     }
 

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
@@ -65,7 +65,10 @@ class NativeLoginManagerTest {
 
     @After
     fun tearDown() {
-        realUserAccountManager.signoutCurrentUser(null, false, OAuth2.LogoutReason.USER_LOGOUT)
+        if (realUserAccountManager.currentAccount != null) {
+            realUserAccountManager.signoutCurrentUser(null, false, OAuth2.LogoutReason.USER_LOGOUT)
+        }
+        instrumentation.waitForIdleSync()
         activityMonitors.forEach(instrumentation::removeMonitor)
         unmockkAll()
     }

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/auth/NativeLoginManagerTest.kt
@@ -65,9 +65,7 @@ class NativeLoginManagerTest {
 
     @After
     fun tearDown() {
-        if (realUserAccountManager.currentAccount != null) {
-            realUserAccountManager.signoutCurrentUser(null, false, OAuth2.LogoutReason.USER_LOGOUT)
-        }
+        realUserAccountManager.signoutCurrentUser(null, false, OAuth2.LogoutReason.USER_LOGOUT)
         instrumentation.waitForIdleSync()
         activityMonitors.forEach(instrumentation::removeMonitor)
         unmockkAll()


### PR DESCRIPTION
## Summary

- prevent late JavaScript test results from blocking or being attributed to the next test
- increase timeouts for the slower MobileSync and SmartStore JavaScript suites
- wait for Android teardown work to become idle before removing instrumentation state
- add production null-account logout protection and a regression test
- merge Firebase rerun XML into sharded reports so passing retries are classified as flaky successes

## API 37 production hardening

The API 37 failure included a Binder buffer crash while Android was delivering com.salesforce.CLEANUP after repeated teardown sign-out calls. UserAccountManager.signoutCurrentUser now resolves the current account once and returns without invoking logout when no account exists.

This prevents accidental or repeated null-account sign-out calls in production from emitting unnecessary cleanup and logout broadcasts, reducing one-way Binder traffic in the same path that triggered the API 37 crash. Direct SalesforceSDKManager.logout(null) behavior remains unchanged for callers that intentionally request global cleanup.

NativeLoginManagerTest now relies on this production guard instead of duplicating the account check, while retaining waitForIdleSync for real logout cleanup. UserAccountManagerTest verifies that no LOGOUT_COMPLETE broadcast is emitted when there is no current account.

## Verification

- red/green regression: null-account sign-out test failed before the guard because LOGOUT_COMPLETE was broadcast, then passed after the guard
- NativeLoginManagerTest plus UserAccountManagerTest: 44/44 passed on API 36
- targeted API 37 remaining SalesforceSDK shard from the original failure investigation: 838/838 passed after teardown stabilization
- sharded rerun control-flow check failed before the workflow change and passed after it
- exact embedded XML merger passed fixtures for both successful and failed retry outcomes
- workflow YAML parsed successfully and the extracted Copy Test Results shell body passed bash syntax validation
- git diff --check passed

Related CI runs:
- https://github.com/forcedotcom/SalesforceMobileSDK-Android/actions/runs/33600595445
- https://github.com/forcedotcom/SalesforceMobileSDK-Android/actions/runs/33700254428