### PR TITLE
Fix OAuth refresh preserving optional account fields

### DIFF
--- a/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
+++ b/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/OAuth2.java
@@ -1260,13 +1260,13 @@ public class OAuth2 {
                         }
                     }
                 }
-                idToken = parsedResponse.optString(ID_TOKEN);
-                lightningDomain = parsedResponse.optString(LIGHTNING_DOMAIN);
-                lightningSid = parsedResponse.optString(LIGHTNING_SID);
-                vfDomain = parsedResponse.optString(VF_DOMAIN);
-                vfSid = parsedResponse.optString(VF_SID);
-                contentDomain = parsedResponse.optString(CONTENT_DOMAIN);
-                contentSid = parsedResponse.optString(CONTENT_SID);
+                idToken = parsedResponse.optString(ID_TOKEN, null);
+                lightningDomain = parsedResponse.optString(LIGHTNING_DOMAIN, null);
+                lightningSid = parsedResponse.optString(LIGHTNING_SID, null);
+                vfDomain = parsedResponse.optString(VF_DOMAIN, null);
+                vfSid = parsedResponse.optString(VF_SID, null);
+                contentDomain = parsedResponse.optString(CONTENT_DOMAIN, null);
+                contentSid = parsedResponse.optString(CONTENT_SID, null);
                 csrfToken = parsedResponse.optString(CSRF_TOKEN);
                 cookieClientSrc = parsedResponse.optString(COOKIE_CLIENT_SRC);
                 cookieSidClient = parsedResponse.optString(COOKIE_SID_CLIENT);

--- a/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
+++ b/libs/test/SalesforceSDKTest/src/com/salesforce/androidsdk/accounts/UserAccountTest.java
@@ -233,6 +233,46 @@ public class UserAccountTest {
     }
 
     @Test
+    public void test_givenRefreshResponseOmittingOptionalAccountFields_whenRebuildingAccount_thenOriginalValuesRemain() {
+        final UserAccount original = createTestAccount();
+        final Map<String, String> params = new HashMap<>();
+        params.put("access_token", TEST_AUTH_TOKEN);
+        params.put("instance_url", TEST_INSTANCE_URL);
+        params.put("id", TEST_IDENTITY_URL);
+        final ResponseBody responseBody = ResponseBody.create(
+                new JSONObject(params).toString(), MediaType.parse("application/json"));
+        final Response response = new Response.Builder()
+                .code(200)
+                .message("OK")
+                .protocol(Protocol.HTTP_1_1)
+                .request(new Request.Builder().url("https://something.salesforce.com").build())
+                .body(responseBody)
+                .build();
+
+        final OAuth2.TokenEndpointResponse tokenResponse =
+                new OAuth2.TokenEndpointResponse(response, createAdditionalOauthKeys());
+        Assert.assertNull(tokenResponse.idToken);
+        Assert.assertNull(tokenResponse.lightningDomain);
+        Assert.assertNull(tokenResponse.lightningSid);
+        Assert.assertNull(tokenResponse.vfDomain);
+        Assert.assertNull(tokenResponse.vfSid);
+        Assert.assertNull(tokenResponse.contentDomain);
+        Assert.assertNull(tokenResponse.contentSid);
+
+        final UserAccount rebuilt = UserAccountBuilder.getInstance()
+                .populateFromUserAccount(original)
+                .allowUnset(false)
+                .populateFromTokenEndpointResponse(tokenResponse)
+                .build();
+        Assert.assertEquals(TEST_LIGHTNING_DOMAIN, rebuilt.getLightningDomain());
+        Assert.assertEquals(TEST_LIGHTNING_SID, rebuilt.getLightningSid());
+        Assert.assertEquals(TEST_VF_DOMAIN, rebuilt.getVFDomain());
+        Assert.assertEquals(TEST_VF_SID, rebuilt.getVFSid());
+        Assert.assertEquals(TEST_CONTENT_DOMAIN, rebuilt.getContentDomain());
+        Assert.assertEquals(TEST_CONTENT_SID, rebuilt.getContentSid());
+    }
+
+    @Test
     public void testEqualsUsesUserAndOrgIdentityRatherThanAccountName() {
         final UserAccount original = createTestAccount();
         final UserAccount sameUserWithDifferentAccountName = UserAccountBuilder.getInstance()


### PR DESCRIPTION
## Summary
- preserve existing Lightning, Visualforce, and Content domain/SID values when token refresh responses omit them
- represent omitted optional token endpoint fields as null so `allowUnset(false)` retains stored account values
- add a regression test covering response parsing and production-order account rebuilding

## Testing
- focused regression test passed on Pixel 4 XL API 33
- `./gradlew :libs:SalesforceSDK:assembleAndroidTest`
- `./gradlew :libs:SalesforceSDK:build`

## Work Item
- [W-24103502](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002jyBTLYA2/view)