### PR TITLE
Fix add server keyboard.

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/components/PickerBottomSheet.kt
@@ -702,7 +702,10 @@ internal fun AddConnection(
                 onValueChange = { url = it },
                 label = { Text(stringResource(sf__server_url_default_custom_url)) },
                 singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri,
+                    autoCorrect = false,
+                ),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = PADDING_SIZE.dp, end = PADDING_SIZE.dp)


### PR DESCRIPTION
This PR fixes a minor annoyance: when adding a URL into the Add Connection screen, typing a `.` automatically adds a space afterwords.  

This behavior changed with Compose 1.7.6, which defaulted `autoCorrect = true`.  